### PR TITLE
feat: support multiple consecutive variable-size fields

### DIFF
--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -132,6 +132,10 @@ type field_access =
     }
   | Dynamic of (bytes -> int -> int)
   | Variable of { off : int; size_fn : bytes -> int -> int }
+  | Variable_dynamic of {
+      off_fn : bytes -> int -> int;
+      size_fn : bytes -> int -> int;
+    }
 
 type ('a, 'r) field = {
   name : string;
@@ -1251,6 +1255,32 @@ and compile_scalar_or_var : type a r.
       }
   | None -> compile_var_bytes ctx fld
 
+and var_bytes_reader : type a.
+    a typ -> (bytes -> int -> int) -> (bytes -> int -> int) -> bytes -> int -> a
+    =
+ fun typ off_fn size_fn buf base ->
+  let fo = off_fn buf base in
+  let sz = size_fn buf base in
+  match typ with
+  | Byte_slice _ -> Slice.make_or_eod buf ~first:(base + fo) ~length:sz
+  | Byte_array _ -> Bytes.sub_string buf (base + fo) sz
+  | _ -> assert false
+
+and var_bytes_writer : type a r.
+    a typ -> (r -> a) -> (bytes -> int -> int) -> r -> bytes -> int -> unit =
+ fun typ get off_fn v buf off ->
+  let fo = off_fn buf off in
+  let value = get v in
+  match typ with
+  | Byte_slice _ ->
+      let src = (value : Slice.t) in
+      Bytes.blit (Slice.bytes src) (Slice.first src) buf (off + fo)
+        (Slice.length src)
+  | Byte_array _ ->
+      let s = (value : string) in
+      Bytes.blit_string s 0 buf (off + fo) (String.length s)
+  | _ -> assert false
+
 and compile_var_bytes : type a r.
     layout_ctx -> (a, r) field -> (a, r) compiled_field =
  fun ctx fld ->
@@ -1262,31 +1292,18 @@ and compile_var_bytes : type a r.
     | _ -> invalid_arg "add_field: unsupported variable-size field type"
   in
   let size_fn = compile_expr ctx.lc_field_readers size_expr in
-  let field_off =
-    require_static_off ctx ~what:"multiple variable-size fields"
+  let off_fn, (field_access : field_access), validator_off =
+    match ctx.lc_next_off with
+    | Static_next n ->
+        ( (fun (_buf : bytes) (_base : int) -> n),
+          Variable { off = n; size_fn },
+          n )
+    | Dynamic_next prev_end ->
+        let off_fn buf base = prev_end buf base - base in
+        (off_fn, Variable_dynamic { off_fn; size_fn }, -1)
   in
-  let raw_reader : bytes -> int -> a =
-   fun buf base ->
-    let sz = size_fn buf base in
-    match typ with
-    | Byte_slice _ -> Slice.make_or_eod buf ~first:(base + field_off) ~length:sz
-    | Byte_array _ -> Bytes.sub_string buf (base + field_off) sz
-    | _ -> assert false
-  in
-  let get = fld.get in
-  let raw_writer : r -> bytes -> int -> unit =
-   fun v buf off ->
-    let value = get v in
-    match typ with
-    | Byte_slice _ ->
-        let src = (value : Slice.t) in
-        let len = Slice.length src in
-        Bytes.blit (Slice.bytes src) (Slice.first src) buf (off + field_off) len
-    | Byte_array _ ->
-        let s = (value : string) in
-        Bytes.blit_string s 0 buf (off + field_off) (String.length s)
-    | _ -> assert false
-  in
+  let raw_reader = var_bytes_reader typ off_fn size_fn in
+  let raw_writer = var_bytes_writer typ fld.get off_fn in
   let int_reader buf base =
     match int_of_typ_value typ (raw_reader buf base) with
     | Some v -> v
@@ -1297,14 +1314,17 @@ and compile_var_bytes : type a r.
     raw_reader;
     raw_writer;
     extra_writers = [];
-    field_access = Variable { off = field_off; size_fn };
+    field_access;
     size_delta = 0;
     next_off =
-      Dynamic_next (fun buf base -> base + field_off + size_fn buf base);
+      Dynamic_next
+        (fun buf base ->
+          let fo = off_fn buf base in
+          base + fo + size_fn buf base);
     bf_after = None;
     int_reader;
     nested_readers = [];
-    validator_off = field_off;
+    validator_off;
     populate;
   }
 
@@ -1761,6 +1781,16 @@ let rec build_staged_reader : type a. a typ -> field_access -> bytes -> int -> a
       fun buf base ->
         let sz = size_fn buf base in
         Bytes.sub_string buf (base + off) sz
+  | Byte_slice _, Variable_dynamic { off_fn; size_fn } ->
+      fun buf base ->
+        let fo = off_fn buf base in
+        let sz = size_fn buf base in
+        Slice.make_or_eod buf ~first:(base + fo) ~length:sz
+  | Byte_array _, Variable_dynamic { off_fn; size_fn } ->
+      fun buf base ->
+        let fo = off_fn buf base in
+        let sz = size_fn buf base in
+        Bytes.sub_string buf (base + fo) sz
   | Where { inner; _ }, _ -> build_staged_reader inner access
   | Enum { base; _ }, _ -> build_staged_reader base access
   | Map { inner; decode; _ }, _ ->
@@ -1768,7 +1798,7 @@ let rec build_staged_reader : type a. a typ -> field_access -> bytes -> int -> a
       fun buf base -> decode (read buf base)
   | _, Bitfield _ ->
       invalid_arg "Codec.get: non-bitfield type with bitfield access"
-  | _, Variable _ ->
+  | _, Variable _ | _, Variable_dynamic _ ->
       invalid_arg "Codec.get: unsupported variable-size field type"
 
 (* Build a staged writer from field type and access info. *)
@@ -1798,6 +1828,17 @@ let rec build_staged_writer : type a.
       fun buf base value ->
         let s = (value : string) in
         Bytes.blit_string s 0 buf (base + off) (String.length s)
+  | Byte_slice _, Variable_dynamic { off_fn; _ } ->
+      fun buf base value ->
+        let fo = off_fn buf base in
+        let src = (value : Slice.t) in
+        let len = Slice.length src in
+        Bytes.blit (Slice.bytes src) (Slice.first src) buf (base + fo) len
+  | Byte_array _, Variable_dynamic { off_fn; _ } ->
+      fun buf base value ->
+        let fo = off_fn buf base in
+        let s = (value : string) in
+        Bytes.blit_string s 0 buf (base + fo) (String.length s)
   | Where { inner; _ }, _ -> build_staged_writer inner access
   | Enum { base; _ }, _ -> build_staged_writer base access
   | Map { inner; encode; _ }, _ ->
@@ -1805,7 +1846,7 @@ let rec build_staged_writer : type a.
       fun buf base value -> write buf base (encode value)
   | _, Bitfield _ ->
       invalid_arg "Codec.set: non-bitfield type with bitfield access"
-  | _, Variable _ ->
+  | _, Variable _ | _, Variable_dynamic _ ->
       invalid_arg "Codec.set: unsupported variable-size field type"
 
 let field_access codec name =

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -2963,6 +2963,138 @@ let test_tm_like_roundtrip () =
   Alcotest.(check (option int)) "ocf" original.tm_ocf decoded.tm_ocf;
   Alcotest.(check (option int)) "fecf" original.tm_fecf decoded.tm_fecf
 
+(* ── Multiple consecutive variable-size fields (CFDP-style) ──
+
+   CCSDS CFDP (727.0-B-5) has three consecutive variable-size byte_array
+   fields in its PDU header, each sized by expressions over earlier fixed
+   fields. This layout was previously rejected by [require_static_off]. *)
+
+type cfdp_hdr = {
+  cfdp_eid_len : int;
+  cfdp_txseq_len : int;
+  cfdp_src : string;
+  cfdp_txseq : string;
+  cfdp_dst : string;
+}
+
+let f_cfdp_eid_len = Field.v "EIDLen" uint8
+let f_cfdp_txseq_len = Field.v "TxSeqLen" uint8
+
+let cfdp_codec =
+  let open Codec in
+  v "CFDPHeader"
+    (fun eid_len txseq_len src txseq dst ->
+      {
+        cfdp_eid_len = eid_len;
+        cfdp_txseq_len = txseq_len;
+        cfdp_src = src;
+        cfdp_txseq = txseq;
+        cfdp_dst = dst;
+      })
+    [
+      (f_cfdp_eid_len $ fun r -> r.cfdp_eid_len);
+      (f_cfdp_txseq_len $ fun r -> r.cfdp_txseq_len);
+      ( Field.v "SourceEID"
+          (byte_array ~size:Expr.(Field.ref f_cfdp_eid_len + int 1))
+      $ fun r -> r.cfdp_src );
+      ( Field.v "TxSeqNum"
+          (byte_array ~size:Expr.(Field.ref f_cfdp_txseq_len + int 1))
+      $ fun r -> r.cfdp_txseq );
+      ( Field.v "DestEID"
+          (byte_array ~size:Expr.(Field.ref f_cfdp_eid_len + int 1))
+      $ fun r -> r.cfdp_dst );
+    ]
+
+let test_multi_var_decode () =
+  (* EIDLen=1 -> 2-byte entities, TxSeqLen=2 -> 3-byte txseq.
+     Layout: [1] [2] [AA BB] [CC DD EE] [FF 00] *)
+  let buf = Bytes.create 9 in
+  Bytes.set_uint8 buf 0 1;
+  Bytes.set_uint8 buf 1 2;
+  Bytes.blit_string "\xAA\xBB" 0 buf 2 2;
+  Bytes.blit_string "\xCC\xDD\xEE" 0 buf 4 3;
+  Bytes.blit_string "\xFF\x00" 0 buf 7 2;
+  let r = decode_ok (Codec.decode cfdp_codec buf 0) in
+  Alcotest.(check int) "eid_len" 1 r.cfdp_eid_len;
+  Alcotest.(check int) "txseq_len" 2 r.cfdp_txseq_len;
+  Alcotest.(check string) "src" "\xAA\xBB" r.cfdp_src;
+  Alcotest.(check string) "txseq" "\xCC\xDD\xEE" r.cfdp_txseq;
+  Alcotest.(check string) "dst" "\xFF\x00" r.cfdp_dst
+
+let test_multi_var_roundtrip () =
+  let original =
+    {
+      cfdp_eid_len = 1;
+      cfdp_txseq_len = 2;
+      cfdp_src = "\xAA\xBB";
+      cfdp_txseq = "\xCC\xDD\xEE";
+      cfdp_dst = "\xFF\x00";
+    }
+  in
+  let buf = Bytes.create 9 in
+  Codec.encode cfdp_codec original buf 0;
+  let decoded = decode_ok (Codec.decode cfdp_codec buf 0) in
+  Alcotest.(check string) "src roundtrip" original.cfdp_src decoded.cfdp_src;
+  Alcotest.(check string)
+    "txseq roundtrip" original.cfdp_txseq decoded.cfdp_txseq;
+  Alcotest.(check string) "dst roundtrip" original.cfdp_dst decoded.cfdp_dst
+
+let test_multi_var_get () =
+  (* Staged get must work on the second and third variable-size fields. *)
+  let buf = Bytes.create 9 in
+  Bytes.set_uint8 buf 0 1;
+  Bytes.set_uint8 buf 1 2;
+  Bytes.blit_string "\xAA\xBB" 0 buf 2 2;
+  Bytes.blit_string "\xCC\xDD\xEE" 0 buf 4 3;
+  Bytes.blit_string "\xFF\x00" 0 buf 7 2;
+  let cf_txseq =
+    Codec.(
+      Field.v "TxSeqNum"
+        (byte_array ~size:Expr.(Field.ref f_cfdp_txseq_len + int 1))
+      $ fun r -> r.cfdp_txseq)
+  in
+  let cf_dst =
+    Codec.(
+      Field.v "DestEID"
+        (byte_array ~size:Expr.(Field.ref f_cfdp_eid_len + int 1))
+      $ fun r -> r.cfdp_dst)
+  in
+  let get_txseq = Staged.unstage (Codec.get cfdp_codec cf_txseq) in
+  let get_dst = Staged.unstage (Codec.get cfdp_codec cf_dst) in
+  Alcotest.(check string) "get txseq" "\xCC\xDD\xEE" (get_txseq buf 0);
+  Alcotest.(check string) "get dst" "\xFF\x00" (get_dst buf 0)
+
+let test_multi_var_fixed_after () =
+  (* A fixed-size field after multiple variable-size fields must also work. *)
+  let f_elen = Field.v "ELen" uint8 in
+  let f_tlen = Field.v "TLen" uint8 in
+  let codec =
+    let open Codec in
+    v "VarTrail"
+      (fun elen tlen src txseq trail -> (elen, tlen, src, txseq, trail))
+      [
+        (f_elen $ fun (e, _, _, _, _) -> e);
+        (f_tlen $ fun (_, t, _, _, _) -> t);
+        ( Field.v "Src" (byte_array ~size:Expr.(Field.ref f_elen + int 1))
+        $ fun (_, _, s, _, _) -> s );
+        ( Field.v "Tx" (byte_array ~size:Expr.(Field.ref f_tlen + int 1))
+        $ fun (_, _, _, t, _) -> t );
+        (Field.v "Trail" uint16be $ fun (_, _, _, _, tr) -> tr);
+      ]
+  in
+  (* elen=0 -> 1-byte src, tlen=1 -> 2-byte tx, trail=0xBEEF
+     Layout: [0] [1] [AA] [BB CC] [BE EF] *)
+  let buf = Bytes.create 7 in
+  Bytes.set_uint8 buf 0 0;
+  Bytes.set_uint8 buf 1 1;
+  Bytes.set_uint8 buf 2 0xAA;
+  Bytes.blit_string "\xBB\xCC" 0 buf 3 2;
+  Bytes.set_uint16_be buf 5 0xBEEF;
+  let _, _, src, tx, trail = decode_ok (Codec.decode codec buf 0) in
+  Alcotest.(check string) "src" "\xAA" src;
+  Alcotest.(check string) "tx" "\xBB\xCC" tx;
+  Alcotest.(check int) "trail" 0xBEEF trail
+
 (* ── Adversarial bit-order tests ──
 
    These pin the default [bit_order = Msb_first] against real protocol
@@ -3342,4 +3474,10 @@ let suite =
         test_tm_like_no_trailing;
       Alcotest.test_case "composition: tm-like roundtrip" `Quick
         test_tm_like_roundtrip;
+      (* multiple consecutive variable-size fields *)
+      Alcotest.test_case "multi-var: decode" `Quick test_multi_var_decode;
+      Alcotest.test_case "multi-var: roundtrip" `Quick test_multi_var_roundtrip;
+      Alcotest.test_case "multi-var: get" `Quick test_multi_var_get;
+      Alcotest.test_case "multi-var: fixed after" `Quick
+        test_multi_var_fixed_after;
     ] )


### PR DESCRIPTION
Removes the limitation that rejected a second byte_array/byte_slice after a variable-size field. The codec now composes Dynamic_next offset closures, enabling CFDP-style layouts with three consecutive variable-size fields sized by expressions over earlier fixed fields.