### PR TITLE
feat: decouple bit_order from byte order, default to Msb_first

### DIFF
--- a/lib/bitfield.ml
+++ b/lib/bitfield.ml
@@ -50,19 +50,18 @@ let write_word base buf off v =
   | BF_U32 Little -> UInt32.set_le buf off v
   | BF_U32 Big -> UInt32.set_be buf off v
 
-(** Is this base type LSB-first (matching EverParse convention)? UINT8, UINT16
-    (little), UINT32 (little) are LSBFirst. UINT16BE, UINT32BE are MSBFirst. *)
-let is_lsb_first = function
-  | BF_U8 | BF_U16 Little | BF_U32 Little -> true
-  | BF_U16 Big | BF_U32 Big -> false
+(** EverParse's native bit order for a base: LE bases default to LSB-first (MSVC
+    C bit-field packing), BE bases to MSB-first (network byte order). *)
+let native_bit_order = function
+  | BF_U8 | BF_U16 Little | BF_U32 Little -> Lsb_first
+  | BF_U16 Big | BF_U32 Big -> Msb_first
 
-(** Extract [width] bits at position [bits_used] in a [total]-bit word. Bit
-    ordering follows EverParse 3D conventions:
-    - LSBFirst (UINT8, UINT16, UINT32): first declared field at bit 0
-    - MSBFirst (UINT16BE, UINT32BE): first declared field at MSB *)
-let extract ~base ~total ~bits_used ~width word =
-  let shift =
-    if is_lsb_first base then bits_used else total - bits_used - width
-  in
+let[@inline] shift ~bit_order ~total ~bits_used ~width =
+  match bit_order with
+  | Lsb_first -> bits_used
+  | Msb_first -> total - bits_used - width
+
+let extract ~bit_order ~total ~bits_used ~width word =
+  let s = shift ~bit_order ~total ~bits_used ~width in
   let mask = (1 lsl width) - 1 in
-  (word lsr shift) land mask
+  (word lsr s) land mask

--- a/lib/bitfield.mli
+++ b/lib/bitfield.mli
@@ -14,18 +14,25 @@ val read_word : Types.bitfield_base -> bytes -> int -> int
 val write_word : Types.bitfield_base -> bytes -> int -> int -> unit
 (** Write the base word to bytes at offset. *)
 
-val is_lsb_first : Types.bitfield_base -> bool
-(** [is_lsb_first base] is [true] for LSBFirst bases (UINT8, UINT16, UINT32),
-    [false] for MSBFirst (UINT16BE, UINT32BE). Matches EverParse 3D convention.
-*)
+val native_bit_order : Types.bitfield_base -> Types.bit_order
+(** [native_bit_order base] returns the bit order matching EverParse 3D's native
+    packing for [base]: [Lsb_first] for the little-endian bases ([UINT8],
+    [UINT16], [UINT32]) and [Msb_first] for the big-endian bases ([UINT16BE],
+    [UINT32BE]). *)
+
+val shift :
+  bit_order:Types.bit_order -> total:int -> bits_used:int -> width:int -> int
+(** [shift ~bit_order ~total ~bits_used ~width] returns the right-shift amount
+    for a [width]-bit field starting at bit position [bits_used] inside a
+    [total]-bit word, honoring the requested [bit_order]. *)
 
 val extract :
-  base:Types.bitfield_base ->
+  bit_order:Types.bit_order ->
   total:int ->
   bits_used:int ->
   width:int ->
   int ->
   int
-(** Extract bits from a word. Bit ordering follows EverParse 3D: LSBFirst bases
-    pack the first declared field at bit 0, MSBFirst bases pack the first
-    declared field at the MSB. *)
+(** Extract bits from a word. [bit_order] is independent of the base's byte
+    order: [Msb_first] places the first declared field at the most significant
+    bit, [Lsb_first] at the least. *)

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -179,6 +179,7 @@ type (_, _) readers =
 (* Bitfield group state: tracks the current base word being packed. *)
 type bf_codec_state = {
   bfc_base : bitfield_base;
+  bfc_bit_order : bit_order;
   bfc_base_off : int; (* byte offset of base word within record *)
   bfc_bits_used : int; (* bits consumed so far in current group *)
   bfc_total_bits : int; (* 8, 16, or 32 *)
@@ -769,7 +770,7 @@ let add_field : type a f r. (a -> f, r) record -> (a, r) field -> (f, r) record
             wrap_writer (fun buf off value -> writer buf off (encode value)))
           None
     | Enum { base; _ } -> add base get_wire wrap_reader wrap_writer eq
-    | Bits { width; base } ->
+    | Bits { width; base; bit_order } ->
         let total = bf_base_total_bits base in
         let static_off =
           match r.r_next_off with
@@ -782,6 +783,7 @@ let add_field : type a f r. (a -> f, r) record -> (a, r) field -> (f, r) record
           match r.r_bf with
           | Some bf
             when bf_base_equal bf.bfc_base base
+                 && bf.bfc_bit_order = bit_order
                  && bf.bfc_bits_used + width <= bf.bfc_total_bits ->
               (bf.bfc_base_off, bf.bfc_bits_used, 0, [])
           | _ ->
@@ -791,10 +793,7 @@ let add_field : type a f r. (a -> f, r) record -> (a, r) field -> (f, r) record
                 bf_base_byte_size base,
                 [ (fun _v buf off -> clear buf off) ] )
         in
-        let shift =
-          if Bitfield.is_lsb_first base then bits_used
-          else total - bits_used - width
-        in
+        let shift = Bitfield.shift ~bit_order ~total ~bits_used ~width in
         let raw_reader = build_bf_reader base base_off shift width in
         let raw_writer = build_bf_writer base base_off shift width in
         let int_reader buf off = (raw_reader buf off : int) in
@@ -802,6 +801,7 @@ let add_field : type a f r. (a -> f, r) record -> (a, r) field -> (f, r) record
         let new_bf =
           {
             bfc_base = base;
+            bfc_bit_order = bit_order;
             bfc_base_off = base_off;
             bfc_bits_used = bits_used + width;
             bfc_total_bits = total;

--- a/lib/everparse.ml
+++ b/lib/everparse.ml
@@ -91,6 +91,105 @@ let map_field_action idx (Types.Field f) =
         }
   | None -> Types.Field f
 
+(* Conjoin a list of constraint expressions, skipping [None]s. *)
+let conjoin_constraints constraints =
+  List.fold_left
+    (fun acc c ->
+      match (acc, c) with
+      | acc, None -> acc
+      | None, Some c -> Some c
+      | Some a, Some b -> Some (Types.And (a, b)))
+    None constraints
+
+(* Collapse all constraints in a reversed bit group onto the last field,
+   where every referenced field has already been parsed. Backward
+   references to other fields in the group would otherwise break under
+   reversal, because the reversed field is parsed before its referents.
+
+   The combined constraint is semantically equivalent for validation
+   (accept/reject) — EverParse's per-field constraints are pure boolean
+   predicates, so moving them later in the parse still produces the same
+   overall verdict. Bitfield actions use 3D's [:act] form, which fires
+   regardless of validation outcome, so moving constraints does not
+   affect callback behaviour. *)
+let collapse_constraints_to_last group =
+  let constraints = List.map (fun (Types.Field f) -> f.constraint_) group in
+  let combined = conjoin_constraints constraints in
+  let rec walk = function
+    | [] -> []
+    | [ Types.Field f ] -> [ Types.Field { f with constraint_ = combined } ]
+    | Types.Field f :: rest ->
+        Types.Field { f with constraint_ = None } :: walk rest
+  in
+  walk group
+
+(* Reorder consecutive bitfield groups so every pairing of [bitfield_base] and
+   [bit_order] projects to a valid EverParse 3D struct while keeping the same
+   byte layout. EverParse couples bit order to the base's byte order
+   (LE -> LSB-first, BE -> MSB-first). When the user's [bit_order] differs
+   from that native choice, we reverse the group's declaration order and
+   prepend [total_bits - used_bits] of anonymous padding; in EverParse's
+   native packing this produces the identical bit layout. Fields outside
+   bit groups are left untouched. Extern-call indices embedded in actions
+   are stamped before reordering, so WireSet callbacks still write into the
+   original (wire-declaration) slots — the stub generator never sees the
+   reordered struct. *)
+let reorder_bit_groups_for_3d fields =
+  let is_same_bit_group base bit_order = function
+    | Types.Field
+        { field_typ = Types.Bits { base = b2; bit_order = bo2; _ }; _ } ->
+        b2 = base && bo2 = bit_order
+    | _ -> false
+  in
+  let bit_width = function
+    | Types.Field { field_typ = Types.Bits { width; _ }; _ } -> width
+    | _ -> 0
+  in
+  let rec go acc = function
+    | [] -> List.rev acc
+    | (Types.Field { field_typ = Types.Bits { base; bit_order; _ }; _ } as f0)
+      :: rest ->
+        let total = Bitfield.total_bits base in
+        let native = Bitfield.native_bit_order base in
+        (* Greedy: collect consecutive Bits with the same (base, bit_order)
+           that still fit in one base word. *)
+        let rec collect used group = function
+          | f :: rest' when is_same_bit_group base bit_order f ->
+              let w = bit_width f in
+              if used + w <= total then collect (used + w) (f :: group) rest'
+              else (used, List.rev group, f :: rest')
+          | rest' -> (used, List.rev group, rest')
+        in
+        let used, group, rest' = collect (bit_width f0) [ f0 ] rest in
+        if bit_order = native then go (List.rev_append group acc) rest'
+        else begin
+          let reversed = List.rev group in
+          (* Backward references in reversed order would break: fields now
+             come before the values their constraints read. Collapse all
+             constraints onto the last reversed field. *)
+          let reversed = collapse_constraints_to_last reversed in
+          let padded =
+            let padding = total - used in
+            if padding > 0 then
+              let pad_typ =
+                Types.Bits { width = padding; base; bit_order = native }
+              in
+              Types.Field
+                {
+                  field_name = None;
+                  field_typ = pad_typ;
+                  constraint_ = None;
+                  action = None;
+                }
+              :: reversed
+            else reversed
+          in
+          go (List.rev_append padded acc) rest'
+        end
+    | other :: rest -> go (other :: acc) rest
+  in
+  go [] fields
+
 let with_output (s : Types.struct_) : Types.decl list =
   (* Extern declarations for the callback mechanism *)
   let ctx_struct = Types.struct_ "WireCtx" [] in
@@ -98,9 +197,12 @@ let with_output (s : Types.struct_) : Types.decl list =
   let ctx_param = Types.mutable_param "ctx" (Types.struct_typ ctx_struct) in
   (* Extern setter functions *)
   let u32 = Types.Uint32 Types.Little in
-  (* Count named fields to assign indices *)
+  (* Count named fields to assign indices in the ORIGINAL declaration order.
+     The idx baked into each Extern_call is preserved through the reorder
+     below, so WireSet callbacks still populate the original field slot. *)
   let idx = ref 0 in
   let parse_fields = List.map (map_field_action idx) s.fields in
+  let parse_fields = reorder_bit_groups_for_3d parse_fields in
   let parse_struct =
     Types.param_struct s.name (s.params @ [ ctx_param ]) ?where:s.where
       parse_fields

--- a/lib/test/bitfield/test_bitfield.ml
+++ b/lib/test/bitfield/test_bitfield.ml
@@ -55,12 +55,22 @@ let test_read_write_roundtrip () =
     "u32be roundtrip" 0x12345678
     (Bitfield.read_word bf_u32_be buf 0)
 
-let test_is_lsb_first () =
-  Alcotest.(check bool) "u8 is lsb" true (Bitfield.is_lsb_first bf_u8);
-  Alcotest.(check bool) "u16le is lsb" true (Bitfield.is_lsb_first bf_u16_le);
-  Alcotest.(check bool) "u16be is msb" false (Bitfield.is_lsb_first bf_u16_be);
-  Alcotest.(check bool) "u32le is lsb" true (Bitfield.is_lsb_first bf_u32_le);
-  Alcotest.(check bool) "u32be is msb" false (Bitfield.is_lsb_first bf_u32_be)
+let test_native_bit_order () =
+  Alcotest.(check bool)
+    "u8 native lsb" true
+    (Bitfield.native_bit_order bf_u8 = Types.Lsb_first);
+  Alcotest.(check bool)
+    "u16le native lsb" true
+    (Bitfield.native_bit_order bf_u16_le = Types.Lsb_first);
+  Alcotest.(check bool)
+    "u16be native msb" true
+    (Bitfield.native_bit_order bf_u16_be = Types.Msb_first);
+  Alcotest.(check bool)
+    "u32le native lsb" true
+    (Bitfield.native_bit_order bf_u32_le = Types.Lsb_first);
+  Alcotest.(check bool)
+    "u32be native msb" true
+    (Bitfield.native_bit_order bf_u32_be = Types.Msb_first)
 
 let test_extract_lsb_first () =
   (* LSBFirst: first declared field at bit 0 *)
@@ -68,24 +78,44 @@ let test_extract_lsb_first () =
   let word = 0xD6 in
   Alcotest.(check int)
     "lsb bits 0..3" 6
-    (Bitfield.extract ~base:bf_u8 ~total:8 ~bits_used:0 ~width:4 word);
+    (Bitfield.extract ~bit_order:Types.Lsb_first ~total:8 ~bits_used:0 ~width:4
+       word);
   (* Extract 4 bits at offset 4 -> 0b1101 = 13 *)
   Alcotest.(check int)
     "lsb bits 4..7" 13
-    (Bitfield.extract ~base:bf_u8 ~total:8 ~bits_used:4 ~width:4 word)
+    (Bitfield.extract ~bit_order:Types.Lsb_first ~total:8 ~bits_used:4 ~width:4
+       word)
 
 let test_extract_msb_first () =
   (* MSBFirst: first declared field at MSB *)
-  (* Word 0xD600 = 0b1101011000000000 in 16-bit BE context *)
+  (* Word 0xD600 = 0b1101011000000000 in 16-bit context *)
   let word = 0xD600 in
   (* Extract 4 bits at offset 0 (MSB side) -> 0b1101 = 13 *)
   Alcotest.(check int)
     "msb bits 0..3" 13
-    (Bitfield.extract ~base:bf_u16_be ~total:16 ~bits_used:0 ~width:4 word);
+    (Bitfield.extract ~bit_order:Types.Msb_first ~total:16 ~bits_used:0 ~width:4
+       word);
   (* Extract 4 bits at offset 4 -> 0b0110 = 6 *)
   Alcotest.(check int)
     "msb bits 4..7" 6
-    (Bitfield.extract ~base:bf_u16_be ~total:16 ~bits_used:4 ~width:4 word)
+    (Bitfield.extract ~bit_order:Types.Msb_first ~total:16 ~bits_used:4 ~width:4
+       word)
+
+(* Independence: bit_order is orthogonal to the base's byte order. Show that
+   an LSB-first extraction on a BE base and MSB-first extraction on a LE base
+   both behave according to the bit_order choice, not the base endian. *)
+let test_extract_bit_order_independent () =
+  (* LSB-first extraction on a BE base: still operates on the low bits. *)
+  let word = 0xD6 in
+  Alcotest.(check int)
+    "lsb-first on u16be base" 6
+    (Bitfield.extract ~bit_order:Types.Lsb_first ~total:16 ~bits_used:0 ~width:4
+       word);
+  (* MSB-first extraction on an 8-bit LE base: operates on the top bits. *)
+  Alcotest.(check int)
+    "msb-first on u8 base" 13
+    (Bitfield.extract ~bit_order:Types.Msb_first ~total:8 ~bits_used:0 ~width:4
+       word)
 
 let suite =
   ( "bitfield",
@@ -95,7 +125,9 @@ let suite =
       Alcotest.test_case "equal" `Quick test_equal;
       Alcotest.test_case "read_word/write_word roundtrip" `Quick
         test_read_write_roundtrip;
-      Alcotest.test_case "is_lsb_first" `Quick test_is_lsb_first;
-      Alcotest.test_case "extract LSBFirst" `Quick test_extract_lsb_first;
-      Alcotest.test_case "extract MSBFirst" `Quick test_extract_msb_first;
+      Alcotest.test_case "native_bit_order" `Quick test_native_bit_order;
+      Alcotest.test_case "extract LSB-first" `Quick test_extract_lsb_first;
+      Alcotest.test_case "extract MSB-first" `Quick test_extract_msb_first;
+      Alcotest.test_case "bit_order independent of base endian" `Quick
+        test_extract_bit_order_independent;
     ] )

--- a/lib/test/stubs/test_wire_stubs.ml
+++ b/lib/test/stubs/test_wire_stubs.ml
@@ -338,6 +338,11 @@ let test_e2e_with_constraint () =
 |}
 
 let test_e2e_bitfields () =
+  (* Adversarial: drive the EverParse-generated C parser on a real IPv4-style
+     byte [0x45] and check that Wire's default [bit_order = Msb_first] makes
+     [version] land at the top nibble (=4) and [flags] at the bottom (=5).
+     This is the end-to-end interop witness: if Wire and EverParse disagree
+     on bit placement, this test breaks. *)
   let f_version = Wire.Field.v "version" (bits ~width:4 U8) in
   let f_flags = Wire.Field.v "flags" (bits ~width:4 U8) in
   let f_length = Wire.Field.v "length" uint16be in
@@ -360,9 +365,9 @@ let test_e2e_bitfields () =
   Bytes.set_uint8 buf 0 0x45;
   Bytes.set_uint16_be buf 1 100;
   let r = Stubs.bfheader_parse buf 0 in
-  (* EverParse uses LSB-first bit numbering: version=bits[0..4], flags=bits[4..8] *)
-  assert (r.Stubs.version = 5);
-  assert (r.Stubs.flags = 4);
+  (* Default Msb_first: version = top nibble (4), flags = bottom nibble (5). *)
+  assert (r.Stubs.version = 4);
+  assert (r.Stubs.flags = 5);
   assert (r.Stubs.length = 100)
 |}
 

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -1,4 +1,5 @@
 type endian = Little | Big
+type bit_order = Msb_first | Lsb_first
 
 (* Sequence builder for Array/Repeat — Jsont-style accumulator pattern.
    Existentially hides the builder type so callers control the output container. *)
@@ -69,7 +70,12 @@ and _ typ =
   | Uint32 : endian -> UInt32.t typ
   | Uint63 : endian -> UInt63.t typ
   | Uint64 : endian -> int64 typ (* boxed, for full 64-bit *)
-  | Bits : { width : int; base : bitfield_base } -> int typ
+  | Bits : {
+      width : int;
+      base : bitfield_base;
+      bit_order : bit_order;
+    }
+      -> int typ
   | Unit : unit typ
   | All_bytes : string typ
   | All_zeros : string typ
@@ -214,7 +220,7 @@ let bf_uint16 = BF_U16 Little
 let bf_uint16be = BF_U16 Big
 let bf_uint32 = BF_U32 Little
 let bf_uint32be = BF_U32 Big
-let bits ~width base = Bits { width; base }
+let bits ?(bit_order = Msb_first) ~width base = Bits { width; base; bit_order }
 let bit b = Bool.to_int b
 let is_set n = n <> 0
 let map decode encode inner = Map { inner; decode; encode }
@@ -613,7 +619,7 @@ let rec field_suffix : type a.
     a typ -> field_suffix * (Format.formatter -> unit) =
  fun typ ->
   match typ with
-  | Bits { width; base } ->
+  | Bits { width; base; _ } ->
       (Bitwidth width, fun ppf -> pp_bitfield_base ppf base)
   | Byte_array { size } | Byte_slice { size } ->
       (Byte_array size, fun ppf -> Fmt.string ppf "UINT8")

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -2,6 +2,22 @@
 
 type endian = Little | Big  (** Byte order. *)
 
+type bit_order =
+  | Msb_first
+  | Lsb_first
+      (** Which end of a packed base word the first declared bitfield occupies.
+
+          [Msb_first] places the first declared field at the most significant
+          bit, matching how RFC, CCSDS, and IETF specs draw their bit diagrams.
+          [Lsb_first] places it at bit 0, matching MSVC C bit-field packing.
+
+          Bit order is independent of byte order. Every combination of base word
+          and bit order is a valid wire description. When projecting to
+          EverParse 3D, the export layer reverses field declaration order within
+          a bit group if the user's bit order differs from EverParse's native
+          choice for the base; this preserves byte layout in memory and is
+          invisible to the user. *)
+
 (** {1 Sequence builders} *)
 
 type ('elt, 'seq) seq_map =
@@ -84,7 +100,12 @@ and _ typ =
   | Uint32 : endian -> UInt32.t typ  (** 32-bit unsigned. *)
   | Uint63 : endian -> UInt63.t typ  (** 63-bit unsigned. *)
   | Uint64 : endian -> int64 typ  (** 64-bit unsigned. *)
-  | Bits : { width : int; base : bitfield_base } -> int typ  (** Bitfield. *)
+  | Bits : {
+      width : int;
+      base : bitfield_base;
+      bit_order : bit_order;
+    }
+      -> int typ  (** Bitfield. *)
   | Unit : unit typ  (** Zero-width. *)
   | All_bytes : string typ  (** Remaining bytes as string. *)
   | All_zeros : string typ  (** Remaining bytes, must be zero. *)
@@ -335,8 +356,9 @@ val bf_uint32 : bitfield_base
 val bf_uint32be : bitfield_base
 (** 32-bit bitfield base, big-endian. *)
 
-val bits : width:int -> bitfield_base -> int typ
-(** [bits ~width base] extracts [width] bits from a bitfield base. *)
+val bits : ?bit_order:bit_order -> width:int -> bitfield_base -> int typ
+(** [bits ~width base] extracts [width] bits from a bitfield base. [bit_order]
+    defaults to {!Msb_first}. *)
 
 val map : ('w -> 'a) -> ('a -> 'w) -> 'w typ -> 'a typ
 (** Map a wire type to a different OCaml type. *)

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -73,12 +73,16 @@ let optional_or = Types.optional_or
 let repeat = Types.repeat
 let repeat_seq = Types.repeat_seq
 
-let bits ~width = function
-  | U8 -> Types.bits ~width Types.bf_uint8
-  | U16 -> Types.bits ~width Types.bf_uint16
-  | U16be -> Types.bits ~width Types.bf_uint16be
-  | U32 -> Types.bits ~width Types.bf_uint32
-  | U32be -> Types.bits ~width Types.bf_uint32be
+let bits ?(bit_order = Types.Msb_first) ~width bf =
+  let base =
+    match bf with
+    | U8 -> Types.bf_uint8
+    | U16 -> Types.bf_uint16
+    | U16be -> Types.bf_uint16be
+    | U32 -> Types.bf_uint32
+    | U32be -> Types.bf_uint32be
+  in
+  Types.bits ~bit_order ~width base
 
 module Expr = struct
   include Expr
@@ -240,6 +244,7 @@ let read_all dec =
 (* Bitfield accumulator for packed struct parsing. *)
 type bf_accum = {
   bf_base : bitfield_base;
+  bf_bit_order : bit_order;
   bf_word : int;
   bf_bits_used : int;
   bf_total_bits : int;
@@ -251,26 +256,28 @@ let bf_read_word dec base =
 
 let bf_extract accum width =
   let value =
-    Bitfield.extract ~base:accum.bf_base ~total:accum.bf_total_bits
+    Bitfield.extract ~bit_order:accum.bf_bit_order ~total:accum.bf_total_bits
       ~bits_used:accum.bf_bits_used ~width accum.bf_word
   in
   (value, { accum with bf_bits_used = accum.bf_bits_used + width })
 
 let bf_has_room accum width = accum.bf_bits_used + width <= accum.bf_total_bits
 
-let parse_bits dec base width =
+let parse_bits dec base bit_order width =
   let word = bf_read_word dec base in
   let total = Bitfield.total_bits base in
-  Bitfield.extract ~base ~total ~bits_used:0 ~width word
+  Bitfield.extract ~bit_order ~total ~bits_used:0 ~width word
 
 let[@inline] parse_int dec n get =
   let off = read_small dec n in
   get dec.i off
 
-let parse_bf_field dec accum_opt base width =
+let parse_bf_field dec accum_opt base bit_order width =
   match accum_opt with
-  | Some accum when Bitfield.equal accum.bf_base base && bf_has_room accum width
-    ->
+  | Some accum
+    when Bitfield.equal accum.bf_base base
+         && accum.bf_bit_order = bit_order
+         && bf_has_room accum width ->
       let v, new_accum = bf_extract accum width in
       let accum_opt' =
         if new_accum.bf_bits_used = new_accum.bf_total_bits then None
@@ -283,6 +290,7 @@ let parse_bf_field dec accum_opt base width =
       let accum =
         {
           bf_base = base;
+          bf_bit_order = bit_order;
           bf_word = word;
           bf_bits_used = 0;
           bf_total_bits = total;
@@ -326,7 +334,7 @@ let rec parse_with : type a. decoder -> ctx -> a typ -> a * ctx =
   | Uint63 Big -> (parse_int dec 8 UInt63.be, ctx)
   | Uint64 Little -> (parse_int dec 8 Bytes.get_int64_le, ctx)
   | Uint64 Big -> (parse_int dec 8 Bytes.get_int64_be, ctx)
-  | Bits { width; base } -> (parse_bits dec base width, ctx)
+  | Bits { width; base; bit_order } -> (parse_bits dec base bit_order width, ctx)
   | Unit -> ((), ctx)
   | All_bytes -> (read_all dec, ctx)
   | All_zeros -> (parse_all_zeros dec, ctx)
@@ -426,7 +434,8 @@ and parse_struct_fields dec ctx fields =
       bf_accum option -> a typ -> a * bf_accum option =
    fun accum_opt typ ->
     match typ with
-    | Bits { width; base } -> parse_bf_field dec accum_opt base width
+    | Bits { width; base; bit_order } ->
+        parse_bf_field dec accum_opt base bit_order width
     | _ ->
         let v, _ = parse_with dec ctx typ in
         (v, None)
@@ -506,9 +515,11 @@ let rec parse_direct : type a. a typ -> bytes -> int -> int -> a =
   | Uint64 Big ->
       check_eof len (off + 8);
       Bytes.get_int64_be buf off
-  | Bits { width; base } ->
+  | Bits { width; base; bit_order } ->
       check_eof len (off + Bitfield.byte_size base);
-      Bitfield.read_word base buf off land ((1 lsl width) - 1)
+      let total = Bitfield.total_bits base in
+      let word = Bitfield.read_word base buf off in
+      Bitfield.extract ~bit_order ~total ~bits_used:0 ~width word
   | Unit -> ()
   | Map { inner; decode; _ } -> (
       match decode (parse_direct inner buf off len) with
@@ -664,9 +675,11 @@ let rec encode_with_ctx : type a. ctx -> a typ -> a -> encoder -> ctx =
   | Uint64 Big ->
       write_int64_be enc v;
       ctx
-  | Bits { width; base } ->
+  | Bits { width; base; bit_order } ->
       let mask = (1 lsl width) - 1 in
-      let masked = v land mask in
+      let total = Bitfield.total_bits base in
+      let shift = Bitfield.shift ~bit_order ~total ~bits_used:0 ~width in
+      let masked = (v land mask) lsl shift in
       (match base with
       | BF_U8 -> write_byte enc masked
       | BF_U16 Little -> write_uint16_le enc masked
@@ -764,9 +777,11 @@ let rec encode_direct : type a. a typ -> bytes -> int -> a -> int =
   | Uint64 Big ->
       Bytes.set_int64_be buf off v;
       off + 8
-  | Bits { width; base } -> (
+  | Bits { width; base; bit_order } -> (
       let mask = (1 lsl width) - 1 in
-      let masked = v land mask in
+      let total = Bitfield.total_bits base in
+      let shift = Bitfield.shift ~bit_order ~total ~bits_used:0 ~width in
+      let masked = (v land mask) lsl shift in
       match base with
       | BF_U8 ->
           Bytes.set_uint8 buf off masked;

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -55,6 +55,27 @@ end
 
 type 'a expr
 type bitfield = U8 | U16 | U16be | U32 | U32be
+
+type bit_order = Types.bit_order =
+  | Msb_first
+  | Lsb_first
+      (** Which end of a packed base word the first declared bitfield occupies.
+
+          - [Msb_first] (default): the first declared field lands at the most
+            significant bit of the base word, matching how RFC, CCSDS, and IETF
+            specs draw their bit diagrams. Copy-pasting a spec into field
+            declarations just works.
+
+          - [Lsb_first]: the first declared field lands at bit 0 of the base
+            word, matching MSVC's C bit-field packing. Useful when mirroring a C
+            struct.
+
+          Bit order is independent of byte order: any combination of base word
+          and bit order is a valid wire description, and the EverParse 3D
+          projection reverses declaration order within a bit group when
+          necessary so that every pairing emits a valid 3D schema with identical
+          byte layout. *)
+
 type 'a typ
 
 type param
@@ -359,8 +380,13 @@ val uint64be : int64 typ
 (** [uint64be] is an unsigned 64-bit big-endian integer represented as [int64].
 *)
 
-val bits : width:int -> bitfield -> int typ
-(** Bitfield of the given width within the given base word. *)
+val bits : ?bit_order:bit_order -> width:int -> bitfield -> int typ
+(** [bits ~width base] declares a bitfield of [width] bits inside [base].
+
+    [~bit_order] selects which end of the base word the first declared bitfield
+    occupies. It defaults to {!Msb_first}, which makes the DSL match how
+    protocol specifications draw their bit diagrams. Pass [~bit_order:Lsb_first]
+    when mirroring MSVC-style C bit-fields. *)
 
 val map : decode:('w -> 'a) -> encode:('a -> 'w) -> 'w typ -> 'a typ
 (** [map ~decode ~encode t] views a wire value through conversion functions. *)

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -511,6 +511,8 @@ let test_view_get_bitfield () =
     ((Staged.unstage (Codec.get codec cf_d)) buf 0)
 
 let test_view_get_bool () =
+  (* Default [bit_order = Msb_first]: first-declared field lives at the MSB,
+     so the flag bit is bit 7 of the byte. *)
   let codec, cf_flag =
     let f_flag = Field.v "flag" (bit (bits ~width:1 U8)) in
     let cf_flag = Codec.(f_flag $ fst) in
@@ -523,7 +525,7 @@ let test_view_get_bool () =
     (codec, cf_flag)
   in
   let buf = Bytes.create 1 in
-  Bytes.set_uint8 buf 0 0x01;
+  Bytes.set_uint8 buf 0 0x80;
   Alcotest.(check bool)
     "get flag=true" true
     ((Staged.unstage (Codec.get codec cf_flag)) buf 0);
@@ -616,6 +618,7 @@ let test_view_with_offset () =
     ((Staged.unstage (Codec.get codec cf_a)) buf 2)
 
 let test_view_set_bool () =
+  (* Default [bit_order = Msb_first]: first-declared field lives at bit 7. *)
   let codec, cf_flag =
     let f_flag = Field.v "flag" (bit (bits ~width:1 U8)) in
     let cf_flag = Codec.(f_flag $ fst) in
@@ -633,7 +636,7 @@ let test_view_set_bool () =
   Alcotest.(check bool)
     "get flag after set true" true
     ((Staged.unstage (Codec.get codec cf_flag)) buf 0);
-  Alcotest.(check int) "byte value" 0x01 (Bytes.get_uint8 buf 0);
+  Alcotest.(check int) "byte value (MSB-first)" 0x80 (Bytes.get_uint8 buf 0);
   (Staged.unstage (Codec.set codec cf_flag)) buf 0 false;
   Alcotest.(check bool)
     "get flag after set false" false
@@ -678,10 +681,10 @@ let test_view_shared_field_spec () =
     ((Staged.unstage (Codec.get codec2 cf2_x)) buf2 0)
 
 let test_view_shared_bitfield_spec () =
-  (* Two codecs with different bitfield layouts, each with their own field "a".
-     Codec1: [3-bit a] [5-bit b]            -> a is bottom 3 bits (LSBFirst)
-     Codec2: [5-bit pad] [3-bit a]           -> a is top 3 bits (LSBFirst)
-     Each codec gets a fresh field object. *)
+  (* Two codecs with different bitfield layouts using the default
+     [bit_order = Msb_first].
+     Codec1: [3-bit a] [5-bit b]       -> a is top 3 bits
+     Codec2: [5-bit pad] [3-bit a]     -> a is bottom 3 bits *)
   let f1_a = Field.v "a" (bits ~width:3 U8) in
   let cf1_a = Codec.(f1_a $ fun (a, _) -> a) in
   let codec1 =
@@ -699,19 +702,20 @@ let test_view_shared_bitfield_spec () =
       [ (Field.v "pad" (bits ~width:5 U8) $ fun _ -> 0); cf2_a ]
   in
   (* 0xE3 = 0b_1110_0011
-     codec1 reads bottom 3 bits -> 3
-     codec2 reads top 3 bits -> 7 *)
+     codec1 reads top 3 bits    -> 0b111 = 7
+     codec2 reads bottom 3 bits -> 0b011 = 3 *)
   let buf = Bytes.create 1 in
   Bytes.set_uint8 buf 0 0xE3;
   Alcotest.(check int)
-    "codec1 get a (bot 3)" 3
+    "codec1 get a (top 3)" 7
     ((Staged.unstage (Codec.get codec1 cf1_a)) buf 0);
   Alcotest.(check int)
-    "codec2 get a (top 3)" 7
+    "codec2 get a (bot 3)" 3
     ((Staged.unstage (Codec.get codec2 cf2_a)) buf 0)
 
 let test_view_shared_set_independent () =
-  (* set via one codec's field must not affect the other's interpretation *)
+  (* set via one codec's field must not affect the other's interpretation.
+     Default [bit_order = Msb_first]: first-declared field at top. *)
   let f1 = Field.v "v" (bits ~width:4 U8) in
   let cf1 = Codec.(f1 $ fun (v, _) -> v) in
   let codec1 =
@@ -728,18 +732,18 @@ let test_view_shared_set_independent () =
       (fun pad v -> (v, pad))
       [ (Field.v "pad" (bits ~width:4 U8) $ fun (_, p) -> p); cf2 ]
   in
-  (* Start: 0x00. Set codec1's field (bottom nibble) to 0xA *)
+  (* Codec1's v is the top nibble; set to 0xA. *)
   let buf = Bytes.create 1 in
   (Staged.unstage (Codec.set codec1 cf1)) buf 0 0xA;
-  Alcotest.(check int) "byte after set1" 0x0A (Bytes.get_uint8 buf 0);
-  (* codec2's field is top nibble -- should still be 0 *)
+  Alcotest.(check int) "byte after set1" 0xA0 (Bytes.get_uint8 buf 0);
+  (* Codec2's v is the bottom nibble -- should still be 0. *)
   Alcotest.(check int)
     "codec2 get after set1" 0
     ((Staged.unstage (Codec.get codec2 cf2)) buf 0);
-  (* Set codec2's field (top nibble) to 0x5 *)
+  (* Set codec2's v (bottom nibble) to 0x5. *)
   (Staged.unstage (Codec.set codec2 cf2)) buf 0 0x5;
-  Alcotest.(check int) "byte after set2" 0x5A (Bytes.get_uint8 buf 0);
-  (* codec1's field should still be 0xA *)
+  Alcotest.(check int) "byte after set2" 0xA5 (Bytes.get_uint8 buf 0);
+  (* Codec1's v should still be 0xA. *)
   Alcotest.(check int)
     "codec1 get after set2" 0xA
     ((Staged.unstage (Codec.get codec1 cf1)) buf 0)
@@ -1099,7 +1103,9 @@ let test_get_two_staged_same_field () =
   Alcotest.(check int) "env2" 0xBB (Param.get env2 out)
 
 let test_encode_shared_bitfield () =
-  (* Encode via a codec that shares a bitfield with another codec *)
+  (* Encode via a codec that shares a bitfield with another codec.
+     Default [bit_order] is [Msb_first], so the first-declared field [a]
+     lives in the top nibble of the byte. *)
   let f_a = Field.v "a" (bits ~width:4 U8) in
   let cf_a = Codec.(f_a $ fun a -> a) in
   let codec1 =
@@ -1114,10 +1120,9 @@ let test_encode_shared_bitfield () =
       (fun _b a -> a)
       [ (Field.v "b" (bits ~width:4 U8) $ fun _ -> 0); cf_a ]
   in
-  (* Encode via codec1: a in bottom nibble *)
   let buf = Bytes.make 1 '\x00' in
   Codec.encode codec1 0xA buf 0;
-  Alcotest.(check int) "bottom nibble" 0x0A (Bytes.get_uint8 buf 0)
+  Alcotest.(check int) "top nibble (MSB-first)" 0xA0 (Bytes.get_uint8 buf 0)
 
 (* ── API misuse / safety tests ── *)
 
@@ -1320,7 +1325,8 @@ let test_same_field_two_codecs_encode () =
   Alcotest.(check int) "byte 1" 0x00 (Bytes.get_uint8 buf 1)
 
 let test_same_bitfield_two_codecs () =
-  (* Same bitfield bound field in two codecs with different bit positions. *)
+  (* Same bitfield bound field in two codecs with different bit positions.
+     Default [bit_order = Msb_first]: first-declared field at top of byte. *)
   let f_a = Field.v "a" (bits ~width:4 U8) in
   let cf_a = Codec.(f_a $ fun a -> a) in
   let codec1 =
@@ -1335,16 +1341,16 @@ let test_same_bitfield_two_codecs () =
       (fun _b a -> a)
       [ (Field.v "b" (bits ~width:4 U8) $ fun _ -> 0); cf_a ]
   in
-  (* 0xA3: bottom nibble = 3, top nibble = 0xA *)
+  (* 0xA3: top nibble = 0xA, bottom nibble = 3. *)
   let buf = Bytes.create 1 in
   Bytes.set_uint8 buf 0 0xA3;
-  (* codec1: a is bottom 4 bits -> 3 *)
+  (* codec1: a is first-declared, so top 4 bits -> 0xA. *)
   Alcotest.(check int)
-    "codec1 get a (bottom)" 3
+    "codec1 get a (top)" 0xA
     ((Staged.unstage (Codec.get codec1 cf_a)) buf 0);
-  (* codec2: a is top 4 bits -> 0xA *)
+  (* codec2: a is second-declared, so bottom 4 bits -> 3. *)
   Alcotest.(check int)
-    "codec2 get a (top)" 0xA
+    "codec2 get a (bottom)" 3
     ((Staged.unstage (Codec.get codec2 cf_a)) buf 0)
 
 let test_same_field_staged_before_second_seal () =
@@ -1472,6 +1478,8 @@ let test_raw_get_uint () =
     ((Staged.unstage (Codec.get codec cf_b)) buf 0)
 
 let test_raw_get_bitfield () =
+  (* Default [bit_order = Msb_first]: [hi] (first declared) is the top nibble,
+     matching the natural naming. *)
   let f_hi = Field.v "hi" (bits ~width:4 U8) in
   let f_lo = Field.v "lo" (bits ~width:4 U8) in
   let cf_hi = Codec.(f_hi $ fun (h, _) -> h) in
@@ -1479,12 +1487,11 @@ let test_raw_get_bitfield () =
   let codec = Codec.v "RawBF" (fun hi lo -> (hi, lo)) [ cf_hi; cf_lo ] in
   let buf = Bytes.create 1 in
   Bytes.set_uint8 buf 0 0xA7;
-  (* hi=bits 3-0=0x7, lo=bits 7-4=0xA *)
   Alcotest.(check int)
-    "get hi" 0x7
+    "get hi" 0xA
     ((Staged.unstage (Codec.get codec cf_hi)) buf 0);
   Alcotest.(check int)
-    "get lo" 0xA
+    "get lo" 0x7
     ((Staged.unstage (Codec.get codec cf_lo)) buf 0)
 
 let test_raw_set_uint () =
@@ -1501,6 +1508,7 @@ let test_raw_set_uint () =
   Alcotest.(check int) "set b" 0x42 (Bytes.get_uint8 buf 2)
 
 let test_raw_set_bitfield () =
+  (* Default [bit_order = Msb_first]: [hi] goes to the top nibble. *)
   let f_hi = Field.v "hi" (bits ~width:4 U8) in
   let f_lo = Field.v "lo" (bits ~width:4 U8) in
   let cf_hi = Codec.(f_hi $ fun (h, _) -> h) in
@@ -1510,7 +1518,7 @@ let test_raw_set_bitfield () =
   Bytes.set_uint8 buf 0 0x00;
   (Staged.unstage (Codec.set codec cf_hi)) buf 0 0xC;
   (Staged.unstage (Codec.set codec cf_lo)) buf 0 0x3;
-  Alcotest.(check int) "set bf byte" 0x3C (Bytes.get_uint8 buf 0)
+  Alcotest.(check int) "set bf byte" 0xC3 (Bytes.get_uint8 buf 0)
 
 let test_raw_sub_nested () =
   (* Two-layer nested protocol using sub + get: zero alloc *)
@@ -1996,9 +2004,9 @@ let bf_codec =
     Codec.[ bf_cf_hi; bf_cf_lo ]
 
 let test_bitfield_extract () =
+  (* Default [bit_order = Msb_first]: [hi] is the top nibble. *)
   let buf = Bytes.create 1 in
   Bytes.set_uint8 buf 0 0xA7;
-  (* hi=bits 3-0=0x7, lo=bits 7-4=0xA *)
   let bf_hi = Codec.bitfield bf_codec bf_cf_hi in
   let bf_lo = Codec.bitfield bf_codec bf_cf_lo in
   let load = Staged.unstage (Codec.load_word bf_hi) in
@@ -2010,8 +2018,8 @@ let test_bitfield_extract () =
   let get_lo = Staged.unstage (Codec.get bf_codec bf_cf_lo) in
   Alcotest.(check int) "extract hi = get hi" (get_hi buf 0) hi;
   Alcotest.(check int) "extract lo = get lo" (get_lo buf 0) lo;
-  Alcotest.(check int) "hi" 0x7 hi;
-  Alcotest.(check int) "lo" 0xA lo
+  Alcotest.(check int) "hi" 0xA hi;
+  Alcotest.(check int) "lo" 0x7 lo
 
 let test_bitfield_non_bf_raises () =
   let f_x = Field.v "x" uint16be in
@@ -2152,9 +2160,9 @@ let bf_outer_codec =
 let test_codec_embed_bitfield () =
   let buf = Bytes.create 4 in
   Bytes.set_uint16_be buf 0 0x1234;
-  (* U8 bitfield is LSB-first: version in bits 0-3, flags in bits 4-7 *)
-  (* version=0xA, flags=0x5 -> byte = 0x5A *)
-  Bytes.set_uint8 buf 2 0x5A;
+  (* Default [bit_order = Msb_first]: version (first declared) at top nibble,
+     flags at bottom nibble. version=0xA, flags=0x5 -> byte = 0xA5. *)
+  Bytes.set_uint8 buf 2 0xA5;
   Bytes.set_uint8 buf 3 0xFF;
   let r = decode_ok (Codec.decode bf_outer_codec buf 0) in
   Alcotest.(check int) "id" 0x1234 r.id;
@@ -2440,9 +2448,10 @@ let bf_frame_codec =
       ]
 
 let test_codec_cross_field_ref_bitfield () =
-  (* len=3 (low nibble) and flags=0xA (high nibble) -> byte = 0xA3 *)
+  (* Default [bit_order = Msb_first]: [BfLen] (first declared) is the top
+     nibble, [BfFlags] is the bottom nibble. len=3, flags=0xA -> byte = 0x3A. *)
   let buf = Bytes.create 4 in
-  Bytes.set_uint8 buf 0 0xA3;
+  Bytes.set_uint8 buf 0 0x3A;
   Bytes.blit_string "XYZ" 0 buf 1 3;
   let r = decode_ok (Codec.decode bf_frame_codec buf 0) in
   Alcotest.(check int) "len" 3 r.bff_hdr.bh_len;
@@ -2954,6 +2963,101 @@ let test_tm_like_roundtrip () =
   Alcotest.(check (option int)) "ocf" original.tm_ocf decoded.tm_ocf;
   Alcotest.(check (option int)) "fecf" original.tm_fecf decoded.tm_fecf
 
+(* ── Adversarial bit-order tests ──
+
+   These pin the default [bit_order = Msb_first] against real protocol
+   bytes drawn from published specs. If anything shifts the bit layout,
+   these tests fail with a concrete "0x45 decoded as (5, 4) instead of
+   (4, 5)" error, not silently. *)
+
+type ipv4_vihl = { v : int; ihl : int }
+
+let ipv4_vihl_codec =
+  let open Codec in
+  v "IPv4VIHL"
+    (fun v ihl -> { v; ihl })
+    [
+      (Field.v "Version" (bits ~width:4 U8) $ fun p -> p.v);
+      (Field.v "IHL" (bits ~width:4 U8) $ fun p -> p.ihl);
+    ]
+
+let test_bit_order_ipv4_vihl_decode () =
+  (* RFC 791: first byte of an IPv4 header with Version=4, IHL=5 is 0x45,
+     Version in the top nibble, IHL in the bottom nibble. *)
+  let buf = Bytes.of_string "\x45" in
+  let r = decode_ok (Codec.decode ipv4_vihl_codec buf 0) in
+  Alcotest.(check int) "Version = 4 (top nibble)" 4 r.v;
+  Alcotest.(check int) "IHL = 5 (bottom nibble)" 5 r.ihl
+
+let test_bit_order_ipv4_vihl_encode_roundtrip () =
+  let original = { v = 4; ihl = 5 } in
+  let buf = Bytes.create 1 in
+  Codec.encode ipv4_vihl_codec original buf 0;
+  Alcotest.(check int) "encoded byte" 0x45 (Bytes.get_uint8 buf 0);
+  let decoded = decode_ok (Codec.decode ipv4_vihl_codec buf 0) in
+  Alcotest.(check int) "roundtrip v" original.v decoded.v;
+  Alcotest.(check int) "roundtrip ihl" original.ihl decoded.ihl
+
+type ipv4_flags_frag = { flags : int; frag : int }
+
+let ipv4_flags_frag_codec =
+  let open Codec in
+  v "IPv4FF"
+    (fun flags frag -> { flags; frag })
+    [
+      (Field.v "Flags" (bits ~width:3 U16be) $ fun p -> p.flags);
+      (Field.v "FragmentOffset" (bits ~width:13 U16be) $ fun p -> p.frag);
+    ]
+
+let test_bit_order_ipv4_flags_frag () =
+  (* RFC 791: Flags (3 bits) then Fragment Offset (13 bits), MSB-first.
+     Flags = 0b010 (DF set), FragOffset = 0 -> 0x4000. *)
+  let buf = Bytes.of_string "\x40\x00" in
+  let r = decode_ok (Codec.decode ipv4_flags_frag_codec buf 0) in
+  Alcotest.(check int) "Flags = 0b010" 0b010 r.flags;
+  Alcotest.(check int) "FragOffset = 0" 0 r.frag
+
+type mcu_reg = { lo : int; hi : int }
+
+let mcu_reg_codec =
+  let open Codec in
+  v "McuReg"
+    (fun lo hi -> { lo; hi })
+    [
+      (Field.v "lo" (bits ~bit_order:Lsb_first ~width:4 U8) $ fun r -> r.lo);
+      (Field.v "hi" (bits ~bit_order:Lsb_first ~width:4 U8) $ fun r -> r.hi);
+    ]
+
+let test_bit_order_lsb_first_opt_in () =
+  (* MSVC-style C struct: first declared field in the low bits. *)
+  let buf = Bytes.of_string "\xA5" in
+  let r = decode_ok (Codec.decode mcu_reg_codec buf 0) in
+  Alcotest.(check int) "lo (Lsb_first)" 0x5 r.lo;
+  Alcotest.(check int) "hi (Lsb_first)" 0xA r.hi
+
+type bit_order_split = { bos_x : int; bos_y : int }
+
+let bit_order_split_codec =
+  let open Codec in
+  v "BitOrderSplit"
+    (fun x y -> { bos_x = x; bos_y = y })
+    [
+      (Field.v "x" (bits ~bit_order:Msb_first ~width:4 U8) $ fun r -> r.bos_x);
+      (Field.v "y" (bits ~bit_order:Lsb_first ~width:4 U8) $ fun r -> r.bos_y);
+    ]
+
+let test_bit_order_different_start_new_word () =
+  (* Two fields with the same base but different [bit_order] must NOT share
+     a base word — the codec allocates a fresh byte for each. Catches any
+     regression that would let mismatched bit orders silently collide. *)
+  Alcotest.(check int) "wire size = 2" 2 (Codec.wire_size bit_order_split_codec);
+  let buf = Bytes.create 2 in
+  Codec.encode bit_order_split_codec { bos_x = 0xA; bos_y = 0x5 } buf 0;
+  Alcotest.(check int)
+    "byte 0 = 0xA0 (Msb_first x)" 0xA0 (Bytes.get_uint8 buf 0);
+  Alcotest.(check int)
+    "byte 1 = 0x05 (Lsb_first y)" 0x05 (Bytes.get_uint8 buf 1)
+
 (* ── Suite ── *)
 
 let suite =
@@ -3088,6 +3192,17 @@ let suite =
         test_view_shared_bitfield_spec;
       Alcotest.test_case "view: shared set independent" `Quick
         test_view_shared_set_independent;
+      (* bit_order adversarial tests *)
+      Alcotest.test_case "bit_order: IPv4 Version/IHL decode" `Quick
+        test_bit_order_ipv4_vihl_decode;
+      Alcotest.test_case "bit_order: IPv4 Version/IHL roundtrip" `Quick
+        test_bit_order_ipv4_vihl_encode_roundtrip;
+      Alcotest.test_case "bit_order: IPv4 Flags/FragOffset" `Quick
+        test_bit_order_ipv4_flags_frag;
+      Alcotest.test_case "bit_order: Lsb_first opt-in" `Quick
+        test_bit_order_lsb_first_opt_in;
+      Alcotest.test_case "bit_order: different orders separate words" `Quick
+        test_bit_order_different_start_new_word;
       (* byte_slice *)
       Alcotest.test_case "view: byte_slice get" `Quick test_view_byte_slice_get;
       Alcotest.test_case "view: byte_slice decode" `Quick

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -300,6 +300,119 @@ let test_3d_tm_like () =
     "Packet type referenced" true
     (contains ~sub:"Packet" output)
 
+(* ── Bit-order projection tests ──
+
+   Non-native (base, bit_order) combinations should still emit a valid 3D
+   struct by reversing declaration order within the bit group and, if the
+   widths don't fill the word, prepending anonymous padding. These tests
+   lock in that the reorder actually happens in the emitted 3D text. *)
+
+(* Return the byte offset of the first occurrence of [sub] in [s],
+   or -1 if not found. Used to assert relative field ordering. *)
+let index_of ~sub s =
+  let re = Re.compile (Re.str sub) in
+  match Re.exec_opt re s with Some g -> Re.Group.start g 0 | None -> -1
+
+let test_3d_bit_order_u8_msb_first_reorder () =
+  (* Non-native: (U8, Msb_first). EverParse native for UINT8 is LSB-first,
+     so the projection reverses [a; b] to [b; a] in the emitted 3D text.
+     Widths sum to 8 -> no padding. *)
+  let codec =
+    let open Codec in
+    v "ReorderU8"
+      (fun a b -> (a, b))
+      [
+        Field.v "a" (bits ~width:3 U8) $ fst;
+        Field.v "b" (bits ~width:5 U8) $ snd;
+      ]
+  in
+  let schema = Everparse.schema codec in
+  let s = Wire.Everparse.Raw.to_3d schema.module_ in
+  let ia = index_of ~sub:"UINT8 a" s in
+  let ib = index_of ~sub:"UINT8 b" s in
+  Alcotest.(check bool) "a found" true (ia >= 0);
+  Alcotest.(check bool) "b found" true (ib >= 0);
+  Alcotest.(check bool) "reordered: b before a" true (ib < ia)
+
+let test_3d_bit_order_u8_msb_first_padding () =
+  (* Non-native and incomplete: two 3-bit fields in (U8, Msb_first).
+     Reversal alone would place the 6 bits at LSB-first positions 0..5;
+     the projection prepends 2 bits of anonymous padding so the user's
+     fields land at bits 2..7 (matching their Msb_first intent). *)
+  let codec =
+    let open Codec in
+    v "ReorderU8Pad"
+      (fun a b -> (a, b))
+      [
+        Field.v "a" (bits ~width:3 U8) $ fst;
+        Field.v "b" (bits ~width:3 U8) $ snd;
+      ]
+  in
+  let schema = Everparse.schema codec in
+  let s = Wire.Everparse.Raw.to_3d schema.module_ in
+  Alcotest.(check bool)
+    "has anonymous padding field" true
+    (contains ~sub:"UINT8 _anon_" s);
+  Alcotest.(check bool) "padding width = 2" true (contains ~sub:": 2" s)
+
+let test_3d_bit_order_constraint_collapse () =
+  (* Non-native: (U8, Msb_first) with a backward-reference constraint.
+     Original order [a {a<=5}; b {a+b<=10}]. After reversal to [b; a],
+     a constraint [a+b<=10] attached to b would fire before [a] was
+     parsed. The projection therefore collapses all group constraints
+     onto the last reversed field (here [a]), where every referent is
+     available. *)
+  let f_a_placeholder = Field.v "a" (bits ~width:4 U8) in
+  let f_b_placeholder = Field.v "b" (bits ~width:4 U8) in
+  let f_a =
+    Field.v "a"
+      ~constraint_:Expr.(Field.ref f_a_placeholder <= int 5)
+      (bits ~width:4 U8)
+  in
+  let f_b =
+    Field.v "b"
+      ~constraint_:
+        Expr.(Field.ref f_a_placeholder + Field.ref f_b_placeholder <= int 10)
+      (bits ~width:4 U8)
+  in
+  let codec =
+    let open Codec in
+    v "Ranged" (fun a b -> (a, b)) [ f_a $ fst; f_b $ snd ]
+  in
+  let schema = Wire.Everparse.schema codec in
+  let s = Wire.Everparse.Raw.to_3d schema.module_ in
+  (* b appears first in 3D (reversed), without a constraint block. *)
+  let ia = index_of ~sub:"UINT8 a : 4" s in
+  let ib = index_of ~sub:"UINT8 b : 4" s in
+  Alcotest.(check bool) "b before a" true (ib < ia);
+  (* The combined constraint lands on [a] (last in reversed order),
+     including both the original [a <= 5] and [a + b <= 10]. *)
+  Alcotest.(check bool)
+    "a still referenced in combined constraint" true (contains ~sub:"a <= 5" s);
+  Alcotest.(check bool)
+    "b still referenced in combined constraint" true
+    (contains ~sub:"(a + b) <= 10" s)
+
+let test_3d_bit_order_native_no_reorder () =
+  (* Native: (U32be, Msb_first). Fields stay in declared order, no padding. *)
+  let codec =
+    let open Codec in
+    v "NativeU32Be"
+      (fun a b -> (a, b))
+      [
+        Field.v "x" (bits ~width:4 U32be) $ fst;
+        Field.v "y" (bits ~width:28 U32be) $ snd;
+      ]
+  in
+  let schema = Everparse.schema codec in
+  let s = Wire.Everparse.Raw.to_3d schema.module_ in
+  let ix = index_of ~sub:"UINT32BE x" s in
+  let iy = index_of ~sub:"UINT32BE y" s in
+  Alcotest.(check bool) "x found" true (ix >= 0);
+  Alcotest.(check bool) "y found" true (iy >= 0);
+  Alcotest.(check bool) "x before y (no reorder)" true (ix < iy);
+  Alcotest.(check bool) "no padding" false (contains ~sub:"_anon_" s)
+
 let suite =
   ( "everparse",
     [
@@ -315,4 +428,12 @@ let suite =
       Alcotest.test_case "3d: optional absent" `Quick test_3d_optional_absent;
       Alcotest.test_case "3d: repeat" `Quick test_3d_repeat;
       Alcotest.test_case "3d: tm-like" `Quick test_3d_tm_like;
+      Alcotest.test_case "3d: bit_order U8 Msb_first reorder" `Quick
+        test_3d_bit_order_u8_msb_first_reorder;
+      Alcotest.test_case "3d: bit_order U8 Msb_first padding" `Quick
+        test_3d_bit_order_u8_msb_first_padding;
+      Alcotest.test_case "3d: bit_order native no reorder" `Quick
+        test_3d_bit_order_native_no_reorder;
+      Alcotest.test_case "3d: bit_order constraint collapse" `Quick
+        test_3d_bit_order_constraint_collapse;
     ] )

--- a/test/test_wire.ml
+++ b/test/test_wire.ml
@@ -418,10 +418,61 @@ let test_encode_variants () =
   Alcotest.(check string) "variants encoding" "\x01" encoded
 
 let test_encode_bitfield () =
+  (* Default [bit_order] is [Msb_first]: a 6-bit field lives in the top
+     6 bits of the base word. On a LE U32 base, writing 63 = 0x3F gives
+     word = 0x3F lsl 26 = 0xFC000000, which serialises to [\x00\x00\x00\xFC]. *)
   let t = bits ~width:6 U32 in
   let encoded = encode_to_string t 63 in
-  (* 63 = 0x3F, but stored in 4 bytes as uint32 LE *)
-  Alcotest.(check string) "bitfield encoding" "\x3F\x00\x00\x00" encoded
+  Alcotest.(check string)
+    "bitfield encoding (MSB-first)" "\x00\x00\x00\xFC" encoded
+
+let test_encode_bitfield_lsb_first () =
+  (* Explicit [~bit_order:Lsb_first] recovers the C bit-field packing: the
+     value goes into the low 6 bits of the word. *)
+  let t = bits ~bit_order:Lsb_first ~width:6 U32 in
+  let encoded = encode_to_string t 63 in
+  Alcotest.(check string)
+    "bitfield encoding (LSB-first)" "\x3F\x00\x00\x00" encoded
+
+(* Adversarial bit-order tests: hardcoded byte positions anchor the new
+   default [bit_order = Msb_first] so a regression in the shift logic
+   surfaces as a noisy test failure, not a silent interop bug. *)
+
+let test_bits_single_field_positions () =
+  (* A 3-bit field holding value 0b101 = 5. *)
+  let t_msb = bits ~width:3 U8 in
+  let t_lsb = bits ~bit_order:Lsb_first ~width:3 U8 in
+  let s_msb = encode_to_string t_msb 5 in
+  let s_lsb = encode_to_string t_lsb 5 in
+  (* Msb_first: value at bits 5..7 -> 0b1010_0000 = 0xA0. *)
+  Alcotest.(check string) "msb-first single field" "\xA0" s_msb;
+  (* Lsb_first: value at bits 0..2 -> 0b0000_0101 = 0x05. *)
+  Alcotest.(check string) "lsb-first single field" "\x05" s_lsb
+
+let test_bits_roundtrip_all_combos () =
+  (* Property: for every (base, bit_order), encode then decode is identity.
+     Covers all five Wire bitfield bases crossed with both bit orders. *)
+  let bases = [ (U8, 4); (U16, 5); (U16be, 6); (U32, 7); (U32be, 3) ] in
+  let orders = [ Msb_first; Lsb_first ] in
+  List.iter
+    (fun (base, width) ->
+      let max_val = (1 lsl width) - 1 in
+      let values = [ 0; 1; max_val; max_val / 2 ] in
+      List.iter
+        (fun order ->
+          let t = bits ~bit_order:order ~width base in
+          List.iter
+            (fun expected ->
+              let s = encode_to_string t expected in
+              match decode_string t s with
+              | Ok got ->
+                  Alcotest.(check int)
+                    (Fmt.str "roundtrip width=%d" width)
+                    expected got
+              | Error e -> Alcotest.failf "decode failed: %a" pp_parse_error e)
+            values)
+        orders)
+    bases
 
 (* ── Roundtrip tests ── *)
 
@@ -601,6 +652,12 @@ let suite =
       Alcotest.test_case "encode: byte_array" `Quick test_encode_byte_array;
       Alcotest.test_case "encode: variants" `Quick test_encode_variants;
       Alcotest.test_case "encode: bitfield" `Quick test_encode_bitfield;
+      Alcotest.test_case "encode: bitfield LSB-first" `Quick
+        test_encode_bitfield_lsb_first;
+      Alcotest.test_case "bits: single-field positions" `Quick
+        test_bits_single_field_positions;
+      Alcotest.test_case "bits: roundtrip all (base, bit_order)" `Quick
+        test_bits_roundtrip_all_combos;
       (* roundtrip *)
       Alcotest.test_case "roundtrip: uint8" `Quick test_roundtrip_uint8;
       Alcotest.test_case "roundtrip: uint16" `Quick test_roundtrip_uint16;


### PR DESCRIPTION
Adds a [bit_order = Msb_first | Lsb_first] parameter to [bits], defaulting to Msb_first so RFC/CCSDS/IETF bit diagrams transcribe literally (IPv4 Version/IHL at byte 0x45 now decodes to Version=4, IHL=5). The EverParse 3D projection reverses declaration order and prepends padding within a bit group when the user's bit_order differs from EverParse's native for the base, preserving byte layout; constraints in reversed groups are collapsed onto the last field to keep ranged bits valid.

See https://github.com/project-everest/everparse/pull/95 for context