### PR TITLE
3d: generate _ExternalTypedefs.h alongside C parsers

### DIFF
--- a/lib/3d/wire_3d.ml
+++ b/lib/3d/wire_3d.ml
@@ -54,6 +54,32 @@ let copy_everparse_endianness ~outdir =
 
 let has_3d_exe () = locate_3d_exe () <> None
 
+let external_typedefs_content =
+  "#ifndef WIRECTX_DEFINED\n\
+   #define WIRECTX_DEFINED\n\
+   #include <stdint.h>\n\
+   typedef struct { int64_t *fields; } WIRECTX;\n\
+   #endif\n"
+
+let write_external_typedefs ~outdir schemas =
+  List.iter
+    (fun s ->
+      if Wire.Everparse.uses_wire_ctx s then begin
+        let path = Filename.concat outdir (s.name ^ "_ExternalTypedefs.h") in
+        let oc = open_out path in
+        output_string oc external_typedefs_content;
+        close_out oc
+      end)
+    schemas
+
+let external_typedefs_files schemas =
+  List.filter_map
+    (fun s ->
+      if Wire.Everparse.uses_wire_ctx s then
+        Some (s.name ^ "_ExternalTypedefs.h")
+      else None)
+    schemas
+
 let run_everparse ?(quiet = true) ~outdir schemas =
   let exe =
     match locate_3d_exe () with
@@ -164,6 +190,7 @@ let generate_c ?(quiet = true) ~outdir schemas =
   ensure_dir outdir;
   if has_3d_exe () then begin
     run_everparse ~quiet ~outdir schemas;
+    write_external_typedefs ~outdir schemas;
     generate_test ~outdir schemas
   end
   else
@@ -180,6 +207,7 @@ let generate_dune ~outdir ~package schemas =
   let pr fmt = Fmt.pf ppf fmt in
   let names = List.map (fun s -> s.name) schemas in
   let c_files = List.concat_map (fun n -> [ n ^ ".h"; n ^ ".c" ]) names in
+  let ext_files = external_typedefs_files schemas in
   let three_d_files = List.map (fun n -> n ^ ".3d") names in
   let test_bin =
     "test_" ^ String.map (fun c -> if c = '-' then '_' else c) package
@@ -195,12 +223,12 @@ let generate_dune ~outdir ~package schemas =
   pr " (alias gen)\n";
   pr " (mode fallback)\n";
   pr " (targets EverParse.h EverParseEndianness.h %s test.c)\n"
-    (String.concat " " c_files);
+    (String.concat " " (c_files @ ext_files));
   pr " (deps gen.exe %s)\n" (String.concat " " three_d_files);
   pr " (action\n";
   pr "  (run ./gen.exe c)))\n\n";
   let all_deps =
-    [ "test.c"; "EverParse.h"; "EverParseEndianness.h" ] @ c_files
+    [ "test.c"; "EverParse.h"; "EverParseEndianness.h" ] @ c_files @ ext_files
   in
   let c_srcs = List.map (fun n -> n ^ ".c") names in
   pr "(rule\n";
@@ -216,6 +244,7 @@ let generate_dune ~outdir ~package schemas =
   pr " (files\n";
   List.iter (fun f -> pr "  (%s as c/%s)\n" f f) three_d_files;
   List.iter (fun f -> pr "  (%s as c/%s)\n" f f) c_files;
+  List.iter (fun f -> pr "  (%s as c/%s)\n" f f) ext_files;
   pr "  (EverParse.h as c/EverParse.h)\n";
   pr "  (EverParseEndianness.h as c/EverParseEndianness.h)))\n";
   Format.pp_print_flush ppf ();

--- a/lib/everparse.ml
+++ b/lib/everparse.ml
@@ -300,6 +300,15 @@ let schema (type r) (codec : r Codec.t) : t =
 
 let filename s = String.capitalize_ascii s.name ^ ".3d"
 
+let uses_wire_ctx s =
+  List.exists
+    (function
+      | Types.Typedef { extern_ = true; struct_ = { name = "WireCtx"; _ }; _ }
+        ->
+          true
+      | _ -> false)
+    s.module_.decls
+
 let write_3d ~outdir schemas =
   List.iter
     (fun s -> Types.to_3d_file (Filename.concat outdir (filename s)) s.module_)

--- a/lib/everparse.mli
+++ b/lib/everparse.mli
@@ -54,6 +54,14 @@ val filename : t -> string
 (** [filename s] is the [.3d] output filename for schema [s]. EverParse requires
     filenames to start with a capital letter. *)
 
+val uses_wire_ctx : t -> bool
+(** [uses_wire_ctx s] is [true] when the schema declares the [WireCtx] extern
+    typedef, meaning its generated C header [#include]s
+    [<Name>_ExternalTypedefs.h]. Schemas built via {!schema} /
+    {!schema_of_struct} always satisfy this; raw modules assembled via
+    {!Raw.of_module} do so only if they explicitly declare the extern typedef.
+*)
+
 type struct_ = Types.struct_
 type decl = Types.decl
 type decl_case = Types.decl_case

--- a/lib/test/everparse/test_wire_3d.ml
+++ b/lib/test/everparse/test_wire_3d.ml
@@ -64,8 +64,24 @@ let test_generate_c () =
     Wire_3d.generate_3d ~outdir:tmpdir [ s ];
     Wire_3d.generate_c ~outdir:tmpdir [ s ];
     let c_path = Filename.concat tmpdir "TestSimple.c" in
-    Alcotest.(check bool) "C file generated" true (Sys.file_exists c_path)
+    Alcotest.(check bool) "C file generated" true (Sys.file_exists c_path);
+    let ext_path = Filename.concat tmpdir "TestSimple_ExternalTypedefs.h" in
+    Alcotest.(check bool)
+      "ExternalTypedefs.h generated" true (Sys.file_exists ext_path)
   end
+
+let test_uses_wire_ctx () =
+  let s = Wire.Everparse.schema_of_struct simple_struct in
+  Alcotest.(check bool)
+    "schema_of_struct uses WireCtx" true
+    (Wire.Everparse.uses_wire_ctx s);
+  let raw =
+    Wire.Everparse.Raw.of_module ~name:"TestSimple" ~module_:simple_module
+      ~wire_size:3
+  in
+  Alcotest.(check bool)
+    "raw module without extern WireCtx" false
+    (Wire.Everparse.uses_wire_ctx raw)
 
 let test_has_3d_exe () =
   (* Just check the function is callable and returns a bool *)
@@ -86,6 +102,7 @@ let suite =
       Alcotest.test_case "schema_of_struct" `Quick test_schema_of_struct;
       Alcotest.test_case "ensure_dir" `Quick test_ensure_dir;
       Alcotest.test_case "generate_c (needs 3d.exe)" `Quick test_generate_c;
+      Alcotest.test_case "uses_wire_ctx" `Quick test_uses_wire_ctx;
       Alcotest.test_case "has_3d_exe" `Quick test_has_3d_exe;
       Alcotest.test_case "main exists" `Quick test_main_exists;
     ] )

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -777,6 +777,12 @@ module Everparse : sig
   val filename : t -> string
   (** [filename s] is the [.3d] output filename for schema [s]. *)
 
+  val uses_wire_ctx : t -> bool
+  (** [uses_wire_ctx s] is [true] when the schema declares the [WireCtx] extern
+      typedef. The generated C header then [#include]s
+      [<Name>_ExternalTypedefs.h], so that file must be present at compile time.
+      Schemas built via {!schema} always satisfy this. *)
+
   val write_3d : outdir:string -> t list -> unit
   (** Writes one [.3d] file per schema into [outdir]. *)
 


### PR DESCRIPTION
EverParse-generated headers #include <Name>_ExternalTypedefs.h when the schema declares the WireCtx extern typedef, but Wire_3d never emitted them -- only Wire_stubs did, leaving packages that use wire.3d without wire.stubs unable to compile. generate_c now writes the header, and generate_dune lists it in targets, runtest deps, and the install stanza.