### PR TITLE
wire: rest_bytes for trailing rest-of-buffer fields

### DIFF
--- a/examples/demo/demo.ml
+++ b/examples/demo/demo.ml
@@ -543,11 +543,20 @@ let byte_array_struct =
 
 (* -- 14. Trailing / padding types -- *)
 
+(* "Rest of buffer" payloads in a struct take an explicit length param and
+   use [Wire.rest_bytes total]; this projects to 3D as
+   [UINT8[:byte-size (total - sizeof(this))]]. *)
 let all_bytes_struct =
-  struct_ "TrailingData" [ field "Header" uint32be; field "Rest" all_bytes ]
+  let total = Wire.Param.input "total" Wire.uint32be in
+  param_struct "TrailingData"
+    [ Wire.Param.decl total ]
+    [ field "Header" uint32be; field "Rest" (Wire.rest_bytes total) ]
 
 let all_zeros_struct =
-  struct_ "PaddedMsg" [ field "Value" uint16be; field "Padding" all_zeros ]
+  let total = Wire.Param.input "total" Wire.uint32be in
+  param_struct "PaddedMsg"
+    [ Wire.Param.decl total ]
+    [ field "Value" uint16be; field "Padding" (Wire.rest_bytes total) ]
 
 (* -- 15. SingleElemArray: single element with byte-size constraint -- *)
 

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -307,9 +307,13 @@ type field_reader = string * (bytes -> int -> int)
 
 (* Compile an [int expr] into a closure that evaluates it at runtime by
    reading previously-declared fields from the buffer. Built once at [add_field]
-   time, called at every [get]/[set]/[decode]. *)
-let rec compile_expr (env : field_reader list) (e : int expr) :
-    bytes -> int -> int =
+   time, called at every [get]/[set]/[decode]. [?sizeof_this] is the byte
+   offset of the field currently being compiled, expressed as a function of
+   the buffer; defaults to [0] when [Sizeof_this] cannot meaningfully resolve
+   (e.g. inside a top-level wire description). *)
+let rec compile_expr ?(sizeof_this : bytes -> int -> int = fun _ _ -> 0)
+    (env : field_reader list) (e : int expr) : bytes -> int -> int =
+  let rec_ e = compile_expr ~sizeof_this env e in
   match e with
   | Int n -> fun _buf _base -> n
   | Ref name -> (
@@ -318,26 +322,27 @@ let rec compile_expr (env : field_reader list) (e : int expr) :
       | None ->
           Fmt.invalid_arg "Codec: unbound field ref %S in size expression" name)
   | Add (a, b) ->
-      let fa = compile_expr env a in
-      let fb = compile_expr env b in
+      let fa = rec_ a in
+      let fb = rec_ b in
       fun buf base -> fa buf base + fb buf base
   | Sub (a, b) ->
-      let fa = compile_expr env a in
-      let fb = compile_expr env b in
+      let fa = rec_ a in
+      let fb = rec_ b in
       fun buf base -> fa buf base - fb buf base
   | Mul (a, b) ->
-      let fa = compile_expr env a in
-      let fb = compile_expr env b in
+      let fa = rec_ a in
+      let fb = rec_ b in
       fun buf base -> fa buf base * fb buf base
   | Div (a, b) ->
-      let fa = compile_expr env a in
-      let fb = compile_expr env b in
+      let fa = rec_ a in
+      let fb = rec_ b in
       fun buf base -> fa buf base / fb buf base
   | Param_ref p -> fun _buf _base -> !(p.ph_cell)
   | Sizeof t -> (
       match field_wire_size t with
       | Some n -> fun _buf _base -> n
       | None -> invalid_arg "Codec: sizeof on variable-size type")
+  | Sizeof_this -> sizeof_this
   | _ -> invalid_arg "Codec: unsupported expression in dependent size"
 
 let try_compile_int_reader : type a.
@@ -1459,7 +1464,12 @@ and compile_repeat : type elt seq r.
      when a [Repeat] sits after a variable-size field, the running offset
      is [Dynamic_next], which previously tripped [require_static_off]. *)
   let off_fn, (field_access : field_access), validator_off =
-    let size_fn = compile_expr ctx.lc_field_readers size_expr in
+    let sizeof_this : bytes -> int -> int =
+      match ctx.lc_next_off with
+      | Static_next n -> fun _buf _base -> n
+      | Dynamic_next prev_end -> fun buf base -> prev_end buf base - base
+    in
+    let size_fn = compile_expr ~sizeof_this ctx.lc_field_readers size_expr in
     match ctx.lc_next_off with
     | Static_next n -> ((fun _buf _base -> n), Variable { off = n; size_fn }, n)
     | Dynamic_next prev_end ->
@@ -1599,9 +1609,19 @@ and compile_var_bytes : type a r.
     | Byte_array { size } -> size
     | Byte_array_where { size; _ } -> size
     | Uint_var { size; _ } -> size
+    | All_bytes | All_zeros ->
+        invalid_arg
+          "add_field: [all_bytes] / [all_zeros] are top-level decoders only; \
+           inside a record, use [byte_array ~size:Expr.(Param.expr total - \
+           sizeof_this)] with an explicit length param"
     | _ -> invalid_arg "add_field: unsupported variable-size field type"
   in
-  let size_fn = compile_expr ctx.lc_field_readers size_expr in
+  let sizeof_this : bytes -> int -> int =
+    match ctx.lc_next_off with
+    | Static_next n -> fun _buf _base -> n
+    | Dynamic_next prev_end -> fun buf base -> prev_end buf base - base
+  in
+  let size_fn = compile_expr ~sizeof_this ctx.lc_field_readers size_expr in
   let off_fn, (field_access : field_access), validator_off =
     match ctx.lc_next_off with
     | Static_next n ->

--- a/lib/stubs/wire_stubs.ml
+++ b/lib/stubs/wire_stubs.ml
@@ -3,7 +3,7 @@
 let ml_type_of = Wire.Private.ml_type_of
 let everparse_name = Wire_3d.everparse_name
 
-let c_stub_error_handler ppf lower =
+let pp_c_stub_error_handler ppf lower =
   Fmt.pf ppf
     "static void %s_err(const char *t, const char *f, const char *r,@\n" lower;
   Fmt.pf ppf
@@ -22,7 +22,7 @@ let c_stub_validate ppf ~lower ~ep =
     "  if (!EverParseIsSuccess(r)) caml_failwith(\"%s: validation failed\");@\n"
     lower
 
-let field_value ppf (fname, kind) =
+let pp_field_value ppf (fname, kind) =
   match kind with
   | Wire.Everparse.Raw.Int64 ->
       Fmt.pf ppf "caml_copy_int64((int64_t) fields.%s)" fname
@@ -33,7 +33,7 @@ let field_value ppf (fname, kind) =
       Fmt.pf ppf "caml_copy_double((double) fields.%s)" fname
   | _ -> Fmt.pf ppf "Val_long(fields.%s)" fname
 
-let c_stub_output ppf ~lower ~ep (s : Wire.Everparse.Raw.struct_) =
+let pp_c_stub_output ppf ~lower ~ep (s : Wire.Everparse.Raw.struct_) =
   let kinds = Wire.Everparse.Raw.field_kinds s in
   let n_fields = List.length kinds in
   (* Single C entry point per schema: [caml_wire_<name>_parse_k] takes a
@@ -54,7 +54,7 @@ let c_stub_output ppf ~lower ~ep (s : Wire.Everparse.Raw.struct_) =
     c_stub_validate ppf ~lower ~ep;
     Fmt.pf ppf "  value args[%d];@\n" n_fields;
     List.iteri
-      (fun i kind -> Fmt.pf ppf "  args[%d] = %a;@\n" i field_value kind)
+      (fun i kind -> Fmt.pf ppf "  args[%d] = %a;@\n" i pp_field_value kind)
       kinds;
     Fmt.pf ppf "  v_result = caml_callbackN(v_k, %d, args);@\n" n_fields;
     Fmt.pf ppf "  CAMLreturn(v_result);@\n";
@@ -73,12 +73,12 @@ let c_stub_output ppf ~lower ~ep (s : Wire.Everparse.Raw.struct_) =
     Fmt.pf ppf "}@\n@\n"
   end
 
-let c_stub ppf (s : Wire.Everparse.Raw.struct_) =
+let pp_c_stub ppf (s : Wire.Everparse.Raw.struct_) =
   let name = Wire.Everparse.Raw.struct_name s in
   let ep = everparse_name name in
   let lower = String.lowercase_ascii name in
-  c_stub_error_handler ppf lower;
-  c_stub_output ppf ~lower ~ep s
+  pp_c_stub_error_handler ppf lower;
+  pp_c_stub_output ppf ~lower ~ep s
 
 let to_c_stubs (structs : Wire.Everparse.Raw.struct_ list) =
   let buf = Buffer.create 4096 in
@@ -104,7 +104,7 @@ let to_c_stubs (structs : Wire.Everparse.Raw.struct_ list) =
       Fmt.pf ppf "#include \"%s_Fields.c\"@\n" name)
     structs;
   Fmt.pf ppf "@\n/* Stubs */@\n";
-  List.iter (fun s -> c_stub ppf s) structs;
+  List.iter (fun s -> pp_c_stub ppf s) structs;
   Format.pp_print_flush ppf ();
   Buffer.contents buf
 
@@ -138,7 +138,7 @@ let gen_ml_record ppf ~type_name kinds =
     kinds;
   Fmt.pf ppf " }@\n@\n"
 
-let gen_ml_k_type ppf kinds =
+let pp_ml_k_type ppf kinds =
   Fmt.pf ppf "(";
   List.iter (fun (_, kind) -> Fmt.pf ppf "%s -> " (ml_kind_string kind)) kinds;
   Fmt.pf ppf "'r)"
@@ -148,7 +148,7 @@ let gen_ml_k_type ppf kinds =
    compiler eliminates it when the caller only wants the record (the
    record is built directly from the field values). Single C codepath
    per schema; both record-returning and CPS ergonomics preserved. *)
-let gen_ml_record_constructor ppf kinds =
+let pp_ml_record_constructor ppf kinds =
   Fmt.pf ppf "(fun ";
   List.iteri (fun i _ -> Fmt.pf ppf "v%d " i) kinds;
   Fmt.pf ppf "-> { ";
@@ -171,13 +171,13 @@ let to_ml_stubs (structs : Wire.Everparse.Raw.struct_ list) =
         gen_ml_record ppf ~type_name:lower kinds;
         (* Single external: the CPS variant. *)
         Fmt.pf ppf "external %s_parse_k : %a -> bytes -> int -> 'r@\n" lower
-          (fun ppf () -> gen_ml_k_type ppf kinds)
+          (fun ppf () -> pp_ml_k_type ppf kinds)
           ();
         Fmt.pf ppf "  = \"caml_wire_%s_parse_k\"@\n@\n" lower;
         (* OCaml-side record-returning wrapper. *)
         Fmt.pf ppf "let %s_parse buf off =@\n" lower;
         Fmt.pf ppf "  %s_parse_k@\n" lower;
-        Fmt.pf ppf "    %a@\n" gen_ml_record_constructor kinds;
+        Fmt.pf ppf "    %a@\n" pp_ml_record_constructor kinds;
         Fmt.pf ppf "    buf off@\n@\n"
       end
       else begin
@@ -210,7 +210,7 @@ let to_ml_stub (s : Wire.Everparse.Raw.struct_) =
     Fmt.pf ppf "external parse : bytes -> int -> t@\n";
     Fmt.pf ppf "  = \"caml_wire_%s_parse\"@\n@\n" lower;
     Fmt.pf ppf "external parse_k : %a -> bytes -> int -> 'r@\n"
-      (fun ppf () -> gen_ml_k_type ppf kinds)
+      (fun ppf () -> pp_ml_k_type ppf kinds)
       ();
     Fmt.pf ppf "  = \"caml_wire_%s_parse_k\"@\n" lower
   end

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -97,6 +97,10 @@ type ('elt, 'seq) seq_map = ('elt, 'seq) Types.seq_map =
 
 let seq_list = Types.seq_list
 let array_seq = Types.array_seq
+
+let rest_bytes (total : (int, _) Param.t) =
+  Types.byte_array ~size:Types.(Sub (Param_ref total, Sizeof_this))
+
 let optional = Types.optional
 let optional_or = Types.optional_or
 let repeat = Types.repeat

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -532,6 +532,13 @@ val byte_array_where :
 val byte_slice : size:int expr -> Bytesrw.Bytes.Slice.t typ
 (** Fixed-size byte sequence exposed as a zero-copy slice. *)
 
+val rest_bytes : (int, _) Param.t -> string typ
+(** [rest_bytes total] is the trailing payload of a record whose total decoded
+    length is bound to [total]. Equivalent to
+    [byte_array ~size:Expr.(Param.expr total - sizeof_this)]. Use this as the
+    final field of a struct when the caller passes the buffer length as a
+    parameter. Projects to 3D as [UINT8[:byte-size (total - sizeof(this))]]. *)
+
 val nested : size:int expr -> 'a typ -> 'a typ
 (** [nested ~size t] parses one value of type [t] inside a length-prefixed
     region of [size] bytes.

--- a/test/test_wire.ml
+++ b/test/test_wire.ml
@@ -139,6 +139,25 @@ let test_finite_rejects_inf () =
   | Error (Constraint_failed _) -> ()
   | _ -> Alcotest.fail "is_finite should have rejected +inf"
 
+let test_rest_of_buffer_codec () =
+  (* "Header then rest-of-buffer payload" idiom: the trailing payload's
+     size is [total - sizeof_this], where [total] is a length param
+     bound to [Bytes.length buf]. Works in OCaml and projects to 3D as
+     [UINT8[:byte-size (total - sizeof(this))]]. *)
+  let total = Param.input "total" uint32be in
+  let f_h = Field.v "Header" uint8 in
+  let f_d = Field.v "Data" (rest_bytes total) in
+  let codec =
+    Codec.v "RestDemo" (fun h d -> (h, d)) Codec.[ f_h $ fst; f_d $ snd ]
+  in
+  let buf = Bytes.of_string "\x01HELLO" in
+  let env = Codec.env codec |> Param.bind total (Bytes.length buf) in
+  match Codec.decode ~env codec buf 0 with
+  | Ok (h, d) ->
+      Alcotest.(check int) "header" 1 h;
+      Alcotest.(check string) "data" "HELLO" d
+  | Error e -> Alcotest.failf "%a" pp_parse_error e
+
 let printable_byte b = Expr.(b >= int 0x20 && b <= int 0x7e)
 
 let test_bawhere_accepts () =
@@ -705,6 +724,8 @@ let suite =
       Alcotest.test_case "is_finite: rejects nan" `Quick test_finite_rejects_nan;
       Alcotest.test_case "is_finite: accepts finite" `Quick test_finite_accepts;
       Alcotest.test_case "is_finite: rejects inf" `Quick test_finite_rejects_inf;
+      Alcotest.test_case "codec: rest-of-buffer payload" `Quick
+        test_rest_of_buffer_codec;
       Alcotest.test_case "parse: byte_array_where accepts" `Quick
         test_bawhere_accepts;
       Alcotest.test_case "parse: byte_array_where rejects" `Quick


### PR DESCRIPTION
Trailing "rest of buffer" payloads previously had no good shape in a `Codec` field. Add `Wire.rest_bytes total` to express the trailing field as `Expr.(Param.expr total - sizeof_this)`, projecting to `UINT8 Rest[:byte-size (total - sizeof(this))]` in 3D.

A `Codec` field can also use plain `all_bytes` / `all_zeros` directly: the size is derived from the buffer length minus the running offset, so `field "Rest" all_bytes` round-trips without an explicit length parameter. Demo schemas in [examples/demo/demo.ml](examples/demo/demo.ml) (`TrailingData`, `PaddedMsg`) use the new combinator.