### PR TITLE
feat: generalize Field.ref to accept any field type

### DIFF
--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -124,6 +124,11 @@ let rec build_populate : type a.
   | Uint32 _ -> fun arr buf base -> arr.(idx) <- UInt32.to_int (reader buf base)
   | Uint63 _ -> fun arr buf base -> arr.(idx) <- UInt63.to_int (reader buf base)
   | Bits _ -> fun arr buf base -> arr.(idx) <- reader buf base
+  | Uint64 _ -> (
+      fun arr buf base ->
+        match Int64.unsigned_to_int (reader buf base) with
+        | Some v -> arr.(idx) <- v
+        | None -> ())
   | Where { inner; _ } -> build_populate inner idx reader
   | Enum { base; _ } -> build_populate base idx reader
   | Map { inner; encode; _ } ->

--- a/lib/field.mli
+++ b/lib/field.mli
@@ -25,9 +25,10 @@ val v :
 val anon : 'a Types.typ -> 'a anon
 (** [anon typ] creates an anonymous (padding) field. *)
 
-val ref : int t -> int Types.expr
-(** [ref f] returns the expression referencing this field. Only int-sized fields
-    can be referenced (not uint64). *)
+val ref : 'a t -> int Types.expr
+(** [ref f] returns the expression referencing this field's underlying integer
+    value. Works on any field whose wire type is or wraps an integer, including
+    [bool] fields created with {!Wire.bit}. *)
 
 val name : 'a t -> string
 (** Field name. *)

--- a/lib/test/field/test_field.ml
+++ b/lib/test/field/test_field.ml
@@ -56,6 +56,33 @@ let test_no_constraint () =
   | None -> ()
   | Some _ -> Alcotest.fail "expected no constraint"
 
+(* ref on non-int fields: bool, mapped, uint64. The expression is always
+   Ref name — the type system no longer restricts the field's OCaml type. *)
+
+let test_ref_bool_field () =
+  let f = Field.v "Flag" (Types.bool Types.uint8) in
+  match Field.ref f with
+  | Types.Ref name -> Alcotest.(check string) "ref name" "Flag" name
+  | _ -> Alcotest.fail "expected Ref"
+
+let test_ref_mapped_field () =
+  let f =
+    Field.v "Code"
+      (Types.map
+         (fun n -> string_of_int n)
+         (fun s -> int_of_string s)
+         Types.uint8)
+  in
+  match Field.ref f with
+  | Types.Ref name -> Alcotest.(check string) "ref name" "Code" name
+  | _ -> Alcotest.fail "expected Ref"
+
+let test_ref_uint64_field () =
+  let f = Field.v "Timestamp" (Types.Uint64 Types.Big) in
+  match Field.ref f with
+  | Types.Ref name -> Alcotest.(check string) "ref name" "Timestamp" name
+  | _ -> Alcotest.fail "expected Ref"
+
 let suite =
   ( "field",
     [
@@ -64,6 +91,9 @@ let suite =
       Alcotest.test_case "name returns name" `Quick test_name_returns_name;
       Alcotest.test_case "anon" `Quick test_anon;
       Alcotest.test_case "ref returns Ref expr" `Quick test_ref_returns_ref_expr;
+      Alcotest.test_case "ref on bool field" `Quick test_ref_bool_field;
+      Alcotest.test_case "ref on mapped field" `Quick test_ref_mapped_field;
+      Alcotest.test_case "ref on uint64 field" `Quick test_ref_uint64_field;
       Alcotest.test_case "pp prints name" `Quick test_pp_prints_name;
       Alcotest.test_case "to_decl named" `Quick test_to_decl_named;
       Alcotest.test_case "to_decl anon" `Quick test_to_decl_anon;

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -736,26 +736,29 @@ let rec encode_with_ctx : type a. ctx -> a typ -> a -> encoder -> ctx =
       let ctx' = Stdlib.ref ctx in
       seq.iter (fun elem_v -> ctx' := encode_with_ctx !ctx' elem elem_v enc) v;
       !ctx'
-  | Casetype { tag; cases; _ } ->
-      let rec find_case = function
-        | [] -> failwith "casetype encoding: no matching case"
-        | Case_branch { cb_tag; cb_inner; cb_project; _ } :: rest -> (
-            match cb_project v with
-            | Some body ->
-                let ctx' =
-                  match cb_tag with
-                  | Some t -> encode_with_ctx ctx tag t enc
-                  | None ->
-                      failwith "casetype encoding: cannot encode default case"
-                in
-                encode_with_ctx ctx' cb_inner body enc
-            | None -> find_case rest)
-      in
-      find_case cases
+  | Casetype { tag; cases; _ } -> encode_casetype ctx tag cases v enc
   | Struct _ -> failwith "struct encoding: use Record module"
   | Type_ref _ -> failwith "type_ref requires a type registry"
   | Qualified_ref _ -> failwith "qualified_ref requires a type registry"
   | Apply _ -> failwith "apply requires a type registry"
+
+and encode_casetype : type a.
+    ctx -> int typ -> a case_branch list -> a -> encoder -> ctx =
+ fun ctx tag cases v enc ->
+  let rec find_case = function
+    | [] -> failwith "casetype encoding: no matching case"
+    | Case_branch { cb_tag; cb_inner; cb_project; _ } :: rest -> (
+        match cb_project v with
+        | Some body ->
+            let ctx' =
+              match cb_tag with
+              | Some t -> encode_with_ctx ctx tag t enc
+              | None -> failwith "casetype encoding: cannot encode default case"
+            in
+            encode_with_ctx ctx' cb_inner body enc
+        | None -> find_case rest)
+  in
+  find_case cases
 
 let encode typ v writer =
   let enc = encoder writer in

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -336,10 +336,10 @@ module Field : sig
   val anon : 'a typ -> 'a anon
   (** [anon typ] creates an anonymous (padding) field. *)
 
-  val ref : int t -> int expr
-  (** [ref f] returns the expression referencing this field. Only works for
-      int-sized fields (uint8, uint16, uint32, bitfields). uint64 fields cannot
-      be referenced in size/constraint expressions. *)
+  val ref : 'a t -> int expr
+  (** [ref f] returns the expression referencing this field's underlying integer
+      value. Works on any field whose wire type is or wraps an integer,
+      including [bool] fields created with {!bit}. *)
 end
 
 (** {1 Type Descriptions}

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -2695,6 +2695,75 @@ let test_dyn_opt_get_trail () =
   Bytes.set_uint8 buf2 1 0xBB;
   Alcotest.(check int) "trail (absent)" 0xBB (get_trail buf2 0)
 
+(* Dynamic optional via Field.ref on a bool field — the TM frame pattern.
+   Field.ref now accepts 'a t, so a bool field created with [bit] can be
+   referenced directly in expressions. *)
+
+type tm_opt = {
+  to_ocf_flag : bool;
+  to_data : int;
+  to_ocf : int option;
+  to_trail : int;
+}
+
+let f_to_ocf_flag = Field.v "OCFFlag" (bit (bits ~width:1 U8))
+
+let tm_opt_codec =
+  Codec.v "TmOpt"
+    (fun ocf_flag _pad data ocf trail ->
+      { to_ocf_flag = ocf_flag; to_data = data; to_ocf = ocf; to_trail = trail })
+    Codec.
+      [
+        (f_to_ocf_flag $ fun r -> r.to_ocf_flag);
+        (Field.v "Pad" (bits ~width:7 U8) $ fun _ -> 0);
+        (Field.v "Data" uint16be $ fun r -> r.to_data);
+        ( Field.v "OCF"
+            (optional Expr.(Field.ref f_to_ocf_flag <> int 0) uint32be)
+        $ fun r -> r.to_ocf );
+        (Field.v "Trail" uint8 $ fun r -> r.to_trail);
+      ]
+
+let test_dyn_opt_anyref_present () =
+  let buf = Bytes.create 8 in
+  Bytes.set_uint8 buf 0 0x80;
+  Bytes.set_uint16_be buf 1 0x1234;
+  Bytes.set_int32_be buf 3 0xDEADBEEFl;
+  Bytes.set_uint8 buf 7 0xFF;
+  let r = decode_ok (Codec.decode tm_opt_codec buf 0) in
+  Alcotest.(check bool) "ocf_flag" true r.to_ocf_flag;
+  Alcotest.(check int) "data" 0x1234 r.to_data;
+  Alcotest.(check (option int)) "ocf" (Some 0xDEADBEEF) r.to_ocf;
+  Alcotest.(check int) "trail" 0xFF r.to_trail
+
+let test_dyn_opt_anyref_absent () =
+  let buf = Bytes.create 4 in
+  Bytes.set_uint8 buf 0 0x00;
+  Bytes.set_uint16_be buf 1 0x1234;
+  Bytes.set_uint8 buf 3 0xFF;
+  let r = decode_ok (Codec.decode tm_opt_codec buf 0) in
+  Alcotest.(check bool) "ocf_flag" false r.to_ocf_flag;
+  Alcotest.(check int) "data" 0x1234 r.to_data;
+  Alcotest.(check (option int)) "ocf" None r.to_ocf;
+  Alcotest.(check int) "trail" 0xFF r.to_trail
+
+let test_uint64_ref_in_size () =
+  let f_len = Field.v "Len" uint64be in
+  let codec =
+    let open Codec in
+    v "U64Ref"
+      (fun len data -> (len, data))
+      [
+        (f_len $ fun (l, _) -> l);
+        (Field.v "Data" (byte_array ~size:(Field.ref f_len)) $ fun (_, d) -> d);
+      ]
+  in
+  let buf = Bytes.create 11 in
+  Bytes.set_int64_be buf 0 3L;
+  Bytes.blit_string "ABC" 0 buf 8 3;
+  let len, data = decode_ok (Codec.decode codec buf 0) in
+  Alcotest.(check int64) "len" 3L len;
+  Alcotest.(check string) "data" "ABC" data
+
 (* ── Nested: Repeat typ: parse elements until byte budget exhausted ── *)
 
 type container = { cnt_length : int; cnt_items : inner list }
@@ -3516,6 +3585,12 @@ let suite =
       Alcotest.test_case "optional: dynamic absent" `Quick test_dyn_opt_absent;
       Alcotest.test_case "optional: dynamic get trail" `Quick
         test_dyn_opt_get_trail;
+      Alcotest.test_case "optional: bool ref present" `Quick
+        test_dyn_opt_anyref_present;
+      Alcotest.test_case "optional: bool ref absent" `Quick
+        test_dyn_opt_anyref_absent;
+      Alcotest.test_case "ref: uint64 in size expr" `Quick
+        test_uint64_ref_in_size;
       (* repeat *)
       Alcotest.test_case "repeat: decode empty" `Quick test_repeat_decode_empty;
       Alcotest.test_case "repeat: decode one" `Quick test_repeat_decode_one;


### PR DESCRIPTION
Field.ref was restricted to int fields, forcing protocol definitions to use int instead of bool for flag fields that participate in expressions (e.g. OCF flag controlling optional fields in TM frames). Now accepts 'a t -> int expr: the codec already stores every field's underlying int value in the decode array, so bool, mapped, and uint64 fields all work.