### PR TITLE
fix: escape reserved words in WireSet action value references

### DIFF
--- a/examples/demo/demo.ml
+++ b/examples/demo/demo.ml
@@ -466,6 +466,22 @@ let lowercase_codec =
         (Field.v "y" uint16be $ fun r -> r.lc_y);
       ]
 
+(* ── 13. Reserved-word field names ── *)
+
+type reserved_fields = { rf_type : int; rf_case : int; rf_value : int }
+
+let reserved_fields_codec =
+  let f_type = Field.v "type" uint8 in
+  Codec.v "ReservedFields"
+    (fun t c v -> { rf_type = t; rf_case = c; rf_value = v })
+    Codec.
+      [
+        (f_type $ fun r -> r.rf_type);
+        ( Field.v "case" ~constraint_:Expr.(Field.ref f_type <= int 10) uint8
+        $ fun r -> r.rf_case );
+        (Field.v "value" uint16be $ fun r -> r.rf_value);
+      ]
+
 (* ══════════════════════════════════════════════════════════════════════════
    3D Feature Coverage
    ══════════════════════════════════════════════════════════════════════════

--- a/examples/demo/demo.mli
+++ b/examples/demo/demo.mli
@@ -327,6 +327,12 @@ val lowercase_codec : lowercase_record Wire.Codec.t
 (** Codec with a lowercase snake_case name. Exercises filename capitalization in
     the 3D pipeline (EverParse requires filenames to start uppercase). *)
 
+type reserved_fields
+
+val reserved_fields_codec : reserved_fields Wire.Codec.t
+(** Codec with reserved-word field names (type, case). Exercises 3D identifier
+    escaping in both field declarations and action value references. *)
+
 (** {1 3D Feature Coverage}
 
     The following are struct/module definitions exercising Wire DSL features

--- a/examples/validate_3d.ml
+++ b/examples/validate_3d.ml
@@ -19,6 +19,7 @@ let schemas =
     s Demo.enum_demo_codec;
     s Demo.constrained_codec;
     s Demo.lowercase_codec;
+    s Demo.reserved_fields_codec;
     s Space.clcw_codec;
     s Space.packet_codec;
     s Space.full_packet_codec;

--- a/lib/everparse.ml
+++ b/lib/everparse.ml
@@ -74,7 +74,7 @@ let setter_call : type a.
       ("WireSetBytes", off)
     else
       let { setter_name; _ } = setter_of typ in
-      (setter_name, name)
+      (setter_name, Types.escape_3d name)
   in
   Types.Extern_call (setter, [ "ctx"; Fmt.str "(UINT32) %d" field_idx; value ])
 

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -611,6 +611,9 @@ val to_3d : module_ -> string
 val to_3d_file : string -> module_ -> unit
 (** [to_3d_file path m] writes module [m] to a [.3d] file at [path]. *)
 
+val escape_3d : string -> string
+(** [escape_3d name] appends [_] if [name] is a 3D or C reserved word. *)
+
 (** {1 Parse Errors} *)
 
 type parse_error =


### PR DESCRIPTION
The setter_call helper passed the raw field name into Extern_call arguments, bypassing escape_3d. Fields named "type" or "case" would generate actions referencing the unescaped name while the field declaration used the escaped form, causing a 3d.exe parse error.