### PR TITLE
feat: support variable-size schemas in EverParse projection

### DIFF
--- a/lib/3d/wire_3d.ml
+++ b/lib/3d/wire_3d.ml
@@ -70,29 +70,28 @@ let run_everparse ?(quiet = true) ~outdir schemas =
     schemas;
   copy_everparse_endianness ~outdir
 
-let emit_schema_test ppf s =
+let emit_schema_test ppf s wire_size =
   let pr fmt = Fmt.pf ppf fmt in
   let ep = everparse_name s.name in
   let lower = String.lowercase_ascii s.name in
-  pr "\n  /* %s (%d bytes) */\n" s.name s.wire_size;
+  pr "\n  /* %s (%d bytes) */\n" s.name wire_size;
   pr "  {\n";
   pr "    int pass = 0, fail = 0;\n";
-  pr "    uint8_t buf[%d];\n" s.wire_size;
+  pr "    uint8_t buf[%d];\n" wire_size;
   pr "    uint64_t r;\n\n";
-  pr "    memset(buf, 0, %d);\n" s.wire_size;
+  pr "    memset(buf, 0, %d);\n" wire_size;
   pr "    r = %sValidate%s(NULL, counting_error_handler, buf, %d, 0);\n" ep ep
-    s.wire_size;
+    wire_size;
   pr "    CHECK(\"zero buffer validates\", EverParseIsSuccess(r));\n";
-  pr "    CHECK(\"position advanced to %d\", r == %d);\n" s.wire_size
-    s.wire_size;
+  pr "    CHECK(\"position advanced to %d\", r == %d);\n" wire_size wire_size;
   pr "\n";
   pr "    r = %sValidate%s(NULL, counting_error_handler, buf, %d, 0);\n" ep ep
-    (s.wire_size * 2);
+    (wire_size * 2);
   pr "    CHECK(\"larger buffer validates\", EverParseIsSuccess(r));\n";
-  pr "    CHECK(\"position is %d not %d\", r == %d);\n" s.wire_size
-    (s.wire_size * 2) s.wire_size;
+  pr "    CHECK(\"position is %d not %d\", r == %d);\n" wire_size
+    (wire_size * 2) wire_size;
   pr "\n";
-  pr "    for (uint64_t len = 0; len < %d; len++) {\n" s.wire_size;
+  pr "    for (uint64_t len = 0; len < %d; len++) {\n" wire_size;
   pr "      error_count = 0;\n";
   pr "      r = %sValidate%s(NULL, counting_error_handler, buf, len, 0);\n" ep
     ep;
@@ -104,12 +103,12 @@ let emit_schema_test ppf s =
   pr "\n";
   pr "    srand(42);\n";
   pr "    for (int i = 0; i < 1000; i++) {\n";
-  pr "      for (int j = 0; j < %d; j++)\n" s.wire_size;
+  pr "      for (int j = 0; j < %d; j++)\n" wire_size;
   pr "        buf[j] = (uint8_t)(rand() & 0xff);\n";
   pr "      r = %sValidate%s(NULL, counting_error_handler, buf, %d, 0);\n" ep ep
-    s.wire_size;
+    wire_size;
   pr "      CHECK(\"random buffer validates\", EverParseIsSuccess(r));\n";
-  pr "      CHECK(\"random position correct\", r == %d);\n" s.wire_size;
+  pr "      CHECK(\"random position correct\", r == %d);\n" wire_size;
   pr "    }\n";
   pr "\n";
   pr "    printf(\"%s: %%d passed, %%d failed\\n\", pass, fail);\n" lower;
@@ -125,7 +124,12 @@ let generate_test ~outdir schemas =
   pr "#include <stdint.h>\n";
   pr "#include <string.h>\n";
   pr "#include \"EverParse.h\"\n";
-  List.iter (fun s -> pr "#include \"%s.h\"\n" s.name) schemas;
+  let fixed_schemas =
+    List.filter_map
+      (fun s -> Option.map (fun ws -> (s, ws)) s.wire_size)
+      schemas
+  in
+  List.iter (fun (s, _) -> pr "#include \"%s.h\"\n" s.name) fixed_schemas;
   pr "\nstatic int error_count;\n\n";
   pr "static void counting_error_handler(\n";
   pr "  EVERPARSE_STRING t, EVERPARSE_STRING f, EVERPARSE_STRING r,\n";
@@ -139,7 +143,7 @@ let generate_test ~outdir schemas =
   pr "} while(0)\n\n";
   pr "int main(void) {\n";
   pr "  int failures = 0;\n";
-  List.iter (emit_schema_test ppf) schemas;
+  List.iter (fun (s, ws) -> emit_schema_test ppf s ws) fixed_schemas;
   pr "\n  if (failures == 0)\n";
   pr "    printf(\"All tests passed.\\n\");\n";
   pr "  else\n";

--- a/lib/diff-gen/wire_diff_gen.ml
+++ b/lib/diff-gen/wire_diff_gen.ml
@@ -6,7 +6,7 @@
 type schema = Wire.Everparse.t = {
   name : string;
   module_ : Wire.Everparse.Raw.module_;
-  wire_size : int;
+  wire_size : int option;
 }
 
 let schema ~name ~struct_ ~module_ =
@@ -86,8 +86,9 @@ let generate_test_runner ~outdir ?(num_values = 1000) schemas =
   List.iter
     (fun s ->
       let lower = String.lowercase_ascii s.name in
+      let ws = Option.get s.wire_size in
       pr "  { name = %S; wire_size = %d; c_check = Stubs.%s_check };\n" s.name
-        s.wire_size lower)
+        ws lower)
     schemas;
   pr "]\n\n";
   pr "let () =\n";

--- a/lib/everparse.ml
+++ b/lib/everparse.ml
@@ -1,8 +1,11 @@
 (** 3D code generation from Wire codecs. *)
 
-type t = { name : string; module_ : Types.module_; wire_size : int }
+type t = { name : string; module_ : Types.module_; wire_size : int option }
 
-let pp ppf t = Fmt.pf ppf "%s(%d)" t.name t.wire_size
+let pp ppf t =
+  match t.wire_size with
+  | Some n -> Fmt.pf ppf "%s(%d)" t.name n
+  | None -> Fmt.pf ppf "%s(var)" t.name
 
 let rec is_bitfield : type a. a Types.typ -> bool = function
   | Types.Bits _ -> true
@@ -243,9 +246,6 @@ let schema_of_struct (s : Types.struct_) : t =
         | Some a, Some b -> Some (a + b)
         | _ -> None)
       (Some 0) s.fields
-    |> function
-    | Some n -> n
-    | None -> Fmt.failwith "schema %s has variable-length fields" name
   in
   let decls = with_output s in
   let m = Types.module_ decls in
@@ -336,5 +336,6 @@ module Raw = struct
         | _ -> None)
       (Some 0) s.fields
 
-  let of_module ~name ~module_ ~wire_size = { name; module_; wire_size }
+  let of_module ~name ~module_ ~wire_size =
+    { name; module_; wire_size = Some wire_size }
 end

--- a/lib/everparse.mli
+++ b/lib/everparse.mli
@@ -3,8 +3,9 @@
     The main path is {!struct_of_codec}, {!schema}, and {!write_3d}. For unusual
     3D constructs that have no codec equivalent yet, use {!Raw}. *)
 
-type t = { name : string; module_ : Types.module_; wire_size : int }
-(** A named 3D schema with its module and wire size. *)
+type t = { name : string; module_ : Types.module_; wire_size : int option }
+(** A named 3D schema with its module and wire size ([None] for variable-size
+    schemas). *)
 
 val pp : Format.formatter -> t -> unit
 

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -757,8 +757,9 @@ module Everparse : sig
   type module_
   (** A 3D module. *)
 
-  type t = { name : string; module_ : module_; wire_size : int }
-  (** A named 3D schema with its module and wire size. *)
+  type t = { name : string; module_ : module_; wire_size : int option }
+  (** A named 3D schema with its module and wire size ([None] for variable-size
+      schemas). *)
 
   val struct_of_codec : 'r Codec.t -> struct_
   (** Projects a record codec to a 3D struct. *)

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -413,6 +413,47 @@ let test_3d_bitorder_native_noreorder () =
   Alcotest.(check bool) "x before y (no reorder)" true (ix < iy);
   Alcotest.(check bool) "no padding" false (contains ~sub:"_anon_" s)
 
+(* ── Variable-size schema projection ── *)
+
+type dep_frame = { frame_length : int; data : string }
+
+let f_frame_length = Field.v "FrameLength" uint16be
+let header_size = 2
+
+let dep_frame_codec =
+  Codec.v "DepFrame"
+    (fun frame_length data -> { frame_length; data })
+    Codec.
+      [
+        (f_frame_length $ fun r -> r.frame_length);
+        ( Field.v "Data"
+            (byte_array ~size:Expr.(Field.ref f_frame_length - int header_size))
+        $ fun r -> r.data );
+      ]
+
+let test_3d_dep_size_schema () =
+  let schema = Everparse.schema dep_frame_codec in
+  Alcotest.(check bool) "variable wire_size" true (schema.wire_size = None);
+  let s = Wire.Everparse.Raw.to_3d schema.module_ in
+  Alcotest.(check bool)
+    "contains FrameLength" true
+    (contains ~sub:"FrameLength" s);
+  Alcotest.(check bool) "contains Data" true (contains ~sub:"Data" s);
+  Alcotest.(check bool)
+    "contains byte-size expr" true
+    (contains ~sub:":byte-size (FrameLength - 2)" s)
+
+let test_3d_dep_size_roundtrip () =
+  let original = { frame_length = 7; data = "HELLO" } in
+  let buf = Bytes.create 7 in
+  Codec.encode dep_frame_codec original buf 0;
+  let decoded = Codec.decode dep_frame_codec buf 0 in
+  match decoded with
+  | Ok v ->
+      Alcotest.(check int) "frame_length" 7 v.frame_length;
+      Alcotest.(check string) "data" "HELLO" v.data
+  | Error e -> Alcotest.failf "%a" pp_parse_error e
+
 let suite =
   ( "everparse",
     [
@@ -436,4 +477,7 @@ let suite =
         test_3d_bitorder_native_noreorder;
       Alcotest.test_case "3d: bit_order constraint collapse" `Quick
         test_3d_bitorder_constraint_collapse;
+      Alcotest.test_case "3d: dep-size schema" `Quick test_3d_dep_size_schema;
+      Alcotest.test_case "3d: dep-size roundtrip" `Quick
+        test_3d_dep_size_roundtrip;
     ] )


### PR DESCRIPTION
Everparse.t.wire_size is now int option instead of int, so schemas with dependent-length fields (e.g. byte_array ~size:(Field.ref f - int n)) can be projected to 3D. The [:byte-size expr] rendering already worked; only schema_of_struct was rejecting variable-size structs.