### PR TITLE
wire: Field.v ?self_constraint for self-referencing constraints

### DIFF
--- a/lib/3d/wire_3d.ml
+++ b/lib/3d/wire_3d.ml
@@ -409,13 +409,19 @@ let generate_test ~outdir schemas =
       if Wire.Everparse.uses_wire_ctx s then
         pr "#include \"%s_Fields.h\"\n" base)
     fixed_schemas;
-  pr "\nstatic int error_count;\n\n";
-  pr "static void counting_error_handler(\n";
-  pr "  EVERPARSE_STRING t, EVERPARSE_STRING f, EVERPARSE_STRING r,\n";
-  pr "  uint64_t c, uint8_t *ctx, uint8_t *i, uint64_t p) {\n";
-  pr "  (void)t; (void)f; (void)r; (void)c; (void)ctx; (void)i; (void)p;\n";
-  pr "  error_count++;\n";
-  pr "}\n\n";
+  (* counting_error_handler is only referenced from the per-schema test
+     blocks emit_schema_test emits, which run only for fixed-size schemas.
+     Skip it entirely when there are none, otherwise -Wunused-function
+     under strict flags rejects the file. *)
+  if fixed_schemas <> [] then begin
+    pr "\nstatic int error_count;\n\n";
+    pr "static void counting_error_handler(\n";
+    pr "  EVERPARSE_STRING t, EVERPARSE_STRING f, EVERPARSE_STRING r,\n";
+    pr "  uint64_t c, uint8_t *ctx, uint8_t *i, uint64_t p) {\n";
+    pr "  (void)t; (void)f; (void)r; (void)c; (void)ctx; (void)i; (void)p;\n";
+    pr "  error_count++;\n";
+    pr "}\n\n"
+  end;
   pr "#define CHECK(msg, cond) do { \\\n";
   pr "  if (cond) { pass++; } \\\n";
   pr "  else { fail++; fprintf(stderr, \"  FAIL: %%s\\n\", msg); } \\\n";

--- a/lib/field.ml
+++ b/lib/field.ml
@@ -8,7 +8,16 @@ type 'a t = {
 type 'a anon = { anon_typ : 'a Types.typ }
 
 let pp ppf f = Fmt.pf ppf "%s" f.name
-let v name ?constraint_ ?action typ = { name; typ; constraint_; action }
+
+let v name ?constraint_ ?self_constraint ?action typ =
+  let constraint_ =
+    match (constraint_, self_constraint) with
+    | c, None -> c
+    | None, Some f -> Some (f (Types.Ref name))
+    | Some c, Some f -> Some (Types.And (c, f (Types.Ref name)))
+  in
+  { name; typ; constraint_; action }
+
 let anon typ = { anon_typ = typ }
 let ref f = Types.Ref f.name
 let name f = f.name

--- a/lib/field.mli
+++ b/lib/field.mli
@@ -17,10 +17,26 @@ type 'a anon
 val v :
   string ->
   ?constraint_:bool Types.expr ->
+  ?self_constraint:(int Types.expr -> bool Types.expr) ->
   ?action:Types.action ->
   'a Types.typ ->
   'a t
-(** [v name typ] creates a named field. *)
+(** [v name typ] creates a named field.
+
+    [?self_constraint] receives a reference to the field being declared and
+    returns a constraint over it; the typical use is to prove a later
+    size-expression safe, e.g.:
+
+    {[
+      let f_len =
+        Field.v "Length" uint16be ~self_constraint:(fun self ->
+            Expr.(self >= int 7))
+    ]}
+
+    projects to [UINT16BE Length {{ Length >= 7 }}], which EverParse's SMT can
+    then use to discharge [byte-size (Length - 7)] on a later field. If both
+    [?constraint_] and [?self_constraint] are given, the two are combined with
+    [And]. *)
 
 val anon : 'a Types.typ -> 'a anon
 (** [anon typ] creates an anonymous (padding) field. *)

--- a/lib/test/everparse/test_wire_3d.ml
+++ b/lib/test/everparse/test_wire_3d.ml
@@ -145,12 +145,31 @@ let e2e_mixed_codec =
   let fh = Field.v "h" uint8 in
   Codec.v "EP_Header" (fun h -> h) [ Codec.( $ ) fh (fun h -> h) ]
 
+(* Proximity1-style: variable-length data whose size is expressed as
+   [length - header]. EverParse's SMT needs a constraint on [length]
+   to prove the subtraction doesn't underflow, or verification of the
+   generated .fst fails. [?self_constraint] on the length field emits
+   that constraint inline. *)
+let e2e_underflow_codec =
+  let open Wire in
+  let header_size = 7 in
+  let f_len =
+    Field.v "Length" uint16be ~self_constraint:(fun self ->
+        Expr.(self >= int header_size))
+  in
+  let f_data =
+    Field.v "Data" (byte_array ~size:Expr.(Field.ref f_len - int header_size))
+  in
+  let open Codec in
+  v "UnderflowCheck" (fun len data -> (len, data)) [ f_len $ fst; f_data $ snd ]
+
 let test_e2e_compile_run () =
   compile_and_run ~name:"Demo" e2e_simple_codec;
   compile_and_run ~name:"CLCW" e2e_allcaps_codec;
   compile_and_run ~name:"TMFrame" e2e_tm_codec;
   compile_and_run ~name:"rpmsg_endpoint_info" e2e_snake_codec;
-  compile_and_run ~name:"EP_Header" e2e_mixed_codec
+  compile_and_run ~name:"EP_Header" e2e_mixed_codec;
+  compile_and_run ~name:"UnderflowCheck" e2e_underflow_codec
 
 let test_uses_wire_ctx () =
   let s = Wire.Everparse.schema_of_struct simple_struct in

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -334,8 +334,17 @@ module Field : sig
 
   type packed = Named : 'a t -> packed | Anon : 'a anon -> packed
 
-  val v : string -> ?constraint_:bool expr -> ?action:Action.t -> 'a typ -> 'a t
-  (** [v name typ] creates a named field. *)
+  val v :
+    string ->
+    ?constraint_:bool expr ->
+    ?self_constraint:(int expr -> bool expr) ->
+    ?action:Action.t ->
+    'a typ ->
+    'a t
+  (** [v name typ] creates a named field. [?self_constraint] receives the
+      field's own ref and returns a constraint over it; useful for proving a
+      later size-expression safe (e.g. [self >= int 7] when a later field uses
+      [byte_slice ~size:(ref len - int 7)]). *)
 
   val anon : 'a typ -> 'a anon
   (** [anon typ] creates an anonymous (padding) field. *)


### PR DESCRIPTION
Fields whose size is expressed as [length - header] need a proof that the subtraction doesn't underflow before EverParse's SMT will accept the schema. Writing the constraint on the length field requires referencing the field by name, which is awkward when declaring it. [?self_constraint] takes a closure that receives the field's own Ref and returns a constraint, avoiding the forward-reference dance:

  let f_len =
    Field.v "Length" uint16be
      ~self_constraint:(fun self -> Expr.(self >= int 7))

projects to [UINT16BE Length { (Length >= 7) }], which EverParse's SMT uses to discharge [byte-size (Length - 7)] on a later field.

If both ?constraint_ and ?self_constraint are given the two are combined with And.

Also skip emitting the counting_error_handler in test.c when there are no fixed-size schemas (otherwise -Wunused-function rejects the file under strict flags), and extend the e2e compile+run test with a Proximity1-style underflow-prone codec to keep the whole pipeline honest.