### PR TITLE
wire: per-byte refinement on byte arrays (byte_array_where)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,7 +16,7 @@
   projection synthesises a 1-byte refinement struct per use and
   references it from the parent field, so both wire and EverParse C
   enforce the same per-element constraint. Motivating shape:
-  printable-ASCII bodies (SSH name-list, RFC 4251 §5) (@samoht)
+  printable-ASCII bodies (SSH name-list, RFC 4251 sec 5) (@samoht)
 
 ### Changed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,13 @@
   `Slice.first (Codec.get ...)` pattern (#37, @samoht)
 - `Wire.codec` type alias for `'r Codec.t`, and `Wire.pp_value` to
   print a record field-by-field through its codec (@samoht)
+- `Wire.byte_array_where ~size ~per_byte`: byte span with a per-byte
+  refinement. Decode raises `Parse_error` on the first byte that
+  violates the constraint; encode raises `Invalid_argument`. The 3D
+  projection synthesises a 1-byte refinement struct per use and
+  references it from the parent field, so both wire and EverParse C
+  enforce the same per-element constraint. Motivating shape:
+  printable-ASCII bodies (SSH name-list, RFC 4251 §5) (@samoht)
 
 ### Changed
 

--- a/lib/ascii.ml
+++ b/lib/ascii.ml
@@ -121,6 +121,8 @@ let field_segment (Types.Field { field_name; field_typ; constraint_; _ }) =
             match field_typ with
             | Byte_array { size } | Byte_slice { size } ->
                 Fmt.str "%s (%s bytes)" name (string_of_expr size)
+            | Byte_array_where { size; _ } ->
+                Fmt.str "%s (%s bytes, refined)" name (string_of_expr size)
             | Array { len; elem; _ } ->
                 let elem_info =
                   match Types.field_wire_size elem with

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -4,6 +4,12 @@ module Param = Param
 
 (** Build a specialized field encoder: writes field value to bytes at offset.
     Returns the new offset. Works directly on the slice's underlying bytes. *)
+let blit_string_padded n buf off v =
+  let len = min n (String.length v) in
+  Bytes.blit_string v 0 buf off len;
+  if len < n then Bytes.fill buf (off + len) (n - len) '\x00';
+  off + n
+
 let rec build_field_encoder : type a. a typ -> bytes -> int -> a -> int =
  fun typ ->
   match typ with
@@ -47,12 +53,8 @@ let rec build_field_encoder : type a. a typ -> bytes -> int -> a -> int =
       fun buf off v ->
         Uint_var.write endian buf off n v;
         off + n
-  | Byte_array { size = Int n } ->
-      fun buf off v ->
-        let len = min n (String.length v) in
-        Bytes.blit_string v 0 buf off len;
-        if len < n then Bytes.fill buf (off + len) (n - len) '\x00';
-        off + n
+  | Byte_array { size = Int n } -> blit_string_padded n
+  | Byte_array_where { size = Int n; _ } -> blit_string_padded n
   | Byte_slice { size = Int n } ->
       fun buf off v ->
         let len = min n (Slice.length v) in
@@ -105,6 +107,8 @@ let rec build_field_reader : type a. a typ -> int -> bytes -> int -> a =
   | Uint_var { size = Int n; endian } ->
       fun buf base -> Uint_var.read endian buf (base + field_off) n
   | Byte_array { size = Int n } ->
+      fun buf base -> Bytes.sub_string buf (base + field_off) n
+  | Byte_array_where { size = Int n; _ } ->
       fun buf base -> Bytes.sub_string buf (base + field_off) n
   | Byte_slice { size = Int n } ->
       fun buf base -> Slice.make buf ~first:(base + field_off) ~length:n
@@ -765,6 +769,9 @@ let rec iter_param_refs_typ : type a. (Param.packed -> unit) -> a typ -> unit =
  fun f typ ->
   match typ with
   | Byte_array { size } | Byte_slice { size } -> iter_param_refs f size
+  | Byte_array_where { size; cond; _ } ->
+      iter_param_refs f size;
+      iter_param_refs f cond
   | Uint_var { size; _ } -> iter_param_refs f size
   | Single_elem { size; elem; _ } ->
       iter_param_refs f size;
@@ -1404,6 +1411,7 @@ and var_bytes_reader : type a.
   match typ with
   | Byte_slice _ -> Slice.make_or_eod buf ~first:(base + fo) ~length:sz
   | Byte_array _ -> Bytes.sub_string buf (base + fo) sz
+  | Byte_array_where _ -> Bytes.sub_string buf (base + fo) sz
   | _ -> assert false
 
 and var_bytes_writer : type a r.
@@ -1419,6 +1427,9 @@ and var_bytes_writer : type a r.
   | Byte_array _ ->
       let s = (value : string) in
       Bytes.blit_string s 0 buf (off + fo) (String.length s)
+  | Byte_array_where _ ->
+      let s = (value : string) in
+      Bytes.blit_string s 0 buf (off + fo) (String.length s)
   | _ -> assert false
 
 and compile_var_bytes : type a r.
@@ -1429,6 +1440,7 @@ and compile_var_bytes : type a r.
     match typ with
     | Byte_slice { size } -> size
     | Byte_array { size } -> size
+    | Byte_array_where { size; _ } -> size
     | Uint_var { size; _ } -> size
     | _ -> invalid_arg "add_field: unsupported variable-size field type"
   in
@@ -2175,12 +2187,21 @@ let rec build_staged_reader : type a. a typ -> field_access -> bytes -> int -> a
       fun buf base ->
         let sz = size_fn buf base in
         Bytes.sub_string buf (base + off) sz
+  | Byte_array_where _, Variable { off; size_fn } ->
+      fun buf base ->
+        let sz = size_fn buf base in
+        Bytes.sub_string buf (base + off) sz
   | Byte_slice _, Variable_dynamic { off_fn; size_fn } ->
       fun buf base ->
         let fo = off_fn buf base in
         let sz = size_fn buf base in
         Slice.make_or_eod buf ~first:(base + fo) ~length:sz
   | Byte_array _, Variable_dynamic { off_fn; size_fn } ->
+      fun buf base ->
+        let fo = off_fn buf base in
+        let sz = size_fn buf base in
+        Bytes.sub_string buf (base + fo) sz
+  | Byte_array_where _, Variable_dynamic { off_fn; size_fn } ->
       fun buf base ->
         let fo = off_fn buf base in
         let sz = size_fn buf base in
@@ -2222,6 +2243,10 @@ let rec build_staged_writer : type a.
       fun buf base value ->
         let s = (value : string) in
         Bytes.blit_string s 0 buf (base + off) (String.length s)
+  | Byte_array_where _, Variable { off; _ } ->
+      fun buf base value ->
+        let s = (value : string) in
+        Bytes.blit_string s 0 buf (base + off) (String.length s)
   | Byte_slice _, Variable_dynamic { off_fn; _ } ->
       fun buf base value ->
         let fo = off_fn buf base in
@@ -2229,6 +2254,11 @@ let rec build_staged_writer : type a.
         let len = Slice.length src in
         Bytes.blit (Slice.bytes src) (Slice.first src) buf (base + fo) len
   | Byte_array _, Variable_dynamic { off_fn; _ } ->
+      fun buf base value ->
+        let fo = off_fn buf base in
+        let s = (value : string) in
+        Bytes.blit_string s 0 buf (base + fo) (String.length s)
+  | Byte_array_where _, Variable_dynamic { off_fn; _ } ->
       fun buf base value ->
         let fo = off_fn buf base in
         let s = (value : string) in

--- a/lib/eval.ml
+++ b/lib/eval.ml
@@ -10,9 +10,10 @@
 
 open Types
 
-type ctx = unit
+type ctx = (string * int) list
 
-let empty : ctx = ()
+let empty : ctx = []
+let bind name v ctx = (name, v) :: ctx
 
 (* Convert a typed value to [int]. Returns [None] for types that don't
    fit in OCaml int (uint64 over 2^63, non-numeric). *)
@@ -31,9 +32,9 @@ let rec int_of : type a. a typ -> a -> int option =
   | Single_elem { elem; _ } -> int_of elem v
   | Apply { typ; _ } -> int_of typ v
   | Map { inner; encode; _ } -> int_of inner (encode v)
-  | Unit | All_bytes | All_zeros | Array _ | Byte_array _ | Byte_slice _
-  | Casetype _ | Struct _ | Type_ref _ | Qualified_ref _ | Codec _ | Optional _
-  | Optional_or _ | Repeat _ ->
+  | Unit | All_bytes | All_zeros | Array _ | Byte_array _ | Byte_array_where _
+  | Byte_slice _ | Casetype _ | Struct _ | Type_ref _ | Qualified_ref _
+  | Codec _ | Optional _ | Optional_or _ | Repeat _ ->
       None
 
 let rec expr : type a. ctx -> a expr -> a =
@@ -42,10 +43,13 @@ let rec expr : type a. ctx -> a expr -> a =
   | Int n -> n
   | Int64 n -> n
   | Bool b -> b
-  | Ref name ->
-      failwith
-        ("Eval.expr: unbound field " ^ name
-       ^ " (cross-field references are only valid inside a struct)")
+  | Ref name -> (
+      match List.assoc_opt name ctx with
+      | Some v -> v
+      | None ->
+          failwith
+            ("Eval.expr: unbound field " ^ name
+           ^ " (cross-field references are only valid inside a struct)"))
   | Param_ref p -> !(p.ph_cell)
   | Sizeof t -> field_wire_size t |> Option.value ~default:0
   | Sizeof_this -> 0

--- a/lib/eval.mli
+++ b/lib/eval.mli
@@ -15,7 +15,7 @@ type ctx
     machinery; at top level the binding is empty unless explicitly extended. *)
 
 val empty : ctx
-(** Empty context — no bindings. *)
+(** Empty context, no bindings. *)
 
 val bind : string -> int -> ctx -> ctx
 (** [bind name v ctx] extends [ctx] so that [Ref name] evaluates to [v]. *)

--- a/lib/eval.mli
+++ b/lib/eval.mli
@@ -8,11 +8,17 @@
     expressions in {!empty}: no field references, no cross-field dependencies.
 *)
 
-type ctx = unit
-(** Empty context type. Cross-field state lives in [Codec]'s int-array
-    machinery; at top level there is nothing to thread. *)
+type ctx
+(** Top-level evaluation context. Used by [Byte_array_where]'s per-element
+    refinement, which binds the element variable to the byte value before
+    evaluating its constraint. Cross-field state lives in [Codec]'s int-array
+    machinery; at top level the binding is empty unless explicitly extended. *)
 
 val empty : ctx
+(** Empty context — no bindings. *)
+
+val bind : string -> int -> ctx -> ctx
+(** [bind name v ctx] extends [ctx] so that [Ref name] evaluates to [v]. *)
 
 val int_of : 'a Types.typ -> 'a -> int option
 (** [int_of typ v] converts a typed value to [int]. Returns [None] for types

--- a/lib/everparse.ml
+++ b/lib/everparse.ml
@@ -20,7 +20,9 @@ let rec is_bitfield : type a. a Types.typ -> bool = function
   | _ -> false
 
 let rec is_byte_field : type a. a Types.typ -> bool = function
-  | Types.Byte_array _ | Types.Byte_slice _ | Types.Uint_var _ -> true
+  | Types.Byte_array _ | Types.Byte_array_where _ | Types.Byte_slice _
+  | Types.Uint_var _ ->
+      true
   | Types.Optional { present = Types.Bool _; _ } -> false
   | Types.Optional _ -> true
   | Types.Optional_or { present = Types.Bool _; _ } -> false
@@ -58,7 +60,8 @@ let rec type_suffix : type a. a Types.typ -> string = function
 let rec setter_of : type a. string -> a Types.typ -> setter_info =
  fun schema_name t ->
   match t with
-  | Types.Byte_array _ | Types.Byte_slice _ | Types.Uint_var _ ->
+  | Types.Byte_array _ | Types.Byte_array_where _ | Types.Byte_slice _
+  | Types.Uint_var _ ->
       {
         setter_name = schema_name ^ "SetBytes";
         setter_val_typ = Types.Pack_typ (Types.Uint32 Types.Little);
@@ -280,6 +283,24 @@ let collect_extern_setters schema_name ctx_struct u32 fields =
           end)
     fields
 
+(* For each [Byte_array_where] field in [s], synthesise a 1-byte struct that
+   names the element [elt_var] and applies [cond] as a field constraint.
+   3D's syntax does not allow per-element refinement on the byte-size array
+   itself, so we lift the refinement into a wrapper struct and reference it
+   from the parent field. The naming convention shared with
+   [Types.synth_name_of_elt_var] keeps the field rendering and the typedef
+   name in sync without threading state. *)
+let refined_byte_typedefs (s : Types.struct_) : Types.decl list =
+  List.filter_map
+    (fun (Types.Field f) ->
+      match f.field_typ with
+      | Types.Byte_array_where { elt_var; cond; _ } ->
+          let synth = Types.synth_name_of_elt_var elt_var in
+          let elt_field = Types.field elt_var ~constraint_:cond Types.uint8 in
+          Some (Types.typedef (Types.struct_ synth [ elt_field ]))
+      | _ -> None)
+    s.fields
+
 let with_output (s : Types.struct_) : Types.decl list =
   (* Extern declarations for the callback mechanism *)
   let ctx_struct = Types.struct_ "WireCtx" [] in
@@ -307,7 +328,8 @@ let with_output (s : Types.struct_) : Types.decl list =
   in
   let parse_decl = Types.typedef ~entrypoint:true parse_struct in
   let extern_decls = collect_extern_setters s.name ctx_struct u32 s.fields in
-  [ ctx_decl ] @ extern_decls @ [ parse_decl ]
+  let refined_decls = refined_byte_typedefs s in
+  [ ctx_decl ] @ extern_decls @ refined_decls @ [ parse_decl ]
 
 (* Byte size of a struct after bitfield coalescing, mirroring Codec.compile_bits'
    logic: consecutive same-base, same-bit_order bitfields pack into one base

--- a/lib/param.ml
+++ b/lib/param.ml
@@ -17,9 +17,9 @@ let rec to_int : type a. a Types.typ -> a -> int =
   | Single_elem { elem; _ } -> to_int elem v
   | Map { inner; encode; _ } -> to_int inner (encode v)
   | Apply { typ; _ } -> to_int typ v
-  | Unit | All_bytes | All_zeros | Array _ | Byte_array _ | Byte_slice _
-  | Casetype _ | Struct _ | Type_ref _ | Qualified_ref _ | Codec _ | Optional _
-  | Optional_or _ | Repeat _ ->
+  | Unit | All_bytes | All_zeros | Array _ | Byte_array _ | Byte_array_where _
+  | Byte_slice _ | Casetype _ | Struct _ | Type_ref _ | Qualified_ref _
+  | Codec _ | Optional _ | Optional_or _ | Repeat _ ->
       invalid_arg "Param: unsupported parameter type"
 
 let rec of_int : type a. a Types.typ -> int -> a =
@@ -37,9 +37,9 @@ let rec of_int : type a. a Types.typ -> int -> a =
   | Single_elem { elem; _ } -> of_int elem v
   | Map { inner; decode; _ } -> decode (of_int inner v)
   | Apply { typ; _ } -> of_int typ v
-  | Unit | All_bytes | All_zeros | Array _ | Byte_array _ | Byte_slice _
-  | Casetype _ | Struct _ | Type_ref _ | Qualified_ref _ | Codec _ | Optional _
-  | Optional_or _ | Repeat _ ->
+  | Unit | All_bytes | All_zeros | Array _ | Byte_array _ | Byte_array_where _
+  | Byte_slice _ | Casetype _ | Struct _ | Type_ref _ | Qualified_ref _
+  | Codec _ | Optional _ | Optional_or _ | Repeat _ ->
       invalid_arg "Param: unsupported parameter type"
 
 let rec is_int_representable : type a. a Types.typ -> bool = function

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -89,6 +89,12 @@ and _ typ =
     }
       -> 'seq typ
   | Byte_array : { size : int expr } -> string typ
+  | Byte_array_where : {
+      size : int expr;
+      elt_var : string;
+      cond : bool expr;
+    }
+      -> string typ
   | Byte_slice : { size : int expr } -> Bytesrw.Bytes.Slice.t typ
   | Single_elem : { size : int expr; elem : 'a typ; at_most : bool } -> 'a typ
   | Enum : {
@@ -293,6 +299,26 @@ let seq_list : ('a, 'a list) seq_map =
 let array ~len elem = Array { len; elem; seq = seq_list }
 let array_seq seq ~len elem = Array { len; elem; seq }
 let byte_array ~size = Byte_array { size }
+let byte_array_where_counter = Stdlib.ref 0
+let elt_var_prefix = "__elt_"
+
+let byte_array_where ~size ~per_byte =
+  let n = !byte_array_where_counter in
+  Stdlib.incr byte_array_where_counter;
+  let elt_var = elt_var_prefix ^ string_of_int n in
+  let cond = per_byte (Ref elt_var) in
+  Byte_array_where { size; elt_var; cond }
+
+(* The 3D synthesized typedef name derived from an elt_var. The element
+   field inside the synthesized struct keeps the elt_var as its name so the
+   captured [cond] (which references [elt_var] via [Ref]) renders as a
+   constraint on that field directly. *)
+let synth_name_of_elt_var ev =
+  let plen = String.length elt_var_prefix in
+  if String.length ev > plen && String.sub ev 0 plen = elt_var_prefix then
+    "_RefByte_" ^ String.sub ev plen (String.length ev - plen)
+  else "_RefByte_" ^ ev
+
 let byte_slice ~size = Byte_slice { size }
 let optional present inner = Optional { present; inner }
 let optional_or present ~default inner = Optional_or { present; inner; default }
@@ -423,6 +449,7 @@ let rec ocaml_kind_of : type a. a typ -> ocaml_kind = function
   | Enum { base; _ } -> ocaml_kind_of base
   | Where { inner; _ } -> ocaml_kind_of inner
   | Byte_array _ -> K_string
+  | Byte_array_where _ -> K_string
   | Byte_slice _ -> K_string (* approximate: slice becomes string in output *)
   | Unit | All_bytes | All_zeros -> K_unit
   | _ -> K_int (* fallback *)
@@ -647,6 +674,8 @@ and pp_typ : type a. a typ Fmt.t =
   | Array { len; elem; _ } -> Fmt.pf ppf "%a[%a]" pp_typ elem pp_expr len
   | Byte_array { size } | Byte_slice { size } ->
       Fmt.pf ppf "UINT8[:byte-size %a]" pp_expr size
+  | Byte_array_where { size; cond; _ } ->
+      Fmt.pf ppf "UINT8 { %a }[:byte-size %a]" pp_expr cond pp_expr size
   | Single_elem { size; elem; at_most = false } ->
       Fmt.pf ppf "%a[:byte-size-single-element-array %a]" pp_typ elem pp_expr
         size
@@ -738,6 +767,9 @@ and field_suffix : type a. a typ -> field_suffix * (Format.formatter -> unit) =
   | Uint_var { size; _ } -> (Byte_array size, fun ppf -> Fmt.string ppf "UINT8")
   | Byte_array { size } | Byte_slice { size } ->
       (Byte_array size, fun ppf -> Fmt.string ppf "UINT8")
+  | Byte_array_where { size; elt_var; _ } ->
+      let synth = synth_name_of_elt_var elt_var in
+      (Byte_array size, fun ppf -> Fmt.string ppf synth)
   | Single_elem { size; elem; at_most } ->
       (Single_elem { size; at_most }, fun ppf -> pp_typ ppf elem)
   | Array { len; elem; _ } -> (Array len, fun ppf -> pp_typ ppf elem)
@@ -915,7 +947,10 @@ let rec field_wire_size : type a. a typ -> int option = function
       | BF_U16 _ -> Some 2
       | BF_U32 _ -> Some 4)
   | Unit -> Some 0
-  | Byte_array { size = Int n } | Byte_slice { size = Int n } -> Some n
+  | Byte_array { size = Int n }
+  | Byte_array_where { size = Int n; _ }
+  | Byte_slice { size = Int n } ->
+      Some n
   | Where { inner; _ } -> field_wire_size inner
   | Enum { base; _ } -> field_wire_size base
   | Map { inner; _ } -> field_wire_size inner

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -121,6 +121,14 @@ and _ typ =
     }
       -> 'seq typ  (** Fixed-count array. *)
   | Byte_array : { size : int expr } -> string typ  (** Byte span as string. *)
+  | Byte_array_where : {
+      size : int expr;
+      elt_var : string;
+      cond : bool expr;
+    }
+      -> string typ
+      (** Byte span with a per-byte refinement: each decoded byte must satisfy
+          [cond], where [elt_var] is bound to the byte's value. *)
   | Byte_slice : { size : int expr } -> Bytesrw.Bytes.Slice.t typ
       (** Zero-copy byte span. *)
   | Single_elem : { size : int expr; elem : 'a typ; at_most : bool } -> 'a typ
@@ -406,6 +414,19 @@ val array_seq : ('a, 'seq) seq_map -> len:int expr -> 'a typ -> 'seq typ
 
 val byte_array : size:int expr -> string typ
 (** Byte span as a string. *)
+
+val byte_array_where :
+  size:int expr -> per_byte:(int expr -> bool expr) -> string typ
+(** [byte_array_where ~size ~per_byte] is a byte span of [size] bytes where each
+    byte must satisfy [per_byte]. The argument to [per_byte] is an expression
+    bound to the current byte's integer value. Decode raises [Parse_error] on
+    the first byte that violates the constraint; encode raises
+    [Invalid_argument]. *)
+
+val synth_name_of_elt_var : string -> string
+(** [synth_name_of_elt_var ev] is the 3D-side synthesised refinement-typedef
+    name derived from a [byte_array_where] element variable. Internal: used by
+    the EverParse projection. *)
 
 val byte_slice : size:int expr -> Bytesrw.Bytes.Slice.t typ
 (** Zero-copy byte span. *)

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -484,9 +484,8 @@ let rec encode_into : type a. a typ -> a -> encoder -> unit =
         (fun i c ->
           let n = Char.code c in
           if not (Eval.expr (Eval.bind elt_var n Eval.empty) cond) then
-            invalid_arg
-              (Fmt.str "byte_array_where: byte %d=0x%02x violates constraint" i
-                 n))
+            Fmt.invalid_arg
+              "byte_array_where: byte %d=0x%02x violates constraint" i n)
         v;
       write_string enc v
   | Byte_slice _ ->

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -177,6 +177,15 @@ let rec parse_direct : type a. a typ -> bytes -> int -> int -> a * int =
       let n = Eval.expr Eval.empty size in
       check_eof len (off + n);
       (Bytes.sub_string buf off n, off + n)
+  | Byte_array_where { size; elt_var; cond } ->
+      let n = Eval.expr Eval.empty size in
+      check_eof len (off + n);
+      for i = 0 to n - 1 do
+        let v = Bytes.get_uint8 buf (off + i) in
+        if not (Eval.expr (Eval.bind elt_var v Eval.empty) cond) then
+          raise (Parse_exn (Constraint_failed "byte_array_where: per-byte"))
+      done;
+      (Bytes.sub_string buf off n, off + n)
   | Byte_slice { size } ->
       let n = Eval.expr Eval.empty size in
       check_eof len (off + n);
@@ -470,6 +479,16 @@ let rec encode_into : type a. a typ -> a -> encoder -> unit =
   | Array { elem; seq = Seq_map seq; _ } ->
       seq.iter (fun elem_v -> encode_into elem elem_v enc) v
   | Byte_array _ -> write_string enc v
+  | Byte_array_where { elt_var; cond; _ } ->
+      String.iteri
+        (fun i c ->
+          let n = Char.code c in
+          if not (Eval.expr (Eval.bind elt_var n Eval.empty) cond) then
+            invalid_arg
+              (Fmt.str "byte_array_where: byte %d=0x%02x violates constraint" i
+                 n))
+        v;
+      write_string enc v
   | Byte_slice _ ->
       let src = Slice.bytes v in
       let off = Slice.first v in

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -481,7 +481,7 @@ val byte_array_where :
 
     Decode raises {!exception:Parse_error} on the first byte that violates the
     constraint; encode raises [Invalid_argument]. The motivating shape is SSH
-    name-list payloads (RFC 4251 §5), where every byte must be printable
+    name-list payloads (RFC 4251 sec 5), where every byte must be printable
     US-ASCII. *)
 
 val byte_slice : size:int expr -> Bytesrw.Bytes.Slice.t typ

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -473,6 +473,17 @@ val array_seq : ('a, 'seq) seq_map -> len:int expr -> 'a typ -> 'seq typ
 val byte_array : size:int expr -> string typ
 (** Fixed-size byte sequence copied as a string. *)
 
+val byte_array_where :
+  size:int expr -> per_byte:(int expr -> bool expr) -> string typ
+(** [byte_array_where ~size ~per_byte] is a byte sequence of [size] bytes where
+    each byte must satisfy [per_byte]. The argument to [per_byte] is an
+    expression bound to the current byte's integer value.
+
+    Decode raises {!exception:Parse_error} on the first byte that violates the
+    constraint; encode raises [Invalid_argument]. The motivating shape is SSH
+    name-list payloads (RFC 4251 §5), where every byte must be printable
+    US-ASCII. *)
+
 val byte_slice : size:int expr -> Bytesrw.Bytes.Slice.t typ
 (** Fixed-size byte sequence exposed as a zero-copy slice. *)
 

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -517,6 +517,40 @@ let test_reserved_word_escaping () =
     "no bare reserved word as field" false
     (contains ~sub:"UINT8 type;" output)
 
+let test_3d_byte_array_where () =
+  (* Synthesises a refinement struct so 3D can apply the per-byte constraint
+     to each element of the byte-size array. *)
+  let f_len = Field.v "Length" uint16be in
+  let f_data =
+    Field.v "Data"
+      (byte_array_where ~size:(Field.ref f_len)
+         ~per_byte:Expr.(fun b -> b >= int 0x20 && b <= int 0x7e))
+  in
+  let codec =
+    Codec.v "Printable"
+      (fun len data -> (len, data))
+      Codec.[ f_len $ fst; f_data $ snd ]
+  in
+  let schema = Wire.Everparse.schema codec in
+  let s = Wire.Everparse.Raw.to_3d schema.module_ in
+  Alcotest.(check bool)
+    "synth typedef present" true
+    (contains ~sub:"struct __RefByte_" s);
+  Alcotest.(check bool)
+    "field references synth" true
+    (contains ~sub:"_RefByte_" s);
+  Alcotest.(check bool)
+    "constraint inlined" true
+    (contains ~sub:">= 32" s && contains ~sub:"<= 126" s);
+  let synth_ref =
+    Re.execp
+      (Re.compile
+         (Re.seq
+            [ Re.str "_RefByte_"; Re.rep1 Re.digit; Re.str " Data[:byte-size" ]))
+      s
+  in
+  Alcotest.(check bool) "Data references synth not raw UINT8" true synth_ref
+
 let suite =
   ( "everparse",
     [
@@ -546,4 +580,6 @@ let suite =
       Alcotest.test_case "3d: param in size" `Quick test_3d_param_in_size;
       Alcotest.test_case "3d: reserved word escaping" `Quick
         test_reserved_word_escaping;
+      Alcotest.test_case "3d: byte_array_where synth typedef" `Quick
+        test_3d_byte_array_where;
     ] )

--- a/test/test_wire.ml
+++ b/test/test_wire.ml
@@ -69,6 +69,28 @@ let test_parse_byte_array () =
   | Ok v -> Alcotest.(check string) "byte_array value" "hello" v
   | Error e -> Alcotest.failf "%a" pp_parse_error e
 
+let printable_byte b = Expr.(b >= int 0x20 && b <= int 0x7e)
+
+let test_bawhere_accepts () =
+  let t = byte_array_where ~size:(int 5) ~per_byte:printable_byte in
+  match of_string t "abc D" with
+  | Ok v -> Alcotest.(check string) "printable" "abc D" v
+  | Error e -> Alcotest.failf "%a" pp_parse_error e
+
+let test_bawhere_rejects () =
+  let t = byte_array_where ~size:(int 4) ~per_byte:printable_byte in
+  match of_string t "ab\x01c" with
+  | Ok _ -> Alcotest.fail "expected per-byte refinement to reject"
+  | Error (Constraint_failed _) -> ()
+  | Error e ->
+      Alcotest.failf "expected Constraint_failed, got %a" pp_parse_error e
+
+let test_bawhere_enc_rejects () =
+  let t = byte_array_where ~size:(int 3) ~per_byte:printable_byte in
+  match to_string t "a\x01b" with
+  | exception Invalid_argument _ -> ()
+  | _ -> Alcotest.fail "expected encode to reject non-printable byte"
+
 let test_parse_variants_valid () =
   let input = "\x01" in
   let t = variants "Test" [ ("A", `A); ("B", `B); ("C", `C) ] uint8 in
@@ -599,6 +621,12 @@ let suite =
       Alcotest.test_case "parse: uint64 le" `Quick test_parse_uint64_le;
       Alcotest.test_case "parse: array" `Quick test_parse_array;
       Alcotest.test_case "parse: byte_array" `Quick test_parse_byte_array;
+      Alcotest.test_case "parse: byte_array_where accepts" `Quick
+        test_bawhere_accepts;
+      Alcotest.test_case "parse: byte_array_where rejects" `Quick
+        test_bawhere_rejects;
+      Alcotest.test_case "encode: byte_array_where rejects" `Quick
+        test_bawhere_enc_rejects;
       Alcotest.test_case "parse: variants valid" `Quick
         test_parse_variants_valid;
       Alcotest.test_case "parse: variants invalid" `Quick


### PR DESCRIPTION
`byte_array_where ~size ~per_byte` is a `string typ` where every decoded byte must satisfy `per_byte`. The captured constraint binds the byte's value via a fresh element variable so each call gets its own scope.

The OCaml validator loops over the bytes and evaluates the constraint through `Eval` (now extended with a single-name binding context). The 3D projection synthesises a 1-byte refinement struct per use, and the parent field references it as `_RefByte_<n> name[:byte-size <size>]` -- so wire's OCaml decoder and EverParse's verified C decoder enforce the same per-element predicate, with no inline-refinement syntax that 3D rejects.

Motivating shape: printable-ASCII payloads such as the SSH name-list in RFC 4251 sec 5.