### PR TITLE
feat: collect params from field type expressions in 3D projection

### DIFF
--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -753,9 +753,48 @@ let iter_param_refs_action f = function
   | Types.On_success stmts | Types.On_act stmts ->
       List.iter (iter_param_refs_stmt f) stmts
 
+let rec iter_param_refs_typ : type a. (Param.packed -> unit) -> a typ -> unit =
+ fun f typ ->
+  match typ with
+  | Byte_array { size } | Byte_slice { size } -> iter_param_refs f size
+  | Uint_var { size; _ } -> iter_param_refs f size
+  | Single_elem { size; elem; _ } ->
+      iter_param_refs f size;
+      iter_param_refs_typ f elem
+  | Array { len; elem; _ } ->
+      iter_param_refs f len;
+      iter_param_refs_typ f elem
+  | Repeat { size; elem; _ } ->
+      iter_param_refs f size;
+      iter_param_refs_typ f elem
+  | Where { cond; inner } ->
+      iter_param_refs f cond;
+      iter_param_refs_typ f inner
+  | Optional { present; inner } ->
+      iter_param_refs f present;
+      iter_param_refs_typ f inner
+  | Optional_or { present; inner; _ } ->
+      iter_param_refs f present;
+      iter_param_refs_typ f inner
+  | Apply { typ; args } ->
+      iter_param_refs_typ f typ;
+      List.iter (fun (Types.Pack_expr e) -> iter_param_refs f e) args
+  | Map { inner; _ } -> iter_param_refs_typ f inner
+  | Enum { base; _ } -> iter_param_refs_typ f base
+  | Casetype { tag; cases; _ } ->
+      iter_param_refs_typ f tag;
+      List.iter
+        (fun (Types.Case_branch { cb_inner; _ }) ->
+          iter_param_refs_typ f cb_inner)
+        cases
+  | Uint8 | Uint16 _ | Uint32 _ | Uint63 _ | Uint64 _ | Bits _ | Unit
+  | All_bytes | All_zeros | Struct _ | Type_ref _ | Qualified_ref _ | Codec _ ->
+      ()
+
 let iter_param_refs_fields f fields where =
   List.iter
     (fun (Types.Field fld) ->
+      iter_param_refs_typ f fld.field_typ;
       Option.iter (iter_param_refs f) fld.constraint_;
       Option.iter (iter_param_refs_action f) fld.action)
     fields;

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -454,6 +454,29 @@ let test_3d_dep_size_roundtrip () =
       Alcotest.(check string) "data" "HELLO" v.data
   | Error e -> Alcotest.failf "%a" pp_parse_error e
 
+type param_frame = { pf_data : string }
+
+let p_len = Param.input "len" uint16be
+
+let param_frame_codec =
+  Codec.v "ParamFrame"
+    (fun data -> { pf_data = data })
+    Codec.
+      [
+        ( Field.v "Data" (byte_array ~size:(Param.expr p_len)) $ fun r ->
+          r.pf_data );
+      ]
+
+let test_3d_param_in_size () =
+  (* A byte_array whose size is driven by a formal parameter must thread
+     the parameter into the 3D typedef signature. *)
+  let schema = Everparse.schema param_frame_codec in
+  let s = Wire.Everparse.Raw.to_3d schema.module_ in
+  Alcotest.(check bool)
+    "typedef carries len param" true
+    (contains ~sub:"UINT16BE len" s);
+  Alcotest.(check bool) "size uses len" true (contains ~sub:":byte-size len" s)
+
 let suite =
   ( "everparse",
     [
@@ -480,4 +503,5 @@ let suite =
       Alcotest.test_case "3d: dep-size schema" `Quick test_3d_dep_size_schema;
       Alcotest.test_case "3d: dep-size roundtrip" `Quick
         test_3d_dep_size_roundtrip;
+      Alcotest.test_case "3d: param in size" `Quick test_3d_param_in_size;
     ] )


### PR DESCRIPTION
iter_param_refs_typ now visits embedded expressions inside field types (byte_array size, optional present, etc.) so that params used only in those positions are threaded into the 3D typedef signature.