### PR TITLE
feat: add inject/project to casetype for typed tag-dispatched unions

### DIFF
--- a/fuzz/fuzz_everparse.ml
+++ b/fuzz/fuzz_everparse.ml
@@ -144,14 +144,23 @@ let test_casetype_random n =
   let _ = Wire.Everparse.Raw.to_3d m in
   ()
 
+type ep_case_val = [ `U16 of int | `U32 of int | `Default of int ]
 (** Test inline casetype. *)
+
 let test_casetype_inline () =
-  let t =
+  let t : ep_case_val Wire.typ =
     Wire.casetype "Tag" Wire.uint8
       [
-        Wire.case 0 Wire.uint16;
-        Wire.case 1 Wire.uint32;
-        Wire.default Wire.uint8;
+        Wire.case Wire.uint16
+          ~inject:(fun v -> `U16 v)
+          ~project:(function `U16 v -> Some v | _ -> None);
+        Wire.case Wire.uint32
+          ~inject:(fun v -> `U32 (Wire.Private.UInt32.to_int v))
+          ~project:(function
+            | `U32 v -> Some (Wire.Private.UInt32.of_int v) | _ -> None);
+        Wire.default Wire.uint8
+          ~inject:(fun v -> `Default v)
+          ~project:(function `Default v -> Some v | _ -> None);
       ]
   in
   let s =

--- a/fuzz/fuzz_wire.ml
+++ b/fuzz/fuzz_wire.ml
@@ -264,14 +264,23 @@ let test_parse_anon_field buf =
   let _ = Wire.Codec.decode c (Bytes.of_string buf) 0 in
   ()
 
+type test_case_val = [ `U8 of int | `U16 of int | `Default of int ]
+
 let test_parse_casetype buf =
   let buf = truncate buf in
-  let t =
+  let t : test_case_val Wire.typ =
     Wire.casetype "Tag" Wire.uint8
       [
-        Wire.case 0 Wire.uint8;
-        Wire.case 1 Wire.uint16;
-        Wire.default Wire.uint32;
+        Wire.case Wire.uint8
+          ~inject:(fun v -> `U8 v)
+          ~project:(function `U8 v -> Some v | _ -> None);
+        Wire.case Wire.uint16
+          ~inject:(fun v -> `U16 v)
+          ~project:(function `U16 v -> Some v | _ -> None);
+        Wire.default Wire.uint32
+          ~inject:(fun v -> `Default (Wire.Private.UInt32.to_int v))
+          ~project:(function
+            | `Default v -> Some (Wire.Private.UInt32.of_int v) | _ -> None);
       ]
   in
   let _ = Wire.decode_string t buf in

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -61,6 +61,25 @@ let rec build_field_encoder : type a. a typ -> bytes -> int -> a -> int =
       let enc = build_field_encoder inner in
       fun buf off v -> enc buf off (encode v)
   | Unit -> fun _buf off () -> off
+  | Casetype { tag; cases; _ } ->
+      let tag_enc = build_field_encoder tag in
+      fun buf off v ->
+        let rec find = function
+          | [] -> failwith "build_field_encoder: casetype: no matching case"
+          | Case_branch { cb_tag; cb_inner; cb_project; _ } :: rest -> (
+              match cb_project v with
+              | Some body ->
+                  let off' =
+                    match cb_tag with
+                    | Some t -> tag_enc buf off t
+                    | None ->
+                        failwith
+                          "build_field_encoder: cannot encode default case"
+                  in
+                  build_field_encoder cb_inner buf off' body
+              | None -> find rest)
+        in
+        find cases
   | _ ->
       (* Fallback for complex types - not specialized *)
       fun _buf _off _v -> failwith "build_field_encoder: unsupported type"

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -97,8 +97,8 @@ and _ typ =
       -> int typ
   | Casetype : {
       name : string;
-      tag : 'tag typ;
-      cases : ('tag option * 'a typ) list;
+      tag : int typ;
+      cases : 'a case_branch list;
     }
       -> 'a typ
   | Struct : struct_ -> unit typ
@@ -128,6 +128,15 @@ and _ typ =
       seq : ('a, 'seq) seq_map;
     }
       -> 'seq typ
+
+and 'a case_branch =
+  | Case_branch : {
+      cb_tag : int option;
+      cb_inner : 'w typ;
+      cb_inject : 'w -> 'a;
+      cb_project : 'a -> 'w option;
+    }
+      -> 'a case_branch
 
 and packed_expr = Pack_expr : 'a expr -> packed_expr
 
@@ -299,11 +308,64 @@ let variants name cases base =
   map decode encode (enum name enum_cases base)
 
 (* Casetype *)
-type ('tag, 'a) case = 'tag option * 'a typ
+type 'a case_def =
+  | Case_def : {
+      cd_index : int option;
+      cd_inner : 'w typ;
+      cd_inject : 'w -> 'a;
+      cd_project : 'a -> 'w option;
+    }
+      -> 'a case_def
+  | Default_def : {
+      dd_inner : 'w typ;
+      dd_inject : 'w -> 'a;
+      dd_project : 'a -> 'w option;
+    }
+      -> 'a case_def
 
-let case tag typ = (Some tag, typ)
-let default typ = (None, typ)
-let casetype name tag cases = Casetype { name; tag; cases }
+let case ?index inner ~inject ~project =
+  Case_def
+    {
+      cd_index = index;
+      cd_inner = inner;
+      cd_inject = inject;
+      cd_project = project;
+    }
+
+let default inner ~inject ~project =
+  Default_def { dd_inner = inner; dd_inject = inject; dd_project = project }
+
+let casetype ?(first = 0) ?(step = 1) name tag defs =
+  let counter = Stdlib.ref first in
+  let resolve = function
+    | Case_def { cd_index; cd_inner; cd_inject; cd_project } ->
+        let idx =
+          match cd_index with
+          | Some i ->
+              counter := i + step;
+              i
+          | None ->
+              let i = !counter in
+              counter := i + step;
+              i
+        in
+        Case_branch
+          {
+            cb_tag = Some idx;
+            cb_inner = cd_inner;
+            cb_inject = cd_inject;
+            cb_project = cd_project;
+          }
+    | Default_def { dd_inner; dd_inject; dd_project } ->
+        Case_branch
+          {
+            cb_tag = None;
+            cb_inner = dd_inner;
+            cb_inject = dd_inject;
+            cb_project = dd_project;
+          }
+  in
+  Casetype { name; tag; cases = List.map resolve defs }
 
 (* Struct fields *)
 let field name ?constraint_ ?action typ =

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -129,8 +129,8 @@ and _ typ =
       -> int typ  (** Named enumeration. *)
   | Casetype : {
       name : string;
-      tag : 'tag typ;
-      cases : ('tag option * 'a typ) list;
+      tag : int typ;
+      cases : 'a case_branch list;
     }
       -> 'a typ  (** Tag-dispatched union. *)
   | Struct : struct_ -> unit typ  (** Nested struct. *)
@@ -164,6 +164,15 @@ and _ typ =
       seq : ('a, 'seq) seq_map;
     }
       -> 'seq typ  (** Repeated elements filling a byte budget. *)
+
+and 'a case_branch =
+  | Case_branch : {
+      cb_tag : int option;
+      cb_inner : 'w typ;
+      cb_inject : 'w -> 'a;
+      cb_project : 'a -> 'w option;
+    }
+      -> 'a case_branch
 
 and packed_expr =
   | Pack_expr : 'a expr -> packed_expr  (** Existentially packed expression. *)
@@ -417,16 +426,23 @@ val enum : string -> (string * int) list -> int typ -> int typ
 val variants : string -> (string * 'a) list -> int typ -> 'a typ
 (** Named variant mapping over an integer base. *)
 
-type ('tag, 'a) case = 'tag option * 'a typ
-(** A casetype branch. *)
+type 'a case_def
+(** A casetype branch definition. *)
 
-val case : 'tag -> 'a typ -> ('tag, 'a) case
+val case :
+  ?index:int ->
+  'w typ ->
+  inject:('w -> 'a) ->
+  project:('a -> 'w option) ->
+  'a case_def
 (** A branch matching a specific tag value. *)
 
-val default : 'a typ -> ('tag, 'a) case
+val default :
+  'w typ -> inject:('w -> 'a) -> project:('a -> 'w option) -> 'a case_def
 (** A default branch. *)
 
-val casetype : string -> 'tag typ -> ('tag, 'a) case list -> 'a typ
+val casetype :
+  ?first:int -> ?step:int -> string -> int typ -> 'a case_def list -> 'a typ
 (** Tag-dispatched union type. *)
 
 (** {1 Struct Constructors} *)

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -368,14 +368,16 @@ let rec parse_with : type a. decoder -> ctx -> a typ -> a * ctx =
   | Casetype { cases; tag; _ } ->
       let tag_val, ctx' = parse_with dec ctx tag in
       let rec find_case = function
-        | [] ->
-            raise
-              (Parse_exn
-                 (Invalid_tag (val_to_int tag tag_val |> Option.value ~default:0)))
-        | (Some expected, case_typ) :: rest ->
-            if expected = tag_val then parse_with dec ctx' case_typ
+        | [] -> raise (Parse_exn (Invalid_tag tag_val))
+        | Case_branch { cb_tag = Some expected; cb_inner; cb_inject; _ } :: rest
+          ->
+            if expected = tag_val then
+              let body, ctx'' = parse_with dec ctx' cb_inner in
+              (cb_inject body, ctx'')
             else find_case rest
-        | (None, case_typ) :: _ -> parse_with dec ctx' case_typ
+        | Case_branch { cb_tag = None; cb_inner; cb_inject; _ } :: _ ->
+            let body, ctx'' = parse_with dec ctx' cb_inner in
+            (cb_inject body, ctx'')
       in
       find_case cases
   | Struct { fields; where; _ } ->
@@ -734,7 +736,22 @@ let rec encode_with_ctx : type a. ctx -> a typ -> a -> encoder -> ctx =
       let ctx' = Stdlib.ref ctx in
       seq.iter (fun elem_v -> ctx' := encode_with_ctx !ctx' elem elem_v enc) v;
       !ctx'
-  | Casetype _ -> failwith "casetype encoding: use Record module"
+  | Casetype { tag; cases; _ } ->
+      let rec find_case = function
+        | [] -> failwith "casetype encoding: no matching case"
+        | Case_branch { cb_tag; cb_inner; cb_project; _ } :: rest -> (
+            match cb_project v with
+            | Some body ->
+                let ctx' =
+                  match cb_tag with
+                  | Some t -> encode_with_ctx ctx tag t enc
+                  | None ->
+                      failwith "casetype encoding: cannot encode default case"
+                in
+                encode_with_ctx ctx' cb_inner body enc
+            | None -> find_case rest)
+      in
+      find_case cases
   | Struct _ -> failwith "struct encoding: use Record module"
   | Type_ref _ -> failwith "type_ref requires a type registry"
   | Qualified_ref _ -> failwith "qualified_ref requires a type registry"

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -476,15 +476,22 @@ val variants : string -> (string * 'a) list -> int typ -> 'a typ
 (** [variants name cases base] maps integer values to OCaml values via a named
     enumeration. Unlike {!enum}, this converts to proper OCaml values. *)
 
-type ('tag, 'a) case
+type 'a case_def
 
-val case : 'tag -> 'a typ -> ('tag, 'a) case
+val case :
+  ?index:int ->
+  'w typ ->
+  inject:('w -> 'a) ->
+  project:('a -> 'w option) ->
+  'a case_def
 (** Tagged branch of a casetype. *)
 
-val default : 'a typ -> ('tag, 'a) case
+val default :
+  'w typ -> inject:('w -> 'a) -> project:('a -> 'w option) -> 'a case_def
 (** Default branch of a casetype. *)
 
-val casetype : string -> 'tag typ -> ('tag, 'a) case list -> 'a typ
+val casetype :
+  ?first:int -> ?step:int -> string -> int typ -> 'a case_def list -> 'a typ
 (** Tag-dispatched choice between several descriptions. *)
 
 val size : 'a typ -> int option


### PR DESCRIPTION
Casetype branches now carry inject/project functions that map between the wire representation and OCaml types, enabling proper typed encoding and decoding. Tag values are auto-numbered with configurable first/step parameters. This replaces the untyped tag+typ pairs and enables bidirectional casetype encoding (previously a stub).