### PR TITLE
feat: validate all example schemas with 3d.exe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,7 @@
 ```
 make build              # dune build
 make test               # dune runtest
+make 3d                 # validate all schemas with 3d.exe (needs 3d.exe)
 make bench              # EverParse C vs OCaml (needs 3d.exe)
 make bench-routing      # APID demux throughput
 make bench-gateway      # TM frame reassembly

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test bench bench-demo bench-routing bench-gateway bench-clcw \
+.PHONY: build test 3d bench bench-demo bench-routing bench-gateway bench-clcw \
        prof memtrace memtrace-demo memtrace-routing memtrace-gateway memtrace-clcw clean
 
 build:
@@ -6,6 +6,9 @@ build:
 
 test:
 	dune runtest
+
+3d:
+	dune exec examples/validate_3d.exe
 
 bench: bench-demo bench-routing bench-gateway bench-clcw
 

--- a/examples/demo/demo.ml
+++ b/examples/demo/demo.ml
@@ -572,6 +572,17 @@ let param_demo_struct =
       field "Data" (byte_array ~size:(field_ref f_pd_length));
     ]
 
+(* ── 19b. Parameterized byte_array: payload sized by input parameter ── *)
+
+let param_payload_struct =
+  let p_size = Wire.Param.input "payload_size" uint8 in
+  param_struct "ParamPayload"
+    [ param "payload_size" uint8 ]
+    [
+      field "Tag" uint8;
+      field "Data" (byte_array ~size:(Wire.Param.expr p_size));
+    ]
+
 (* ── 20. Casetype: tagged union (different wire layout per tag) ──
    Unlike enum (same wire size, different named values), casetype selects
    a different struct/type based on a discriminant field. *)

--- a/examples/demo/demo.mli
+++ b/examples/demo/demo.mli
@@ -356,6 +356,9 @@ val action_full_struct : Wire.Everparse.Raw.struct_
 val param_demo_struct : Wire.Everparse.Raw.struct_
 (** Parameterised struct demo. *)
 
+val param_payload_struct : Wire.Everparse.Raw.struct_
+(** Parameterised byte_array demo: payload sized by input parameter. *)
+
 val casetype_module : Wire.Everparse.Raw.module_
 (** Casetype module demo. *)
 

--- a/examples/dune
+++ b/examples/dune
@@ -3,6 +3,11 @@
  (modules gen_3d)
  (libraries wire demo space net))
 
+(executable
+ (name validate_3d)
+ (modules validate_3d)
+ (libraries wire wire.3d demo space net))
+
 (rule
  (targets
   Minimal.3d

--- a/examples/gen_3d.ml
+++ b/examples/gen_3d.ml
@@ -31,9 +31,12 @@ let () =
       Demo.action_struct;
       Demo.action_full_struct;
       Demo.param_demo_struct;
+      Demo.param_payload_struct;
       Space.clcw_struct;
       Space.packet_struct;
+      Wire.Everparse.struct_of_codec Space.full_packet_codec;
       Space.tm_frame_struct;
+      Wire.Everparse.struct_of_codec Space.tm_with_ocf_codec;
       Wire.Everparse.struct_of_codec Space.inner_cmd_codec;
       Wire.Everparse.struct_of_codec Space.outer_hdr_codec;
       Net.ethernet_struct;

--- a/examples/space/space.ml
+++ b/examples/space/space.ml
@@ -72,6 +72,47 @@ let packet_data n =
       Bytes.set_uint16_be b 4 (i mod 256);
       b)
 
+(* -- 1b. Proximity-1-style frame: header + dependent-size payload --
+   The FrameLength field gives the total frame size in bytes; the data
+   payload occupies FrameLength - header_size bytes. This exercises
+   byte_array ~size:(Field.ref f - int n) with arithmetic. *)
+
+type full_packet = {
+  fp_version : int;
+  fp_type : int;
+  fp_apid : int;
+  fp_frame_len : int;
+  fp_data : string;
+}
+
+let fp_header_size = 6
+let f_fp_frame_len = Field.v "FrameLength" uint16be
+
+let full_packet_codec =
+  Codec.v "FullPacket"
+    (fun version type_ apid frame_len data ->
+      {
+        fp_version = version;
+        fp_type = type_;
+        fp_apid = apid;
+        fp_frame_len = frame_len;
+        fp_data = data;
+      })
+    Codec.
+      [
+        (Field.v "Version" (bits ~width:3 U16be) $ fun p -> p.fp_version);
+        (Field.v "Type" (bits ~width:1 U16be) $ fun p -> p.fp_type);
+        (Field.v "APID" (bits ~width:12 U16be) $ fun p -> p.fp_apid);
+        ( Field.v "FrameLength"
+            ~constraint_:Expr.(Field.ref f_fp_frame_len >= int fp_header_size)
+            uint16be
+        $ fun p -> p.fp_frame_len );
+        ( Field.v "Data"
+            (byte_array
+               ~size:Expr.(Field.ref f_fp_frame_len - int fp_header_size))
+        $ fun p -> p.fp_data );
+      ]
+
 (* -- 2. CLCW: 4 bytes of bitfields -- *)
 
 type clcw = {
@@ -256,6 +297,50 @@ let tm_frame_data n =
       Bytes.set_uint16_be b 2 (((i mod 256) lsl 8) lor (i * 7 mod 256));
       Bytes.set_uint16_be b 4 ((1 lsl 14) lor (3 lsl 11) lor (i mod 2048));
       b)
+
+(* -- 3b. TM Frame with optional OCF --
+   CCSDS: the 4-byte Operational Control Field is present when OCFFlag == 1.
+   This exercises optional (Field.ref f <> int 0) typ. *)
+
+type tm_with_ocf = {
+  tmo_version : int;
+  tmo_scid : int;
+  tmo_vcid : int;
+  tmo_ocf_flag : bool;
+  tmo_mc_count : int;
+  tmo_vc_count : int;
+  tmo_first_hdr : int;
+  tmo_ocf : int option;
+}
+
+let f_tmo_ocf_flag = Field.v "OCFFlag" (bit (bits ~width:1 U16be))
+
+let tm_with_ocf_codec =
+  Codec.v "TMWithOCF"
+    (fun version scid vcid ocf_flag mc vc hdr ocf ->
+      {
+        tmo_version = version;
+        tmo_scid = scid;
+        tmo_vcid = vcid;
+        tmo_ocf_flag = ocf_flag;
+        tmo_mc_count = mc;
+        tmo_vc_count = vc;
+        tmo_first_hdr = hdr;
+        tmo_ocf = ocf;
+      })
+    Codec.
+      [
+        (Field.v "Version" (bits ~width:2 U16be) $ fun f -> f.tmo_version);
+        (Field.v "SCID" (bits ~width:10 U16be) $ fun f -> f.tmo_scid);
+        (Field.v "VCID" (bits ~width:3 U16be) $ fun f -> f.tmo_vcid);
+        (f_tmo_ocf_flag $ fun f -> f.tmo_ocf_flag);
+        (Field.v "MCCount" (bits ~width:8 U16be) $ fun f -> f.tmo_mc_count);
+        (Field.v "VCCount" (bits ~width:8 U16be) $ fun f -> f.tmo_vc_count);
+        (Field.v "FirstHdrPtr" (bits ~width:11 U16be) $ fun f -> f.tmo_first_hdr);
+        ( Field.v "OCF"
+            (optional Expr.(Field.ref f_tmo_ocf_flag <> int 0) uint32be)
+        $ fun f -> f.tmo_ocf );
+      ]
 
 (* -- 4. Nested protocol -- *)
 

--- a/examples/space/space.mli
+++ b/examples/space/space.mli
@@ -80,6 +80,15 @@ val bf_sp_data_len : (int, packet) Wire.Codec.field
 val packet_data : int -> bytes array
 (** [packet_data n] generates [n] synthetic Space Packet byte buffers. *)
 
+(** {2 FullPacket} *)
+
+type full_packet
+
+val full_packet_codec : full_packet Wire.Codec.t
+(** Full Space Packet: 6-byte header + variable-size data payload. Exercises
+    [byte_array ~size:Expr.(Field.ref f + int 1)] — CCSDS defines DataLength as
+    num_octets_in_data_field minus 1. *)
+
 (** {2 TMFrame} *)
 
 type tm_frame
@@ -110,6 +119,15 @@ val bf_tf_first_hdr : (int, tm_frame) Wire.Codec.field
 
 val tm_frame_data : int -> bytes array
 (** [tm_frame_data n] generates [n] synthetic TM Frame byte buffers. *)
+
+(** {2 TMWithOCF} *)
+
+type tm_with_ocf
+
+val tm_with_ocf_codec : tm_with_ocf Wire.Codec.t
+(** TM Frame header with optional 4-byte Operational Control Field. Exercises
+    [optional Expr.(Field.ref f <> int 0) uint32be] — CCSDS defines the OCF as
+    present when OCFFlag == 1. *)
 
 (** {2 Nested protocol} *)
 

--- a/examples/validate_3d.ml
+++ b/examples/validate_3d.ml
@@ -1,0 +1,68 @@
+(** Validate all example schemas through the EverParse 3d.exe pipeline.
+
+    For each codec, this generates the full output-types schema (with WireSet
+    callbacks), writes the .3d file, and runs 3d.exe to verify it produces valid
+    C. Exits with code 1 if 3d.exe rejects any schema. *)
+
+let schemas =
+  let s = Wire.Everparse.schema in
+  [
+    s Demo.minimal_codec;
+    s Demo.all_ints_codec;
+    s Demo.bf8_codec;
+    s Demo.bf16_codec;
+    s Demo.bf32_codec;
+    s Demo.bool_fields_codec;
+    s Demo.large_mixed_codec;
+    s Demo.mapped_codec;
+    s Demo.cases_demo_codec;
+    s Demo.enum_demo_codec;
+    s Demo.constrained_codec;
+    s Space.clcw_codec;
+    s Space.packet_codec;
+    s Space.full_packet_codec;
+    s Space.tm_frame_codec;
+    s Space.tm_with_ocf_codec;
+    s Space.inner_cmd_codec;
+    s Space.outer_hdr_codec;
+    s Net.ethernet_codec;
+    s Net.ipv4_codec;
+    s Net.tcp_codec;
+    s Net.udp_codec;
+  ]
+
+let validate_one ~tmpdir s =
+  let name = s.Wire.Everparse.name in
+  Wire_3d.generate_3d ~outdir:tmpdir [ s ];
+  try
+    Wire_3d.run_everparse ~quiet:true ~outdir:tmpdir [ s ];
+    Fmt.pr "  OK  %s\n%!" name;
+    true
+  with Failure msg ->
+    let path = Filename.concat tmpdir (name ^ ".3d") in
+    let content =
+      try In_channel.with_open_text path In_channel.input_all
+      with Sys_error _ -> "(could not read .3d file)"
+    in
+    Fmt.epr "  FAIL %s: %s\n%s\n%!" name msg content;
+    false
+
+let () =
+  if not (Wire_3d.has_3d_exe ()) then (
+    Fmt.pr "3d.exe not found, skipping validation\n";
+    exit 0);
+  let tmpdir = Filename.temp_dir "wire_validate_3d" "" in
+  Fmt.pr "Validating %d schemas with 3d.exe\n%!" (List.length schemas);
+  let passed =
+    List.fold_left
+      (fun n s -> if validate_one ~tmpdir s then n + 1 else n)
+      0 schemas
+  in
+  let total = List.length schemas in
+  Fmt.pr "%d/%d schemas accepted by 3d.exe\n" passed total;
+  Array.iter
+    (fun f ->
+      try Sys.remove (Filename.concat tmpdir f) with Sys_error _ -> ())
+    (Sys.readdir tmpdir);
+  (try Unix.rmdir tmpdir with Unix.Unix_error _ -> ());
+  if passed < total then exit 1

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -375,6 +375,10 @@ let rec compile_int_arr (cc : compile_ctx) (e : int expr) : int array -> int =
       | `U16 -> fun a -> fe a land 0xFFFF
       | `U32 -> fun a -> fe a land 0xFFFF_FFFF
       | `U64 -> fun a -> fe a)
+  | If_then_else (c, t, e) ->
+      let fc = compile_bool_arr cc c in
+      let ft = compile_int_arr cc t and fe = compile_int_arr cc e in
+      fun a -> if fc a then ft a else fe a
 
 (* Try to compile an expression of unknown type as int.
    Returns None if the expression is not an int expr. *)
@@ -733,6 +737,10 @@ let rec iter_param_refs : type a. (Param.packed -> unit) -> a expr -> unit =
   | Not a -> iter_param_refs f a
   | Lnot a -> iter_param_refs f a
   | Cast (_, a) -> iter_param_refs f a
+  | If_then_else (c, t, e) ->
+      iter_param_refs f c;
+      iter_param_refs f t;
+      iter_param_refs f e
   | Int _ | Int64 _ | Bool _ | Ref _ | Sizeof _ | Sizeof_this | Field_pos -> ()
 
 let rec iter_param_refs_stmt f = function

--- a/lib/eval.ml
+++ b/lib/eval.ml
@@ -74,6 +74,7 @@ let rec expr : type a. ctx -> a expr -> a =
       | `U16 -> v land 0xFFFF
       | `U32 -> v land 0xFFFF_FFFF
       | `U64 -> v)
+  | If_then_else (c, t, e) -> if expr ctx c then expr ctx t else expr ctx e
 
 type action_outcome = Continue of ctx | Return of bool * ctx | Abort
 

--- a/lib/everparse.ml
+++ b/lib/everparse.ml
@@ -16,6 +16,10 @@ let rec is_bitfield : type a. a Types.typ -> bool = function
 
 let rec is_byte_field : type a. a Types.typ -> bool = function
   | Types.Byte_array _ | Types.Byte_slice _ | Types.Uint_var _ -> true
+  | Types.Optional { present = Types.Bool _; _ } -> false
+  | Types.Optional _ -> true
+  | Types.Optional_or { present = Types.Bool _; _ } -> false
+  | Types.Optional_or _ -> true
   | Types.Map { inner; _ } -> is_byte_field inner
   | _ -> false
 
@@ -43,11 +47,13 @@ let rec type_suffix : type a. a Types.typ -> string = function
   | _ -> "Bytes"
 
 let rec setter_of : type a. a Types.typ -> setter_info = function
-  | Types.Byte_array _ | Types.Byte_slice _ ->
+  | Types.Byte_array _ | Types.Byte_slice _ | Types.Uint_var _ ->
       {
         setter_name = "WireSetBytes";
         setter_val_typ = Types.Pack_typ (Types.Uint32 Types.Little);
       }
+  | Types.Optional { inner; _ } -> setter_of inner
+  | Types.Optional_or { inner; _ } -> setter_of inner
   | Types.Map { inner; _ } -> setter_of inner
   | Types.Enum { base; _ } -> setter_of base
   | Types.Where { inner; _ } -> setter_of inner
@@ -55,44 +61,65 @@ let rec setter_of : type a. a Types.typ -> setter_info = function
       let suffix = type_suffix t in
       { setter_name = "WireSet" ^ suffix; setter_val_typ = Types.Pack_typ t }
 
-let map_field_action idx (Types.Field f) =
-  match f.field_name with
-  | Some name ->
-      let field_idx = !idx in
-      incr idx;
-      let new_action =
-        let { setter_name = setter; _ } = setter_of f.field_typ in
-        let value =
-          if is_byte_field f.field_typ then "(UINT32) field_pos" else name
-        in
-        let call =
-          Types.Extern_call
-            (setter, [ "ctx"; Fmt.str "(UINT32) %d" field_idx; value ])
-        in
-        if is_bitfield f.field_typ then
-          (* Bitfields: :act (non-failing, required for coalescing) *)
-          match f.action with
-          | None -> Some (Types.On_act [ call ])
-          | Some (Types.On_act stmts) -> Some (Types.On_act (stmts @ [ call ]))
-          | Some (Types.On_success stmts) ->
-              Some (Types.On_act (stmts @ [ call ]))
-        else
-          (* Non-bitfields: :on-success (runs after validation) *)
-          match f.action with
-          | None -> Some (Types.On_success [ call; Types.Return Types.true_ ])
-          | Some (Types.On_success stmts) ->
-              Some
-                (Types.On_success (stmts @ [ call; Types.Return Types.true_ ]))
-          | Some (Types.On_act stmts) -> Some (Types.On_act (stmts @ [ call ]))
+let setter_call : type a.
+    a Types.typ -> string -> int -> int option -> Types.action_stmt =
+ fun typ name field_idx byte_off ->
+  let setter, value =
+    if is_byte_field typ then
+      let off =
+        match byte_off with
+        | Some off -> Fmt.str "(UINT32) %d" off
+        | None -> Fmt.str "(UINT32) 0"
       in
-      Types.Field
-        {
-          field_name = Some name;
-          field_typ = f.field_typ;
-          constraint_ = f.constraint_;
-          action = new_action;
-        }
-  | None -> Types.Field f
+      ("WireSetBytes", off)
+    else
+      let { setter_name; _ } = setter_of typ in
+      (setter_name, name)
+  in
+  Types.Extern_call (setter, [ "ctx"; Fmt.str "(UINT32) %d" field_idx; value ])
+
+let map_field_action idx byte_off (Types.Field f) =
+  let field_size = Types.field_wire_size f.field_typ in
+  let next_off =
+    match (byte_off, field_size) with
+    | Some o, Some s -> Some (o + s)
+    | _ -> None
+  in
+  let result =
+    match f.field_name with
+    | Some name ->
+        let field_idx = !idx in
+        incr idx;
+        let call = setter_call f.field_typ name field_idx byte_off in
+        let new_action =
+          if is_bitfield f.field_typ then
+            (* Bitfields: :act fires per sub-field during coalesced parsing *)
+            match f.action with
+            | None -> Some (Types.On_act [ call ])
+            | Some (Types.On_act stmts) ->
+                Some (Types.On_act (stmts @ [ call ]))
+            | Some (Types.On_success stmts) ->
+                Some (Types.On_act (stmts @ [ call ]))
+          else
+            (* Scalars and byte-size fields: :on-success *)
+            match f.action with
+            | None -> Some (Types.On_success [ call; Types.Return Types.true_ ])
+            | Some (Types.On_success stmts) ->
+                Some
+                  (Types.On_success (stmts @ [ call; Types.Return Types.true_ ]))
+            | Some (Types.On_act stmts) ->
+                Some (Types.On_act (stmts @ [ call ]))
+        in
+        Types.Field
+          {
+            field_name = Some name;
+            field_typ = f.field_typ;
+            constraint_ = f.constraint_;
+            action = new_action;
+          }
+    | None -> Types.Field f
+  in
+  (result, next_off)
 
 (* Conjoin a list of constraint expressions, skipping [None]s. *)
 let conjoin_constraints constraints =
@@ -193,6 +220,38 @@ let reorder_bit_groups_for_3d fields =
   in
   go [] fields
 
+let bytes_setter =
+  {
+    setter_name = "WireSetBytes";
+    setter_val_typ = Types.Pack_typ (Types.Uint32 Types.Little);
+  }
+
+let collect_extern_setters ctx_struct u32 fields =
+  let seen = Hashtbl.create 8 in
+  List.filter_map
+    (fun (Types.Field f) ->
+      match f.field_name with
+      | None -> None
+      | Some _ ->
+          let si =
+            if is_byte_field f.field_typ then bytes_setter
+            else setter_of f.field_typ
+          in
+          if Hashtbl.mem seen si.setter_name then None
+          else begin
+            Hashtbl.add seen si.setter_name ();
+            let (Types.Pack_typ val_typ) = si.setter_val_typ in
+            Some
+              (Types.extern_fn si.setter_name
+                 [
+                   Types.mutable_param "ctx" (Types.struct_typ ctx_struct);
+                   Types.param "idx" u32;
+                   Types.param "v" val_typ;
+                 ]
+                 Types.Unit)
+          end)
+    fields
+
 let with_output (s : Types.struct_) : Types.decl list =
   (* Extern declarations for the callback mechanism *)
   let ctx_struct = Types.struct_ "WireCtx" [] in
@@ -204,37 +263,22 @@ let with_output (s : Types.struct_) : Types.decl list =
      The idx baked into each Extern_call is preserved through the reorder
      below, so WireSet callbacks still populate the original field slot. *)
   let idx = ref 0 in
-  let parse_fields = List.map (map_field_action idx) s.fields in
+  let parse_fields =
+    let off = ref (Some 0) in
+    List.map
+      (fun f ->
+        let f', next = map_field_action idx !off f in
+        off := next;
+        f')
+      s.fields
+  in
   let parse_fields = reorder_bit_groups_for_3d parse_fields in
   let parse_struct =
     Types.param_struct s.name (s.params @ [ ctx_param ]) ?where:s.where
       parse_fields
   in
   let parse_decl = Types.typedef ~entrypoint:true parse_struct in
-  (* Collect unique extern function declarations *)
-  let seen = Hashtbl.create 8 in
-  let extern_decls =
-    List.filter_map
-      (fun (Types.Field f) ->
-        match f.field_name with
-        | None -> None
-        | Some _ ->
-            let si = setter_of f.field_typ in
-            if Hashtbl.mem seen si.setter_name then None
-            else begin
-              Hashtbl.add seen si.setter_name ();
-              let (Types.Pack_typ val_typ) = si.setter_val_typ in
-              Some
-                (Types.extern_fn si.setter_name
-                   [
-                     Types.mutable_param "ctx" (Types.struct_typ ctx_struct);
-                     Types.param "idx" u32;
-                     Types.param "v" val_typ;
-                   ]
-                   Types.Unit)
-            end)
-      s.fields
-  in
+  let extern_decls = collect_extern_setters ctx_struct u32 s.fields in
   [ ctx_decl ] @ extern_decls @ [ parse_decl ]
 
 let schema_of_struct (s : Types.struct_) : t =

--- a/lib/everparse.mli
+++ b/lib/everparse.mli
@@ -1,7 +1,48 @@
 (** EverParse 3D export derived from wire descriptions.
 
     The main path is {!struct_of_codec}, {!schema}, and {!write_3d}. For unusual
-    3D constructs that have no codec equivalent yet, use {!Raw}. *)
+    3D constructs that have no codec equivalent yet, use {!Raw}.
+
+    {2 3D projection rules}
+
+    Wire types project to EverParse 3D struct fields. Each named field gets a
+    [WireSet*] callback that extracts its value into a flat array during
+    validation. Three EverParse limitations shape the projection:
+
+    + The 3D parser rejects [field_pos] inside actions on [[:byte-size]] fields,
+      so byte-field callbacks receive a static byte offset precomputed at schema
+      generation time instead.
+    + EverParse coalesces adjacent bitfields into a single base word. Callbacks
+      must fire per sub-field as each is parsed, so bitfields use the [:act]
+      form (fires unconditionally) rather than [:on-success] (fires only after
+      the entire coalesced word validates).
+    + 3D has no field-level [if]/[else] syntax. Dynamic optional fields are
+      expressed as [[:byte-size ((cond) ? n : 0)]], which conditionally includes
+      [n] bytes or zero bytes depending on a previously-parsed field.
+
+    {b Scalar fields} ([uint8], [uint16be], ...) project to their 3D equivalents
+    ([UINT8], [UINT16BE], ...) with an [:on-success] action:
+    [{:on-success WireSet*(ctx, idx, Name); return true; }].
+
+    {b Bitfields} ([bits ~width:n base]) project to [BASE Name : n] with an
+    [:act] action: [{:act WireSet*(ctx, idx, Name); }].
+
+    {b Byte-size fields} ([byte_array], [byte_slice], [repeat], and dynamic
+    [optional]) project to [UINT8 Name[:byte-size expr]] with an [:on-success]
+    action: [{:on-success WireSetBytes(ctx, idx, (UINT32) off); return true; }]
+    where [off] is the static byte offset.
+
+    {b Dynamic optional} ([optional cond inner]) where [cond] is not a literal
+    bool projects to [TYPE Name[:byte-size ((cond) ? inner_size : 0)]] where
+    [TYPE] is the 3D base type of [inner] and [inner_size] its fixed wire size.
+
+    {b Static optional} ([optional (Bool true) inner]) projects as the inner
+    field directly; [optional (Bool false) _] projects as [UINT8[:byte-size 0]]
+    (zero bytes).
+
+    {b Constraints} project as [{{ expr }}] on the field. Constraints are not
+    supported on [[:byte-size]] fields; they should be placed on the field whose
+    value the expression references. *)
 
 type t = { name : string; module_ : Types.module_; wire_size : int option }
 (** A named 3D schema with its module and wire size ([None] for variable-size

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -59,6 +59,7 @@ and _ expr =
   | Or : bool expr * bool expr -> bool expr
   | Not : bool expr -> bool expr
   | Cast : [ `U8 | `U16 | `U32 | `U64 ] * int expr -> int expr
+  | If_then_else : bool expr * int expr * int expr -> int expr
 
 (* Bitfield base types - standalone, not mutually recursive *)
 and bitfield_base = BF_U8 | BF_U16 of endian | BF_U32 of endian
@@ -608,6 +609,8 @@ let rec pp_expr : type a. a expr Fmt.t =
   | Or (a, b) -> Fmt.pf ppf "(%a || %a)" pp_expr a pp_expr b
   | Not a -> Fmt.pf ppf "(!%a)" pp_expr a
   | Cast (t, e) -> Fmt.pf ppf "((%a) %a)" pp_cast_type t pp_expr e
+  | If_then_else (c, t, e) ->
+      Fmt.pf ppf "((%a) ? %a : %a)" pp_expr c pp_expr t pp_expr e
 
 and pp_typ : type a. a typ Fmt.t =
  fun ppf typ ->
@@ -687,8 +690,30 @@ type field_suffix =
   | Single_elem of { size : int expr; at_most : bool }
   | Array of int expr
 
-let rec field_suffix : type a.
-    a typ -> field_suffix * (Format.formatter -> unit) =
+let rec inner_wire_size : type a. a typ -> int option = function
+  | Uint8 -> Some 1
+  | Uint16 _ -> Some 2
+  | Uint32 _ -> Some 4
+  | Uint64 _ -> Some 8
+  | Bits { base = BF_U8; _ } -> Some 1
+  | Bits { base = BF_U16 _; _ } -> Some 2
+  | Bits { base = BF_U32 _; _ } -> Some 4
+  | Unit -> Some 0
+  | Map { inner; _ } -> inner_wire_size inner
+  | Enum { base; _ } -> inner_wire_size base
+  | Where { inner; _ } -> inner_wire_size inner
+  | _ -> None
+
+and optional_suffix : type a.
+    bool expr -> a typ -> field_suffix * (Format.formatter -> unit) =
+ fun present inner ->
+  match inner_wire_size inner with
+  | Some n ->
+      let size = If_then_else (present, Int n, Int 0) in
+      (Byte_array size, fun ppf -> pp_typ ppf inner)
+  | None -> (No_suffix, fun ppf -> Fmt.pf ppf "optional(%a)" pp_typ inner)
+
+and field_suffix : type a. a typ -> field_suffix * (Format.formatter -> unit) =
  fun typ ->
   match typ with
   | Bits { width; base; _ } ->
@@ -704,9 +729,11 @@ let rec field_suffix : type a.
   | Optional { present = Bool true; inner } -> field_suffix inner
   | Optional { present = Bool false; _ } ->
       (Byte_array (Int 0), fun ppf -> Fmt.string ppf "UINT8")
+  | Optional { present; inner } -> optional_suffix present inner
   | Optional_or { present = Bool true; inner; _ } -> field_suffix inner
   | Optional_or { present = Bool false; _ } ->
       (Byte_array (Int 0), fun ppf -> Fmt.string ppf "UINT8")
+  | Optional_or { present; inner; _ } -> optional_suffix present inner
   | Repeat { size; elem; _ } ->
       (* Variable-length array with byte-size budget *)
       (Byte_array size, fun ppf -> pp_typ ppf elem)

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -86,6 +86,8 @@ and _ expr =
   | Or : bool expr * bool expr -> bool expr
   | Not : bool expr -> bool expr
   | Cast : [ `U8 | `U16 | `U32 | `U64 ] * int expr -> int expr
+  | If_then_else : bool expr * int expr * int expr -> int expr
+      (** Ternary [(cond ? then_ : else_)] for conditional byte-size. *)
 
 (** {1 Types} *)
 


### PR DESCRIPTION
Adds `make 3d` which runs all codec schemas through the full Everparse.schema pipeline, catching invalid 3D output at build time. Fixes byte-field callbacks to use static byte offsets instead of field_pos (rejected by 3D on [:byte-size] fields). Documents the 3D projection rules and the EverParse limitations that shape them.