### PR TITLE
test: add bitfield reorder and constraint codecs to 3d validation

### DIFF
--- a/examples/demo/demo.ml
+++ b/examples/demo/demo.ml
@@ -482,6 +482,36 @@ let reserved_fields_codec =
         (Field.v "value" uint16be $ fun r -> r.rf_value);
       ]
 
+(* ── 14. Bitfield reorder: MSB-first on U8 (non-native) ── *)
+
+type bf_reorder = { bfr_a : int; bfr_b : int }
+
+let bf_reorder_codec =
+  Codec.v "BfReorder"
+    (fun a b -> { bfr_a = a; bfr_b = b })
+    Codec.
+      [
+        (Field.v "a" (bits ~width:3 U8) $ fun r -> r.bfr_a);
+        (Field.v "b" (bits ~width:5 U8) $ fun r -> r.bfr_b);
+      ]
+
+(* ── 15. Constrained bitfield ── *)
+
+type bf_constrained = { bfc_version : int; bfc_flags : int }
+
+let bf_constrained_codec =
+  let f_version = Field.v "Version" (bits ~width:4 U8) in
+  Codec.v "BfConstrained"
+    (fun version flags -> { bfc_version = version; bfc_flags = flags })
+    Codec.
+      [
+        (f_version $ fun r -> r.bfc_version);
+        ( Field.v "Flags"
+            ~constraint_:Expr.(Field.ref f_version <= int 5)
+            (bits ~width:4 U8)
+        $ fun r -> r.bfc_flags );
+      ]
+
 (* ══════════════════════════════════════════════════════════════════════════
    3D Feature Coverage
    ══════════════════════════════════════════════════════════════════════════

--- a/examples/demo/demo.mli
+++ b/examples/demo/demo.mli
@@ -333,6 +333,18 @@ val reserved_fields_codec : reserved_fields Wire.Codec.t
 (** Codec with reserved-word field names (type, case). Exercises 3D identifier
     escaping in both field declarations and action value references. *)
 
+type bf_reorder
+
+val bf_reorder_codec : bf_reorder Wire.Codec.t
+(** Bitfield with MSB-first on U8 base (non-native). Exercises the 3D bit-group
+    reordering logic. *)
+
+type bf_constrained
+
+val bf_constrained_codec : bf_constrained Wire.Codec.t
+(** Bitfield with a cross-field constraint. Exercises constraint collapsing
+    under bit-group reordering. *)
+
 (** {1 3D Feature Coverage}
 
     The following are struct/module definitions exercising Wire DSL features

--- a/examples/validate_3d.ml
+++ b/examples/validate_3d.ml
@@ -20,6 +20,8 @@ let schemas =
     s Demo.constrained_codec;
     s Demo.lowercase_codec;
     s Demo.reserved_fields_codec;
+    s Demo.bf_reorder_codec;
+    s Demo.bf_constrained_codec;
     s Space.clcw_codec;
     s Space.packet_codec;
     s Space.full_packet_codec;


### PR DESCRIPTION
BfReorder exercises MSB-first on U8 (non-native bit order), which triggers the 3D bit-group reversal logic. BfConstrained adds a cross-field constraint that must be collapsed onto the last reversed field to remain valid after reordering.