### PR TITLE
3d: fix bitfield projection so wire_size matches Codec.wire_size

### DIFF
--- a/lib/3d/wire_3d.ml
+++ b/lib/3d/wire_3d.ml
@@ -4,16 +4,27 @@ open Wire.Everparse
 
 let is_upper c = Char.uppercase_ascii c = c && Char.lowercase_ascii c <> c
 
-let everparse_name name =
-  let len = String.length name in
+(* Apply EverParse's normalization to a single identifier segment (no
+   underscores): if the segment begins with two or more uppercase letters,
+   lowercase the whole segment and capitalize the first letter ([SSID ->
+   Ssid], [TMFrame -> Tmframe]); otherwise leave it alone. *)
+let normalize_segment seg =
+  let len = String.length seg in
   let rec count_upper i =
-    if i < len && is_upper name.[i] then count_upper (i + 1) else i
+    if i < len && is_upper seg.[i] then count_upper (i + 1) else i
   in
   if len > 0 && count_upper 0 >= 2 then
     String.init len (fun i ->
-        let c = Char.lowercase_ascii name.[i] in
+        let c = Char.lowercase_ascii seg.[i] in
         if i = 0 then Char.uppercase_ascii c else c)
-  else name
+  else seg
+
+(* EverParse strips underscores when generating C identifiers and
+   CamelCases each segment. [EP_Header -> EpHeader],
+   [MC_Status_Reply -> McStatusReply], [SSID -> Ssid]. *)
+let everparse_name name =
+  String.split_on_char '_' name
+  |> List.map normalize_segment |> String.concat ""
 
 (* EverParse normalizes extern callback names in ways that are awkward to
    mirror exactly (runs of uppercase after a digit get lowercased, trailing
@@ -244,25 +255,27 @@ let run_everparse ?(quiet = true) ~outdir schemas =
     schemas;
   copy_everparse_endianness ~outdir
 
-let emit_schema_test ppf s wire_size =
+let emit_sanity_check ppf ~name ~ep ~ctx_arg wire_size =
   let pr fmt = Fmt.pf ppf fmt in
-  let ep = everparse_name s.name in
-  let lower = String.lowercase_ascii s.name in
-  let uses_ctx = Wire.Everparse.uses_wire_ctx s in
-  let ctx_arg = if uses_ctx then "(WIRECTX *) &ctx, " else "" in
-  pr "\n  /* %s (%d bytes) */\n" s.name wire_size;
-  pr "  {\n";
-  pr "    int pass = 0, fail = 0;\n";
-  pr "    uint8_t buf[%d];\n" wire_size;
-  pr "    uint64_t r;\n";
-  if uses_ctx then pr "    %sFields ctx = {0};\n" s.name;
-  pr "\n";
-  pr "    memset(buf, 0, %d);\n" wire_size;
+  (* Sanity: the OCaml codec's wire_size must match what the EverParse
+     validator consumes. A mismatch means the .3d projection of the codec
+     packs to a different size than the codec declares -- almost always a
+     bug in the codec's bitfield declarations. Later checks are meaningless
+     if this fails, so abort the whole test binary with a clear message. *)
   pr "    r = %sValidate%s(%sNULL, counting_error_handler, buf, %d, 0);\n" ep ep
     ctx_arg wire_size;
-  pr "    CHECK(\"zero buffer validates\", EverParseIsSuccess(r));\n";
-  pr "    CHECK(\"position advanced to %d\", r == %d);\n" wire_size wire_size;
-  pr "\n";
+  pr "    if (!EverParseIsSuccess(r) || r != %d) {\n" wire_size;
+  pr "      fprintf(stderr,\n";
+  pr "        \"FATAL: %s wire_size mismatch -- codec declared %d bytes, \"\n"
+    name wire_size;
+  pr "        \"EverParse validator returned %%llu. Fix the OCaml codec's \"\n";
+  pr "        \"wire_size or the .3d projection.\\n\",\n";
+  pr "        (unsigned long long) r);\n";
+  pr "      return 2;\n";
+  pr "    }\n"
+
+let emit_truncation_checks ppf ~ep ~ctx_arg wire_size =
+  let pr fmt = Fmt.pf ppf fmt in
   pr "    r = %sValidate%s(%sNULL, counting_error_handler, buf, %d, 0);\n" ep ep
     ctx_arg (wire_size * 2);
   pr "    CHECK(\"larger buffer validates\", EverParseIsSuccess(r));\n";
@@ -278,8 +291,10 @@ let emit_schema_test ppf s wire_size =
   pr "\n";
   pr "    r = %sValidate%s(%sNULL, counting_error_handler, buf, 0, 0);\n" ep ep
     ctx_arg;
-  pr "    CHECK(\"empty input fails\", EverParseIsError(r));\n";
-  pr "\n";
+  pr "    CHECK(\"empty input fails\", EverParseIsError(r));\n"
+
+let emit_random_checks ppf ~ep ~ctx_arg wire_size =
+  let pr fmt = Fmt.pf ppf fmt in
   pr "    srand(42);\n";
   pr "    for (int i = 0; i < 1000; i++) {\n";
   pr "      for (int j = 0; j < %d; j++)\n" wire_size;
@@ -288,7 +303,29 @@ let emit_schema_test ppf s wire_size =
     ep ctx_arg wire_size;
   pr "      CHECK(\"random buffer validates\", EverParseIsSuccess(r));\n";
   pr "      CHECK(\"random position correct\", r == %d);\n" wire_size;
-  pr "    }\n";
+  pr "    }\n"
+
+let emit_schema_test ppf s wire_size =
+  let pr fmt = Fmt.pf ppf fmt in
+  let ep = everparse_name s.name in
+  let lower = String.lowercase_ascii s.name in
+  let uses_ctx = Wire.Everparse.uses_wire_ctx s in
+  let ctx_arg = if uses_ctx then "(WIRECTX *) &ctx, " else "" in
+  pr "\n  /* %s (%d bytes) */\n" s.name wire_size;
+  pr "  {\n";
+  pr "    int pass = 0, fail = 0;\n";
+  pr "    uint8_t buf[%d];\n" wire_size;
+  pr "    uint64_t r;\n";
+  if uses_ctx then pr "    %sFields ctx = {0};\n" s.name;
+  pr "\n";
+  pr "    memset(buf, 0, %d);\n" wire_size;
+  emit_sanity_check ppf ~name:s.name ~ep ~ctx_arg wire_size;
+  pr "    CHECK(\"zero buffer validates\", EverParseIsSuccess(r));\n";
+  pr "    CHECK(\"position advanced to %d\", r == %d);\n" wire_size wire_size;
+  pr "\n";
+  emit_truncation_checks ppf ~ep ~ctx_arg wire_size;
+  pr "\n";
+  emit_random_checks ppf ~ep ~ctx_arg wire_size;
   pr "\n";
   if uses_ctx then pr "    (void) ctx;\n";
   pr "    printf(\"%s: %%d passed, %%d failed\\n\", pass, fail);\n" lower;

--- a/lib/everparse.ml
+++ b/lib/everparse.ml
@@ -180,21 +180,33 @@ let collapse_constraints_to_last group =
    are stamped before reordering, so WireSet callbacks still write into the
    original (wire-declaration) slots -- the stub generator never sees the
    reordered struct. *)
+(* Extract bitfield info through any number of [Map]/[Enum]/[Where] wrappers.
+   [bit (bits ~width:1 U8)] is [Map { inner = Bits _ }] at the outer level;
+   without unwrapping, grouping logic would treat it as a non-bitfield and
+   break apart consecutive bit groups, producing wrong .3d layouts. *)
+let rec unwrap_bits : type a.
+    a Types.typ -> (Types.bitfield_base * Types.bit_order * int) option =
+  function
+  | Types.Bits { base; bit_order; width } -> Some (base, bit_order, width)
+  | Types.Map { inner; _ } -> unwrap_bits inner
+  | Types.Enum { base; _ } -> unwrap_bits base
+  | Types.Where { inner; _ } -> unwrap_bits inner
+  | _ -> None
+
 let reorder_bit_groups_for_3d fields =
-  let is_same_bit_group base bit_order = function
-    | Types.Field
-        { field_typ = Types.Bits { base = b2; bit_order = bo2; _ }; _ } ->
-        b2 = base && bo2 = bit_order
-    | _ -> false
+  let is_same_bit_group base bit_order (Types.Field f) =
+    match unwrap_bits f.field_typ with
+    | Some (b2, bo2, _) -> b2 = base && bo2 = bit_order
+    | None -> false
   in
-  let bit_width = function
-    | Types.Field { field_typ = Types.Bits { width; _ }; _ } -> width
-    | _ -> 0
+  let bit_width (Types.Field f) =
+    match unwrap_bits f.field_typ with Some (_, _, w) -> w | None -> 0
   in
   let rec go acc = function
     | [] -> List.rev acc
-    | (Types.Field { field_typ = Types.Bits { base; bit_order; _ }; _ } as f0)
-      :: rest ->
+    | (Types.Field f as f0) :: rest
+      when Option.is_some (unwrap_bits f.field_typ) ->
+        let base, bit_order, _ = Option.get (unwrap_bits f.field_typ) in
         let total = Bitfield.total_bits base in
         let native = Bitfield.native_bit_order base in
         (* Greedy: collect consecutive Bits with the same (base, bit_order)
@@ -297,16 +309,44 @@ let with_output (s : Types.struct_) : Types.decl list =
   let extern_decls = collect_extern_setters s.name ctx_struct u32 s.fields in
   [ ctx_decl ] @ extern_decls @ [ parse_decl ]
 
+(* Byte size of a struct after bitfield coalescing, mirroring Codec.compile_bits'
+   logic: consecutive same-base, same-bit_order bitfields pack into one base
+   word if their widths sum within the word; they roll over to a new base word
+   otherwise. Matches what EverParse's validator actually consumes. Returns
+   [None] for schemas with variable-size fields. *)
+let coalesced_wire_size fields =
+  let exception Bail in
+  let close_bit_group total = function
+    | None -> total
+    | Some base -> total + Bitfield.byte_size base
+  in
+  try
+    let total, open_base, _, _ =
+      List.fold_left
+        (fun (total, open_base, bits_used, bit_order) (Types.Field f) ->
+          match unwrap_bits f.field_typ with
+          | Some (base, order, width) -> (
+              match open_base with
+              | Some b
+                when b = base && bit_order = Some order
+                     && bits_used + width <= Bitfield.total_bits base ->
+                  (total, open_base, bits_used + width, bit_order)
+              | _ ->
+                  let total' = close_bit_group total open_base in
+                  (total', Some base, width, Some order))
+          | None -> (
+              let total' = close_bit_group total open_base in
+              match Types.field_wire_size f.field_typ with
+              | Some n -> (total' + n, None, 0, None)
+              | None -> raise Bail))
+        (0, None, 0, None) fields
+    in
+    Some (close_bit_group total open_base)
+  with Bail -> None
+
 let schema_of_struct (s : Types.struct_) : t =
   let name = Types.struct_name s in
-  let wire_size =
-    List.fold_left
-      (fun acc (Types.Field f) ->
-        match (acc, Types.field_wire_size f.field_typ) with
-        | Some a, Some b -> Some (a + b)
-        | _ -> None)
-      (Some 0) s.fields
-  in
+  let wire_size = coalesced_wire_size s.fields in
   let decls = with_output s in
   let m = Types.module_ decls in
   { name; module_ = m; wire_size; source = Some s }

--- a/lib/test/everparse/test_wire_3d.ml
+++ b/lib/test/everparse/test_wire_3d.ml
@@ -23,6 +23,16 @@ let test_everparse_name () =
   Alcotest.(check string)
     "Hello -> Hello" "Hello"
     (Wire_3d.everparse_name "Hello");
+  (* Underscore-separated: each segment normalized, underscores dropped *)
+  Alcotest.(check string)
+    "EP_Header -> EpHeader" "EpHeader"
+    (Wire_3d.everparse_name "EP_Header");
+  Alcotest.(check string)
+    "MC_Status_Reply -> McStatusReply" "McStatusReply"
+    (Wire_3d.everparse_name "MC_Status_Reply");
+  Alcotest.(check string)
+    "Foo_Bar -> FooBar" "FooBar"
+    (Wire_3d.everparse_name "Foo_Bar");
   (* Empty string *)
   Alcotest.(check string) "empty" "" (Wire_3d.everparse_name "")
 
@@ -94,6 +104,119 @@ let test_main_exists () =
   let _ = (Wire_3d.main : package:string -> Wire.Everparse.t list -> unit) in
   ()
 
+(* Adversarial: [schema.wire_size] must agree with [Codec.wire_size] AND with
+   the byte count we expect by hand for every bitfield layout. Two layers:
+   if the projection silently drifts from [Codec.wire_size] we validate the
+   wrong amount of data; if the expected value is itself wrong, hand-computed
+   constants catch that too. *)
+let check_size ~name ~expected codec =
+  let schema = Everparse.schema codec in
+  let codec_size = Codec.wire_size codec in
+  Alcotest.(check int)
+    (Fmt.str "%s: Codec.wire_size = %d" name expected)
+    expected codec_size;
+  Alcotest.(check (option int))
+    (Fmt.str "%s: schema.wire_size = %d" name expected)
+    (Some expected) schema.Everparse.wire_size
+
+(* SSID-like layout: mix of [bit (bits 1 U8)] and bare [bits N U8] summing to
+   exactly one U8. Historical bug: the Map-wrapped fields fell out of the bit
+   group and produced spurious anon padding. *)
+let ssid_style_codec =
+  let f1 = Field.v "a" (bit (bits ~width:1 U8)) in
+  let f2 = Field.v "b" (bits ~width:2 U8) in
+  let f3 = Field.v "c" (bits ~width:4 U8) in
+  let f4 = Field.v "d" (bit (bits ~width:1 U8)) in
+  let open Codec in
+  v "SsidStyle"
+    (fun a b c d -> (a, b, c, d))
+    [
+      (f1 $ fun (a, _, _, _) -> a);
+      (f2 $ fun (_, b, _, _) -> b);
+      (f3 $ fun (_, _, c, _) -> c);
+      (f4 $ fun (_, _, _, d) -> d);
+    ]
+
+(* All [bit] (Map-wrapped), packed into one U8. *)
+let all_bool_codec =
+  let f1 = Field.v "a" (bit (bits ~width:1 U8)) in
+  let f2 = Field.v "b" (bit (bits ~width:1 U8)) in
+  let f3 = Field.v "c" (bit (bits ~width:1 U8)) in
+  let f4 = Field.v "d" (bit (bits ~width:1 U8)) in
+  let open Codec in
+  v "AllBool"
+    (fun a b c d -> (a, b, c, d))
+    [
+      (f1 $ fun (a, _, _, _) -> a);
+      (f2 $ fun (_, b, _, _) -> b);
+      (f3 $ fun (_, _, c, _) -> c);
+      (f4 $ fun (_, _, _, d) -> d);
+    ]
+
+(* Spilling across a base-word boundary: 5+5 bits on U8 must roll into two U8s. *)
+let spill_u8_codec =
+  let f1 = Field.v "a" (bits ~width:5 U8) in
+  let f2 = Field.v "b" (bits ~width:5 U8) in
+  let open Codec in
+  v "SpillU8" (fun a b -> (a, b)) [ f1 $ fst; f2 $ snd ]
+
+(* Bit group broken by a non-bitfield field. Two separate U8 groups plus
+   the intervening scalar. *)
+let broken_by_scalar_codec =
+  let f1 = Field.v "a" (bits ~width:4 U8) in
+  let f2 = Field.v "b" (bits ~width:4 U8) in
+  let f3 = Field.v "sep" uint8 in
+  let f4 = Field.v "c" (bits ~width:4 U8) in
+  let f5 = Field.v "d" (bits ~width:4 U8) in
+  let open Codec in
+  v "BrokenByScalar"
+    (fun a b sep c d -> (a, b, sep, c, d))
+    [
+      (f1 $ fun (a, _, _, _, _) -> a);
+      (f2 $ fun (_, b, _, _, _) -> b);
+      (f3 $ fun (_, _, s, _, _) -> s);
+      (f4 $ fun (_, _, _, c, _) -> c);
+      (f5 $ fun (_, _, _, _, d) -> d);
+    ]
+
+(* U32BE bitfields: total 32 bits -> one U32. *)
+let u32_pack_codec =
+  let f1 = Field.v "a" (bits ~width:8 U32be) in
+  let f2 = Field.v "b" (bits ~width:16 U32be) in
+  let f3 = Field.v "c" (bits ~width:8 U32be) in
+  let open Codec in
+  v "U32Pack"
+    (fun a b c -> (a, b, c))
+    [
+      (f1 $ fun (a, _, _) -> a);
+      (f2 $ fun (_, b, _) -> b);
+      (f3 $ fun (_, _, c) -> c);
+    ]
+
+(* Bitfield wrapped in Where (constraint). Must still coalesce. *)
+let where_wrapped_codec =
+  let f1_ref = Field.v "a" (bits ~width:4 U8) in
+  let f1 =
+    Field.v "a" (bits ~width:4 U8) ~constraint_:Expr.(Field.ref f1_ref <= int 5)
+  in
+  let f2 = Field.v "b" (bits ~width:4 U8) in
+  let open Codec in
+  v "WhereWrapped" (fun a b -> (a, b)) [ f1 $ fst; f2 $ snd ]
+
+let test_projection_sizes () =
+  (* SSID: 1+2+4+1 = 8 bits, one U8. *)
+  check_size ~name:"SsidStyle" ~expected:1 ssid_style_codec;
+  (* 4 bool bits, one U8. *)
+  check_size ~name:"AllBool" ~expected:1 all_bool_codec;
+  (* 5+5 = 10 bits, must spill to two U8s. *)
+  check_size ~name:"SpillU8" ~expected:2 spill_u8_codec;
+  (* Two bit groups of one U8 each + an intervening uint8 = 3 bytes. *)
+  check_size ~name:"BrokenByScalar" ~expected:3 broken_by_scalar_codec;
+  (* 8+16+8 = 32 bits, one U32be. *)
+  check_size ~name:"U32Pack" ~expected:4 u32_pack_codec;
+  (* 4+4 = 8 bits, one U8, Where wrapping the first field. *)
+  check_size ~name:"WhereWrapped" ~expected:1 where_wrapped_codec
+
 let suite =
   ( "wire_3d",
     [
@@ -105,4 +228,6 @@ let suite =
       Alcotest.test_case "uses_wire_ctx" `Quick test_uses_wire_ctx;
       Alcotest.test_case "has_3d_exe" `Quick test_has_3d_exe;
       Alcotest.test_case "main exists" `Quick test_main_exists;
+      Alcotest.test_case "projection: wire_size matches Codec" `Quick
+        test_projection_sizes;
     ] )


### PR DESCRIPTION
The projection disagreed with Codec.wire_size on schemas mixing Map-wrapped bool fields with bare bitfields, or using underscore- separated identifiers. AX.25 SSID came out as 10 bits across 2 bytes instead of 8 bits in 1 byte.

- reorder_bit_groups_for_3d now unwraps Map/Enum/Where when grouping bitfields.
- schema_of_struct uses coalesced_wire_size mirroring Codec.compile_bits' grouping.
- everparse_name splits on _ before normalizing each segment.

Adversarial tests assert schema.wire_size equals Codec.wire_size for mixed, all-bool, spilling, broken-by-scalar, U32be, and Where-wrapped bitfields; test.c now aborts loudly on mismatch instead of burying the failure.