### PR TITLE
test: extract shared codec fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ AGENTS.md
 .crush/
 .claude/
 _opam/
+todo/

--- a/fuzz/fuzz_param.ml
+++ b/fuzz/fuzz_param.ml
@@ -172,17 +172,6 @@ let test_typed_assign buf =
   let _ = Wire.Param.get env out in
   ()
 
-(* Fuzz: map ~decode ~encode roundtrip *)
-let test_map_roundtrip n =
-  let n = abs n mod 256 in
-  let t =
-    Wire.map ~decode:(fun x -> x * 2) ~encode:(fun x -> x / 2) Wire.uint8
-  in
-  let encoded = Wire.to_string t (n * 2) in
-  match Wire.of_string t encoded with
-  | Ok decoded -> if n * 2 <> decoded then fail "map roundtrip mismatch"
-  | Error _ -> fail "map roundtrip parse failed"
-
 (** {1 Test Registration} *)
 
 let parse_tests =
@@ -200,7 +189,6 @@ let param_ref_tests =
     test_case "param_ref where" [ bytes ] test_param_ref_where;
     test_case "param_ref constraint" [ bytes ] test_param_ref_constraint;
     test_case "typed assign" [ bytes ] test_typed_assign;
-    test_case "map roundtrip" [ int ] test_map_roundtrip;
   ]
 
 let suite = ("param", parse_tests @ param_ref_tests)

--- a/test/dune
+++ b/test/dune
@@ -1,3 +1,3 @@
 (test
  (name test)
- (libraries wire wire.3d alcotest re))
+ (libraries wire wire.3d test_fixtures alcotest re))

--- a/test/fixtures/dune
+++ b/test/fixtures/dune
@@ -1,0 +1,3 @@
+(library
+ (name test_fixtures)
+ (libraries wire))

--- a/test/fixtures/test_fixtures.ml
+++ b/test/fixtures/test_fixtures.ml
@@ -1,0 +1,104 @@
+open Wire
+
+type inner = { tag : int; value : int }
+
+let f_inner_tag = Field.v "Tag" uint8
+let f_inner_value = Field.v "Value" uint16be
+
+let inner_codec =
+  Codec.v "Inner"
+    (fun tag value -> { tag; value })
+    Codec.[ (f_inner_tag $ fun r -> r.tag); (f_inner_value $ fun r -> r.value) ]
+
+type outer = { header : int; inner : inner; trailer : int }
+
+let outer_codec =
+  Codec.v "Outer"
+    (fun header inner trailer -> { header; inner; trailer })
+    Codec.
+      [
+        (Field.v "Header" uint8 $ fun r -> r.header);
+        (Field.v "Inner" (codec inner_codec) $ fun r -> r.inner);
+        (Field.v "Trailer" uint8 $ fun r -> r.trailer);
+      ]
+
+type l2 = { l2_x : int }
+type l1 = { l1_inner : l2; l1_y : int }
+type l0 = { l0_inner : l1; l0_z : int }
+
+let l2_codec =
+  Codec.v "L2"
+    (fun x -> { l2_x = x })
+    Codec.[ (Field.v "X" uint8 $ fun r -> r.l2_x) ]
+
+let l1_codec =
+  Codec.v "L1"
+    (fun inner y -> { l1_inner = inner; l1_y = y })
+    Codec.
+      [
+        (Field.v "Inner" (codec l2_codec) $ fun r -> r.l1_inner);
+        (Field.v "Y" uint16be $ fun r -> r.l1_y);
+      ]
+
+let l0_codec =
+  Codec.v "L0"
+    (fun inner z -> { l0_inner = inner; l0_z = z })
+    Codec.
+      [
+        (Field.v "Inner" (codec l1_codec) $ fun r -> r.l0_inner);
+        (Field.v "Z" uint8 $ fun r -> r.l0_z);
+      ]
+
+type opt_record = { opt_hdr : int; opt_payload : int option; opt_trail : int }
+
+let opt_codec ~present =
+  Codec.v "OptRecord"
+    (fun hdr payload trail ->
+      { opt_hdr = hdr; opt_payload = payload; opt_trail = trail })
+    Codec.
+      [
+        (Field.v "Hdr" uint8 $ fun r -> r.opt_hdr);
+        ( Field.v "Payload" (optional (bool present) uint16be) $ fun r ->
+          r.opt_payload );
+        (Field.v "Trail" uint8 $ fun r -> r.opt_trail);
+      ]
+
+let opt_codec_present = opt_codec ~present:true
+let opt_codec_absent = opt_codec ~present:false
+
+type container = { cnt_length : int; cnt_items : inner list }
+
+let f_cnt_length = Field.v "Length" uint8
+
+let repeat_codec =
+  Codec.v "Container"
+    (fun length items -> { cnt_length = length; cnt_items = items })
+    Codec.
+      [
+        (f_cnt_length $ fun r -> r.cnt_length);
+        ( Field.v "Items"
+            (repeat ~size:(Field.ref f_cnt_length) (codec inner_codec))
+        $ fun r -> r.cnt_items );
+      ]
+
+type packet = { pkt_id : int; pkt_data : int }
+
+let packet_codec =
+  Codec.v "Packet"
+    (fun id data -> { pkt_id = id; pkt_data = data })
+    Codec.
+      [
+        (Field.v "Id" uint8 $ fun r -> r.pkt_id);
+        (Field.v "Data" uint16be $ fun r -> r.pkt_data);
+      ]
+
+type multi_record = { x : int; y : int }
+
+let multi_record_codec =
+  Codec.v "MultiRecord"
+    (fun x y -> { x; y })
+    Codec.
+      [
+        (Field.v "x" uint16be $ fun r -> r.x);
+        (Field.v "y" uint16be $ fun r -> r.y);
+      ]

--- a/test/fixtures/test_fixtures.mli
+++ b/test/fixtures/test_fixtures.mli
@@ -1,0 +1,69 @@
+(** Shared codec fixtures used by the test suites. *)
+
+open Wire
+
+type inner = { tag : int; value : int }
+
+val f_inner_tag : int Field.t
+(** [f_inner_tag] is the field reference for [inner.tag]; reused by codecs that
+    depend on the parsed tag value. *)
+
+val f_inner_value : int Field.t
+(** [f_inner_value] is the field reference for [inner.value]. *)
+
+val inner_codec : inner Codec.t
+(** [inner_codec] is the tag-prefixed inner record used as the building block
+    for [outer_codec], [repeat_codec], and many test cases. *)
+
+type outer = { header : int; inner : inner; trailer : int }
+
+val outer_codec : outer Codec.t
+(** [outer_codec] embeds [inner_codec] between a header and trailer byte;
+    exercises the [codec] field combinator. *)
+
+type l2 = { l2_x : int }
+type l1 = { l1_inner : l2; l1_y : int }
+type l0 = { l0_inner : l1; l0_z : int }
+
+val l2_codec : l2 Codec.t
+(** [l2_codec] is the innermost level of a 3-deep codec nesting. *)
+
+val l1_codec : l1 Codec.t
+(** [l1_codec] is the middle level, embedding [l2_codec]. *)
+
+val l0_codec : l0 Codec.t
+(** [l0_codec] is the outermost level, embedding [l1_codec]; exercises two-level
+    nesting. *)
+
+type opt_record = { opt_hdr : int; opt_payload : int option; opt_trail : int }
+
+val opt_codec : present:bool -> opt_record Codec.t
+(** [opt_codec ~present] is a record with an optional middle field; [present]
+    selects whether the payload is included. *)
+
+val opt_codec_present : opt_record Codec.t
+(** [opt_codec_present] is [opt_codec ~present:true]. *)
+
+val opt_codec_absent : opt_record Codec.t
+(** [opt_codec_absent] is [opt_codec ~present:false]. *)
+
+type container = { cnt_length : int; cnt_items : inner list }
+
+val f_cnt_length : int Field.t
+(** [f_cnt_length] is the field reference for [container.cnt_length], used to
+    size the trailing [repeat] body. *)
+
+val repeat_codec : container Codec.t
+(** [repeat_codec] is a length-prefixed list of [inner] elements. *)
+
+type packet = { pkt_id : int; pkt_data : int }
+
+val packet_codec : packet Codec.t
+(** [packet_codec] is a fixed-shape packet record reused by TM-frame style
+    composition tests. *)
+
+type multi_record = { x : int; y : int }
+
+val multi_record_codec : multi_record Codec.t
+(** [multi_record_codec] is a two-[uint16be]-field record reused by ASCII
+    rendering and codec encode/decode tests. *)

--- a/test/test_ascii.ml
+++ b/test/test_ascii.ml
@@ -4,6 +4,7 @@
 
 open Wire
 open Wire.Everparse.Raw
+open Test_fixtures
 
 let check name s expected =
   let output = Ascii.of_struct s in
@@ -110,21 +111,11 @@ let test_variable () =
     "contains data" true
     (Re.execp (Re.compile (Re.str "data")) output)
 
-(* -- Codec rendering -- *)
-
-type simple_record = { x : int; y : int }
-
-let simple_codec =
-  Codec.v "Simple"
-    (fun x y -> { x; y })
-    Codec.
-      [
-        (Field.v "x" uint16be $ fun r -> r.x);
-        (Field.v "y" uint16be $ fun r -> r.y);
-      ]
+(* -- Codec rendering --
+   [multi_record_codec] lives in {!Test_fixtures}. *)
 
 let test_of_codec () =
-  let output = Ascii.of_codec simple_codec in
+  let output = Ascii.of_codec multi_record_codec in
   let expected =
     ruler
     ^ " +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+\n\
@@ -138,13 +129,13 @@ let test_of_codec () =
 let test_pp_codec () =
   let buf = Buffer.create 128 in
   let ppf = Format.formatter_of_buffer buf in
-  Ascii.pp_codec ppf simple_codec;
+  Ascii.pp_codec ppf multi_record_codec;
   Format.pp_print_flush ppf ();
   let output = Buffer.contents buf in
   Alcotest.(check bool) "pp_codec non-empty" true (String.length output > 0);
   Alcotest.(check string)
     "pp_codec matches of_codec"
-    (Ascii.of_codec simple_codec)
+    (Ascii.of_codec multi_record_codec)
     output
 
 let test_pp_struct () =

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -2,6 +2,7 @@
 
 open Wire
 open Wire.Everparse.Raw
+open Test_fixtures
 
 let contains ~sub s = Re.execp (Re.compile (Re.str sub)) s
 
@@ -215,17 +216,8 @@ let test_struct_of_codec_metadata () =
     "contains mutable outx param" true
     (contains ~sub:"mutable" output)
 
-(* Record with multiple uint16be fields *)
-type multi_record = { x : int; y : int }
-
-let multi_record_codec =
-  let open Codec in
-  v "MultiRecord"
-    (fun x y -> { x; y })
-    [
-      (Field.v "x" uint16be $ fun r -> r.x);
-      (Field.v "y" uint16be $ fun r -> r.y);
-    ]
+(* Record with multiple uint16be fields --
+   [multi_record] / [multi_record_codec] live in {!Test_fixtures}. *)
 
 let test_record_with_multi () =
   let original = { x = 0x1234; y = 0x5678 } in
@@ -468,8 +460,8 @@ let test_view_get_uint () =
   let codec, cf_x, cf_y =
     let f_x = Field.v "x" uint16be in
     let f_y = Field.v "y" uint16be in
-    let cf_x = Codec.(f_x $ fun r -> r.x) in
-    let cf_y = Codec.(f_y $ fun r -> r.y) in
+    let cf_x = Codec.(f_x $ fun (r : multi_record) -> r.x) in
+    let cf_y = Codec.(f_y $ fun (r : multi_record) -> r.y) in
     let codec =
       Codec.v "ViewUint" (fun a b -> { x = a; y = b }) [ cf_x; cf_y ]
     in
@@ -575,8 +567,8 @@ let test_view_set_uint () =
   let codec, cf_x, cf_y =
     let f_x = Field.v "x" uint16be in
     let f_y = Field.v "y" uint16be in
-    let cf_x = Codec.(f_x $ fun r -> r.x) in
-    let cf_y = Codec.(f_y $ fun r -> r.y) in
+    let cf_x = Codec.(f_x $ fun (r : multi_record) -> r.x) in
+    let cf_y = Codec.(f_y $ fun (r : multi_record) -> r.y) in
     let codec = Codec.v "ViewSetUint" (fun x y -> { x; y }) [ cf_x; cf_y ] in
     (codec, cf_x, cf_y)
   in
@@ -2064,31 +2056,8 @@ let test_bitfield_load_shared () =
   Alcotest.(check int) "a" 0xA a;
   Alcotest.(check int) "b" 0xB b
 
-(* -- Nested: sub-codec used for embedding -- *)
-
-type inner = { tag : int; value : int }
-
-let f_inner_tag = Field.v "Tag" uint8
-let f_inner_value = Field.v "Value" uint16be
-
-let inner_codec =
-  Codec.v "Inner"
-    (fun tag value -> { tag; value })
-    Codec.[ (f_inner_tag $ fun r -> r.tag); (f_inner_value $ fun r -> r.value) ]
-
-(* -- Nested: Codec typ: embed a sub-codec as a field -- *)
-
-type outer = { header : int; inner : inner; trailer : int }
-
-let outer_codec =
-  Codec.v "Outer"
-    (fun header inner trailer -> { header; inner; trailer })
-    Codec.
-      [
-        (Field.v "Header" uint8 $ fun r -> r.header);
-        (Field.v "Inner" (codec inner_codec) $ fun r -> r.inner);
-        (Field.v "Trailer" uint8 $ fun r -> r.trailer);
-      ]
+(* -- Nested: Codec typ: embed a sub-codec as a field --
+   [inner] / [outer] / [inner_codec] / [outer_codec] live in {!Test_fixtures}. *)
 
 let test_codec_embed_decode () =
   (* header(1) + tag(1) + value(2) + trailer(1) = 5 bytes *)
@@ -2168,34 +2137,8 @@ let test_codec_embed_bitfield () =
   Alcotest.(check int) "flags" 0x5 r.bf.flags;
   Alcotest.(check int) "checksum" 0xFF r.checksum
 
-(* Two levels of nesting *)
-
-type l2 = { l2_x : int }
-type l1 = { l1_inner : l2; l1_y : int }
-type l0 = { l0_inner : l1; l0_z : int }
-
-let l2_codec =
-  Codec.v "L2"
-    (fun x -> { l2_x = x })
-    Codec.[ (Field.v "X" uint8 $ fun r -> r.l2_x) ]
-
-let l1_codec =
-  Codec.v "L1"
-    (fun inner y -> { l1_inner = inner; l1_y = y })
-    Codec.
-      [
-        (Field.v "Inner" (codec l2_codec) $ fun r -> r.l1_inner);
-        (Field.v "Y" uint16be $ fun r -> r.l1_y);
-      ]
-
-let l0_codec =
-  Codec.v "L0"
-    (fun inner z -> { l0_inner = inner; l0_z = z })
-    Codec.
-      [
-        (Field.v "Inner" (codec l1_codec) $ fun r -> r.l0_inner);
-        (Field.v "Z" uint8 $ fun r -> r.l0_z);
-      ]
+(* Two levels of nesting --
+   [l0] / [l1] / [l2] and their codecs live in {!Test_fixtures}. *)
 
 let test_codec_embed_nested () =
   (* l2(1) + l1_y(2) + z(1) = 4 bytes *)
@@ -2456,24 +2399,9 @@ let test_codec_crossref_field_bitfield () =
   Alcotest.(check int) "flags" 0xA r.bff_hdr.bh_flags;
   Alcotest.(check string) "data" "XYZ" r.bff_data
 
-(* -- Nested: Optional typ: conditional field presence -- *)
-
-type opt_record = { opt_hdr : int; opt_payload : int option; opt_trail : int }
-
-let opt_codec ~present =
-  Codec.v "OptRecord"
-    (fun hdr payload trail ->
-      { opt_hdr = hdr; opt_payload = payload; opt_trail = trail })
-    Codec.
-      [
-        (Field.v "Hdr" uint8 $ fun r -> r.opt_hdr);
-        ( Field.v "Payload" (optional (bool present) uint16be) $ fun r ->
-          r.opt_payload );
-        (Field.v "Trail" uint8 $ fun r -> r.opt_trail);
-      ]
-
-let opt_codec_present = opt_codec ~present:true
-let opt_codec_absent = opt_codec ~present:false
+(* -- Nested: Optional typ: conditional field presence --
+   [opt_record], [opt_codec], [opt_codec_present], [opt_codec_absent] live
+   in {!Test_fixtures}. *)
 
 let test_optional_present_decode () =
   (* hdr(1) + payload(2) + trail(1) = 4 bytes *)
@@ -2586,7 +2514,7 @@ let test_optional_codec_absent () =
   Alcotest.(check int) "hdr" 0xAA r.oc_hdr;
   Alcotest.(check (option int))
     "inner" None
-    (Option.map (fun i -> i.tag) r.oc_inner);
+    (Option.map (fun (i : inner) -> i.tag) r.oc_inner);
   Alcotest.(check int) "trail" 0xBB r.oc_trail
 
 (* Multiple optional fields (TM frame pattern) *)
@@ -2762,22 +2690,8 @@ let test_uint64_ref_in_size () =
   Alcotest.(check int64) "len" 3L len;
   Alcotest.(check string) "data" "ABC" data
 
-(* -- Nested: Repeat typ: parse elements until byte budget exhausted -- *)
-
-type container = { cnt_length : int; cnt_items : inner list }
-
-let f_cnt_length = Field.v "Length" uint8
-
-let repeat_codec =
-  Codec.v "Container"
-    (fun length items -> { cnt_length = length; cnt_items = items })
-    Codec.
-      [
-        (f_cnt_length $ fun r -> r.cnt_length);
-        ( Field.v "Items"
-            (repeat ~size:(Field.ref f_cnt_length) (codec inner_codec))
-        $ fun r -> r.cnt_items );
-      ]
+(* -- Nested: Repeat typ: parse elements until byte budget exhausted --
+   [container], [f_cnt_length], [repeat_codec] live in {!Test_fixtures}. *)
 
 let test_repeat_decode_empty () =
   (* length=0 -> no items *)
@@ -2817,7 +2731,7 @@ let test_repeat_decode_multiple () =
   Alcotest.(check int) "length" 9 r.cnt_length;
   Alcotest.(check int) "item count" 3 (List.length r.cnt_items);
   List.iteri
-    (fun i item ->
+    (fun i (item : inner) ->
       Alcotest.(check int) (Fmt.str "item[%d].tag" i) (i + 1) item.tag;
       Alcotest.(check int) (Fmt.str "item[%d].value" i) (i + 1) item.value)
     r.cnt_items
@@ -2853,7 +2767,7 @@ let test_repeat_roundtrip () =
   Alcotest.(check int) "length" original.cnt_length decoded.cnt_length;
   Alcotest.(check int) "item count" 3 (List.length decoded.cnt_items);
   List.iter2
-    (fun orig dec ->
+    (fun (orig : inner) (dec : inner) ->
       Alcotest.(check int) "tag" orig.tag dec.tag;
       Alcotest.(check int) "value" orig.value dec.value)
     original.cnt_items decoded.cnt_items
@@ -2969,20 +2883,9 @@ let test_repeat_variable_size_elements () =
   Alcotest.(check int) "item1.len" 3 i1.vi_len;
   Alcotest.(check string) "item1.data" "cde" i1.vi_data
 
-(* -- Nested: Composition: optional + repeat + codec -- *)
-
-(* TM-frame-like structure: header + data zone (repeat of packets) + optional OCF + optional FECF *)
-
-type packet = { pkt_id : int; pkt_data : int }
-
-let packet_codec =
-  Codec.v "Packet"
-    (fun id data -> { pkt_id = id; pkt_data = data })
-    Codec.
-      [
-        (Field.v "Id" uint8 $ fun r -> r.pkt_id);
-        (Field.v "Data" uint16be $ fun r -> r.pkt_data);
-      ]
+(* -- Nested: Composition: optional + repeat + codec --
+   TM-frame-like structure: header + data zone (repeat of packets) + optional
+   OCF + optional FECF. [packet] / [packet_codec] live in {!Test_fixtures}. *)
 
 type tm_like = {
   tm_hdr : int;

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -2,6 +2,7 @@
 
 open Wire
 open Wire.Everparse.Raw
+open Test_fixtures
 
 let contains ~sub s = Re.execp (Re.compile (Re.str sub)) s
 
@@ -82,99 +83,10 @@ let test_pretty_print () =
     "contains UINT16BE" true
     (contains ~sub:"UINT16BE" output)
 
-(* -- Codec definitions for 3D extraction tests -- *)
-
-type inner = { tag : int; value : int }
-
-let f_inner_tag = Field.v "Tag" uint8
-let f_inner_value = Field.v "Value" uint16be
-
-let inner_codec =
-  Codec.v "Inner"
-    (fun tag value -> { tag; value })
-    Codec.[ (f_inner_tag $ fun r -> r.tag); (f_inner_value $ fun r -> r.value) ]
-
-type outer = { header : int; inner : inner; trailer : int }
-
-let outer_codec =
-  Codec.v "Outer"
-    (fun header inner trailer -> { header; inner; trailer })
-    Codec.
-      [
-        (Field.v "Header" uint8 $ fun r -> r.header);
-        (Field.v "Inner" (codec inner_codec) $ fun r -> r.inner);
-        (Field.v "Trailer" uint8 $ fun r -> r.trailer);
-      ]
-
-type l2 = { l2_x : int }
-type l1 = { l1_inner : l2; l1_y : int }
-type l0 = { l0_inner : l1; l0_z : int }
-
-let l2_codec =
-  Codec.v "L2"
-    (fun x -> { l2_x = x })
-    Codec.[ (Field.v "X" uint8 $ fun r -> r.l2_x) ]
-
-let l1_codec =
-  Codec.v "L1"
-    (fun inner y -> { l1_inner = inner; l1_y = y })
-    Codec.
-      [
-        (Field.v "Inner" (codec l2_codec) $ fun r -> r.l1_inner);
-        (Field.v "Y" uint16be $ fun r -> r.l1_y);
-      ]
-
-let l0_codec =
-  Codec.v "L0"
-    (fun inner z -> { l0_inner = inner; l0_z = z })
-    Codec.
-      [
-        (Field.v "Inner" (codec l1_codec) $ fun r -> r.l0_inner);
-        (Field.v "Z" uint8 $ fun r -> r.l0_z);
-      ]
-
-type opt_record = { opt_hdr : int; opt_payload : int option; opt_trail : int }
-
-let opt_codec ~present =
-  Codec.v "OptRecord"
-    (fun hdr payload trail ->
-      { opt_hdr = hdr; opt_payload = payload; opt_trail = trail })
-    Codec.
-      [
-        (Field.v "Hdr" uint8 $ fun r -> r.opt_hdr);
-        ( Field.v "Payload" (optional (bool present) uint16be) $ fun r ->
-          r.opt_payload );
-        (Field.v "Trail" uint8 $ fun r -> r.opt_trail);
-      ]
-
-let opt_codec_present = opt_codec ~present:true
-let opt_codec_absent = opt_codec ~present:false
-
-type container = { cnt_length : int; cnt_items : inner list }
-
-let f_cnt_length = Field.v "Length" uint8
-
-let repeat_codec =
-  Codec.v "Container"
-    (fun length items -> { cnt_length = length; cnt_items = items })
-    Codec.
-      [
-        (f_cnt_length $ fun r -> r.cnt_length);
-        ( Field.v "Items"
-            (repeat ~size:(Field.ref f_cnt_length) (codec inner_codec))
-        $ fun r -> r.cnt_items );
-      ]
-
-type packet = { pkt_id : int; pkt_data : int }
-
-let packet_codec =
-  Codec.v "Packet"
-    (fun id data -> { pkt_id = id; pkt_data = data })
-    Codec.
-      [
-        (Field.v "Id" uint8 $ fun r -> r.pkt_id);
-        (Field.v "Data" uint16be $ fun r -> r.pkt_data);
-      ]
+(* -- Codec definitions for 3D extraction tests --
+   The shared codecs ([inner], [outer], [l0]/[l1]/[l2], [opt_record],
+   [container]/[repeat_codec], [packet]/[packet_codec]) live in
+   {!Test_fixtures}. *)
 
 type tm_like = {
   hdr : int;


### PR DESCRIPTION
The codec definitions are duplicated across [test_codec.ml](test/test_codec.ml), [test_everparse.ml](test/test_everparse.ml), and [test_ascii.ml](test/test_ascii.ml). Move them into a new [test/fixtures/](test/fixtures/) sublibrary so each test imports them once. Drop the redundant `test_map_roundtrip` from [fuzz_param.ml](fuzz/fuzz_param.ml), the equivalent test already lives in [fuzz_wire.ml](fuzz/fuzz_wire.ml).