### PR TITLE
fix: resolve merlint warnings

### DIFF
--- a/.merlint
+++ b/.merlint
@@ -8,3 +8,8 @@ rules:
     exclude: [E617]
   - files: test/test_uInt63.ml
     exclude: [E617]
+
+  # Crowbar/Alcobar fuzzer uses random mode for runtest and AFL mode for
+  # the fuzz alias; --gen-corpus is not applicable
+  - files: fuzz/dune
+    exclude: [E718, E724]

--- a/test/bench/bench.ml
+++ b/test/bench/bench.ml
@@ -1,14 +1,14 @@
-let bench_routing () = Routing_bench.check ~n_pkts:10_000
-let bench_clcw () = Clcw_bench.check ~n_words:10_000
-let bench_gateway () = Gateway_bench.check ~n_frames:1_000
+let routing () = Routing_bench.check ~n_pkts:10_000
+let clcw () = Clcw_bench.check ~n_words:10_000
+let gateway () = Gateway_bench.check ~n_frames:1_000
 
 let () =
   Alcotest.run "bench"
     [
       ( "bench",
         [
-          Alcotest.test_case "verify: routing counts" `Quick bench_routing;
-          Alcotest.test_case "verify: clcw anomalies" `Quick bench_clcw;
-          Alcotest.test_case "verify: gateway checksums" `Quick bench_gateway;
+          Alcotest.test_case "verify: routing counts" `Quick routing;
+          Alcotest.test_case "verify: clcw anomalies" `Quick clcw;
+          Alcotest.test_case "verify: gateway checksums" `Quick gateway;
         ] );
     ]


### PR DESCRIPTION
Remove redundant `bench_` prefix from functions in test/bench/bench.ml (E330). Suppress E718/E724 for fuzz/dune since Crowbar/Alcobar fuzzers do not support --gen-corpus.