### PR TITLE
feat: add Uint_var constructor and val uint API

### DIFF
--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -43,6 +43,10 @@ let rec build_field_encoder : type a. a typ -> bytes -> int -> a -> int =
       fun buf off v ->
         Bytes.set_int64_be buf off v;
         off + 8
+  | Uint_var { size = Int n; endian } ->
+      fun buf off v ->
+        Uint_var.write endian buf off n v;
+        off + n
   | Byte_array { size = Int n } ->
       fun buf off v ->
         let len = min n (String.length v) in
@@ -98,6 +102,8 @@ let rec build_field_reader : type a. a typ -> int -> bytes -> int -> a =
   | Uint63 Big -> fun buf base -> UInt63.be buf (base + field_off)
   | Uint64 Little -> fun buf base -> Bytes.get_int64_le buf (base + field_off)
   | Uint64 Big -> fun buf base -> Bytes.get_int64_be buf (base + field_off)
+  | Uint_var { size = Int n; endian } ->
+      fun buf base -> Uint_var.read endian buf (base + field_off) n
   | Byte_array { size = Int n } ->
       fun buf base -> Bytes.sub_string buf (base + field_off) n
   | Byte_slice { size = Int n } ->
@@ -121,6 +127,7 @@ let rec build_populate : type a.
   match typ with
   | Uint8 -> fun arr buf base -> arr.(idx) <- reader buf base
   | Uint16 _ -> fun arr buf base -> arr.(idx) <- reader buf base
+  | Uint_var _ -> fun arr buf base -> arr.(idx) <- reader buf base
   | Uint32 _ -> fun arr buf base -> arr.(idx) <- UInt32.to_int (reader buf base)
   | Uint63 _ -> fun arr buf base -> arr.(idx) <- UInt63.to_int (reader buf base)
   | Bits _ -> fun arr buf base -> arr.(idx) <- reader buf base
@@ -767,6 +774,7 @@ let rec read_elem : type a. a typ -> bytes -> int -> a =
   | Uint63 Big -> UInt63.be buf off
   | Uint64 Little -> Bytes.get_int64_le buf off
   | Uint64 Big -> Bytes.get_int64_be buf off
+  | Uint_var { size = Int n; endian } -> Uint_var.read endian buf off n
   | Codec { codec_decode; _ } -> codec_decode buf off
   | Map { inner; decode; _ } -> decode (read_elem inner buf off)
   | Where { inner; _ } -> read_elem inner buf off
@@ -786,6 +794,7 @@ let rec write_elem : type a. a typ -> bytes -> int -> a -> unit =
   | Uint63 Big -> UInt63.set_be buf off v
   | Uint64 Little -> Bytes.set_int64_le buf off v
   | Uint64 Big -> Bytes.set_int64_be buf off v
+  | Uint_var { size = Int n; endian } -> Uint_var.write endian buf off n v
   | Codec { codec_encode; _ } -> codec_encode v buf off
   | Map { inner; encode; _ } -> write_elem inner buf off (encode v)
   | Where { inner; _ } -> write_elem inner buf off v
@@ -1373,6 +1382,7 @@ and compile_var_bytes : type a r.
     match typ with
     | Byte_slice { size } -> size
     | Byte_array { size } -> size
+    | Uint_var { size; _ } -> size
     | _ -> invalid_arg "add_field: unsupported variable-size field type"
   in
   let size_fn = compile_expr ctx.lc_field_readers size_expr in
@@ -1386,12 +1396,33 @@ and compile_var_bytes : type a r.
         let off_fn buf base = prev_end buf base - base in
         (off_fn, Variable_dynamic { off_fn; size_fn }, -1)
   in
-  let raw_reader = var_bytes_reader typ off_fn size_fn in
-  let raw_writer = var_bytes_writer typ fld.get off_fn in
-  let int_reader buf base =
-    match int_of_typ_value typ (raw_reader buf base) with
-    | Some v -> v
-    | None -> 0
+  let raw_reader, raw_writer, int_reader =
+    match typ with
+    | Uint_var { endian; _ } ->
+        let get = fld.get in
+        let raw_reader : bytes -> int -> a =
+         fun buf base ->
+          let fo = off_fn buf base in
+          let sz = size_fn buf base in
+          Uint_var.read endian buf (base + fo) sz
+        in
+        let raw_writer : r -> bytes -> int -> unit =
+         fun v buf off ->
+          let fo = off_fn buf off in
+          let sz = size_fn buf off in
+          Uint_var.write endian buf (off + fo) sz (get v)
+        in
+        let int_reader : bytes -> int -> int = raw_reader in
+        (raw_reader, raw_writer, int_reader)
+    | _ ->
+        let raw_reader = var_bytes_reader typ off_fn size_fn in
+        let raw_writer = var_bytes_writer typ fld.get off_fn in
+        let int_reader buf base =
+          match int_of_typ_value typ (raw_reader buf base) with
+          | Some v -> v
+          | None -> 0
+        in
+        (raw_reader, raw_writer, int_reader)
   in
   let populate = build_populate typ ctx.lc_n_fields raw_reader in
   {

--- a/lib/eval.ml
+++ b/lib/eval.ml
@@ -16,6 +16,7 @@ let rec int_of : type a. a typ -> a -> int option =
   match typ with
   | Uint8 -> Some v
   | Uint16 _ -> Some v
+  | Uint_var _ -> Some v
   | Uint32 _ -> Some (UInt32.to_int v)
   | Uint63 _ -> Some (UInt63.to_int v)
   | Uint64 _ -> Int64.unsigned_to_int v

--- a/lib/everparse.ml
+++ b/lib/everparse.ml
@@ -12,7 +12,7 @@ let rec is_bitfield : type a. a Types.typ -> bool = function
   | _ -> false
 
 let rec is_byte_field : type a. a Types.typ -> bool = function
-  | Types.Byte_array _ | Types.Byte_slice _ -> true
+  | Types.Byte_array _ | Types.Byte_slice _ | Types.Uint_var _ -> true
   | Types.Map { inner; _ } -> is_byte_field inner
   | _ -> false
 

--- a/lib/param.ml
+++ b/lib/param.ml
@@ -7,6 +7,7 @@ let rec to_int : type a. a Types.typ -> a -> int =
   match typ with
   | Uint8 -> v
   | Uint16 _ -> v
+  | Uint_var _ -> v
   | Uint32 _ -> UInt32.to_int v
   | Uint63 _ -> UInt63.to_int v
   | Uint64 _ -> Int64.unsigned_to_int v |> Option.value ~default:max_int
@@ -26,6 +27,7 @@ let rec of_int : type a. a Types.typ -> int -> a =
   match typ with
   | Uint8 -> v
   | Uint16 _ -> v
+  | Uint_var _ -> v
   | Uint32 _ -> UInt32.of_int v
   | Uint63 _ -> UInt63.of_int v
   | Uint64 _ -> Int64.of_int v
@@ -41,8 +43,8 @@ let rec of_int : type a. a Types.typ -> int -> a =
       invalid_arg "Param: unsupported parameter type"
 
 let rec is_int_representable : type a. a Types.typ -> bool = function
-  | Types.Uint8 | Types.Uint16 _ | Types.Uint32 _ | Types.Uint63 _
-  | Types.Uint64 _ | Types.Bits _ ->
+  | Types.Uint8 | Types.Uint16 _ | Types.Uint_var _ | Types.Uint32 _
+  | Types.Uint63 _ | Types.Uint64 _ | Types.Bits _ ->
       true
   | Types.Enum { base; _ } -> is_int_representable base
   | Types.Map { inner; _ } -> is_int_representable inner

--- a/lib/test/uint_var/dune
+++ b/lib/test/uint_var/dune
@@ -1,0 +1,3 @@
+(test
+ (name test)
+ (libraries wire alcotest))

--- a/lib/test/uint_var/test.ml
+++ b/lib/test/uint_var/test.ml
@@ -1,0 +1,1 @@
+let () = Alcotest.run "uint_var" [ Test_uint_var.suite ]

--- a/lib/test/uint_var/test_uint_var.ml
+++ b/lib/test/uint_var/test_uint_var.ml
@@ -1,0 +1,51 @@
+module Uint_var = Wire__Uint_var
+module Types = Wire__Types
+
+let roundtrip ~endian ~size value () =
+  let buf = Bytes.create size in
+  Uint_var.write endian buf 0 size value;
+  let got = Uint_var.read endian buf 0 size in
+  Alcotest.(check int) "roundtrip" value got
+
+let test_1_byte_be () = roundtrip ~endian:Big ~size:1 0xAB ()
+let test_1_byte_le () = roundtrip ~endian:Little ~size:1 0xAB ()
+let test_2_byte_be () = roundtrip ~endian:Big ~size:2 0x1234 ()
+let test_2_byte_le () = roundtrip ~endian:Little ~size:2 0x1234 ()
+let test_3_byte_be () = roundtrip ~endian:Big ~size:3 0x1A2B3C ()
+let test_3_byte_le () = roundtrip ~endian:Little ~size:3 0x1A2B3C ()
+let test_7_byte_be () = roundtrip ~endian:Big ~size:7 0x01_02_03_04_05_06_07 ()
+
+let test_7_byte_le () =
+  roundtrip ~endian:Little ~size:7 0x01_02_03_04_05_06_07 ()
+
+let test_byte_order () =
+  let buf = Bytes.create 3 in
+  Uint_var.write Big buf 0 3 0x1A2B3C;
+  Alcotest.(check int) "BE byte 0" 0x1A (Bytes.get_uint8 buf 0);
+  Alcotest.(check int) "BE byte 1" 0x2B (Bytes.get_uint8 buf 1);
+  Alcotest.(check int) "BE byte 2" 0x3C (Bytes.get_uint8 buf 2);
+  let buf = Bytes.create 3 in
+  Uint_var.write Little buf 0 3 0x1A2B3C;
+  Alcotest.(check int) "LE byte 0" 0x3C (Bytes.get_uint8 buf 0);
+  Alcotest.(check int) "LE byte 1" 0x2B (Bytes.get_uint8 buf 1);
+  Alcotest.(check int) "LE byte 2" 0x1A (Bytes.get_uint8 buf 2)
+
+let test_zero () =
+  let buf = Bytes.create 4 in
+  Uint_var.write Big buf 0 4 0;
+  Alcotest.(check int) "zero" 0 (Uint_var.read Big buf 0 4)
+
+let suite =
+  ( "uint_var",
+    [
+      Alcotest.test_case "1-byte BE" `Quick test_1_byte_be;
+      Alcotest.test_case "1-byte LE" `Quick test_1_byte_le;
+      Alcotest.test_case "2-byte BE" `Quick test_2_byte_be;
+      Alcotest.test_case "2-byte LE" `Quick test_2_byte_le;
+      Alcotest.test_case "3-byte BE" `Quick test_3_byte_be;
+      Alcotest.test_case "3-byte LE" `Quick test_3_byte_le;
+      Alcotest.test_case "7-byte BE" `Quick test_7_byte_be;
+      Alcotest.test_case "7-byte LE" `Quick test_7_byte_le;
+      Alcotest.test_case "byte order" `Quick test_byte_order;
+      Alcotest.test_case "zero" `Quick test_zero;
+    ] )

--- a/lib/test/uint_var/test_uint_var.mli
+++ b/lib/test/uint_var/test_uint_var.mli
@@ -1,0 +1,2 @@
+val suite : string * unit Alcotest.test_case list
+(** [suite] is the test suite for Uint_var. *)

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -70,6 +70,7 @@ and _ typ =
   | Uint32 : endian -> UInt32.t typ
   | Uint63 : endian -> UInt63.t typ
   | Uint64 : endian -> int64 typ (* boxed, for full 64-bit *)
+  | Uint_var : { size : int expr; endian : endian } -> int typ
   | Bits : {
       width : int;
       base : bitfield_base;
@@ -222,6 +223,13 @@ let uint63 = Uint63 Little
 let uint63be = Uint63 Big
 let uint64 = Uint64 Little
 let uint64be = Uint64 Big
+
+let uint ?(endian = Big) size =
+  (match size with
+  | Int n when n < 1 || n > 7 ->
+      Fmt.invalid_arg "uint: size must be 1–7, got %d" n
+  | _ -> ());
+  Uint_var { size; endian }
 
 (* Bitfield bases *)
 let bf_uint8 = BF_U8
@@ -400,7 +408,7 @@ let struct_project s ~name ~keep =
 type ocaml_kind = K_int | K_int64 | K_bool | K_string | K_unit
 
 let rec ocaml_kind_of : type a. a typ -> ocaml_kind = function
-  | Uint8 | Uint16 _ | Uint32 _ | Uint63 _ -> K_int
+  | Uint8 | Uint16 _ | Uint32 _ | Uint63 _ | Uint_var _ -> K_int
   | Uint64 _ -> K_int64
   | Bits _ -> K_int
   | Map { inner = Bits _; decode = _; encode = _ } ->
@@ -609,6 +617,8 @@ and pp_typ : type a. a typ Fmt.t =
   | Uint32 e -> Fmt.pf ppf "UINT32%a" pp_endian e
   | Uint63 e -> Fmt.pf ppf "UINT63%a" pp_endian e
   | Uint64 e -> Fmt.pf ppf "UINT64%a" pp_endian e
+  | Uint_var { size; endian } ->
+      Fmt.pf ppf "UINT%a(%a)" pp_endian endian pp_expr size
   | Bits { base; _ } -> pp_bitfield_base ppf base
   | Unit -> Fmt.string ppf "unit"
   | All_bytes -> Fmt.string ppf "all_bytes"
@@ -683,6 +693,7 @@ let rec field_suffix : type a.
   match typ with
   | Bits { width; base; _ } ->
       (Bitwidth width, fun ppf -> pp_bitfield_base ppf base)
+  | Uint_var { size; _ } -> (Byte_array size, fun ppf -> Fmt.string ppf "UINT8")
   | Byte_array { size } | Byte_slice { size } ->
       (Byte_array size, fun ppf -> Fmt.string ppf "UINT8")
   | Single_elem { size; elem; at_most } ->
@@ -849,6 +860,8 @@ let rec field_wire_size : type a. a typ -> int option = function
   | Uint16 _ -> Some 2
   | Uint32 _ -> Some 4
   | Uint64 _ -> Some 8
+  | Uint_var { size = Int n; _ } -> Some n
+  | Uint_var _ -> None
   | Bits { base; _ } -> (
       match base with
       | BF_U8 -> Some 1
@@ -874,10 +887,11 @@ let c_type_of : type a. a typ -> string = function
   | Uint16 _ | Bits { base = BF_U16 _; _ } -> "uint16_t"
   | Uint32 _ | Uint63 _ | Bits { base = BF_U32 _; _ } -> "uint32_t"
   | Uint64 _ -> "uint64_t"
+  | Uint_var _ -> "uint32_t"
   | _ -> "uint32_t"
 
 let ml_type_of : type a. a typ -> string = function
-  | Uint8 | Uint16 _ | Bits _ -> "int"
+  | Uint8 | Uint16 _ | Uint_var _ | Bits _ -> "int"
   | Uint32 _ | Uint63 _ -> "int"
   | Uint64 _ -> "int64"
   | _ -> "int"

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -100,6 +100,8 @@ and _ typ =
   | Uint32 : endian -> UInt32.t typ  (** 32-bit unsigned. *)
   | Uint63 : endian -> UInt63.t typ  (** 63-bit unsigned. *)
   | Uint64 : endian -> int64 typ  (** 64-bit unsigned. *)
+  | Uint_var : { size : int expr; endian : endian } -> int typ
+      (** Variable-width unsigned integer (1–7 bytes). *)
   | Bits : {
       width : int;
       base : bitfield_base;
@@ -349,6 +351,10 @@ val uint64 : int64 typ
 
 val uint64be : int64 typ
 (** 64-bit unsigned, big-endian. *)
+
+val uint : ?endian:endian -> int expr -> int typ
+(** [uint size] is an unsigned integer of [size] bytes (1–7). Default endian is
+    {!Big}. The size may be a dynamic expression for parameter-driven widths. *)
 
 val bf_uint8 : bitfield_base
 (** 8-bit bitfield base. *)

--- a/lib/uint_var.ml
+++ b/lib/uint_var.ml
@@ -1,0 +1,37 @@
+let read_be buf off size =
+  let v = ref 0 in
+  for i = 0 to size - 1 do
+    v := (!v lsl 8) lor Bytes.get_uint8 buf (off + i)
+  done;
+  !v
+
+let read_le buf off size =
+  let v = ref 0 in
+  for i = size - 1 downto 0 do
+    v := (!v lsl 8) lor Bytes.get_uint8 buf (off + i)
+  done;
+  !v
+
+let read endian buf off size =
+  match (endian : Types.endian) with
+  | Big -> read_be buf off size
+  | Little -> read_le buf off size
+
+let write_be buf off size v =
+  let v = ref v in
+  for i = size - 1 downto 0 do
+    Bytes.set_uint8 buf (off + i) (!v land 0xFF);
+    v := !v lsr 8
+  done
+
+let write_le buf off size v =
+  let v = ref v in
+  for i = 0 to size - 1 do
+    Bytes.set_uint8 buf (off + i) (!v land 0xFF);
+    v := !v lsr 8
+  done
+
+let write endian buf off size v =
+  match (endian : Types.endian) with
+  | Big -> write_be buf off size v
+  | Little -> write_le buf off size v

--- a/lib/uint_var.mli
+++ b/lib/uint_var.mli
@@ -1,0 +1,7 @@
+(** Variable-width unsigned integer read/write. *)
+
+val read : Types.endian -> bytes -> int -> int -> int
+(** [read endian buf off size] reads [size] bytes as an unsigned int. *)
+
+val write : Types.endian -> bytes -> int -> int -> int -> unit
+(** [write endian buf off size v] writes [v] as [size] bytes. *)

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -322,6 +322,17 @@ let parse_all_zeros dec =
   in
   check 0
 
+let parse_codec dec ~codec_decode ~codec_fixed_size ~codec_size_of =
+  let sz =
+    match codec_fixed_size with
+    | Some n -> n
+    | None ->
+        if available dec = 0 then refill dec;
+        codec_size_of dec.i dec.i_next
+  in
+  let buf = read_bytes dec sz in
+  codec_decode buf 0
+
 let rec parse_with : type a. decoder -> ctx -> a typ -> a * ctx =
  fun dec ctx typ ->
   match typ with
@@ -334,6 +345,10 @@ let rec parse_with : type a. decoder -> ctx -> a typ -> a * ctx =
   | Uint63 Big -> (parse_int dec 8 UInt63.be, ctx)
   | Uint64 Little -> (parse_int dec 8 Bytes.get_int64_le, ctx)
   | Uint64 Big -> (parse_int dec 8 Bytes.get_int64_be, ctx)
+  | Uint_var { size; endian } ->
+      let n = eval_expr ctx size in
+      let off = read_small dec n in
+      (Uint_var.read endian dec.i off n, ctx)
   | Bits { width; base; bit_order } -> (parse_bits dec base bit_order width, ctx)
   | Unit -> ((), ctx)
   | All_bytes -> (read_all dec, ctx)
@@ -393,17 +408,7 @@ let rec parse_with : type a. decoder -> ctx -> a typ -> a * ctx =
       | r -> (r, ctx')
       | exception Parse_error e -> raise (Parse_exn e))
   | Codec { codec_decode; codec_fixed_size; codec_size_of; _ } ->
-      (* Buffer enough bytes for the sub-codec, then decode from a flat buffer *)
-      let sz =
-        match codec_fixed_size with
-        | Some n -> n
-        | None ->
-            (* For variable-size: peek at available data to determine size *)
-            if available dec = 0 then refill dec;
-            codec_size_of dec.i dec.i_next
-      in
-      let buf = read_bytes dec sz in
-      let v = codec_decode buf 0 in
+      let v = parse_codec dec ~codec_decode ~codec_fixed_size ~codec_size_of in
       (v, ctx)
   | Optional { present; inner } ->
       if Eval.expr ctx present then
@@ -517,6 +522,10 @@ let rec parse_direct : type a. a typ -> bytes -> int -> int -> a =
   | Uint64 Big ->
       check_eof len (off + 8);
       Bytes.get_int64_be buf off
+  | Uint_var { size = Int n; endian } ->
+      check_eof len (off + n);
+      Uint_var.read endian buf off n
+  | Uint_var _ -> failwith "parse_direct: Uint_var with dynamic size"
   | Bits { width; base; bit_order } ->
       check_eof len (off + Bitfield.byte_size base);
       let total = Bitfield.total_bits base in
@@ -690,6 +699,12 @@ let rec encode_with_ctx : type a. ctx -> a typ -> a -> encoder -> ctx =
   | Uint64 Big ->
       write_int64_be enc v;
       ctx
+  | Uint_var { size; endian } ->
+      let n = eval_expr ctx size in
+      ensure enc n;
+      Uint_var.write endian enc.o enc.o_next n v;
+      enc.o_next <- enc.o_next + n;
+      ctx
   | Bits { width; base; bit_order } ->
       let mask = (1 lsl width) - 1 in
       let total = Bitfield.total_bits base in
@@ -800,6 +815,10 @@ let rec encode_direct : type a. a typ -> bytes -> int -> a -> int =
   | Uint64 Big ->
       Bytes.set_int64_be buf off v;
       off + 8
+  | Uint_var { size = Int n; endian } ->
+      Uint_var.write endian buf off n v;
+      off + n
+  | Uint_var _ -> failwith "encode_direct: Uint_var with dynamic size"
   | Bits { width; base; bit_order } -> (
       let mask = (1 lsl width) - 1 in
       let total = Bitfield.total_bits base in

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -76,6 +76,10 @@ type bit_order = Types.bit_order =
           necessary so that every pairing emits a valid 3D schema with identical
           byte layout. *)
 
+type endian = Types.endian =
+  | Little
+  | Big  (** Byte order for multi-byte integers. *)
+
 type 'a typ
 
 type param
@@ -379,6 +383,11 @@ val uint64 : int64 typ
 val uint64be : int64 typ
 (** [uint64be] is an unsigned 64-bit big-endian integer represented as [int64].
 *)
+
+val uint : ?endian:endian -> int expr -> int typ
+(** [uint size] is an unsigned integer of [size] bytes (1–7) with the given byte
+    order (default {!Big}). The size may be a dynamic expression for
+    parameter-driven widths. *)
 
 val bits : ?bit_order:bit_order -> width:int -> bitfield -> int typ
 (** [bits ~width base] declares a bitfield of [width] bits inside [base].

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -3219,6 +3219,80 @@ let test_multi_var_fixed_after () =
   Alcotest.(check string) "tx" "\xBB\xCC" tx;
   Alcotest.(check int) "trail" 0xBEEF trail
 
+(* ── uint: variable-width unsigned integer ── *)
+
+type uint_rec = { tag : int; value : int }
+
+let test_uint_3byte_be () =
+  let codec =
+    let open Codec in
+    v "U3BE"
+      (fun tag value -> { tag; value })
+      [
+        (Field.v "Tag" uint8 $ fun r -> r.tag);
+        (Field.v "Value" (uint (Wire.int 3)) $ fun r -> r.value);
+      ]
+  in
+  let original = { tag = 0x42; value = 0x1A2B3C } in
+  let buf = Bytes.create 4 in
+  Codec.encode codec original buf 0;
+  Alcotest.(check int) "tag byte" 0x42 (Bytes.get_uint8 buf 0);
+  Alcotest.(check int) "be byte 0" 0x1A (Bytes.get_uint8 buf 1);
+  Alcotest.(check int) "be byte 1" 0x2B (Bytes.get_uint8 buf 2);
+  Alcotest.(check int) "be byte 2" 0x3C (Bytes.get_uint8 buf 3);
+  let decoded = decode_ok (Codec.decode codec buf 0) in
+  Alcotest.(check int) "tag" original.tag decoded.tag;
+  Alcotest.(check int) "value" original.value decoded.value
+
+let test_uint_1byte () =
+  let codec =
+    let open Codec in
+    v "U1" (fun v -> v) [ (Field.v "V" (uint (Wire.int 1)) $ fun v -> v) ]
+  in
+  let buf = Bytes.create 1 in
+  Codec.encode codec 0xAB buf 0;
+  Alcotest.(check int) "byte" 0xAB (Bytes.get_uint8 buf 0);
+  let decoded = decode_ok (Codec.decode codec buf 0) in
+  Alcotest.(check int) "roundtrip" 0xAB decoded
+
+let test_uint_5byte_le () =
+  let codec =
+    let open Codec in
+    v "U5LE"
+      (fun v -> v)
+      [ (Field.v "V" (uint ~endian:Wire.Little (Wire.int 5)) $ fun v -> v) ]
+  in
+  let value = 0x01_02_03_04_05 in
+  let buf = Bytes.create 5 in
+  Codec.encode codec value buf 0;
+  Alcotest.(check int) "le byte 0" 0x05 (Bytes.get_uint8 buf 0);
+  Alcotest.(check int) "le byte 1" 0x04 (Bytes.get_uint8 buf 1);
+  Alcotest.(check int) "le byte 2" 0x03 (Bytes.get_uint8 buf 2);
+  Alcotest.(check int) "le byte 3" 0x02 (Bytes.get_uint8 buf 3);
+  Alcotest.(check int) "le byte 4" 0x01 (Bytes.get_uint8 buf 4);
+  let decoded = decode_ok (Codec.decode codec buf 0) in
+  Alcotest.(check int) "roundtrip" value decoded
+
+let test_uint_dynamic () =
+  let f_n = Field.v "N" uint8 in
+  let codec =
+    let open Codec in
+    v "UDyn"
+      (fun n value -> (n, value))
+      [
+        (f_n $ fun (n, _) -> n);
+        (Field.v "Value" (uint (Field.ref f_n)) $ fun (_, v) -> v);
+      ]
+  in
+  (* n=2 -> 2-byte BE uint = 0x1234, layout: [02] [12 34] *)
+  let buf = Bytes.create 3 in
+  Bytes.set_uint8 buf 0 2;
+  Bytes.set_uint8 buf 1 0x12;
+  Bytes.set_uint8 buf 2 0x34;
+  let n, value = decode_ok (Codec.decode codec buf 0) in
+  Alcotest.(check int) "n" 2 n;
+  Alcotest.(check int) "value" 0x1234 value
+
 (* ── Adversarial bit-order tests ──
 
    These pin the default [bit_order = Msb_first] against real protocol
@@ -3614,4 +3688,9 @@ let suite =
       Alcotest.test_case "multi-var: get" `Quick test_multi_var_get;
       Alcotest.test_case "multi-var: fixed after" `Quick
         test_multi_var_fixed_after;
+      (* uint: variable-width unsigned integer *)
+      Alcotest.test_case "uint: 3-byte BE roundtrip" `Quick test_uint_3byte_be;
+      Alcotest.test_case "uint: 1-byte like uint8" `Quick test_uint_1byte;
+      Alcotest.test_case "uint: 5-byte LE roundtrip" `Quick test_uint_5byte_le;
+      Alcotest.test_case "uint: dynamic size" `Quick test_uint_dynamic;
     ] )


### PR DESCRIPTION
Adds a variable-width unsigned integer type to the Wire DSL. The new uint constructor takes a size expression (literal or dynamic) and an endianness, returning int typ. Handles 1-7 byte widths in both big-endian and little-endian byte order.