### PR TITLE
feat: capitalize .3d filenames for EverParse compatibility

### DIFF
--- a/examples/demo/demo.ml
+++ b/examples/demo/demo.ml
@@ -453,6 +453,19 @@ let constrained_data n =
   done;
   buf
 
+(* ── 12. Lowercase name: exercises filename capitalization ── *)
+
+type lowercase_record = { lc_x : int; lc_y : int }
+
+let lowercase_codec =
+  Codec.v "lowercase_record"
+    (fun x y -> { lc_x = x; lc_y = y })
+    Codec.
+      [
+        (Field.v "x" uint8 $ fun r -> r.lc_x);
+        (Field.v "y" uint16be $ fun r -> r.lc_y);
+      ]
+
 (* ══════════════════════════════════════════════════════════════════════════
    3D Feature Coverage
    ══════════════════════════════════════════════════════════════════════════

--- a/examples/demo/demo.mli
+++ b/examples/demo/demo.mli
@@ -321,6 +321,12 @@ val constrained_default : constrained
 val constrained_data : int -> bytes
 (** Test data. *)
 
+type lowercase_record
+
+val lowercase_codec : lowercase_record Wire.Codec.t
+(** Codec with a lowercase snake_case name. Exercises filename capitalization in
+    the 3D pipeline (EverParse requires filenames to start uppercase). *)
+
 (** {1 3D Feature Coverage}
 
     The following are struct/module definitions exercising Wire DSL features

--- a/examples/validate_3d.ml
+++ b/examples/validate_3d.ml
@@ -18,6 +18,7 @@ let schemas =
     s Demo.cases_demo_codec;
     s Demo.enum_demo_codec;
     s Demo.constrained_codec;
+    s Demo.lowercase_codec;
     s Space.clcw_codec;
     s Space.packet_codec;
     s Space.full_packet_codec;
@@ -39,7 +40,7 @@ let validate_one ~tmpdir s =
     Fmt.pr "  OK  %s\n%!" name;
     true
   with Failure msg ->
-    let path = Filename.concat tmpdir (name ^ ".3d") in
+    let path = Filename.concat tmpdir (Wire.Everparse.filename s) in
     let content =
       try In_channel.with_open_text path In_channel.input_all
       with Sys_error _ -> "(could not read .3d file)"

--- a/lib/3d/wire_3d.ml
+++ b/lib/3d/wire_3d.ml
@@ -62,7 +62,7 @@ let run_everparse ?(quiet = true) ~outdir schemas =
   in
   List.iter
     (fun s ->
-      let f = s.name ^ ".3d" in
+      let f = Wire.Everparse.filename s in
       let redirect = if quiet then " > /dev/null 2>&1" else "" in
       let cmd = Fmt.str "cd %s && %s --batch %s%s" outdir exe f redirect in
       let ret = Sys.command cmd in

--- a/lib/everparse.ml
+++ b/lib/everparse.ml
@@ -298,10 +298,11 @@ let schema_of_struct (s : Types.struct_) : t =
 let schema (type r) (codec : r Codec.t) : t =
   schema_of_struct (Codec.to_struct codec)
 
+let filename s = String.capitalize_ascii s.name ^ ".3d"
+
 let write_3d ~outdir schemas =
   List.iter
-    (fun s ->
-      Types.to_3d_file (Filename.concat outdir (s.name ^ ".3d")) s.module_)
+    (fun s -> Types.to_3d_file (Filename.concat outdir (filename s)) s.module_)
     schemas
 
 (* Public C-facing types *)

--- a/lib/everparse.mli
+++ b/lib/everparse.mli
@@ -50,6 +50,10 @@ type t = { name : string; module_ : Types.module_; wire_size : int option }
 
 val pp : Format.formatter -> t -> unit
 
+val filename : t -> string
+(** [filename s] is the [.3d] output filename for schema [s]. EverParse requires
+    filenames to start with a capital letter. *)
+
 type struct_ = Types.struct_
 type decl = Types.decl
 type decl_case = Types.decl_case

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -774,6 +774,9 @@ module Everparse : sig
       EverParse output-types pattern: the generated C validates AND extracts all
       field values via extern callbacks ([WireSet*]). *)
 
+  val filename : t -> string
+  (** [filename s] is the [.3d] output filename for schema [s]. *)
+
   val write_3d : outdir:string -> t list -> unit
   (** Writes one [.3d] file per schema into [outdir]. *)
 


### PR DESCRIPTION
EverParse requires .3d filenames to start with a capital letter. Adds Everparse.filename which capitalizes the schema name. Adds a lowercase_record test codec to validate_3d to exercise this path.