### PR TITLE
fix: use EverParse-normalised <Name>Fields in generated C stubs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+## unreleased
+
+- Fix C stub generator: use the EverParse-normalised `<Name>Fields`
+  type name. Schemas with a name segment of 2+ leading capitals
+  (e.g. `IPv4`, `EP_Header`, `MC_Status_Reply`) previously emitted C
+  that referenced an undefined struct.
+
 ## 0.9.0
 
 Initial release.

--- a/bench/clcw/clcw_c.c
+++ b/bench/clcw/clcw_c.c
@@ -1,7 +1,7 @@
 /* CLCW polling loop -- application logic with EverParse field extraction.
 
    Uses EverParse-generated CLCWValidateCLCW to extract bitfields into a typed
-   CLCWFields struct via the default plug. Application logic (anomaly
+   ClcwFields struct via the default plug. Application logic (anomaly
    detection) reads named members of the struct. No hand-written bitfield
    manipulation, no index arithmetic. */
 
@@ -21,7 +21,7 @@ static const int WORD_SIZE = 4;  /* Wire.Codec.wire_size Space.clcw_codec */
 static int count_anomalies(uint8_t *buf, int n_words, int n_iters) {
   int anomalies = 0;
   int expected_seq = 0;
-  CLCWFields fields = {0};
+  ClcwFields fields = {0};
 
   for (int i = 0; i < n_iters; i++) {
     uint8_t *p = buf + (i % n_words) * WORD_SIZE;

--- a/bench/gateway/gateway_c.c
+++ b/bench/gateway/gateway_c.c
@@ -33,7 +33,7 @@ static inline uint64_t hash_int(uint64_t state, int value) {
 
 static void walk_frame(uint8_t *frame, int tm_hdr, int pkt_size,
                         int data_field_size, uint64_t *checksum) {
-  TMFrameFields tf = {0};
+  TmframeFields tf = {0};
   TmframeValidateTmframe((WIRECTX *)&tf, NULL, bench_err, frame, tm_hdr, 0);
 
   int vcid = (int)tf.VCID;

--- a/bench/gen_stubs.ml
+++ b/bench/gen_stubs.ml
@@ -112,7 +112,7 @@ let generate_c oc =
       pr "  CAMLparam1(v_buf);\n";
       pr "  uint8_t *data = (uint8_t *)Bytes_val(v_buf);\n";
       pr "  uint32_t len = caml_string_length(v_buf);\n";
-      pr "  %sFields ctx = {0};\n" name;
+      pr "  %sFields ctx = {0};\n" ep;
       pr
         "  uint64_t r = %sValidate%s((WIRECTX *) &ctx, NULL, bench_err, data, \
          len, 0);\n"
@@ -130,7 +130,7 @@ let generate_c oc =
       pr "  int count = Int_val(v_n);\n";
       pr "  volatile uint64_t result = 0;\n";
       pr "  if (n_items == 0) CAMLreturn(Val_int(0));\n";
-      pr "  %sFields ctx = {0};\n" name;
+      pr "  %sFields ctx = {0};\n" ep;
       pr "  int64_t t0 = now_ns();\n";
       pr "  for (int i = 0; i < count; i++) {\n";
       pr "    uint8_t *item = buf + ((uint32_t)i %% n_items) * item_size;\n";

--- a/lib/stubs/wire_stubs.ml
+++ b/lib/stubs/wire_stubs.ml
@@ -12,8 +12,8 @@ let c_stub_error_handler ppf lower =
     "  (void)t; (void)f; (void)r; (void)c; (void)ctx; (void)i; (void)p;@\n";
   Fmt.pf ppf "}@\n"
 
-let c_stub_validate ppf ~name ~lower ~ep =
-  Fmt.pf ppf "  %sFields fields = {0};@\n" name;
+let c_stub_validate ppf ~lower ~ep =
+  Fmt.pf ppf "  %sFields fields = {0};@\n" ep;
   Fmt.pf ppf
     "  uint64_t r = %sValidate%s((WIRECTX *) &fields, NULL, %s_err, data, len, \
      0);@\n"
@@ -28,7 +28,7 @@ let field_value ppf (fname, kind) =
       Fmt.pf ppf "caml_copy_int64((int64_t) fields.%s)" fname
   | _ -> Fmt.pf ppf "Val_long(fields.%s)" fname
 
-let c_stub_output ppf ~name ~lower ~ep (s : Wire.Everparse.Raw.struct_) =
+let c_stub_output ppf ~lower ~ep (s : Wire.Everparse.Raw.struct_) =
   let kinds = Wire.Everparse.Raw.field_kinds s in
   let n_fields = List.length kinds in
   (* _parse: validate at offset, allocate record directly in C *)
@@ -39,7 +39,7 @@ let c_stub_output ppf ~name ~lower ~ep (s : Wire.Everparse.Raw.struct_) =
   Fmt.pf ppf
     "  uint8_t *data = (uint8_t *)Bytes_val(v_buf) + Int_val(v_off);@\n";
   Fmt.pf ppf "  uint32_t len = caml_string_length(v_buf) - Int_val(v_off);@\n";
-  c_stub_validate ppf ~name ~lower ~ep;
+  c_stub_validate ppf ~lower ~ep;
   if n_fields > 0 then begin
     Fmt.pf ppf "  v_result = caml_alloc(%d, 0);@\n" n_fields;
     List.iteri
@@ -61,7 +61,7 @@ let c_stub_output ppf ~name ~lower ~ep (s : Wire.Everparse.Raw.struct_) =
     Fmt.pf ppf
       "  uint8_t *data = (uint8_t *)Bytes_val(v_buf) + Int_val(v_off);@\n";
     Fmt.pf ppf "  uint32_t len = caml_string_length(v_buf) - Int_val(v_off);@\n";
-    c_stub_validate ppf ~name ~lower ~ep;
+    c_stub_validate ppf ~lower ~ep;
     Fmt.pf ppf "  value args[%d];@\n" n_fields;
     List.iteri
       (fun i kind -> Fmt.pf ppf "  args[%d] = %a;@\n" i field_value kind)
@@ -76,7 +76,7 @@ let c_stub ppf (s : Wire.Everparse.Raw.struct_) =
   let ep = everparse_name name in
   let lower = String.lowercase_ascii name in
   c_stub_error_handler ppf lower;
-  c_stub_output ppf ~name ~lower ~ep s
+  c_stub_output ppf ~lower ~ep s
 
 let to_c_stubs (structs : Wire.Everparse.Raw.struct_ list) =
   let buf = Buffer.create 4096 in

--- a/lib/test/stubs/test_wire_stubs.ml
+++ b/lib/test/stubs/test_wire_stubs.ml
@@ -208,6 +208,16 @@ let test_c_stubs_with_params () =
   Alcotest.(check bool) "has WIRECTX" true (contains ~sub:"WIRECTX" c);
   Alcotest.(check bool) "has error handler" true (contains ~sub:"bounded_err" c)
 
+let test_c_stubs_normalised_fields_name () =
+  let s = struct_ "CLCWReport" [ field "x" uint8 ] in
+  let c = Wire_stubs.to_c_stubs [ s ] in
+  Alcotest.(check bool)
+    "uses EverParse-normalised <Name>Fields type" true
+    (contains ~sub:"ClcwreportFields" c);
+  Alcotest.(check bool)
+    "does not reference the raw-name Fields type" false
+    (contains ~sub:"CLCWReportFields" c)
+
 let test_c_stubs_many_params () =
   let s =
     param_struct "ManyParams"
@@ -654,6 +664,8 @@ let suite =
       Alcotest.test_case "c stubs: no params" `Quick test_c_stubs_no_params;
       Alcotest.test_case "c stubs: with params" `Quick test_c_stubs_with_params;
       Alcotest.test_case "c stubs: many params" `Quick test_c_stubs_many_params;
+      Alcotest.test_case "c stubs: <Name>Fields uses EverParse-normalised name"
+        `Quick test_c_stubs_normalised_fields_name;
       (* stub name *)
       Alcotest.test_case "name: camelCase" `Quick test_name_camel;
       Alcotest.test_case "name: ALLCAPS" `Quick test_name_allcaps;


### PR DESCRIPTION
EverParse normalises any name segment with 2+ leading capitals (`FSR -> Fsr`, `EP_Header -> EpHeader`) when emitting `<Name>Fields` in `<Name>_Fields.h`. The C stub generator was emitting the raw schema name, so any such schema produced stubs that referenced an undefined struct. Schemas with a single leading capital are unaffected.