### PR TITLE
fix: variable-size sub-codecs and repeat after variable fields

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,8 +38,10 @@
 ### Fixed
 
 - Allow `Wire.codec` sub-codecs and `Wire.repeat` after a variable-size
-  field. Previously raised `add_field: variable-size codec after
-  variable-size field not supported` (#38, @samoht)
+  field. Two consecutive variable-size sub-codecs (e.g. SSH-style
+  back-to-back length-prefixed strings) used to raise `add_field:
+  variable-size codec after variable-size field not supported`
+  (#38, @samoht)
 - Fix C stub generator: use the EverParse-normalised `<Name>Fields`
   type name. Schemas with a name segment of 2+ leading capitals (e.g.
   `IPv4`, `EP_Header`) previously emitted C that referenced an

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -227,11 +227,14 @@ type next_off = Static_next of int | Dynamic_next of (bytes -> int -> int)
 (* [compute buf base] returns the absolute byte offset where the next
          field starts. [base] is the record's base offset in [buf]. *)
 
+type field_reader = string * (bytes -> int -> int)
+(* Name + buffer-and-base reader for a previously-declared int field. *)
+
 (* Compile an [int expr] into a closure that evaluates it at runtime by
    reading previously-declared fields from the buffer. Built once at [add_field]
    time, called at every [get]/[set]/[decode]. *)
-let rec compile_expr (env : (string * (bytes -> int -> int)) list)
-    (e : int expr) : bytes -> int -> int =
+let rec compile_expr (env : field_reader list) (e : int expr) :
+    bytes -> int -> int =
   match e with
   | Int n -> fun _buf _base -> n
   | Ref name -> (
@@ -263,9 +266,7 @@ let rec compile_expr (env : (string * (bytes -> int -> int)) list)
   | _ -> invalid_arg "Codec: unsupported expression in dependent size"
 
 let try_compile_int_reader : type a.
-    (string * (bytes -> int -> int)) list ->
-    a expr ->
-    (bytes -> int -> int) option =
+    field_reader list -> a expr -> (bytes -> int -> int) option =
  fun env -> function
   | Int _ as e -> Some (compile_expr env e)
   | Ref _ as e -> Some (compile_expr env e)
@@ -276,8 +277,8 @@ let try_compile_int_reader : type a.
   | Div _ as e -> Some (compile_expr env e)
   | _ -> None
 
-let rec compile_bool_expr (env : (string * (bytes -> int -> int)) list)
-    (e : bool expr) : bytes -> int -> bool =
+let rec compile_bool_expr (env : field_reader list) (e : bool expr) :
+    bytes -> int -> bool =
   match e with
   | Bool b -> fun _buf _base -> b
   | Eq (a, b) -> (
@@ -526,7 +527,7 @@ type ('f, 'r) record =
           (* fields + action-local vars (for array allocation) *)
       r_bf : bf_codec_state option;
       r_field_access_rev : (string * field_access) list;
-      r_field_readers : (string * (bytes -> int -> int)) list;
+      r_field_readers : field_reader list;
       r_where : bool expr option;
     }
       -> ('f, 'r) record
@@ -541,7 +542,7 @@ type 'r t = {
   t_id : int;
   t_name : string;
   t_field_access : (string * field_access) list;
-  t_field_readers : (string * (bytes -> int -> int)) list;
+  t_field_readers : field_reader list;
   t_field_actions : (string * compiled_action) list;
   t_decode : bytes -> int -> 'r;
   t_encode : 'r -> bytes -> int -> unit;
@@ -883,7 +884,7 @@ type ('a, 'r) compiled_field = {
   int_reader : bytes -> int -> int;
       (* Entry stored in [r_field_readers] under the field name; const 0 for
          composite types that have no int-array slot of their own. *)
-  nested_readers : (string * (bytes -> int -> int)) list;
+  nested_readers : field_reader list;
       (* Embedded sub-codec field readers, shifted into the parent frame. *)
   validator_off : int; (* [-1] when the byte offset is dynamic *)
   populate : int array -> bytes -> int -> unit;
@@ -898,7 +899,7 @@ type ('a, 'r) compiled_field = {
 type layout_ctx = {
   lc_next_off : next_off;
   lc_bf : bf_codec_state option;
-  lc_field_readers : (string * (bytes -> int -> int)) list;
+  lc_field_readers : field_reader list;
   lc_n_fields : int;
 }
 
@@ -1121,7 +1122,7 @@ and compile_codec : type a r.
     codec_encode:(a -> bytes -> int -> unit) ->
     codec_fixed_size:int option ->
     codec_size_of:(bytes -> int -> int) ->
-    codec_field_readers:(string * (bytes -> int -> int)) list ->
+    codec_field_readers:field_reader list ->
     (a, r) compiled_field =
  fun ctx fld ~codec_decode ~codec_encode ~codec_fixed_size ~codec_size_of
      ~codec_field_readers ->
@@ -1145,23 +1146,55 @@ and compile_codec : type a r.
         populate = no_populate;
       }
   | None ->
-      let field_off = require_static_off ctx ~what:"variable-size codec" in
-      let size_fn buf base = codec_size_of buf (base + field_off) in
-      {
-        raw_reader = (fun buf base -> codec_decode buf (base + field_off));
-        raw_writer =
-          (fun v buf off -> codec_encode (get v) buf (off + field_off));
-        extra_writers = [];
-        field_access = Variable { off = field_off; size_fn };
-        size_delta = 0;
-        next_off =
-          Dynamic_next (fun buf base -> base + field_off + size_fn buf base);
-        bf_after = None;
-        int_reader = null_int_reader;
-        nested_readers;
-        validator_off = field_off;
-        populate = no_populate;
-      }
+      compile_codec_variable ctx ~get ~codec_decode ~codec_encode ~codec_size_of
+        ~nested_readers
+
+(* Variable-size sub-codec: dispatch on whether we sit at a static or a
+   dynamic running offset. Mirrors [compile_var_bytes] -- both flavours
+   produce a [Variable]/[Variable_dynamic] [field_access] that downstream
+   [build_staged_reader]/[build_staged_writer] already know how to thread.
+   Without the dynamic case, two consecutive variable-size sub-codec fields
+   trip [require_static_off]. *)
+and compile_codec_variable : type a r.
+    layout_ctx ->
+    get:(r -> a) ->
+    codec_decode:(bytes -> int -> a) ->
+    codec_encode:(a -> bytes -> int -> unit) ->
+    codec_size_of:(bytes -> int -> int) ->
+    nested_readers:field_reader list ->
+    (a, r) compiled_field =
+ fun ctx ~get ~codec_decode ~codec_encode ~codec_size_of ~nested_readers ->
+  let off_fn, (field_access : field_access), validator_off =
+    match ctx.lc_next_off with
+    | Static_next n ->
+        let size_fn buf base = codec_size_of buf (base + n) in
+        ((fun _buf _base -> n), Variable { off = n; size_fn }, n)
+    | Dynamic_next prev_end ->
+        let off_fn buf base = prev_end buf base - base in
+        let size_fn buf base = codec_size_of buf (base + off_fn buf base) in
+        (off_fn, Variable_dynamic { off_fn; size_fn }, -1)
+  in
+  let size_fn =
+    match field_access with
+    | Variable { size_fn; _ } -> size_fn
+    | Variable_dynamic { size_fn; _ } -> size_fn
+    | _ -> assert false
+  in
+  {
+    raw_reader = (fun buf base -> codec_decode buf (base + off_fn buf base));
+    raw_writer =
+      (fun v buf off -> codec_encode (get v) buf (off + off_fn buf off));
+    extra_writers = [];
+    field_access;
+    size_delta = 0;
+    next_off =
+      Dynamic_next (fun buf base -> base + off_fn buf base + size_fn buf base);
+    bf_after = None;
+    int_reader = null_int_reader;
+    nested_readers;
+    validator_off;
+    populate = no_populate;
+  }
 
 and dynamic_optional_next_off ctx present_fn fsize =
   let base_off = ctx.lc_next_off in
@@ -1280,6 +1313,42 @@ and compile_optional_or : type a r.
         "add_field: dynamic optional_or with variable-size inner not yet \
          supported"
 
+and repeat_raw_reader : type elt seq.
+    (elt, seq) seq_map ->
+    elt typ ->
+    elem_size:int option ->
+    off_fn:(bytes -> int -> int) ->
+    size_fn:(bytes -> int -> int) ->
+    bytes ->
+    int ->
+    seq =
+ fun (Seq_map seq) elem ~elem_size ~off_fn ~size_fn ->
+  match elem_size with
+  | Some esz ->
+      (* Fixed-size elements: direct fill via builder. *)
+      fun buf base ->
+        let budget = size_fn buf base in
+        let n = if esz > 0 then budget / esz else 0 in
+        let start = base + off_fn buf base in
+        let rec loop acc i =
+          if i >= n then seq.finish acc
+          else
+            loop (seq.add acc (read_elem elem buf (start + (i * esz)))) (i + 1)
+        in
+        loop seq.empty 0
+  | None ->
+      (* Variable-size elements: builder accumulation. *)
+      fun buf base ->
+        let budget = size_fn buf base in
+        let rec loop acc pos remaining =
+          if remaining <= 0 then seq.finish acc
+          else
+            let v = read_elem elem buf pos in
+            let esz = elem_size_of elem buf pos in
+            loop (seq.add acc v) (pos + esz) (remaining - esz)
+        in
+        loop seq.empty (base + off_fn buf base) budget
+
 and compile_repeat : type elt seq r.
     layout_ctx ->
     (seq, r) field ->
@@ -1288,35 +1357,26 @@ and compile_repeat : type elt seq r.
     (elt, seq) seq_map ->
     (seq, r) compiled_field =
  fun ctx fld size_expr elem (Seq_map seq) ->
-  let field_off = require_static_off ctx ~what:"repeat" in
+  (* Same dynamic-offset dispatch as [compile_var_bytes] / [compile_codec]:
+     when a [Repeat] sits after a variable-size field, the running offset
+     is [Dynamic_next], which previously tripped [require_static_off]. *)
+  let off_fn, (field_access : field_access), validator_off =
+    let size_fn = compile_expr ctx.lc_field_readers size_expr in
+    match ctx.lc_next_off with
+    | Static_next n -> ((fun _buf _base -> n), Variable { off = n; size_fn }, n)
+    | Dynamic_next prev_end ->
+        let off_fn buf base = prev_end buf base - base in
+        (off_fn, Variable_dynamic { off_fn; size_fn }, -1)
+  in
+  let size_fn =
+    match field_access with
+    | Variable { size_fn; _ } -> size_fn
+    | Variable_dynamic { size_fn; _ } -> size_fn
+    | _ -> assert false
+  in
   let elem_size = field_wire_size elem in
-  let size_fn = compile_expr ctx.lc_field_readers size_expr in
-  let raw_reader : bytes -> int -> seq =
-    match elem_size with
-    | Some esz ->
-        (* Fixed-size elements: direct fill via builder. *)
-        fun buf base ->
-          let budget = size_fn buf base in
-          let n = if esz > 0 then budget / esz else 0 in
-          let start = base + field_off in
-          let rec loop acc i =
-            if i >= n then seq.finish acc
-            else
-              loop (seq.add acc (read_elem elem buf (start + (i * esz)))) (i + 1)
-          in
-          loop seq.empty 0
-    | None ->
-        (* Variable-size elements: builder accumulation. *)
-        fun buf base ->
-          let budget = size_fn buf base in
-          let rec loop acc pos remaining =
-            if remaining <= 0 then seq.finish acc
-            else
-              let v = read_elem elem buf pos in
-              let esz = elem_size_of elem buf pos in
-              loop (seq.add acc v) (pos + esz) (remaining - esz)
-          in
-          loop seq.empty (base + field_off) budget
+  let raw_reader =
+    repeat_raw_reader (Seq_map seq) elem ~elem_size ~off_fn ~size_fn
   in
   let get = fld.get in
   let step =
@@ -1326,7 +1386,7 @@ and compile_repeat : type elt seq r.
   in
   let raw_writer v buf off =
     let items = get v in
-    let pos = Stdlib.ref (off + field_off) in
+    let pos = Stdlib.ref (off + off_fn buf off) in
     seq.iter
       (fun item ->
         write_elem elem buf !pos item;
@@ -1337,14 +1397,14 @@ and compile_repeat : type elt seq r.
     raw_reader;
     raw_writer;
     extra_writers = [];
-    field_access = Variable { off = field_off; size_fn };
+    field_access;
     size_delta = 0;
     next_off =
-      Dynamic_next (fun buf base -> base + field_off + size_fn buf base);
+      Dynamic_next (fun buf base -> base + off_fn buf base + size_fn buf base);
     bf_after = None;
     int_reader = null_int_reader;
     nested_readers = [];
-    validator_off = field_off;
+    validator_off;
     populate = no_populate;
   }
 
@@ -1849,7 +1909,7 @@ type validator = {
 type validator_acc = {
   va_validators_rev : (int * (int array -> bytes -> int -> unit)) list;
   va_checkers_rev : (int * (int array -> bytes -> int -> unit)) list;
-  va_field_readers : (string * (bytes -> int -> int)) list;
+  va_field_readers : field_reader list;
   va_n_fields : int;
   va_n_array_slots : int;
   va_min_size : int;

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -3217,6 +3217,127 @@ let test_multi_var_fixed_after () =
   Alcotest.(check string) "tx" "\xBB\xCC" tx;
   Alcotest.(check int) "trail" 0xBEEF trail
 
+(* -- Multiple variable-size sub-codecs back-to-back (SSH disconnect /
+      debug shape). [compile_codec] used to bail with [require_static_off]
+      when a [Wire.codec]-embedded variable-size sub-codec sat after
+      another variable-size field. -- *)
+
+module Slice = Bytesrw.Bytes.Slice
+
+type ssh_string = { ss_len : int; ss_data : Slice.t }
+
+let ssh_f_len = Field.v "len" uint32be
+let ssh_f_data = Field.v "data" (byte_slice ~size:(Field.ref ssh_f_len))
+
+let ssh_string_codec =
+  Codec.v "SshString"
+    (fun len data -> { ss_len = len; ss_data = data })
+    Codec.[ (ssh_f_len $ fun s -> s.ss_len); (ssh_f_data $ fun s -> s.ss_data) ]
+
+let mk_ssh_string s =
+  let b = Bytes.of_string s in
+  {
+    ss_len = String.length s;
+    ss_data = Slice.make b ~first:0 ~length:(Bytes.length b);
+  }
+
+let test_ssh_two_var_slices () =
+  (* SSH_MSG_DISCONNECT: reason (uint32) + len + desc + len + lang *)
+  let f_reason = Field.v "reason" uint32be in
+  let f_desc_len = Field.v "desc_len" uint32be in
+  let f_desc = Field.v "desc" (byte_slice ~size:(Field.ref f_desc_len)) in
+  let f_lang_len = Field.v "lang_len" uint32be in
+  let f_lang = Field.v "lang" (byte_slice ~size:(Field.ref f_lang_len)) in
+  let codec =
+    let open Codec in
+    v "Disconnect"
+      (fun reason _ desc _ lang -> (reason, desc, lang))
+      [
+        (f_reason $ fun (r, _, _) -> r);
+        (f_desc_len $ fun (_, d, _) -> Slice.length d);
+        (f_desc $ fun (_, d, _) -> d);
+        (f_lang_len $ fun (_, _, l) -> Slice.length l);
+        (f_lang $ fun (_, _, l) -> l);
+      ]
+  in
+  let v =
+    (11, (mk_ssh_string "bye").ss_data, (mk_ssh_string "en-US").ss_data)
+  in
+  let buf = Bytes.create 200 in
+  Codec.encode codec v buf 0;
+  let r, d, l = decode_ok (Codec.decode codec buf 0) in
+  Alcotest.(check int) "reason" 11 r;
+  Alcotest.(check string) "desc" "bye" (Slice.to_string d);
+  Alcotest.(check string) "lang" "en-US" (Slice.to_string l)
+
+let test_two_var_codecs_embedded () =
+  (* Two consecutive [Wire.codec ssh_string_codec] embedded fields.
+     This is the case that previously tripped [require_static_off]. *)
+  let f_a = Field.v "a" (codec ssh_string_codec) in
+  let f_b = Field.v "b" (codec ssh_string_codec) in
+  let pair_codec =
+    let open Codec in
+    v "Pair" (fun a b -> (a, b)) [ f_a $ fst; f_b $ snd ]
+  in
+  let v = (mk_ssh_string "abcd", mk_ssh_string "xy") in
+  let buf = Bytes.create 200 in
+  Codec.encode pair_codec v buf 0;
+  let a, b = decode_ok (Codec.decode pair_codec buf 0) in
+  Alcotest.(check int) "a.len" 4 a.ss_len;
+  Alcotest.(check string) "a.data" "abcd" (Slice.to_string a.ss_data);
+  Alcotest.(check int) "b.len" 2 b.ss_len;
+  Alcotest.(check string) "b.data" "xy" (Slice.to_string b.ss_data)
+
+let test_three_var_codecs_embedded () =
+  (* SSH_MSG_DEBUG-shaped payload: three variable-size sub-codecs. *)
+  let f_a = Field.v "a" (codec ssh_string_codec) in
+  let f_b = Field.v "b" (codec ssh_string_codec) in
+  let f_c = Field.v "c" (codec ssh_string_codec) in
+  let triple_codec =
+    let open Codec in
+    v "Triple"
+      (fun a b c -> (a, b, c))
+      [
+        (f_a $ fun (a, _, _) -> a);
+        (f_b $ fun (_, b, _) -> b);
+        (f_c $ fun (_, _, c) -> c);
+      ]
+  in
+  let v = (mk_ssh_string "alpha", mk_ssh_string "be", mk_ssh_string "gamma!") in
+  let buf = Bytes.create 200 in
+  Codec.encode triple_codec v buf 0;
+  let a, b, c = decode_ok (Codec.decode triple_codec buf 0) in
+  Alcotest.(check string) "a" "alpha" (Slice.to_string a.ss_data);
+  Alcotest.(check string) "b" "be" (Slice.to_string b.ss_data);
+  Alcotest.(check string) "c" "gamma!" (Slice.to_string c.ss_data)
+
+let test_repeat_after_var_slice () =
+  (* [Repeat] after a variable-size field used to trip [require_static_off]
+     in [compile_repeat]. The fix mirrors [compile_codec]'s. *)
+  let f_prefix_len = Field.v "prefix_len" uint8 in
+  let f_prefix = Field.v "prefix" (byte_slice ~size:(Field.ref f_prefix_len)) in
+  let f_count = Field.v "count" uint8 in
+  let f_items =
+    Field.v "items" (Wire.repeat ~size:(Field.ref f_count) Wire.uint16be)
+  in
+  let codec =
+    let open Codec in
+    v "PrefixedItems"
+      (fun _ prefix _ items -> (prefix, items))
+      [
+        (f_prefix_len $ fun (p, _) -> Slice.length p);
+        (f_prefix $ fun (p, _) -> p);
+        (f_count $ fun (_, items) -> 2 * List.length items);
+        (f_items $ fun (_, items) -> items);
+      ]
+  in
+  let buf = Bytes.create 200 in
+  let v = ((mk_ssh_string "PREFIX").ss_data, [ 0x0102; 0x0304; 0x0506 ]) in
+  Codec.encode codec v buf 0;
+  let prefix, items = decode_ok (Codec.decode codec buf 0) in
+  Alcotest.(check string) "prefix" "PREFIX" (Slice.to_string prefix);
+  Alcotest.(check (list int)) "items" [ 0x0102; 0x0304; 0x0506 ] items
+
 (* -- uint: variable-width unsigned integer -- *)
 
 type uint_rec = { tag : int; value : int }
@@ -3686,6 +3807,14 @@ let suite =
       Alcotest.test_case "multi-var: get" `Quick test_multi_var_get;
       Alcotest.test_case "multi-var: fixed after" `Quick
         test_multi_var_fixed_after;
+      Alcotest.test_case "multi-var: ssh disconnect (two var byte_slice)" `Quick
+        test_ssh_two_var_slices;
+      Alcotest.test_case "multi-var: two embedded sub-codecs" `Quick
+        test_two_var_codecs_embedded;
+      Alcotest.test_case "multi-var: three embedded sub-codecs" `Quick
+        test_three_var_codecs_embedded;
+      Alcotest.test_case "multi-var: repeat after variable byte_slice" `Quick
+        test_repeat_after_var_slice;
       (* uint: variable-width unsigned integer *)
       Alcotest.test_case "uint: 3-byte BE roundtrip" `Quick test_uint_3byte_be;
       Alcotest.test_case "uint: 1-byte like uint8" `Quick test_uint_1byte;


### PR DESCRIPTION
Two consecutive variable-size fields where the second is a `Wire.codec` sub-codec or a `Wire.repeat` used to raise `add_field: variable-size codec after variable-size field not supported`. The motivating shape is RFC 4253 `SSH_MSG_DISCONNECT` / `SSH_MSG_DEBUG`: a fixed prefix followed by several back-to-back length-prefixed strings, each modelled as its own sub-codec.

`compile_var_bytes` already dispatched on `Static_next` / `Dynamic_next`, emitting `Variable` or `Variable_dynamic` field-access. `compile_codec` and `compile_repeat` bailed via `require_static_off` instead. Mirror the same dispatch into both. `build_staged_reader` / `build_staged_writer` already understand both flavours, so the change is local.

`compile_bitfield`'s `require_static_off` stays: bitfields need a static byte offset to lay out the base word, so a bitfield after a variable-size field is a real DSL constraint, not a bug.

Tests cover the SSH disconnect shape (two sub-codecs), SSH debug (three), the previously-passing two-`byte_slice` baseline, and `Wire.repeat` after a variable-size `byte_slice`.