### PR TITLE
feat: support dynamic optional in Codec

### DIFF
--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -247,6 +247,54 @@ let rec compile_expr (env : (string * (bytes -> int -> int)) list)
       | None -> invalid_arg "Codec: sizeof on variable-size type")
   | _ -> invalid_arg "Codec: unsupported expression in dependent size"
 
+let try_compile_int_reader : type a.
+    (string * (bytes -> int -> int)) list ->
+    a expr ->
+    (bytes -> int -> int) option =
+ fun env -> function
+  | Int _ as e -> Some (compile_expr env e)
+  | Ref _ as e -> Some (compile_expr env e)
+  | Param_ref _ as e -> Some (compile_expr env e)
+  | Add _ as e -> Some (compile_expr env e)
+  | Sub _ as e -> Some (compile_expr env e)
+  | Mul _ as e -> Some (compile_expr env e)
+  | Div _ as e -> Some (compile_expr env e)
+  | _ -> None
+
+let rec compile_bool_expr (env : (string * (bytes -> int -> int)) list)
+    (e : bool expr) : bytes -> int -> bool =
+  match e with
+  | Bool b -> fun _buf _base -> b
+  | Eq (a, b) -> (
+      match (try_compile_int_reader env a, try_compile_int_reader env b) with
+      | Some fa, Some fb -> fun buf base -> fa buf base = fb buf base
+      | _ -> fun _buf _base -> true)
+  | Ne (a, b) -> (
+      match (try_compile_int_reader env a, try_compile_int_reader env b) with
+      | Some fa, Some fb -> fun buf base -> fa buf base <> fb buf base
+      | _ -> fun _buf _base -> true)
+  | Lt (a, b) ->
+      let fa = compile_expr env a and fb = compile_expr env b in
+      fun buf base -> fa buf base < fb buf base
+  | Le (a, b) ->
+      let fa = compile_expr env a and fb = compile_expr env b in
+      fun buf base -> fa buf base <= fb buf base
+  | Gt (a, b) ->
+      let fa = compile_expr env a and fb = compile_expr env b in
+      fun buf base -> fa buf base > fb buf base
+  | Ge (a, b) ->
+      let fa = compile_expr env a and fb = compile_expr env b in
+      fun buf base -> fa buf base >= fb buf base
+  | And (a, b) ->
+      let fa = compile_bool_expr env a and fb = compile_bool_expr env b in
+      fun buf base -> fa buf base && fb buf base
+  | Or (a, b) ->
+      let fa = compile_bool_expr env a and fb = compile_bool_expr env b in
+      fun buf base -> fa buf base || fb buf base
+  | Not e ->
+      let fe = compile_bool_expr env e in
+      fun buf base -> not (fe buf base)
+
 (* Compile expressions to read from a per-decode int array instead of a Map.
    The [idx] function maps field names to array indices. Built at [seal] time,
    used at every [decode]. Zero allocation per decode. *)
@@ -1048,6 +1096,40 @@ and compile_codec : type a r.
         populate = no_populate;
       }
 
+and dynamic_optional_next_off ctx present_fn fsize =
+  let base_off = ctx.lc_next_off in
+  Dynamic_next
+    (fun buf base ->
+      let off =
+        match base_off with
+        | Static_next n -> base + n
+        | Dynamic_next f -> f buf base
+      in
+      if present_fn buf base then off + fsize else off)
+
+and optional_compiled : type a r.
+    layout_ctx ->
+    raw_reader:(bytes -> int -> a) ->
+    raw_writer:(r -> bytes -> int -> unit) ->
+    size_delta:int ->
+    next_off:next_off ->
+    populate:(int array -> bytes -> int -> unit) ->
+    (a, r) compiled_field =
+ fun ctx ~raw_reader ~raw_writer ~size_delta ~next_off ~populate ->
+  {
+    raw_reader;
+    raw_writer;
+    extra_writers = [];
+    field_access = fixed_or_dynamic_fa ctx;
+    size_delta;
+    next_off;
+    bf_after = None;
+    int_reader = null_int_reader;
+    nested_readers = [];
+    validator_off = validator_off_of ctx;
+    populate;
+  }
+
 and compile_optional : type a r.
     layout_ctx ->
     (a option, r) field ->
@@ -1055,51 +1137,38 @@ and compile_optional : type a r.
     a typ ->
     (a option, r) compiled_field =
  fun ctx fld present inner ->
-  let present_literal = match present with Bool b -> Some b | _ -> None in
   let inner_size = field_wire_size inner in
-  match (present_literal, inner_size) with
-  | Some true, Some fsize ->
-      (* Statically present, fixed inner: behave like a normal fixed field
-         but wrap in Some. *)
+  match (present, inner_size) with
+  | Bool true, Some fsize ->
       let inner_reader, inner_writer = inner_codec_accessors inner ctx in
-      let raw_reader buf base = Some (inner_reader buf base) in
       let get = fld.get in
-      let raw_writer v buf off =
-        match get v with Some iv -> inner_writer buf off iv | None -> ()
-      in
-      {
-        raw_reader;
-        raw_writer;
-        extra_writers = [];
-        field_access = fixed_or_dynamic_fa ctx;
-        size_delta = fsize;
-        next_off = advance_next_off ctx.lc_next_off fsize;
-        bf_after = None;
-        int_reader = null_int_reader;
-        nested_readers = [];
-        validator_off = validator_off_of ctx;
-        populate = no_populate;
-      }
-  | Some false, _ ->
-      (* Statically absent: zero bytes, always [None]. *)
-      let raw_reader _buf _base = None in
-      let raw_writer _v _buf _off = () in
-      {
-        raw_reader;
-        raw_writer;
-        extra_writers = [];
-        field_access = fixed_or_dynamic_fa ctx;
-        size_delta = 0;
-        next_off = ctx.lc_next_off;
-        bf_after = None;
-        int_reader = null_int_reader;
-        nested_readers = [];
-        validator_off = validator_off_of ctx;
-        populate = no_populate;
-      }
+      optional_compiled ctx
+        ~raw_reader:(fun buf base -> Some (inner_reader buf base))
+        ~raw_writer:(fun v buf off ->
+          match get v with Some iv -> inner_writer buf off iv | None -> ())
+        ~size_delta:fsize
+        ~next_off:(advance_next_off ctx.lc_next_off fsize)
+        ~populate:no_populate
+  | Bool false, _ ->
+      optional_compiled ctx
+        ~raw_reader:(fun _buf _base -> None)
+        ~raw_writer:(fun _v _buf _off -> ())
+        ~size_delta:0 ~next_off:ctx.lc_next_off ~populate:no_populate
+  | _, Some fsize ->
+      let present_fn = compile_bool_expr ctx.lc_field_readers present in
+      let inner_reader, inner_writer = inner_codec_accessors inner ctx in
+      let get = fld.get in
+      optional_compiled ctx
+        ~raw_reader:(fun buf base ->
+          if present_fn buf base then Some (inner_reader buf base) else None)
+        ~raw_writer:(fun v buf off ->
+          match get v with Some iv -> inner_writer buf off iv | None -> ())
+        ~size_delta:0
+        ~next_off:(dynamic_optional_next_off ctx present_fn fsize)
+        ~populate:no_populate
   | _ ->
       invalid_arg
-        "add_field: dynamic optional (non-literal bool expr) not yet supported"
+        "add_field: dynamic optional with variable-size inner not yet supported"
 
 and compile_optional_or : type a r.
     layout_ctx ->
@@ -1109,48 +1178,39 @@ and compile_optional_or : type a r.
     a ->
     (a, r) compiled_field =
  fun ctx fld present inner default ->
-  let present_literal = match present with Bool b -> Some b | _ -> None in
   let inner_size = field_wire_size inner in
-  match (present_literal, inner_size) with
-  | Some true, Some fsize ->
-      (* Statically present: read inner directly. *)
+  match (present, inner_size) with
+  | Bool true, Some fsize ->
       let inner_reader, inner_writer = inner_codec_accessors inner ctx in
       let get = fld.get in
-      let raw_writer v buf off = inner_writer buf off (get v) in
       let populate = build_populate fld.typ ctx.lc_n_fields inner_reader in
-      {
-        raw_reader = inner_reader;
-        raw_writer;
-        extra_writers = [];
-        field_access = fixed_or_dynamic_fa ctx;
-        size_delta = fsize;
-        next_off = advance_next_off ctx.lc_next_off fsize;
-        bf_after = None;
-        int_reader = null_int_reader;
-        nested_readers = [];
-        validator_off = validator_off_of ctx;
-        populate;
-      }
-  | Some false, _ ->
-      (* Statically absent: return default, zero bytes. *)
-      let raw_reader _buf _base = default in
-      let raw_writer _v _buf _off = () in
-      {
-        raw_reader;
-        raw_writer;
-        extra_writers = [];
-        field_access = fixed_or_dynamic_fa ctx;
-        size_delta = 0;
-        next_off = ctx.lc_next_off;
-        bf_after = None;
-        int_reader = null_int_reader;
-        nested_readers = [];
-        validator_off = validator_off_of ctx;
-        populate = no_populate;
-      }
+      optional_compiled ctx ~raw_reader:inner_reader
+        ~raw_writer:(fun v buf off -> inner_writer buf off (get v))
+        ~size_delta:fsize
+        ~next_off:(advance_next_off ctx.lc_next_off fsize)
+        ~populate
+  | Bool false, _ ->
+      optional_compiled ctx
+        ~raw_reader:(fun _buf _base -> default)
+        ~raw_writer:(fun _v _buf _off -> ())
+        ~size_delta:0 ~next_off:ctx.lc_next_off ~populate:no_populate
+  | _, Some fsize ->
+      let present_fn = compile_bool_expr ctx.lc_field_readers present in
+      let inner_reader, inner_writer = inner_codec_accessors inner ctx in
+      let get = fld.get in
+      let raw_reader buf base =
+        if present_fn buf base then inner_reader buf base else default
+      in
+      let populate = build_populate fld.typ ctx.lc_n_fields raw_reader in
+      optional_compiled ctx ~raw_reader
+        ~raw_writer:(fun v buf off ->
+          if present_fn buf off then inner_writer buf off (get v))
+        ~size_delta:0
+        ~next_off:(dynamic_optional_next_off ctx present_fn fsize)
+        ~populate
   | _ ->
       invalid_arg
-        "add_field: dynamic optional_or (non-literal bool expr) not yet \
+        "add_field: dynamic optional_or with variable-size inner not yet \
          supported"
 
 and compile_repeat : type elt seq r.

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -2640,6 +2640,61 @@ let test_optional_mixed () =
   Alcotest.(check (option int)) "ocf" (Some 0x22222222) r.mo_ocf;
   Alcotest.(check (option int)) "fecf" None r.mo_fecf
 
+(* Dynamic optional: presence determined by a previously-parsed field. *)
+
+type dyn_opt = { do_flags : int; do_payload : int option; do_trail : int }
+
+let f_do_flags = Field.v "Flags" uint8
+
+let dyn_opt_codec =
+  Codec.v "DynOpt"
+    (fun flags payload trail ->
+      { do_flags = flags; do_payload = payload; do_trail = trail })
+    Codec.
+      [
+        (f_do_flags $ fun r -> r.do_flags);
+        ( Field.v "Payload"
+            (optional Expr.(Field.ref f_do_flags <> int 0) uint16be)
+        $ fun r -> r.do_payload );
+        (Field.v "Trail" uint8 $ fun r -> r.do_trail);
+      ]
+
+let test_dyn_opt_present () =
+  (* flags=1 -> payload present. Layout: [01] [12 34] [FF] *)
+  let buf = Bytes.create 4 in
+  Bytes.set_uint8 buf 0 1;
+  Bytes.set_uint16_be buf 1 0x1234;
+  Bytes.set_uint8 buf 3 0xFF;
+  let r = decode_ok (Codec.decode dyn_opt_codec buf 0) in
+  Alcotest.(check int) "flags" 1 r.do_flags;
+  Alcotest.(check (option int)) "payload" (Some 0x1234) r.do_payload;
+  Alcotest.(check int) "trail" 0xFF r.do_trail
+
+let test_dyn_opt_absent () =
+  (* flags=0 -> payload absent. Layout: [00] [FF] *)
+  let buf = Bytes.create 2 in
+  Bytes.set_uint8 buf 0 0;
+  Bytes.set_uint8 buf 1 0xFF;
+  let r = decode_ok (Codec.decode dyn_opt_codec buf 0) in
+  Alcotest.(check int) "flags" 0 r.do_flags;
+  Alcotest.(check (option int)) "payload" None r.do_payload;
+  Alcotest.(check int) "trail" 0xFF r.do_trail
+
+let test_dyn_opt_get_trail () =
+  let cf_trail = Codec.(Field.v "Trail" uint8 $ fun r -> r.do_trail) in
+  let get_trail = Staged.unstage (Codec.get dyn_opt_codec cf_trail) in
+  (* Present: trail at offset 3. *)
+  let buf1 = Bytes.create 4 in
+  Bytes.set_uint8 buf1 0 1;
+  Bytes.set_uint16_be buf1 1 0x1234;
+  Bytes.set_uint8 buf1 3 0xAA;
+  Alcotest.(check int) "trail (present)" 0xAA (get_trail buf1 0);
+  (* Absent: trail at offset 1. *)
+  let buf2 = Bytes.create 2 in
+  Bytes.set_uint8 buf2 0 0;
+  Bytes.set_uint8 buf2 1 0xBB;
+  Alcotest.(check int) "trail (absent)" 0xBB (get_trail buf2 0)
+
 (* ── Nested: Repeat typ: parse elements until byte budget exhausted ── *)
 
 type container = { cnt_length : int; cnt_items : inner list }
@@ -3457,6 +3512,10 @@ let suite =
       Alcotest.test_case "optional: both absent" `Quick
         test_optional_both_absent;
       Alcotest.test_case "optional: mixed" `Quick test_optional_mixed;
+      Alcotest.test_case "optional: dynamic present" `Quick test_dyn_opt_present;
+      Alcotest.test_case "optional: dynamic absent" `Quick test_dyn_opt_absent;
+      Alcotest.test_case "optional: dynamic get trail" `Quick
+        test_dyn_opt_get_trail;
       (* repeat *)
       Alcotest.test_case "repeat: decode empty" `Quick test_repeat_decode_empty;
       Alcotest.test_case "repeat: decode one" `Quick test_repeat_decode_one;


### PR DESCRIPTION
Evaluates non-literal bool expressions at runtime for optional and optional_or fields with fixed-size inner types. Fields after a dynamic optional track offsets via Dynamic_next, so staged get/set resolves correctly whether the optional is present or absent.