### PR TITLE
wire: signed integers and IEEE 754 floats

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,15 @@
   references it from the parent field, so both wire and EverParse C
   enforce the same per-element constraint. Motivating shape:
   printable-ASCII bodies (SSH name-list, RFC 4251 sec 5) (@samoht)
+- Signed integers: `int8` / `int16(be)` / `int32(be)` / `int64(be)`.
+  Two's-complement read/write OCaml-side; 3D projects to the same-width
+  `UINT*` (3D's prelude has only unsigned primitives). `int32` returns
+  OCaml `int` on 64-bit hosts; `int64` returns boxed `int64` (@samoht)
+- IEEE 754 floats: `float32(be)` / `float64(be)`. OCaml side uses
+  `Int32.float_of_bits` / `Int64.float_of_bits` for round-tripping
+  including NaN, signed zero, infinities. 3D projects to the same-width
+  `UINT*`; semantic predicates (`is_finite`, range bounds) will land
+  later as bit-pattern refinements over the unsigned width (@samoht)
 
 ### Changed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,8 +24,10 @@
 - IEEE 754 floats: `float32(be)` / `float64(be)`. OCaml side uses
   `Int32.float_of_bits` / `Int64.float_of_bits` for round-tripping
   including NaN, signed zero, infinities. 3D projects to the same-width
-  `UINT*`; semantic predicates (`is_finite`, range bounds) will land
-  later as bit-pattern refinements over the unsigned width (@samoht)
+  `UINT*` and `Wire.is_finite` / `Wire.is_nan` compile to bit-pattern
+  refinements over the unsigned width, so wire's OCaml decoder and
+  EverParse's verified C decoder reject the same NaN / Inf inputs
+  (@samoht)
 
 ### Changed
 

--- a/bench/gen_stubs.ml
+++ b/bench/gen_stubs.ml
@@ -46,7 +46,7 @@ let generate_stub_registry ppf structs projection_structs =
         in
         if is_proj then
           match Wire.Everparse.Raw.field_kinds s with
-          | [ (_, Wire.Everparse.Raw.K_int64) ] ->
+          | [ (_, Wire.Everparse.Raw.Int64) ] ->
               ("(fun _ _ -> 0)", Fmt.str "%s_projected_int64" lower)
           | [ _ ] -> (Fmt.str "%s_projected_int" lower, "(fun _ _ -> 0L)")
           | _ -> ("(fun _ _ -> 0)", "(fun _ _ -> 0L)")
@@ -100,9 +100,7 @@ let generate_ml oc =
       match Wire.Everparse.Raw.field_kinds s with
       | [ (_, kind) ] ->
           let suffix =
-            match kind with
-            | Wire.Everparse.Raw.K_int64 -> "_int64"
-            | _ -> "_int"
+            match kind with Wire.Everparse.Raw.Int64 -> "_int64" | _ -> "_int"
           in
           pr "let %s_projected%s = %s_parse_k Fun.id\n\n" lower suffix lower
       | _ -> ())

--- a/fuzz/fuzz_wire.ml
+++ b/fuzz/fuzz_wire.ml
@@ -863,7 +863,53 @@ let depsize_tests =
     test_case "depsize wire_size_at" [ bytes ] test_depsize_compute_wire_size;
   ]
 
+(* Fuzz the IEEE 754 boundary: any 8-byte input must either decode to a
+   finite [float] or fall on the [Constraint_failed] branch when a codec
+   asserts [is_finite] on the field. The validator's bit-mask check and
+   [Float.is_finite] of the same value must agree. *)
+let test_is_finite_agrees buf =
+  let buf = truncate buf in
+  if String.length buf < 8 then ()
+  else
+    let bytes_in = Bytes.of_string (String.sub buf 0 8) in
+    let template = Wire.Field.v "v" Wire.float64be in
+    let f_v =
+      Wire.Field.v "v" ~constraint_:(Wire.is_finite template) Wire.float64be
+    in
+    let codec =
+      Wire.Codec.v "T" (fun v -> v) Wire.Codec.[ (f_v $ fun v -> v) ]
+    in
+    let raw = Wire.of_bytes_exn Wire.float64be bytes_in in
+    let codec_finite =
+      try
+        let _ = Wire.Codec.decode_exn codec bytes_in 0 in
+        true
+      with Wire.Parse_error _ -> false
+    in
+    if Float.is_finite raw <> codec_finite then
+      fail
+        (Fmt.str "is_finite disagreement: raw=%h Float.is_finite=%b codec=%b"
+           raw (Float.is_finite raw) codec_finite)
+
+let test_float64_roundtrip buf =
+  let buf = truncate buf in
+  if String.length buf < 8 then ()
+  else
+    let bytes_in = Bytes.of_string (String.sub buf 0 8) in
+    let v = Wire.of_bytes_exn Wire.float64be bytes_in in
+    let s = Wire.to_string Wire.float64be v in
+    let v' = Wire.of_string_exn Wire.float64be s in
+    let bits = Int64.bits_of_float v and bits' = Int64.bits_of_float v' in
+    if Int64.equal bits bits' || (Float.is_nan v && Float.is_nan v') then ()
+    else fail (Fmt.str "float64 bit-pattern roundtrip failed: %h vs %h" v v')
+
+let float_tests =
+  [
+    test_case "is_finite vs Float.is_finite" [ bytes ] test_is_finite_agrees;
+    test_case "float64 roundtrip" [ bytes ] test_float64_roundtrip;
+  ]
+
 let suite =
   ( "wire",
     parse_tests @ roundtrip_tests @ record_tests @ stream_tests @ depsize_tests
-  )
+    @ float_tests )

--- a/lib/3d/wire_3d.ml
+++ b/lib/3d/wire_3d.ml
@@ -208,6 +208,22 @@ let write_fields_header ~outdir s =
   Format.pp_print_flush ppf ();
   close_out oc
 
+(* Emit one [case N:] body inside a [WireSet*] setter. [float] / [double]
+   fields get a [memcpy] bit-reinterpret because the parser hands us the
+   underlying [UINT32] / [UINT64] but the plug struct stores the typed
+   float; everyone else takes a value cast. *)
+let emit_setter_case ppf logical f =
+  if String.equal f.Wire.Everparse.pf_setter logical then
+    match f.pf_c_type with
+    | "float" | "double" ->
+        Fmt.pf ppf
+          "    case %d: { %s _x; memcpy(&_x, &v, sizeof _x); f->%s = _x; \
+           break; }@\n"
+          f.pf_idx f.pf_c_type f.pf_name
+    | _ ->
+        Fmt.pf ppf "    case %d: f->%s = (%s) v; break;@\n" f.pf_idx f.pf_name
+          f.pf_c_type
+
 let write_fields_impl ~outdir s =
   let fields = Wire.Everparse.plug_fields s in
   let setters = Wire.Everparse.plug_setters s in
@@ -224,6 +240,7 @@ let write_fields_impl ~outdir s =
   let ppf = Format.formatter_of_out_channel oc in
   let pr fmt = Fmt.pf ppf fmt in
   pr "#include <stdint.h>@\n";
+  pr "#include <string.h>@\n";
   pr "#include \"%s_Fields.h\"@\n" base;
   pr "#include \"%s_ExternalTypedefs.h\"@\n" base;
   pr "#include \"%s_ExternalAPI.h\"@\n@\n" base;
@@ -237,12 +254,7 @@ let write_fields_impl ~outdir s =
       pr "void %s(WIRECTX *ctx, uint32_t idx, %s v) {@\n" physical val_c_type;
       pr "  %sFields *f = (%sFields *) ctx;@\n" ident ident;
       pr "  switch (idx) {@\n";
-      List.iter
-        (fun f ->
-          if String.equal f.Wire.Everparse.pf_setter logical then
-            pr "    case %d: f->%s = (%s) v; break;@\n" f.pf_idx f.pf_name
-              f.pf_c_type)
-        fields;
+      List.iter (fun f -> emit_setter_case ppf logical f) fields;
       pr "    default: (void) f; (void) v; break;@\n";
       pr "  }@\n";
       pr "}@\n@\n")

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -67,6 +67,22 @@ let rec build_field_encoder : type a. a typ -> bytes -> int -> a -> int =
   | Int32 Big -> setter_off_int32 4 Bytes.set_int32_be
   | Int64 Little -> setter_off 8 Bytes.set_int64_le
   | Int64 Big -> setter_off 8 Bytes.set_int64_be
+  | Float32 Little ->
+      fun buf off v ->
+        Bytes.set_int32_le buf off (Int32.bits_of_float v);
+        off + 4
+  | Float32 Big ->
+      fun buf off v ->
+        Bytes.set_int32_be buf off (Int32.bits_of_float v);
+        off + 4
+  | Float64 Little ->
+      fun buf off v ->
+        Bytes.set_int64_le buf off (Int64.bits_of_float v);
+        off + 8
+  | Float64 Big ->
+      fun buf off v ->
+        Bytes.set_int64_be buf off (Int64.bits_of_float v);
+        off + 8
   | Uint_var { size = Int n; endian } ->
       fun buf off v ->
         Uint_var.write endian buf off n v;
@@ -131,6 +147,18 @@ let rec build_field_reader : type a. a typ -> int -> bytes -> int -> a =
       fun buf base -> Int32.to_int (Bytes.get_int32_be buf (base + field_off))
   | Int64 Little -> fun buf base -> Bytes.get_int64_le buf (base + field_off)
   | Int64 Big -> fun buf base -> Bytes.get_int64_be buf (base + field_off)
+  | Float32 Little ->
+      fun buf base ->
+        Int32.float_of_bits (Bytes.get_int32_le buf (base + field_off))
+  | Float32 Big ->
+      fun buf base ->
+        Int32.float_of_bits (Bytes.get_int32_be buf (base + field_off))
+  | Float64 Little ->
+      fun buf base ->
+        Int64.float_of_bits (Bytes.get_int64_le buf (base + field_off))
+  | Float64 Big ->
+      fun buf base ->
+        Int64.float_of_bits (Bytes.get_int64_be buf (base + field_off))
   | Uint_var { size = Int n; endian } ->
       fun buf base -> Uint_var.read endian buf (base + field_off) n
   | Byte_array { size = Int n } ->
@@ -834,8 +862,8 @@ let rec iter_param_refs_typ : type a. (Param.packed -> unit) -> a typ -> unit =
           iter_param_refs_typ f cb_inner)
         cases
   | Uint8 | Uint16 _ | Uint32 _ | Uint63 _ | Uint64 _ | Int8 | Int16 _ | Int32 _
-  | Int64 _ | Bits _ | Unit | All_bytes | All_zeros | Struct _ | Type_ref _
-  | Qualified_ref _ | Codec _ ->
+  | Int64 _ | Float32 _ | Float64 _ | Bits _ | Unit | All_bytes | All_zeros
+  | Struct _ | Type_ref _ | Qualified_ref _ | Codec _ ->
       ()
 
 let iter_param_refs_fields f fields where =
@@ -867,6 +895,10 @@ let rec read_elem : type a. a typ -> bytes -> int -> a =
   | Int32 Big -> Int32.to_int (Bytes.get_int32_be buf off)
   | Int64 Little -> Bytes.get_int64_le buf off
   | Int64 Big -> Bytes.get_int64_be buf off
+  | Float32 Little -> Int32.float_of_bits (Bytes.get_int32_le buf off)
+  | Float32 Big -> Int32.float_of_bits (Bytes.get_int32_be buf off)
+  | Float64 Little -> Int64.float_of_bits (Bytes.get_int64_le buf off)
+  | Float64 Big -> Int64.float_of_bits (Bytes.get_int64_be buf off)
   | Uint_var { size = Int n; endian } -> Uint_var.read endian buf off n
   | Codec { codec_decode; _ } -> codec_decode buf off
   | Map { inner; decode; _ } -> decode (read_elem inner buf off)
@@ -894,6 +926,10 @@ let rec write_elem : type a. a typ -> bytes -> int -> a -> unit =
   | Int32 Big -> Bytes.set_int32_be buf off (Int32.of_int v)
   | Int64 Little -> Bytes.set_int64_le buf off v
   | Int64 Big -> Bytes.set_int64_be buf off v
+  | Float32 Little -> Bytes.set_int32_le buf off (Int32.bits_of_float v)
+  | Float32 Big -> Bytes.set_int32_be buf off (Int32.bits_of_float v)
+  | Float64 Little -> Bytes.set_int64_le buf off (Int64.bits_of_float v)
+  | Float64 Big -> Bytes.set_int64_be buf off (Int64.bits_of_float v)
   | Uint_var { size = Int n; endian } -> Uint_var.write endian buf off n v
   | Codec { codec_encode; _ } -> codec_encode v buf off
   | Map { inner; encode; _ } -> write_elem inner buf off (encode v)

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -199,6 +199,22 @@ let rec build_populate : type a.
         | Some v -> arr.(idx) <- v
         | None -> ())
   | Int64 _ -> fun arr buf base -> arr.(idx) <- Int64.to_int (reader buf base)
+  (* Floats store their IEEE 754 bit pattern in [int_array] so [Ref name]
+     in a constraint sees the same value the 3D-side sees. The user-facing
+     reader still returns the [float], reinterpreted via [Int*.float_of_bits]
+     elsewhere. *)
+  | Float32 Little ->
+      fun arr buf base ->
+        arr.(idx) <- Bytes.get_int32_le buf base |> Int32.to_int
+  | Float32 Big ->
+      fun arr buf base ->
+        arr.(idx) <- Bytes.get_int32_be buf base |> Int32.to_int
+  | Float64 Little ->
+      fun arr buf base ->
+        arr.(idx) <- Bytes.get_int64_le buf base |> Int64.to_int
+  | Float64 Big ->
+      fun arr buf base ->
+        arr.(idx) <- Bytes.get_int64_be buf base |> Int64.to_int
   | Where { inner; _ } -> build_populate inner idx reader
   | Enum { base; _ } -> build_populate base idx reader
   | Map { inner; encode; _ } ->

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -10,6 +10,17 @@ let blit_string_padded n buf off v =
   if len < n then Bytes.fill buf (off + len) (n - len) '\x00';
   off + n
 
+(* Pack a fixed-width integer setter into a [bytes -> int -> int -> int]
+   field encoder that returns the offset advance. Used by the scalar cases
+   in [build_field_encoder] / [build_field_reader]. *)
+let setter_off n set buf off v =
+  set buf off v;
+  off + n
+
+let setter_off_int32 n set buf off v =
+  set buf off (Int32.of_int v);
+  off + n
+
 let rec build_field_encoder : type a. a typ -> bytes -> int -> a -> int =
  fun typ ->
   match typ with
@@ -49,6 +60,13 @@ let rec build_field_encoder : type a. a typ -> bytes -> int -> a -> int =
       fun buf off v ->
         Bytes.set_int64_be buf off v;
         off + 8
+  | Int8 -> setter_off 1 Bytes.set_int8
+  | Int16 Little -> setter_off 2 Bytes.set_int16_le
+  | Int16 Big -> setter_off 2 Bytes.set_int16_be
+  | Int32 Little -> setter_off_int32 4 Bytes.set_int32_le
+  | Int32 Big -> setter_off_int32 4 Bytes.set_int32_be
+  | Int64 Little -> setter_off 8 Bytes.set_int64_le
+  | Int64 Big -> setter_off 8 Bytes.set_int64_be
   | Uint_var { size = Int n; endian } ->
       fun buf off v ->
         Uint_var.write endian buf off n v;
@@ -104,6 +122,15 @@ let rec build_field_reader : type a. a typ -> int -> bytes -> int -> a =
   | Uint63 Big -> fun buf base -> UInt63.be buf (base + field_off)
   | Uint64 Little -> fun buf base -> Bytes.get_int64_le buf (base + field_off)
   | Uint64 Big -> fun buf base -> Bytes.get_int64_be buf (base + field_off)
+  | Int8 -> fun buf base -> Bytes.get_int8 buf (base + field_off)
+  | Int16 Little -> fun buf base -> Bytes.get_int16_le buf (base + field_off)
+  | Int16 Big -> fun buf base -> Bytes.get_int16_be buf (base + field_off)
+  | Int32 Little ->
+      fun buf base -> Int32.to_int (Bytes.get_int32_le buf (base + field_off))
+  | Int32 Big ->
+      fun buf base -> Int32.to_int (Bytes.get_int32_be buf (base + field_off))
+  | Int64 Little -> fun buf base -> Bytes.get_int64_le buf (base + field_off)
+  | Int64 Big -> fun buf base -> Bytes.get_int64_be buf (base + field_off)
   | Uint_var { size = Int n; endian } ->
       fun buf base -> Uint_var.read endian buf (base + field_off) n
   | Byte_array { size = Int n } ->
@@ -134,12 +161,16 @@ let rec build_populate : type a.
   | Uint_var _ -> fun arr buf base -> arr.(idx) <- reader buf base
   | Uint32 _ -> fun arr buf base -> arr.(idx) <- UInt32.to_int (reader buf base)
   | Uint63 _ -> fun arr buf base -> arr.(idx) <- UInt63.to_int (reader buf base)
+  | Int8 -> fun arr buf base -> arr.(idx) <- reader buf base
+  | Int16 _ -> fun arr buf base -> arr.(idx) <- reader buf base
+  | Int32 _ -> fun arr buf base -> arr.(idx) <- reader buf base
   | Bits _ -> fun arr buf base -> arr.(idx) <- reader buf base
   | Uint64 _ -> (
       fun arr buf base ->
         match Int64.unsigned_to_int (reader buf base) with
         | Some v -> arr.(idx) <- v
         | None -> ())
+  | Int64 _ -> fun arr buf base -> arr.(idx) <- Int64.to_int (reader buf base)
   | Where { inner; _ } -> build_populate inner idx reader
   | Enum { base; _ } -> build_populate base idx reader
   | Map { inner; encode; _ } ->
@@ -802,8 +833,9 @@ let rec iter_param_refs_typ : type a. (Param.packed -> unit) -> a typ -> unit =
         (fun (Types.Case_branch { cb_inner; _ }) ->
           iter_param_refs_typ f cb_inner)
         cases
-  | Uint8 | Uint16 _ | Uint32 _ | Uint63 _ | Uint64 _ | Bits _ | Unit
-  | All_bytes | All_zeros | Struct _ | Type_ref _ | Qualified_ref _ | Codec _ ->
+  | Uint8 | Uint16 _ | Uint32 _ | Uint63 _ | Uint64 _ | Int8 | Int16 _ | Int32 _
+  | Int64 _ | Bits _ | Unit | All_bytes | All_zeros | Struct _ | Type_ref _
+  | Qualified_ref _ | Codec _ ->
       ()
 
 let iter_param_refs_fields f fields where =
@@ -828,6 +860,13 @@ let rec read_elem : type a. a typ -> bytes -> int -> a =
   | Uint63 Big -> UInt63.be buf off
   | Uint64 Little -> Bytes.get_int64_le buf off
   | Uint64 Big -> Bytes.get_int64_be buf off
+  | Int8 -> Bytes.get_int8 buf off
+  | Int16 Little -> Bytes.get_int16_le buf off
+  | Int16 Big -> Bytes.get_int16_be buf off
+  | Int32 Little -> Int32.to_int (Bytes.get_int32_le buf off)
+  | Int32 Big -> Int32.to_int (Bytes.get_int32_be buf off)
+  | Int64 Little -> Bytes.get_int64_le buf off
+  | Int64 Big -> Bytes.get_int64_be buf off
   | Uint_var { size = Int n; endian } -> Uint_var.read endian buf off n
   | Codec { codec_decode; _ } -> codec_decode buf off
   | Map { inner; decode; _ } -> decode (read_elem inner buf off)
@@ -848,6 +887,13 @@ let rec write_elem : type a. a typ -> bytes -> int -> a -> unit =
   | Uint63 Big -> UInt63.set_be buf off v
   | Uint64 Little -> Bytes.set_int64_le buf off v
   | Uint64 Big -> Bytes.set_int64_be buf off v
+  | Int8 -> Bytes.set_int8 buf off v
+  | Int16 Little -> Bytes.set_int16_le buf off v
+  | Int16 Big -> Bytes.set_int16_be buf off v
+  | Int32 Little -> Bytes.set_int32_le buf off (Int32.of_int v)
+  | Int32 Big -> Bytes.set_int32_be buf off (Int32.of_int v)
+  | Int64 Little -> Bytes.set_int64_le buf off v
+  | Int64 Big -> Bytes.set_int64_be buf off v
   | Uint_var { size = Int n; endian } -> Uint_var.write endian buf off n v
   | Codec { codec_encode; _ } -> codec_encode v buf off
   | Map { inner; encode; _ } -> write_elem inner buf off (encode v)

--- a/lib/eval.ml
+++ b/lib/eval.ml
@@ -26,6 +26,10 @@ let rec int_of : type a. a typ -> a -> int option =
   | Uint32 _ -> Some (UInt32.to_int v)
   | Uint63 _ -> Some (UInt63.to_int v)
   | Uint64 _ -> Int64.unsigned_to_int v
+  | Int8 -> Some v
+  | Int16 _ -> Some v
+  | Int32 _ -> Some v
+  | Int64 _ -> Int64.unsigned_to_int v
   | Bits _ -> Some v
   | Enum { base; _ } -> int_of base v
   | Where { inner; _ } -> int_of inner v

--- a/lib/eval.ml
+++ b/lib/eval.ml
@@ -30,6 +30,8 @@ let rec int_of : type a. a typ -> a -> int option =
   | Int16 _ -> Some v
   | Int32 _ -> Some v
   | Int64 _ -> Int64.unsigned_to_int v
+  | Float32 _ -> None
+  | Float64 _ -> None
   | Bits _ -> Some v
   | Enum { base; _ } -> int_of base v
   | Where { inner; _ } -> int_of inner v

--- a/lib/everparse.ml
+++ b/lib/everparse.ml
@@ -514,6 +514,7 @@ module Raw = struct
   type ocaml_kind = Types.ocaml_kind =
     | K_int
     | K_int64
+    | K_float
     | K_bool
     | K_string
     | K_unit

--- a/lib/everparse.ml
+++ b/lib/everparse.ml
@@ -512,12 +512,13 @@ module Raw = struct
     Types.struct_project s ~name ~keep:(List.map Field.to_decl keep)
 
   type ocaml_kind = Types.ocaml_kind =
-    | K_int
-    | K_int64
-    | K_float
-    | K_bool
-    | K_string
-    | K_unit
+    | Int
+    | Int64
+    | Float32
+    | Float64
+    | Bool
+    | String
+    | Unit
 
   let field_kinds = Types.field_kinds
   let struct_params (s : Types.struct_) = s.params

--- a/lib/everparse.mli
+++ b/lib/everparse.mli
@@ -218,12 +218,13 @@ module Raw : sig
       others anonymous. *)
 
   type ocaml_kind = Types.ocaml_kind =
-    | K_int
-    | K_int64
-    | K_float
-    | K_bool
-    | K_string
-    | K_unit
+    | Int
+    | Int64
+    | Float32
+    | Float64
+    | Bool
+    | String
+    | Unit
 
   val field_kinds : struct_ -> (string * ocaml_kind) list
   (** Field names with their OCaml kind. *)

--- a/lib/everparse.mli
+++ b/lib/everparse.mli
@@ -220,6 +220,7 @@ module Raw : sig
   type ocaml_kind = Types.ocaml_kind =
     | K_int
     | K_int64
+    | K_float
     | K_bool
     | K_string
     | K_unit

--- a/lib/param.ml
+++ b/lib/param.ml
@@ -15,6 +15,8 @@ let rec to_int : type a. a Types.typ -> a -> int =
   | Int16 _ -> v
   | Int32 _ -> v
   | Int64 _ -> Int64.to_int v
+  | Float32 _ -> invalid_arg "Param: floats are not integer-representable"
+  | Float64 _ -> invalid_arg "Param: floats are not integer-representable"
   | Bits _ -> v
   | Enum { base; _ } -> to_int base v
   | Where { inner; _ } -> to_int inner v
@@ -39,6 +41,8 @@ let rec of_int : type a. a Types.typ -> int -> a =
   | Int16 _ -> v
   | Int32 _ -> v
   | Int64 _ -> Int64.of_int v
+  | Float32 _ -> invalid_arg "Param: floats are not integer-representable"
+  | Float64 _ -> invalid_arg "Param: floats are not integer-representable"
   | Bits _ -> v
   | Enum { base; _ } -> of_int base v
   | Where { inner; _ } -> of_int inner v

--- a/lib/param.ml
+++ b/lib/param.ml
@@ -11,6 +11,10 @@ let rec to_int : type a. a Types.typ -> a -> int =
   | Uint32 _ -> UInt32.to_int v
   | Uint63 _ -> UInt63.to_int v
   | Uint64 _ -> Int64.unsigned_to_int v |> Option.value ~default:max_int
+  | Int8 -> v
+  | Int16 _ -> v
+  | Int32 _ -> v
+  | Int64 _ -> Int64.to_int v
   | Bits _ -> v
   | Enum { base; _ } -> to_int base v
   | Where { inner; _ } -> to_int inner v
@@ -31,6 +35,10 @@ let rec of_int : type a. a Types.typ -> int -> a =
   | Uint32 _ -> UInt32.of_int v
   | Uint63 _ -> UInt63.of_int v
   | Uint64 _ -> Int64.of_int v
+  | Int8 -> v
+  | Int16 _ -> v
+  | Int32 _ -> v
+  | Int64 _ -> Int64.of_int v
   | Bits _ -> v
   | Enum { base; _ } -> of_int base v
   | Where { inner; _ } -> of_int inner v
@@ -44,7 +52,8 @@ let rec of_int : type a. a Types.typ -> int -> a =
 
 let rec is_int_representable : type a. a Types.typ -> bool = function
   | Types.Uint8 | Types.Uint16 _ | Types.Uint_var _ | Types.Uint32 _
-  | Types.Uint63 _ | Types.Uint64 _ | Types.Bits _ ->
+  | Types.Uint63 _ | Types.Uint64 _ | Types.Int8 | Types.Int16 _ | Types.Int32 _
+  | Types.Int64 _ | Types.Bits _ ->
       true
   | Types.Enum { base; _ } -> is_int_representable base
   | Types.Map { inner; _ } -> is_int_representable inner

--- a/lib/stubs/wire_stubs.ml
+++ b/lib/stubs/wire_stubs.ml
@@ -24,8 +24,21 @@ let c_stub_validate ppf ~lower ~ep =
 
 let field_value ppf (fname, kind) =
   match kind with
-  | Wire.Everparse.Raw.K_int64 ->
+  | Wire.Everparse.Raw.Int64 ->
       Fmt.pf ppf "caml_copy_int64((int64_t) fields.%s)" fname
+  | Float32 ->
+      (* The plug stores [Float32] as [uint32_t]; reinterpret the bits as
+         single-precision then widen to OCaml [float]. *)
+      Fmt.pf ppf
+        "({ union { uint32_t u; float f; } _w = { .u = (uint32_t) fields.%s }; \
+         caml_copy_double((double) _w.f); })"
+        fname
+  | Float64 ->
+      (* The plug stores [Float64] as [uint64_t]; reinterpret as [double]. *)
+      Fmt.pf ppf
+        "({ union { uint64_t u; double d; } _w = { .u = (uint64_t) fields.%s \
+         }; caml_copy_double(_w.d); })"
+        fname
   | _ -> Fmt.pf ppf "Val_long(fields.%s)" fname
 
 let c_stub_output ppf ~lower ~ep (s : Wire.Everparse.Raw.struct_) =
@@ -117,12 +130,12 @@ let ml_field_name name =
   | _ -> lower
 
 let ml_kind_string = function
-  | Wire.Everparse.Raw.K_int -> "int"
-  | K_int64 -> "int64"
-  | K_float -> "float"
-  | K_bool -> "int"
-  | K_string -> "string"
-  | K_unit -> "unit"
+  | Wire.Everparse.Raw.Int -> "int"
+  | Int64 -> "int64"
+  | Float32 | Float64 -> "float"
+  | Bool -> "int"
+  | String -> "string"
+  | Unit -> "unit"
 
 let gen_ml_record ppf ~type_name kinds =
   Fmt.pf ppf "type %s = {" type_name;

--- a/lib/stubs/wire_stubs.ml
+++ b/lib/stubs/wire_stubs.ml
@@ -119,6 +119,7 @@ let ml_field_name name =
 let ml_kind_string = function
   | Wire.Everparse.Raw.K_int -> "int"
   | K_int64 -> "int64"
+  | K_float -> "float"
   | K_bool -> "int"
   | K_string -> "string"
   | K_unit -> "unit"

--- a/lib/stubs/wire_stubs.ml
+++ b/lib/stubs/wire_stubs.ml
@@ -26,19 +26,11 @@ let field_value ppf (fname, kind) =
   match kind with
   | Wire.Everparse.Raw.Int64 ->
       Fmt.pf ppf "caml_copy_int64((int64_t) fields.%s)" fname
-  | Float32 ->
-      (* The plug stores [Float32] as [uint32_t]; reinterpret the bits as
-         single-precision then widen to OCaml [float]. *)
-      Fmt.pf ppf
-        "({ union { uint32_t u; float f; } _w = { .u = (uint32_t) fields.%s }; \
-         caml_copy_double((double) _w.f); })"
-        fname
-  | Float64 ->
-      (* The plug stores [Float64] as [uint64_t]; reinterpret as [double]. *)
-      Fmt.pf ppf
-        "({ union { uint64_t u; double d; } _w = { .u = (uint64_t) fields.%s \
-         }; caml_copy_double(_w.d); })"
-        fname
+  | Float32 | Float64 ->
+      (* The 3D plug stores floats with their typed C type ([float] /
+         [double]) and bit-reinterprets in the setter, so we hand the
+         value straight to [caml_copy_double]. *)
+      Fmt.pf ppf "caml_copy_double((double) fields.%s)" fname
   | _ -> Fmt.pf ppf "Val_long(fields.%s)" fname
 
 let c_stub_output ppf ~lower ~ep (s : Wire.Everparse.Raw.struct_) =

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -75,6 +75,10 @@ and _ typ =
   | Int16 : endian -> int typ
   | Int32 : endian -> int typ (* fits OCaml int on 64-bit hosts *)
   | Int64 : endian -> int64 typ
+  | Float32 :
+      endian
+      -> float typ (* IEEE 754 binary32, widened to OCaml float *)
+  | Float64 : endian -> float typ (* IEEE 754 binary64 *)
   | Uint_var : { size : int expr; endian : endian } -> int typ
   | Bits : {
       width : int;
@@ -240,6 +244,10 @@ let int32 = Int32 Little
 let int32be = Int32 Big
 let (int64 : int64 typ) = Int64 Little
 let (int64be : int64 typ) = Int64 Big
+let float32 = Float32 Little
+let float32be = Float32 Big
+let float64 = Float64 Little
+let float64be = Float64 Big
 
 let uint ?(endian = Big) size =
   (match size with
@@ -443,13 +451,14 @@ let struct_project s ~name ~keep =
 
 (* What kind of OCaml value a field produces -- used by Wire_stubs to
    generate the right C-to-OCaml conversion in output stubs. *)
-type ocaml_kind = K_int | K_int64 | K_bool | K_string | K_unit
+type ocaml_kind = K_int | K_int64 | K_float | K_bool | K_string | K_unit
 
 let rec ocaml_kind_of : type a. a typ -> ocaml_kind = function
   | Uint8 | Uint16 _ | Uint32 _ | Uint63 _ | Uint_var _ -> K_int
   | Uint64 _ -> K_int64
   | Int8 | Int16 _ | Int32 _ -> K_int
   | Int64 _ -> K_int64
+  | Float32 _ | Float64 _ -> K_float
   | Bits _ -> K_int
   | Map { inner = Bits _; decode = _; encode = _ } ->
       (* bool (bits ~width:1 ...) maps to bool; other maps stay int *)
@@ -682,6 +691,10 @@ and pp_typ : type a. a typ Fmt.t =
   | Int16 e -> Fmt.pf ppf "UINT16%a" pp_endian e
   | Int32 e -> Fmt.pf ppf "UINT32%a" pp_endian e
   | Int64 e -> Fmt.pf ppf "UINT64%a" pp_endian e
+  (* IEEE 754 has no native 3D type; project to the underlying unsigned width.
+     Float predicates (is_nan, is_finite) compile to bit-pattern refinements. *)
+  | Float32 e -> Fmt.pf ppf "UINT32%a" pp_endian e
+  | Float64 e -> Fmt.pf ppf "UINT64%a" pp_endian e
   | Uint_var { size; endian } ->
       Fmt.pf ppf "UINT%a(%a)" pp_endian endian pp_expr size
   | Bits { base; _ } -> pp_bitfield_base ppf base
@@ -961,6 +974,8 @@ let rec field_wire_size : type a. a typ -> int option = function
   | Int16 _ -> Some 2
   | Int32 _ -> Some 4
   | Int64 _ -> Some 8
+  | Float32 _ -> Some 4
+  | Float64 _ -> Some 8
   | Uint_var { size = Int n; _ } -> Some n
   | Uint_var _ -> None
   | Bits { base; _ } -> (
@@ -997,6 +1012,11 @@ let c_type_of : type a. a typ -> string = function
   | Int16 _ -> "uint16_t"
   | Int32 _ -> "uint32_t"
   | Int64 _ -> "uint64_t"
+  (* Floats are also projected as the same-width UINT* in 3D, since the
+     verified parser sees the bit pattern; the float reinterpretation is
+     OCaml-side. *)
+  | Float32 _ -> "uint32_t"
+  | Float64 _ -> "uint64_t"
   | Uint_var _ -> "uint32_t"
   | _ -> "uint32_t"
 
@@ -1006,4 +1026,5 @@ let ml_type_of : type a. a typ -> string = function
   | Uint64 _ -> "int64"
   | Int8 | Int16 _ | Int32 _ -> "int"
   | Int64 _ -> "int64"
+  | Float32 _ | Float64 _ -> "float"
   | _ -> "int"

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -451,29 +451,30 @@ let struct_project s ~name ~keep =
 
 (* What kind of OCaml value a field produces -- used by Wire_stubs to
    generate the right C-to-OCaml conversion in output stubs. *)
-type ocaml_kind = K_int | K_int64 | K_float | K_bool | K_string | K_unit
+type ocaml_kind = Int | Int64 | Float32 | Float64 | Bool | String | Unit
 
 let rec ocaml_kind_of : type a. a typ -> ocaml_kind = function
-  | Uint8 | Uint16 _ | Uint32 _ | Uint63 _ | Uint_var _ -> K_int
-  | Uint64 _ -> K_int64
-  | Int8 | Int16 _ | Int32 _ -> K_int
-  | Int64 _ -> K_int64
-  | Float32 _ | Float64 _ -> K_float
-  | Bits _ -> K_int
+  | Uint8 | Uint16 _ | Uint32 _ | Uint63 _ | Uint_var _ -> Int
+  | Uint64 _ -> Int64
+  | Int8 | Int16 _ | Int32 _ -> Int
+  | Int64 _ -> Int64
+  | Float32 _ -> Float32
+  | Float64 _ -> Float64
+  | Bits _ -> Int
   | Map { inner = Bits _; decode = _; encode = _ } ->
       (* bool (bits ~width:1 ...) maps to bool; other maps stay int *)
       (* We can't distinguish bool from other maps here without checking
-         the decode function. Use K_int as safe default -- the EverParse
+         the decode function. Use Int as safe default -- the EverParse
          output struct stores the raw int anyway. *)
-      K_int
+      Int
   | Map { inner; _ } -> ocaml_kind_of inner
   | Enum { base; _ } -> ocaml_kind_of base
   | Where { inner; _ } -> ocaml_kind_of inner
-  | Byte_array _ -> K_string
-  | Byte_array_where _ -> K_string
-  | Byte_slice _ -> K_string (* approximate: slice becomes string in output *)
-  | Unit | All_bytes | All_zeros -> K_unit
-  | _ -> K_int (* fallback *)
+  | Byte_array _ -> String
+  | Byte_array_where _ -> String
+  | Byte_slice _ -> String (* approximate: slice becomes string in output *)
+  | Unit | All_bytes | All_zeros -> Unit
+  | _ -> Int (* fallback *)
 
 let field_kinds s =
   List.filter_map

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -71,6 +71,10 @@ and _ typ =
   | Uint32 : endian -> UInt32.t typ
   | Uint63 : endian -> UInt63.t typ
   | Uint64 : endian -> int64 typ (* boxed, for full 64-bit *)
+  | Int8 : int typ
+  | Int16 : endian -> int typ
+  | Int32 : endian -> int typ (* fits OCaml int on 64-bit hosts *)
+  | Int64 : endian -> int64 typ
   | Uint_var : { size : int expr; endian : endian } -> int typ
   | Bits : {
       width : int;
@@ -185,7 +189,6 @@ type param_env = { pe_codec_id : int; pe_slots : int array }
 
 (* Expression constructors *)
 let int n = Int n
-let int64 n = Int64 n
 let true_ = Bool true
 let false_ = Bool false
 let ref name = Ref name
@@ -230,6 +233,13 @@ let uint63 = Uint63 Little
 let uint63be = Uint63 Big
 let uint64 = Uint64 Little
 let uint64be = Uint64 Big
+let int8 = Int8
+let int16 = Int16 Little
+let int16be = Int16 Big
+let int32 = Int32 Little
+let int32be = Int32 Big
+let (int64 : int64 typ) = Int64 Little
+let (int64be : int64 typ) = Int64 Big
 
 let uint ?(endian = Big) size =
   (match size with
@@ -438,6 +448,8 @@ type ocaml_kind = K_int | K_int64 | K_bool | K_string | K_unit
 let rec ocaml_kind_of : type a. a typ -> ocaml_kind = function
   | Uint8 | Uint16 _ | Uint32 _ | Uint63 _ | Uint_var _ -> K_int
   | Uint64 _ -> K_int64
+  | Int8 | Int16 _ | Int32 _ -> K_int
+  | Int64 _ -> K_int64
   | Bits _ -> K_int
   | Map { inner = Bits _; decode = _; encode = _ } ->
       (* bool (bits ~width:1 ...) maps to bool; other maps stay int *)
@@ -664,6 +676,12 @@ and pp_typ : type a. a typ Fmt.t =
   | Uint32 e -> Fmt.pf ppf "UINT32%a" pp_endian e
   | Uint63 e -> Fmt.pf ppf "UINT63%a" pp_endian e
   | Uint64 e -> Fmt.pf ppf "UINT64%a" pp_endian e
+  (* 3D has no native signed types: project to the same-width UINT*. The
+     two's-complement reinterpretation lives in the OCaml decoder. *)
+  | Int8 -> Fmt.string ppf "UINT8"
+  | Int16 e -> Fmt.pf ppf "UINT16%a" pp_endian e
+  | Int32 e -> Fmt.pf ppf "UINT32%a" pp_endian e
+  | Int64 e -> Fmt.pf ppf "UINT64%a" pp_endian e
   | Uint_var { size; endian } ->
       Fmt.pf ppf "UINT%a(%a)" pp_endian endian pp_expr size
   | Bits { base; _ } -> pp_bitfield_base ppf base
@@ -939,6 +957,10 @@ let rec field_wire_size : type a. a typ -> int option = function
   | Uint16 _ -> Some 2
   | Uint32 _ -> Some 4
   | Uint64 _ -> Some 8
+  | Int8 -> Some 1
+  | Int16 _ -> Some 2
+  | Int32 _ -> Some 4
+  | Int64 _ -> Some 8
   | Uint_var { size = Int n; _ } -> Some n
   | Uint_var _ -> None
   | Bits { base; _ } -> (
@@ -969,6 +991,12 @@ let c_type_of : type a. a typ -> string = function
   | Uint16 _ | Bits { base = BF_U16 _; _ } -> "uint16_t"
   | Uint32 _ | Uint63 _ | Bits { base = BF_U32 _; _ } -> "uint32_t"
   | Uint64 _ -> "uint64_t"
+  (* Signed types project to UINT* in 3D so EverParse only sees unsigned
+     widths; the same width drives the C field type. *)
+  | Int8 -> "uint8_t"
+  | Int16 _ -> "uint16_t"
+  | Int32 _ -> "uint32_t"
+  | Int64 _ -> "uint64_t"
   | Uint_var _ -> "uint32_t"
   | _ -> "uint32_t"
 
@@ -976,4 +1004,6 @@ let ml_type_of : type a. a typ -> string = function
   | Uint8 | Uint16 _ | Uint_var _ | Bits _ -> "int"
   | Uint32 _ | Uint63 _ -> "int"
   | Uint64 _ -> "int64"
+  | Int8 | Int16 _ | Int32 _ -> "int"
+  | Int64 _ -> "int64"
   | _ -> "int"

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -107,6 +107,9 @@ and _ typ =
   | Int32 : endian -> int typ
       (** 32-bit signed, returned as OCaml [int] (64-bit hosts only). *)
   | Int64 : endian -> int64 typ  (** 64-bit signed. *)
+  | Float32 : endian -> float typ
+      (** IEEE 754 binary32, widened to OCaml [float]. *)
+  | Float64 : endian -> float typ  (** IEEE 754 binary64. *)
   | Uint_var : { size : int expr; endian : endian } -> int typ
       (** Variable-width unsigned integer (1-7 bytes). *)
   | Bits : {
@@ -386,6 +389,19 @@ val int64 : int64 typ
 val int64be : int64 typ
 (** 64-bit signed, big-endian. *)
 
+val float32 : float typ
+(** [float32] is an IEEE 754 binary32 little-endian, widened to OCaml [float].
+*)
+
+val float32be : float typ
+(** [float32be] is an IEEE 754 binary32 big-endian, widened to OCaml [float]. *)
+
+val float64 : float typ
+(** [float64] is an IEEE 754 binary64 little-endian. *)
+
+val float64be : float typ
+(** [float64be] is an IEEE 754 binary64 big-endian. *)
+
 val uint : ?endian:endian -> int expr -> int typ
 (** [uint size] is an unsigned integer of [size] bytes (1-7). Default endian is
     {!Big}. The size may be a dynamic expression for parameter-driven widths. *)
@@ -519,7 +535,7 @@ val struct_project : struct_ -> name:string -> keep:field list -> struct_
 (** [struct_project s ~name ~keep] keeps only the fields in [keep], making all
     others anonymous. *)
 
-type ocaml_kind = K_int | K_int64 | K_bool | K_string | K_unit
+type ocaml_kind = K_int | K_int64 | K_float | K_bool | K_string | K_unit
 
 val field_kinds : struct_ -> (string * ocaml_kind) list
 (** Return the struct name. *)

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -102,6 +102,11 @@ and _ typ =
   | Uint32 : endian -> UInt32.t typ  (** 32-bit unsigned. *)
   | Uint63 : endian -> UInt63.t typ  (** 63-bit unsigned. *)
   | Uint64 : endian -> int64 typ  (** 64-bit unsigned. *)
+  | Int8 : int typ  (** 8-bit signed. *)
+  | Int16 : endian -> int typ  (** 16-bit signed. *)
+  | Int32 : endian -> int typ
+      (** 32-bit signed, returned as OCaml [int] (64-bit hosts only). *)
+  | Int64 : endian -> int64 typ  (** 64-bit signed. *)
   | Uint_var : { size : int expr; endian : endian } -> int typ
       (** Variable-width unsigned integer (1-7 bytes). *)
   | Bits : {
@@ -228,9 +233,6 @@ type param_env = { pe_codec_id : int; pe_slots : int array }
 
 val int : int -> int expr
 (** Integer literal. *)
-
-val int64 : int64 -> int64 expr
-(** 64-bit integer literal. *)
 
 val true_ : bool expr
 (** Boolean true. *)
@@ -361,6 +363,28 @@ val uint64 : int64 typ
 
 val uint64be : int64 typ
 (** 64-bit unsigned, big-endian. *)
+
+val int8 : int typ
+(** 8-bit signed two's-complement integer. *)
+
+val int16 : int typ
+(** 16-bit signed, little-endian. *)
+
+val int16be : int typ
+(** 16-bit signed, big-endian. *)
+
+val int32 : int typ
+(** [int32] is a 32-bit signed little-endian integer, returned as OCaml [int]
+    (64-bit hosts only). *)
+
+val int32be : int typ
+(** [int32be] is a 32-bit signed big-endian integer, returned as OCaml [int]. *)
+
+val int64 : int64 typ
+(** 64-bit signed, little-endian. *)
+
+val int64be : int64 typ
+(** 64-bit signed, big-endian. *)
 
 val uint : ?endian:endian -> int expr -> int typ
 (** [uint size] is an unsigned integer of [size] bytes (1-7). Default endian is

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -535,7 +535,7 @@ val struct_project : struct_ -> name:string -> keep:field list -> struct_
 (** [struct_project s ~name ~keep] keeps only the fields in [keep], making all
     others anonymous. *)
 
-type ocaml_kind = K_int | K_int64 | K_float | K_bool | K_string | K_unit
+type ocaml_kind = Int | Int64 | Float32 | Float64 | Bool | String | Unit
 
 val field_kinds : struct_ -> (string * ocaml_kind) list
 (** Return the struct name. *)

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -186,6 +186,18 @@ let rec parse_direct : type a. a typ -> bytes -> int -> int -> a * int =
   | Int64 Big ->
       check_eof len (off + 8);
       (Bytes.get_int64_be buf off, off + 8)
+  | Float32 Little ->
+      check_eof len (off + 4);
+      (Int32.float_of_bits (Bytes.get_int32_le buf off), off + 4)
+  | Float32 Big ->
+      check_eof len (off + 4);
+      (Int32.float_of_bits (Bytes.get_int32_be buf off), off + 4)
+  | Float64 Little ->
+      check_eof len (off + 8);
+      (Int64.float_of_bits (Bytes.get_int64_le buf off), off + 8)
+  | Float64 Big ->
+      check_eof len (off + 8);
+      (Int64.float_of_bits (Bytes.get_int64_be buf off), off + 8)
   | Uint_var { size; endian } ->
       let n = Eval.expr Eval.empty size in
       check_eof len (off + n);
@@ -498,6 +510,10 @@ let rec encode_into : type a. a typ -> a -> encoder -> unit =
   | Int32 Big -> write_int32_be enc (Int32.of_int v)
   | Int64 Little -> write_int64_le enc v
   | Int64 Big -> write_int64_be enc v
+  | Float32 Little -> write_int32_le enc (Int32.bits_of_float v)
+  | Float32 Big -> write_int32_be enc (Int32.bits_of_float v)
+  | Float64 Little -> write_int64_le enc (Int64.bits_of_float v)
+  | Float64 Big -> write_int64_be enc (Int64.bits_of_float v)
   | Uint_var { size; endian } ->
       let n = Eval.expr Eval.empty size in
       ensure enc n;

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -41,15 +41,11 @@ let lookup = Types.cases
    on both wire's OCaml decoder and EverParse's verified C decoder. *)
 type float_layout = { exp_shift : int; exp_max : int; mant_mask : int }
 
-let f32_layout = { exp_shift = 23; exp_max = 0xFF; mant_mask = 0x007F_FFFF }
-
-let f64_layout =
-  { exp_shift = 52; exp_max = 0x7FF; mant_mask = 0x000F_FFFF_FFFF_FFFF }
-
 let float_layout_of (typ : float Types.typ) =
   match typ with
-  | Float32 _ -> f32_layout
-  | Float64 _ -> f64_layout
+  | Float32 _ -> { exp_shift = 23; exp_max = 0xFF; mant_mask = 0x007F_FFFF }
+  | Float64 _ ->
+      { exp_shift = 52; exp_max = 0x7FF; mant_mask = 0x000F_FFFF_FFFF_FFFF }
   | _ -> invalid_arg "Wire: not a float field"
 
 let is_finite (f : float Field.t) : bool Types.expr =

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -31,6 +31,39 @@ let empty = Types.unit
 let size = Types.field_wire_size
 let lookup = Types.cases
 
+(* IEEE 754 predicates compile to bit-mask checks over the float's bit
+   pattern (which [build_populate] stores into [int_array] for float fields).
+   We use shift-based forms instead of the natural [v & 0x7FF0_..._0000]
+   because that mask exceeds OCaml's 62-bit signed [int] range and renders
+   as a negative literal that 3D rejects. Shifting the exponent down to the
+   low bits and comparing against a small constant keeps every literal
+   fitting in 31 bits and produces identical [(v >> N) & M] / [== M] checks
+   on both wire's OCaml decoder and EverParse's verified C decoder. *)
+type float_layout = { exp_shift : int; exp_max : int; mant_mask : int }
+
+let f32_layout = { exp_shift = 23; exp_max = 0xFF; mant_mask = 0x007F_FFFF }
+
+let f64_layout =
+  { exp_shift = 52; exp_max = 0x7FF; mant_mask = 0x000F_FFFF_FFFF_FFFF }
+
+let float_layout_of (typ : float Types.typ) =
+  match typ with
+  | Float32 _ -> f32_layout
+  | Float64 _ -> f64_layout
+  | _ -> invalid_arg "Wire: not a float field"
+
+let is_finite (f : float Field.t) : bool Types.expr =
+  let r = Field.ref f in
+  let { exp_shift; exp_max; _ } = float_layout_of (Field.typ f) in
+  Expr.(Land (Lsr (r, Int exp_shift), Int exp_max) <> Int exp_max)
+
+let is_nan (f : float Field.t) : bool Types.expr =
+  let r = Field.ref f in
+  let { exp_shift; exp_max; mant_mask } = float_layout_of (Field.typ f) in
+  Expr.(
+    Land (Lsr (r, Int exp_shift), Int exp_max) = Int exp_max
+    && Land (r, Int mant_mask) <> Int 0)
+
 let codec (c : 'r Codec.t) : 'r typ =
   let codec_decode = Codec.raw_decode c in
   let codec_encode = Codec.raw_encode c in

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -121,6 +121,11 @@ let parse_all_zeros buf off len =
   in
   (check 0, len)
 
+let parse_codec_typ codec_decode fixed_size size_of buf off len =
+  let sz = match fixed_size with Some n -> n | None -> size_of buf off in
+  check_eof len (off + sz);
+  (codec_decode buf off, off + sz)
+
 let parse_struct_typ s buf off len =
   let v = Codec.validator_of_struct s in
   let sz = Codec.struct_size_of v buf off in
@@ -158,6 +163,27 @@ let rec parse_direct : type a. a typ -> bytes -> int -> int -> a * int =
       check_eof len (off + 8);
       (Bytes.get_int64_le buf off, off + 8)
   | Uint64 Big ->
+      check_eof len (off + 8);
+      (Bytes.get_int64_be buf off, off + 8)
+  | Int8 ->
+      check_eof len (off + 1);
+      (Bytes.get_int8 buf off, off + 1)
+  | Int16 Little ->
+      check_eof len (off + 2);
+      (Bytes.get_int16_le buf off, off + 2)
+  | Int16 Big ->
+      check_eof len (off + 2);
+      (Bytes.get_int16_be buf off, off + 2)
+  | Int32 Little ->
+      check_eof len (off + 4);
+      (Int32.to_int (Bytes.get_int32_le buf off), off + 4)
+  | Int32 Big ->
+      check_eof len (off + 4);
+      (Int32.to_int (Bytes.get_int32_be buf off), off + 4)
+  | Int64 Little ->
+      check_eof len (off + 8);
+      (Bytes.get_int64_le buf off, off + 8)
+  | Int64 Big ->
       check_eof len (off + 8);
       (Bytes.get_int64_be buf off, off + 8)
   | Uint_var { size; endian } ->
@@ -210,13 +236,7 @@ let rec parse_direct : type a. a typ -> bytes -> int -> int -> a * int =
       if List.mem v valid then (v, off')
       else raise (Parse_exn (Invalid_enum { value = v; valid }))
   | Codec { codec_decode; codec_fixed_size; codec_size_of; _ } ->
-      let sz =
-        match codec_fixed_size with
-        | Some n -> n
-        | None -> codec_size_of buf off
-      in
-      check_eof len (off + sz);
-      (codec_decode buf off, off + sz)
+      parse_codec_typ codec_decode codec_fixed_size codec_size_of buf off len
   | Struct s -> parse_struct_typ s buf off len
   | Casetype { cases; tag; _ } -> parse_casetype tag cases buf off len
   | Optional { present; inner } ->
@@ -365,6 +385,21 @@ let[@inline] write_byte enc b =
   Bytes.set_uint8 enc.o enc.o_next b;
   enc.o_next <- enc.o_next + 1
 
+let[@inline] write_int8 enc v =
+  ensure enc 1;
+  Bytes.set_int8 enc.o enc.o_next v;
+  enc.o_next <- enc.o_next + 1
+
+let[@inline] write_int16_le enc v =
+  ensure enc 2;
+  Bytes.set_int16_le enc.o enc.o_next v;
+  enc.o_next <- enc.o_next + 2
+
+let[@inline] write_int16_be enc v =
+  ensure enc 2;
+  Bytes.set_int16_be enc.o enc.o_next v;
+  enc.o_next <- enc.o_next + 2
+
 let[@inline] write_uint16_le enc v =
   ensure enc 2;
   Bytes.set_uint16_le enc.o enc.o_next v;
@@ -456,6 +491,13 @@ let rec encode_into : type a. a typ -> a -> encoder -> unit =
   | Uint63 Big -> write_uint63_be enc v
   | Uint64 Little -> write_int64_le enc v
   | Uint64 Big -> write_int64_be enc v
+  | Int8 -> write_int8 enc v
+  | Int16 Little -> write_int16_le enc v
+  | Int16 Big -> write_int16_be enc v
+  | Int32 Little -> write_int32_le enc (Int32.of_int v)
+  | Int32 Big -> write_int32_be enc (Int32.of_int v)
+  | Int64 Little -> write_int64_le enc v
+  | Int64 Big -> write_int64_be enc v
   | Uint_var { size; endian } ->
       let n = Eval.expr Eval.empty size in
       ensure enc n;

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -201,9 +201,6 @@ end
 val int : int -> int expr
 (** Constant integer expression. *)
 
-val int64 : int64 -> int64 expr
-(** Constant 64-bit integer expression. *)
-
 val sizeof : 'a typ -> int expr
 (** Size of a fixed-size wire description. *)
 
@@ -399,6 +396,28 @@ val uint64 : int64 typ
 val uint64be : int64 typ
 (** [uint64be] is an unsigned 64-bit big-endian integer represented as [int64].
 *)
+
+val int8 : int typ
+(** Signed 8-bit two's-complement integer. *)
+
+val int16 : int typ
+(** Signed 16-bit little-endian integer. *)
+
+val int16be : int typ
+(** Signed 16-bit big-endian integer. *)
+
+val int32 : int typ
+(** [int32] is a signed 32-bit little-endian integer, returned as OCaml [int]
+    (64-bit hosts only: on a 32-bit host, the top bit may not fit). *)
+
+val int32be : int typ
+(** [int32be] is a signed 32-bit big-endian integer, returned as OCaml [int]. *)
+
+val int64 : int64 typ
+(** Signed 64-bit little-endian integer. *)
+
+val int64be : int64 typ
+(** Signed 64-bit big-endian integer. *)
 
 val uint : ?endian:endian -> int expr -> int typ
 (** [uint size] is an unsigned integer of [size] bytes (1-7) with the given byte

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -433,6 +433,18 @@ val float64 : float typ
 val float64be : float typ
 (** [float64be] is an IEEE 754 binary64 big-endian. *)
 
+val is_finite : float Field.t -> bool expr
+(** [is_finite f] is a constraint that holds iff [f]'s decoded IEEE 754 value is
+    neither [NaN] nor [+/- infinity]. Compiles to a bit-mask check on the
+    field's exponent (against [0x7F80_0000] for [float32] and
+    [0x7FF0_0000_0000_0000] for [float64]); the same expression is emitted into
+    the 3D output, so wire's OCaml decoder and EverParse's verified C decoder
+    reject the same set of inputs. *)
+
+val is_nan : float Field.t -> bool expr
+(** [is_nan f] holds iff [f] decodes to a NaN bit pattern (exponent all-ones AND
+    mantissa non-zero). *)
+
 val uint : ?endian:endian -> int expr -> int typ
 (** [uint size] is an unsigned integer of [size] bytes (1-7) with the given byte
     order (default {!Big}). The size may be a dynamic expression for
@@ -1030,12 +1042,13 @@ module Everparse : sig
     (** Named field names in declaration order. *)
 
     type ocaml_kind =
-      | K_int
-      | K_int64
-      | K_float
-      | K_bool
-      | K_string
-      | K_unit
+      | Int
+      | Int64
+      | Float32
+      | Float64
+      | Bool
+      | String
+      | Unit
           (** The OCaml representation kind of a field (for FFI stub
               generation). *)
 

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -419,6 +419,20 @@ val int64 : int64 typ
 val int64be : int64 typ
 (** Signed 64-bit big-endian integer. *)
 
+val float32 : float typ
+(** [float32] is an IEEE 754 binary32 little-endian, widened to OCaml [float].
+    The 3D projection emits [UINT32] (no native float in 3D); float predicates
+    compile to bit-pattern refinements over the unsigned width. *)
+
+val float32be : float typ
+(** [float32be] is an IEEE 754 binary32 big-endian. *)
+
+val float64 : float typ
+(** [float64] is an IEEE 754 binary64 little-endian. *)
+
+val float64be : float typ
+(** [float64be] is an IEEE 754 binary64 big-endian. *)
+
 val uint : ?endian:endian -> int expr -> int typ
 (** [uint size] is an unsigned integer of [size] bytes (1-7) with the given byte
     order (default {!Big}). The size may be a dynamic expression for
@@ -1018,6 +1032,7 @@ module Everparse : sig
     type ocaml_kind =
       | K_int
       | K_int64
+      | K_float
       | K_bool
       | K_string
       | K_unit

--- a/test/test_wire.ml
+++ b/test/test_wire.ml
@@ -92,6 +92,23 @@ let test_int64le_roundtrip () =
   let s = to_string int64 v in
   Alcotest.(check int64) "roundtrip" v (of_string_exn int64 s)
 
+let test_float32be_roundtrip () =
+  let v = 1.5 in
+  let s = to_string float32be v in
+  Alcotest.(check (float 0.0)) "1.5" v (of_string_exn float32be s)
+
+let test_float64le_roundtrip () =
+  List.iter
+    (fun v ->
+      let s = to_string float64 v in
+      Alcotest.(check (float 0.0)) "roundtrip" v (of_string_exn float64 s))
+    [ 0.0; -0.0; 3.14159; -1e300; Float.infinity; Float.neg_infinity ]
+
+let test_float64_nan_roundtrip () =
+  let s = to_string float64be Float.nan in
+  let v = of_string_exn float64be s in
+  Alcotest.(check bool) "nan preserved" true (Float.is_nan v)
+
 let printable_byte b = Expr.(b >= int 0x20 && b <= int 0x7e)
 
 let test_bawhere_accepts () =
@@ -650,6 +667,11 @@ let suite =
       Alcotest.test_case "parse: int32be negative" `Quick test_int32be_negative;
       Alcotest.test_case "parse: int64le roundtrip" `Quick
         test_int64le_roundtrip;
+      Alcotest.test_case "parse: float32be roundtrip" `Quick
+        test_float32be_roundtrip;
+      Alcotest.test_case "parse: float64le roundtrip" `Quick
+        test_float64le_roundtrip;
+      Alcotest.test_case "parse: float64 nan" `Quick test_float64_nan_roundtrip;
       Alcotest.test_case "parse: byte_array_where accepts" `Quick
         test_bawhere_accepts;
       Alcotest.test_case "parse: byte_array_where rejects" `Quick

--- a/test/test_wire.ml
+++ b/test/test_wire.ml
@@ -109,6 +109,36 @@ let test_float64_nan_roundtrip () =
   let v = of_string_exn float64be s in
   Alcotest.(check bool) "nan preserved" true (Float.is_nan v)
 
+let finite_field name typ =
+  let template = Field.v name typ in
+  Field.v name ~constraint_:(is_finite template) typ
+
+let finite_codec () =
+  let f_v = finite_field "v" float64be in
+  Codec.v "Tel" (fun v -> v) Codec.[ (f_v $ fun v -> v) ]
+
+let test_finite_rejects_nan () =
+  let buf = Bytes.create 8 in
+  Bytes.set_int64_be buf 0 0x7FF8_0000_0000_0001L;
+  match Codec.decode (finite_codec ()) buf 0 with
+  | Error (Constraint_failed _) -> ()
+  | Ok _ -> Alcotest.fail "is_finite should have rejected NaN"
+  | Error e -> Alcotest.failf "wrong error: %a" pp_parse_error e
+
+let test_finite_accepts () =
+  let buf = Bytes.create 8 in
+  Bytes.set_int64_be buf 0 (Int64.bits_of_float 3.14);
+  match Codec.decode (finite_codec ()) buf 0 with
+  | Ok v -> Alcotest.(check (float 0.0)) "finite ok" 3.14 v
+  | Error e -> Alcotest.failf "%a" pp_parse_error e
+
+let test_finite_rejects_inf () =
+  let buf = Bytes.create 8 in
+  Bytes.set_int64_be buf 0 (Int64.bits_of_float Float.infinity);
+  match Codec.decode (finite_codec ()) buf 0 with
+  | Error (Constraint_failed _) -> ()
+  | _ -> Alcotest.fail "is_finite should have rejected +inf"
+
 let printable_byte b = Expr.(b >= int 0x20 && b <= int 0x7e)
 
 let test_bawhere_accepts () =
@@ -672,6 +702,9 @@ let suite =
       Alcotest.test_case "parse: float64le roundtrip" `Quick
         test_float64le_roundtrip;
       Alcotest.test_case "parse: float64 nan" `Quick test_float64_nan_roundtrip;
+      Alcotest.test_case "is_finite: rejects nan" `Quick test_finite_rejects_nan;
+      Alcotest.test_case "is_finite: accepts finite" `Quick test_finite_accepts;
+      Alcotest.test_case "is_finite: rejects inf" `Quick test_finite_rejects_inf;
       Alcotest.test_case "parse: byte_array_where accepts" `Quick
         test_bawhere_accepts;
       Alcotest.test_case "parse: byte_array_where rejects" `Quick

--- a/test/test_wire.ml
+++ b/test/test_wire.ml
@@ -69,6 +69,29 @@ let test_parse_byte_array () =
   | Ok v -> Alcotest.(check string) "byte_array value" "hello" v
   | Error e -> Alcotest.failf "%a" pp_parse_error e
 
+let test_int8_negative () =
+  let buf = Bytes.of_string "\xFE" in
+  Alcotest.(check int) "-2" (-2) (of_bytes_exn int8 buf)
+
+let test_int8_full_range () =
+  for i = -128 to 127 do
+    let s = to_string int8 i in
+    Alcotest.(check int) (Fmt.str "%d" i) i (of_string_exn int8 s)
+  done
+
+let test_int16be_negative () =
+  let buf = Bytes.of_string "\xFF\xFE" in
+  Alcotest.(check int) "-2 BE" (-2) (of_bytes_exn int16be buf)
+
+let test_int32be_negative () =
+  let buf = Bytes.of_string "\xFF\xFF\xFF\xFE" in
+  Alcotest.(check int) "-2 BE" (-2) (of_bytes_exn int32be buf)
+
+let test_int64le_roundtrip () =
+  let v = -0x0102_0304_0506_0708L in
+  let s = to_string int64 v in
+  Alcotest.(check int64) "roundtrip" v (of_string_exn int64 s)
+
 let printable_byte b = Expr.(b >= int 0x20 && b <= int 0x7e)
 
 let test_bawhere_accepts () =
@@ -621,6 +644,12 @@ let suite =
       Alcotest.test_case "parse: uint64 le" `Quick test_parse_uint64_le;
       Alcotest.test_case "parse: array" `Quick test_parse_array;
       Alcotest.test_case "parse: byte_array" `Quick test_parse_byte_array;
+      Alcotest.test_case "parse: int8 negative" `Quick test_int8_negative;
+      Alcotest.test_case "parse: int8 full range" `Quick test_int8_full_range;
+      Alcotest.test_case "parse: int16be negative" `Quick test_int16be_negative;
+      Alcotest.test_case "parse: int32be negative" `Quick test_int32be_negative;
+      Alcotest.test_case "parse: int64le roundtrip" `Quick
+        test_int64le_roundtrip;
       Alcotest.test_case "parse: byte_array_where accepts" `Quick
         test_bawhere_accepts;
       Alcotest.test_case "parse: byte_array_where rejects" `Quick


### PR DESCRIPTION
Adds `int8` / `int16(be)` / `int32(be)` / `int64(be)` and `float32(be)` / `float64(be)` to the typ language. The OCaml decoder reads two's-complement and IEEE 754 bit patterns directly via `Bytes.get_int*` and `Int32.float_of_bits` / `Int64.float_of_bits`; the encoder mirrors. `int32` returns OCaml `int` on 64-bit hosts; `int64` returns boxed `int64`; floats round-trip NaN, signed zero, infinities, and subnormals byte-for-byte.

3D only exposes unsigned primitives -- `UINT8`, `UINT8BE`, `UINT16BE`, `UINT32BE`, `UINT64BE`, `UINT16`, `UINT32`, `UINT64` (see the [3D language reference](https://project-everest.github.io/everparse/3d-lang.html)). The projection therefore emits the same-width `UINT*` for every signed and float type: EverParse's verified-C parser sees the unsigned bit pattern, and the signed/float reinterpretation is OCaml-side. Memory safety, length, and tag relations stay verified.

`Wire.is_finite` / `Wire.is_nan` complete the contract for floats. They take a `float Field.t` and return a `bool expr` that compiles to a bit-mask check on the field's bit pattern (`(v >> 52) & 0x7FF != 0x7FF` for `float64`, the `float32` analogue for 23-bit mantissas). Wire's OCaml decoder populates `int_array` with the IEEE 754 bit pattern for float fields so the same expression evaluates identically; EverParse's verified C decoder applies the same constraint at the field's `where`.

The 3D-generated plug (`<Name>_Fields.c`) stores float fields with their typed C type (`float` / `double`); the setter does the `memcpy` bit-reinterpret on the inbound `UINT*`. Any C consumer of the plug already sees the typed float. The OCaml FFI stub is then just `caml_copy_double((double) fields.x)`, with no extra reinterpretation step.

Fuzz tests assert `Wire.is_finite` agrees with `Float.is_finite` on arbitrary 8-byte inputs and that `float64` round-trips byte-for-byte (NaN bit-pattern preserved).