### PR TITLE
chore: switch to [Fmt.invalid_arg] / [Fmt.kstr]

### DIFF
--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -234,8 +234,7 @@ let rec compile_expr (env : (string * (bytes -> int -> int)) list)
       match List.assoc_opt name env with
       | Some reader -> reader
       | None ->
-          invalid_arg
-            (Fmt.str "Codec: unbound field ref %S in size expression" name))
+          Fmt.invalid_arg "Codec: unbound field ref %S in size expression" name)
   | Add (a, b) ->
       let fa = compile_expr env a in
       let fb = compile_expr env b in
@@ -1803,10 +1802,9 @@ let seal : type r. (r, r) record -> r t =
     t_encode =
       (fun v buf off ->
         if off + min_size > Bytes.length buf then
-          invalid_arg
-            (Fmt.str "Codec.encode %s: buffer too short (need %d, got %d)"
-               r.r_name min_size
-               (Bytes.length buf - off));
+          Fmt.invalid_arg "Codec.encode %s: buffer too short (need %d, got %d)"
+            r.r_name min_size
+            (Bytes.length buf - off);
         for i = 0 to n_writers - 1 do
           writers.(i) v buf off
         done);
@@ -2247,8 +2245,7 @@ let field_access codec name =
   match List.assoc_opt name codec.t_field_access with
   | Some a -> a
   | None ->
-      invalid_arg
-        (Fmt.str "Codec: field %S not found in codec %S" name codec.t_name)
+      Fmt.invalid_arg "Codec: field %S not found in codec %S" name codec.t_name
 
 let[@inline] get (type a r) ?env (codec : r t) (f : (a, r) field) :
     (bytes -> int -> a) Staged.t =
@@ -2266,9 +2263,9 @@ let[@inline] get (type a r) ?env (codec : r t) (f : (a, r) field) :
         | None -> ((fun _arr -> ()), fun _arr -> ())
         | Some (e : Param.env) ->
             if e.pe_codec_id <> codec.t_id then
-              invalid_arg
-                (Fmt.str "Codec.get: env was not created by Codec.env for %S"
-                   codec.t_name);
+              Fmt.invalid_arg
+                "Codec.get: env was not created by Codec.env for %S"
+                codec.t_name;
             let param_handles = codec.t_param_handles in
             let param_base = codec.t_param_base in
             ( (fun arr ->

--- a/lib/param.ml
+++ b/lib/param.ml
@@ -53,8 +53,8 @@ let rec is_int_representable : type a. a Types.typ -> bool = function
 
 let check_typ name typ =
   if not (is_int_representable typ) then
-    invalid_arg
-      (Fmt.str "Param.%s: only integer-representable types are supported" name)
+    Fmt.invalid_arg "Param.%s: only integer-representable types are supported"
+      name
 
 let input name typ =
   check_typ "input" typ;

--- a/lib/test/everparse/test_wire_3d.ml
+++ b/lib/test/everparse/test_wire_3d.ml
@@ -107,7 +107,7 @@ let compile_and_run ~name codec =
     let ic = Unix.open_process_in cmd in
     let output = In_channel.input_all ic in
     let status = Unix.close_process_in ic in
-    ignore (Sys.command (Fmt.str "rm -rf %s" tmpdir));
+    ignore (Fmt.kstr Sys.command "rm -rf %s" tmpdir);
     match status with
     | Unix.WEXITED 0 -> ()
     | Unix.WEXITED n ->
@@ -329,7 +329,7 @@ let test_projection_filenames () =
     close_in ic;
     Bytes.unsafe_to_string buf
   in
-  ignore (Sys.command (Fmt.str "rm -rf %s" tmpdir));
+  ignore (Fmt.kstr Sys.command "rm -rf %s" tmpdir);
   let contains_exact sub = Re.execp (Re.compile (Re.str sub)) dune_inc in
   Alcotest.(check bool)
     ".3d uses String.capitalize_ascii name" true


### PR DESCRIPTION
Merlint gained a check for `invalid_arg (Fmt.str ...)` and the analogous `f (Fmt.str ...)` continuation pattern. Adopt the formatted-printf forms throughout: `Fmt.invalid_arg "..." args` for the invalid-argument case and `Fmt.kstr Sys.command "..." args` for the `Sys.command` continuation in the EverParse e2e test driver.