### PR TITLE
3d: projection harness + API tightening

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,64 +2,45 @@
 
 ### Added
 
-- `Wire.rest_bytes total` for trailing rest-of-buffer fields, plus
-  direct `all_bytes` / `all_zeros` support as `Codec` field types
+- Add `Field.optional` / `Field.optional_or` / `Field.repeat` /
+  `Field.repeat_seq` (@samoht)
+- Add `Wire.rest_bytes` for trailing "rest of buffer" fields, plus
+  direct `all_bytes` / `all_zeros` support as `Codec` fields
   (#44, @samoht)
-- `Codec.validator_of_struct` / `validate_struct` / `struct_size_of` /
-  `struct_min_size`: build and run a validator from any `Types.struct_`,
-  no record constructor needed (#37, @samoht)
-- `Codec.slice_offset` / `Codec.slice_length`: zero-allocation access to
-  the offset/length of a `byte_slice` field, replacing the
-  `Slice.first (Codec.get ...)` pattern (#37, @samoht)
-- `Wire.codec` type alias for `'r Codec.t`, and `Wire.pp_value` to
-  print a record field-by-field through its codec (@samoht)
-- `Wire.byte_array_where ~size ~per_byte`: byte span with a per-byte
-  refinement. Decode raises `Parse_error` on the first byte that
-  violates the constraint; encode raises `Invalid_argument`. The 3D
-  projection synthesises a 1-byte refinement struct per use and
-  references it from the parent field, so both wire and EverParse C
-  enforce the same per-element constraint. Motivating shape:
-  printable-ASCII bodies (SSH name-list, RFC 4251 sec 5) (@samoht)
-- Signed integers: `int8` / `int16(be)` / `int32(be)` / `int64(be)`.
-  Two's-complement read/write OCaml-side; 3D projects to the same-width
-  `UINT*` (3D's prelude has only unsigned primitives). `int32` returns
-  OCaml `int` on 64-bit hosts; `int64` returns boxed `int64` (@samoht)
-- IEEE 754 floats: `float32(be)` / `float64(be)`. OCaml side uses
-  `Int32.float_of_bits` / `Int64.float_of_bits` for round-tripping
-  including NaN, signed zero, infinities. 3D projects to the same-width
-  `UINT*` and `Wire.is_finite` / `Wire.is_nan` compile to bit-pattern
-  refinements over the unsigned width, so wire's OCaml decoder and
-  EverParse's verified C decoder reject the same NaN / Inf inputs
+- Add signed integers `int8` / `int16(be)` / `int32(be)` / `int64(be)`
+  (#42, @samoht)
+- Add IEEE 754 floats `float32(be)` / `float64(be)` and `Wire.is_finite`
+  / `Wire.is_nan` predicates (#42, @samoht)
+- Add `Wire.byte_array_where ~size ~per_byte` for byte spans with a
+  per-byte refinement (#40, @samoht)
+- Add `Codec.validator_of_struct` / `validate_struct` / `struct_size_of`
+  / `struct_min_size` (#37, @samoht)
+- Add `Codec.slice_offset` / `Codec.slice_length` (#37, @samoht)
+- Add `Wire.codec` type alias for `'r Codec.t` and `Wire.pp_value`
   (@samoht)
 
 ### Changed
 
-- `Codec.bitfield`: ~5% faster on bitfield-heavy workloads (CLCW polling
-  +5%) (#37, @samoht)
+- Remove `Wire.optional` / `Wire.optional_or` / `Wire.repeat` /
+  `Wire.repeat_seq` from the typ-level surface; use the matching
+  `Field.*` combinators instead (@samoht)
 - Rename `Wire.decode_*` / `Wire.encode_*` to `of_string` / `of_bytes` /
-  `of_reader` / `to_string` / `to_bytes` / `to_writer`. Add `_exn`
-  twins that raise `Parse_error` instead of returning a result
-  (@samoht)
-- Fold `Codec.decode_with` into `Codec.decode` via an optional `?env`.
-  Split decode into `Codec.decode` (result) and `Codec.decode_exn`
-  (raises) (@samoht)
+  `of_reader` / `to_string` / `to_bytes` / `to_writer`; add `_exn` twins
+  that raise on parse error (#39, @samoht)
+- Fold `Codec.decode_with` into `Codec.decode` via `?env`; split into
+  `Codec.decode` (result) and `Codec.decode_exn` (raises) (#39, @samoht)
+- Speed up `Codec.bitfield` ~5% (#37, @samoht)
 
 ### Documentation
 
-- Type-check `README.md` and every public `.mli` example under `mdx`
-  (`(using mdx 0.4)`). Stale snippets now break `dune runtest`. (@samoht)
+- Type-check `README.md` and every public `.mli` under `mdx` (@samoht)
 
 ### Fixed
 
-- Allow `Wire.codec` sub-codecs and `Wire.repeat` after a variable-size
-  field. Two consecutive variable-size sub-codecs (e.g. SSH-style
-  back-to-back length-prefixed strings) used to raise `add_field:
-  variable-size codec after variable-size field not supported`
-  (#38, @samoht)
-- Fix C stub generator: use the EverParse-normalised `<Name>Fields`
-  type name. Schemas with a name segment of 2+ leading capitals (e.g.
-  `IPv4`, `EP_Header`) previously emitted C that referenced an
-  undefined struct (#36, @samoht)
+- Allow variable-size sub-codecs and `Field.repeat` after a
+  variable-size field (#38, @samoht)
+- Fix C stub generator for schema names with 2+ leading capitals
+  (e.g. `IPv4`, `EP_Header`) (#36, @samoht)
 
 ## 0.9.0
 

--- a/bench/memtrace/bench.ml
+++ b/bench/memtrace/bench.ml
@@ -79,7 +79,7 @@ let opt_codec_present =
       [
         (Wire.Field.v "Hdr" Wire.uint16be $ fun r -> r.opt_hdr);
         (Wire.Field.v "Data" Wire.uint16be $ fun r -> r.opt_data);
-        ( Wire.Field.v "FECF" (Wire.optional (Wire.bool true) Wire.uint16be)
+        ( Wire.Field.optional "FECF" ~present:(Wire.bool true) Wire.uint16be
         $ fun r -> r.opt_fecf );
       ]
 
@@ -105,8 +105,8 @@ let repeat_codec =
     Wire.Codec.
       [
         (f_r_len $ fun r -> r.r_len);
-        ( Wire.Field.v "Items"
-            (Wire.repeat ~size:(Wire.Field.ref f_r_len) (Wire.codec inner_codec))
+        ( Wire.Field.repeat "Items" ~size:(Wire.Field.ref f_r_len)
+            (Wire.codec inner_codec)
         $ fun r -> r.r_items );
       ]
 

--- a/dune-project
+++ b/dune-project
@@ -1,6 +1,7 @@
 (lang dune 3.21)
 (using directory-targets 0.1)
 (using mdx 0.4)
+(cram enable)
 
 (name wire)
 (version 0.9.0)

--- a/examples/demo/demo.ml
+++ b/examples/demo/demo.ml
@@ -545,7 +545,8 @@ let byte_array_struct =
 
 (* "Rest of buffer" payloads in a struct take an explicit length param and
    use [Wire.rest_bytes total]; this projects to 3D as
-   [UINT8[:byte-size (total - sizeof(this))]]. *)
+   [UINT8[:byte-size (total_ - sizeof(this))]] -- [total] is an F*
+   keyword and gets escaped automatically. *)
 let all_bytes_struct =
   let total = Wire.Param.input "total" Wire.uint32be in
   param_struct "TrailingData"

--- a/examples/dune
+++ b/examples/dune
@@ -3,10 +3,10 @@
  (modules gen_3d)
  (libraries wire demo space net))
 
-(executable
+(test
  (name validate_3d)
  (modules validate_3d)
- (libraries wire wire.3d demo space net))
+ (libraries wire wire.3d demo space net alcotest unix fmt))
 
 (rule
  (targets

--- a/examples/space/space.ml
+++ b/examples/space/space.ml
@@ -337,8 +337,9 @@ let tm_with_ocf_codec =
         (Field.v "MCCount" (bits ~width:8 U16be) $ fun f -> f.tmo_mc_count);
         (Field.v "VCCount" (bits ~width:8 U16be) $ fun f -> f.tmo_vc_count);
         (Field.v "FirstHdrPtr" (bits ~width:11 U16be) $ fun f -> f.tmo_first_hdr);
-        ( Field.v "OCF"
-            (optional Expr.(Field.ref f_tmo_ocf_flag <> int 0) uint32be)
+        ( Field.optional "OCF"
+            ~present:Expr.(Field.ref f_tmo_ocf_flag <> int 0)
+            uint32be
         $ fun f -> f.tmo_ocf );
       ]
 

--- a/examples/validate_3d.ml
+++ b/examples/validate_3d.ml
@@ -1,72 +1,103 @@
-(** Validate all example schemas through the EverParse 3d.exe pipeline.
+(** Validate every example schema by feeding it to [3d.exe] (parse-only, no
+    [--batch]). Skipped when [3d.exe] is unavailable. *)
 
-    For each codec, this generates the full output-types schema (with
-    [<Name>Set*] callbacks), writes the .3d file, and runs 3d.exe to verify it
-    produces valid C. Exits with code 1 if 3d.exe rejects any schema. *)
+module Raw = Wire.Everparse.Raw
 
-let schemas =
-  let s = Wire.Everparse.schema in
+(* Two emission paths matter and both should produce parseable 3D:
+   - [Raw]: a hand-built struct or module written via [to_3d_file].
+   - [Codec]: a Wire codec projected via [Wire.Everparse.schema] and
+     [Wire_3d.generate_3d]. This path adds entrypoint params, output
+     types, and the [<Name>Set*] callbacks that the C validator uses. *)
+type case =
+  | Raw of string * Raw.module_
+  | Codec : string * 'a Wire.Codec.t -> case
+
+let case_name = function Raw (n, _) | Codec (n, _) -> n
+
+let raw_struct ?(entrypoint = true) (s : Raw.struct_) =
+  let module_ = Raw.module_ [ Raw.typedef ~entrypoint s ] in
+  Raw (Raw.struct_name s, module_)
+
+let raw_module name module_ = Raw (name, module_)
+
+let cases =
   [
-    s Demo.minimal_codec;
-    s Demo.all_ints_codec;
-    s Demo.bf8_codec;
-    s Demo.bf16_codec;
-    s Demo.bf32_codec;
-    s Demo.bool_fields_codec;
-    s Demo.large_mixed_codec;
-    s Demo.mapped_codec;
-    s Demo.cases_demo_codec;
-    s Demo.enum_demo_codec;
-    s Demo.constrained_codec;
-    s Demo.lowercase_codec;
-    s Demo.reserved_fields_codec;
-    s Demo.bf_reorder_codec;
-    s Demo.bf_constrained_codec;
-    s Space.clcw_codec;
-    s Space.packet_codec;
-    s Space.full_packet_codec;
-    s Space.tm_frame_codec;
-    s Space.tm_with_ocf_codec;
-    s Space.inner_cmd_codec;
-    s Space.outer_hdr_codec;
-    s Net.ethernet_codec;
-    s Net.ipv4_codec;
-    s Net.tcp_codec;
-    s Net.udp_codec;
+    raw_struct Demo.minimal_struct;
+    raw_struct Demo.all_ints_struct;
+    raw_struct Demo.bf8_struct;
+    raw_struct Demo.bf16_struct;
+    raw_struct Demo.bf32_struct;
+    raw_struct Demo.bool_fields_struct;
+    raw_struct Demo.large_mixed_struct;
+    raw_struct Demo.mapped_struct;
+    raw_struct Demo.cases_demo_struct;
+    raw_struct Demo.enum_demo_struct;
+    raw_struct Demo.constrained_struct;
+    raw_struct Demo.array_struct;
+    raw_struct Demo.byte_array_struct;
+    raw_struct Demo.all_bytes_struct;
+    raw_struct Demo.all_zeros_struct;
+    raw_struct Demo.single_elem_struct;
+    raw_struct Demo.single_elem_at_most_struct;
+    raw_struct Demo.anon_field_struct;
+    raw_struct Demo.action_struct;
+    raw_struct Demo.action_full_struct;
+    raw_struct Demo.param_demo_struct;
+    raw_struct Demo.param_payload_struct;
+    raw_struct Space.clcw_struct;
+    raw_struct Space.packet_struct;
+    raw_struct Space.tm_frame_struct;
+    raw_struct Net.ethernet_struct;
+    raw_struct Net.ipv4_struct;
+    raw_struct Net.tcp_struct;
+    raw_struct Net.udp_struct;
+    raw_module "Message" Demo.casetype_module;
+    raw_module "ExternDemo" Demo.extern_module;
+    raw_module "Outer" Demo.type_ref_module;
+    Codec ("FullPacket", Space.full_packet_codec);
+    Codec ("TMWithOCF", Space.tm_with_ocf_codec);
+    Codec ("InnerCmd", Space.inner_cmd_codec);
+    Codec ("OuterHdr", Space.outer_hdr_codec);
   ]
 
-let validate_one ~tmpdir s =
-  let name = s.Wire.Everparse.name in
-  Wire_3d.generate_3d ~outdir:tmpdir [ s ];
-  try
-    Wire_3d.run_everparse ~quiet:true ~outdir:tmpdir [ s ];
-    Fmt.pr "  OK  %s\n%!" name;
-    true
-  with Failure msg ->
-    let path = Filename.concat tmpdir (Wire.Everparse.filename s) in
-    let content =
-      try In_channel.with_open_text path In_channel.input_all
-      with Sys_error _ -> "(could not read .3d file)"
-    in
-    Fmt.epr "  FAIL %s: %s\n%s\n%!" name msg content;
-    false
+let emit ~outdir = function
+  | Raw (name, module_) ->
+      let path = Filename.concat outdir (name ^ ".3d") in
+      Raw.to_3d_file path module_;
+      name ^ ".3d"
+  | Codec (_, codec) ->
+      let s = Wire.Everparse.schema codec in
+      Wire_3d.generate_3d ~outdir [ s ];
+      Wire.Everparse.filename s
+
+let validate_one case =
+  let outdir = Filename.temp_dir "wire_validate_3d" "" in
+  let cleanup () =
+    Array.iter
+      (fun f ->
+        try Sys.remove (Filename.concat outdir f) with Sys_error _ -> ())
+      (try Sys.readdir outdir with Sys_error _ -> [||]);
+    try Unix.rmdir outdir with Unix.Unix_error _ -> ()
+  in
+  Fun.protect ~finally:cleanup @@ fun () ->
+  let file = emit ~outdir case in
+  match Wire_3d.parse_3d ~outdir file with
+  | Ok () -> ()
+  | Error err ->
+      let path = Filename.concat outdir file in
+      let content =
+        try In_channel.with_open_text path In_channel.input_all
+        with Sys_error _ -> "(could not read .3d)"
+      in
+      Alcotest.failf "@[<v>3d.exe rejected %s:@,%s@,---@,%s@]" (case_name case)
+        err content
+
+let test_case case =
+  Alcotest.test_case (case_name case) `Quick (fun () -> validate_one case)
 
 let () =
-  if not (Wire_3d.has_3d_exe ()) then (
+  if not (Wire_3d.has_3d_exe ()) then begin
     Fmt.pr "3d.exe not found, skipping validation\n";
-    exit 0);
-  let tmpdir = Filename.temp_dir "wire_validate_3d" "" in
-  Fmt.pr "Validating %d schemas with 3d.exe\n%!" (List.length schemas);
-  let passed =
-    List.fold_left
-      (fun n s -> if validate_one ~tmpdir s then n + 1 else n)
-      0 schemas
-  in
-  let total = List.length schemas in
-  Fmt.pr "%d/%d schemas accepted by 3d.exe\n" passed total;
-  Array.iter
-    (fun f ->
-      try Sys.remove (Filename.concat tmpdir f) with Sys_error _ -> ())
-    (Sys.readdir tmpdir);
-  (try Unix.rmdir tmpdir with Unix.Unix_error _ -> ());
-  if passed < total then exit 1
+    exit 0
+  end;
+  Alcotest.run "validate_3d" [ ("schemas", List.map test_case cases) ]

--- a/fuzz/fuzz_everparse.ml
+++ b/fuzz/fuzz_everparse.ml
@@ -551,6 +551,191 @@ let test_complex_nested () =
   let _ = Wire.Everparse.Raw.to_3d m in
   ()
 
+(** Field-level decorations through {!Field.optional} / {!Field.repeat}.
+    Verifies that the construction-time invariant ("decorations only at field
+    top level") doesn't degrade for arbitrary inner sizes. *)
+let test_field_optional_random size =
+  let size = (abs size mod 32) + 1 in
+  let f_p = Wire.Field.v "p" Wire.uint8 in
+  let f =
+    Wire.Field.optional "Body"
+      ~present:Wire.Expr.(Wire.Field.ref f_p <> Wire.int 0)
+      (Wire.byte_array ~size:(Wire.int size))
+  in
+  let codec =
+    Wire.Codec.v "OptR"
+      (fun p body -> (p, body))
+      Wire.Codec.[ f_p $ fst; f $ snd ]
+  in
+  let s = Wire.Everparse.struct_of_codec codec in
+  let m =
+    Wire.Everparse.Raw.module_ [ Wire.Everparse.Raw.typedef ~entrypoint:true s ]
+  in
+  let _ = Wire.Everparse.Raw.to_3d m in
+  ()
+
+let test_field_repeat_random size =
+  let size = (abs size mod 64) + 1 in
+  let f_n = Wire.Field.v "n" Wire.uint16be in
+  let f = Wire.Field.repeat "Items" ~size:(Wire.int size) Wire.uint32be in
+  let codec =
+    Wire.Codec.v "RepR"
+      (fun n items -> (n, items))
+      Wire.Codec.[ f_n $ fst; f $ snd ]
+  in
+  let s = Wire.Everparse.struct_of_codec codec in
+  let m =
+    Wire.Everparse.Raw.module_ [ Wire.Everparse.Raw.typedef ~entrypoint:true s ]
+  in
+  let _ = Wire.Everparse.Raw.to_3d m in
+  ()
+
+(** Reserved-name escaping holds across the projection: any name from the
+    keyword set, used as a param or field, must round-trip through
+    [pp_typ]/[to_3d] without raising. *)
+let test_keyword_param_random idx =
+  let names =
+    [|
+      "total";
+      "let";
+      "fun";
+      "match";
+      "type";
+      "true";
+      "false";
+      "module";
+      "open";
+      "include";
+      "with";
+      "when";
+      "as";
+      "of";
+      "and";
+      "or";
+      "rec";
+      "begin";
+      "end";
+      "ghost";
+      "noeq";
+      "private";
+      "abstract";
+      "synth";
+    |]
+  in
+  let name = names.(abs idx mod Array.length names) in
+  let p = Wire.Param.input name Wire.uint32be in
+  let s =
+    Wire.Everparse.Raw.param_struct "KwParam"
+      [ Wire.Param.decl p ]
+      [
+        Wire.Everparse.Raw.field "x" Wire.uint8;
+        Wire.Everparse.Raw.field "rest"
+          (Wire.byte_array ~size:(Wire.Param.expr p));
+      ]
+  in
+  let m = Wire.Everparse.Raw.module_ [ Wire.Everparse.Raw.typedef s ] in
+  let _ = Wire.Everparse.Raw.to_3d m in
+  ()
+
+let test_keyword_field_random idx =
+  let names =
+    [|
+      "let";
+      "fun";
+      "match";
+      "type";
+      "with";
+      "when";
+      "as";
+      "of";
+      "and";
+      "or";
+      "rec";
+      "begin";
+      "end";
+      "ghost";
+      "noeq";
+      "private";
+    |]
+  in
+  let name = names.(abs idx mod Array.length names) in
+  let s =
+    Wire.Everparse.Raw.struct_ "KwField"
+      [
+        Wire.Everparse.Raw.field name Wire.uint8;
+        Wire.Everparse.Raw.field "tail" Wire.uint16;
+      ]
+  in
+  let m = Wire.Everparse.Raw.module_ [ Wire.Everparse.Raw.typedef s ] in
+  let _ = Wire.Everparse.Raw.to_3d m in
+  ()
+
+(** Where-clause lowering: a struct-level [where] referencing fields must
+    project through without raising, regardless of the field arrangement or how
+    many of them the predicate touches. *)
+let test_where_lowering n =
+  let n = (abs n mod 4) + 1 in
+  let max_ = Wire.Param.input "max" Wire.uint16be in
+  let f_len = Wire.Everparse.Raw.field "Length" Wire.uint16be in
+  let f_len_ref = Wire.Everparse.Raw.field "Length" Wire.uint16be in
+  let extras =
+    List.init n (fun i ->
+        Wire.Everparse.Raw.field (Fmt.str "extra%d" i) Wire.uint8)
+  in
+  let s =
+    Wire.Everparse.Raw.param_struct "WhereLower"
+      [ Wire.Param.decl max_ ]
+      ~where:
+        Wire.Expr.(
+          Wire.Everparse.Raw.field_ref f_len_ref <= Wire.Param.expr max_)
+      (f_len :: extras)
+  in
+  let m = Wire.Everparse.Raw.module_ [ Wire.Everparse.Raw.typedef s ] in
+  let _ = Wire.Everparse.Raw.to_3d m in
+  ()
+
+(** [Action.var name e]: substitution into use sites must hold across arbitrary
+    expression shapes. *)
+let test_action_var_random k =
+  let f_a = Wire.Everparse.Raw.field "Tag" Wire.uint8 in
+  let f_b = Wire.Everparse.Raw.field "Value" Wire.uint16be in
+  let f_x = Wire.Everparse.Raw.field "x" Wire.uint16be in
+  let n = abs k mod 4 in
+  let bound =
+    let open Wire.Expr in
+    match n with
+    | 0 -> Wire.Everparse.Raw.field_ref f_a + Wire.Everparse.Raw.field_ref f_b
+    | 1 -> Wire.Everparse.Raw.field_ref f_a * Wire.int 2
+    | 2 ->
+        Wire.Everparse.Raw.field_ref f_a
+        - (Wire.Everparse.Raw.field_ref f_b / Wire.int 4)
+    | _ -> Wire.Everparse.Raw.field_ref f_a land Wire.int 0xff
+  in
+  let out_value = Wire.Param.output "out" Wire.uint32be in
+  let s =
+    Wire.Everparse.Raw.param_struct "VarFuzz"
+      [ Wire.Param.decl out_value ]
+      [
+        Wire.Everparse.Raw.field "Tag" Wire.uint8;
+        Wire.Everparse.Raw.field "Value" Wire.uint16be
+          ~action:
+            (Wire.Action.on_act
+               [
+                 Wire.Action.var "x" bound;
+                 Wire.Action.if_
+                   Wire.Expr.(Wire.Everparse.Raw.field_ref f_x > Wire.int 0)
+                   [
+                     Wire.Action.assign out_value
+                       (Wire.Everparse.Raw.field_ref f_x);
+                   ]
+                   None;
+               ]);
+      ]
+  in
+  let m = Wire.Everparse.Raw.module_ [ Wire.Everparse.Raw.typedef s ] in
+  let _ = Wire.Everparse.Raw.to_3d m in
+  ()
+
 (** Test big-endian struct with all BE types. *)
 let test_be_struct () =
   let s =
@@ -626,6 +811,12 @@ let codegen_tests =
     test_case "extern_probe" [ const () ] test_extern_probe;
     test_case "complex nested" [ const () ] test_complex_nested;
     test_case "be struct" [ const () ] test_be_struct;
+    test_case "field optional random" [ int ] test_field_optional_random;
+    test_case "field repeat random" [ int ] test_field_repeat_random;
+    test_case "keyword param random" [ int ] test_keyword_param_random;
+    test_case "keyword field random" [ int ] test_keyword_field_random;
+    test_case "where lowering random" [ int ] test_where_lowering;
+    test_case "action var random" [ int ] test_action_var_random;
   ]
 
 let suite = ("everparse", pp_tests @ codegen_tests)

--- a/lib/3d/wire_3d.ml
+++ b/lib/3d/wire_3d.ml
@@ -315,6 +315,33 @@ let run_everparse ?(quiet = true) ~outdir schemas =
     schemas;
   copy_everparse_endianness ~outdir
 
+let parse_3d ~outdir file =
+  let exe =
+    match locate_3d_exe () with
+    | Some e -> e
+    | None -> failwith "3d.exe not found in PATH or ~/.local/everparse/bin/"
+  in
+  let log_path = Filename.temp_file "wire_parse_3d" ".log" in
+  (* 3d.exe emits diagnostics to stdout, so capture both streams. *)
+  let cmd = Fmt.str "cd %s && %s %s > %s 2>&1" outdir exe file log_path in
+  let ret = Sys.command cmd in
+  let captured =
+    try In_channel.with_open_text log_path In_channel.input_all
+    with Sys_error _ -> ""
+  in
+  (try Sys.remove log_path with Sys_error _ -> ());
+  if ret = 0 then Ok ()
+  else
+    let msg =
+      String.split_on_char '\n' captured
+      |> List.filter (fun l ->
+          let l = String.trim l in
+          l <> ""
+          && not (String.length l >= 11 && String.sub l 0 11 = "Processing "))
+      |> String.concat "\n"
+    in
+    Error (if msg = "" then Fmt.str "exit %d" ret else msg)
+
 let emit_sanity_check ppf ~name ~ep ~ctx_arg wire_size =
   let pr fmt = Fmt.pf ppf fmt in
   (* Sanity: the OCaml codec's wire_size must match what the EverParse

--- a/lib/3d/wire_3d.mli
+++ b/lib/3d/wire_3d.mli
@@ -61,6 +61,15 @@ val run_everparse :
 
     Requires [3d.exe] in PATH. *)
 
+val parse_3d : outdir:string -> string -> (unit, string) result
+(** [parse_3d ~outdir file] runs [3d.exe] (without [--batch]) on a single [.3d]
+    file in [outdir]. Returns [Ok ()] when 3D accepts the file, or
+    [Error stderr] with the captured error message otherwise. Faster than
+    {!run_everparse} -- it stops after the 3D type-checker, before F* and
+    KaRaMeL. Intended for projection coverage tests.
+
+    Requires [3d.exe] in PATH. *)
+
 val write_external_typedefs : outdir:string -> Wire.Everparse.t list -> unit
 (** [write_external_typedefs ~outdir schemas] writes the default
     [<Name>_ExternalTypedefs.h] for each schema that uses the WireCtx contract,

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -298,7 +298,7 @@ type bf_codec_state = {
 
 (* Track the byte offset for the next field: static (constant) until we hit
    a variable-size field, then dynamic (computed from the buffer). *)
-type next_off = Static_next of int | Dynamic_next of (bytes -> int -> int)
+type next_off = Static of int | Dynamic of (bytes -> int -> int)
 (* [compute buf base] returns the absolute byte offset where the next
          field starts. [base] is the record's base offset in [buf]. *)
 
@@ -646,7 +646,7 @@ let record_start ?where name make =
       r_readers = Nil;
       r_writers_rev = [];
       r_min_wire_size = 0;
-      r_next_off = Static_next 0;
+      r_next_off = Static 0;
       r_fields_rev = [];
       r_validators_rev = [];
       r_checkers_rev = [];
@@ -1018,36 +1018,36 @@ let layout_ctx_of : type f r. (f, r) record -> layout_ctx =
 (* -- Layout helpers shared by per-type plans -- *)
 
 let static_off_of (ctx : layout_ctx) : int option =
-  match ctx.lc_next_off with Static_next n -> Some n | Dynamic_next _ -> None
+  match ctx.lc_next_off with Static n -> Some n | Dynamic _ -> None
 
 let off_fn_of (ctx : layout_ctx) : bytes -> int -> int =
   match ctx.lc_next_off with
-  | Static_next n -> fun _buf _base -> n
-  | Dynamic_next f -> fun buf base -> f buf base - base
+  | Static n -> fun _buf _base -> n
+  | Dynamic f -> fun buf base -> f buf base - base
 
 (* Byte offset used as [sizeof_this] when compiling constraints/actions: a
    real static offset when known, the [-1] sentinel otherwise. *)
 let validator_off_of (ctx : layout_ctx) : int =
-  match ctx.lc_next_off with Static_next n -> n | Dynamic_next _ -> -1
+  match ctx.lc_next_off with Static n -> n | Dynamic _ -> -1
 
 (* Field access that stores a constant or dynamic offset, based on [ctx]. *)
 let fixed_or_dynamic_fa (ctx : layout_ctx) : field_access =
   match ctx.lc_next_off with
-  | Static_next n -> Fixed n
-  | Dynamic_next _ -> Dynamic (off_fn_of ctx)
+  | Static n -> Fixed n
+  | Dynamic _ -> Dynamic (off_fn_of ctx)
 
 let require_static_off (ctx : layout_ctx) ~what : int =
   match ctx.lc_next_off with
-  | Static_next n -> n
-  | Dynamic_next _ ->
+  | Static n -> n
+  | Dynamic _ ->
       invalid_arg
         ("add_field: " ^ what ^ " after variable-size field not supported")
 
 (* New [next_off] after appending a fixed-size contribution of [n] bytes. *)
 let advance_next_off (no : next_off) (n : int) : next_off =
   match no with
-  | Static_next k -> Static_next (k + n)
-  | Dynamic_next f -> Dynamic_next (fun buf base -> f buf base + n)
+  | Static k -> Static (k + n)
+  | Dynamic f -> Dynamic (fun buf base -> f buf base + n)
 
 let null_int_reader : bytes -> int -> int = fun _buf _base -> 0
 let no_populate : int array -> bytes -> int -> unit = fun _arr _buf _base -> ()
@@ -1210,7 +1210,7 @@ and compile_bits : type r.
     extra_writers;
     field_access;
     size_delta;
-    next_off = Static_next (static_off + size_delta);
+    next_off = Static (static_off + size_delta);
     bf_after;
     int_reader = raw_reader;
     nested_readers = [];
@@ -1269,10 +1269,10 @@ and compile_codec_variable : type a r.
  fun ctx ~get ~codec_decode ~codec_encode ~codec_size_of ~nested_readers ->
   let off_fn, (field_access : field_access), validator_off =
     match ctx.lc_next_off with
-    | Static_next n ->
+    | Static n ->
         let size_fn buf base = codec_size_of buf (base + n) in
         ((fun _buf _base -> n), Variable { off = n; size_fn }, n)
-    | Dynamic_next prev_end ->
+    | Dynamic prev_end ->
         let off_fn buf base = prev_end buf base - base in
         let size_fn buf base = codec_size_of buf (base + off_fn buf base) in
         (off_fn, Variable_dynamic { off_fn; size_fn }, -1)
@@ -1291,7 +1291,7 @@ and compile_codec_variable : type a r.
     field_access;
     size_delta = 0;
     next_off =
-      Dynamic_next (fun buf base -> base + off_fn buf base + size_fn buf base);
+      Dynamic (fun buf base -> base + off_fn buf base + size_fn buf base);
     bf_after = None;
     int_reader = null_int_reader;
     nested_readers;
@@ -1301,12 +1301,10 @@ and compile_codec_variable : type a r.
 
 and dynamic_optional_next_off ctx present_fn fsize =
   let base_off = ctx.lc_next_off in
-  Dynamic_next
+  Dynamic
     (fun buf base ->
       let off =
-        match base_off with
-        | Static_next n -> base + n
-        | Dynamic_next f -> f buf base
+        match base_off with Static n -> base + n | Dynamic f -> f buf base
       in
       if present_fn buf base then off + fsize else off)
 
@@ -1462,17 +1460,17 @@ and compile_repeat : type elt seq r.
  fun ctx fld size_expr elem (Seq_map seq) ->
   (* Same dynamic-offset dispatch as [compile_var_bytes] / [compile_codec]:
      when a [Repeat] sits after a variable-size field, the running offset
-     is [Dynamic_next], which previously tripped [require_static_off]. *)
+     is [Dynamic], which previously tripped [require_static_off]. *)
   let off_fn, (field_access : field_access), validator_off =
     let sizeof_this : bytes -> int -> int =
       match ctx.lc_next_off with
-      | Static_next n -> fun _buf _base -> n
-      | Dynamic_next prev_end -> fun buf base -> prev_end buf base - base
+      | Static n -> fun _buf _base -> n
+      | Dynamic prev_end -> fun buf base -> prev_end buf base - base
     in
     let size_fn = compile_expr ~sizeof_this ctx.lc_field_readers size_expr in
     match ctx.lc_next_off with
-    | Static_next n -> ((fun _buf _base -> n), Variable { off = n; size_fn }, n)
-    | Dynamic_next prev_end ->
+    | Static n -> ((fun _buf _base -> n), Variable { off = n; size_fn }, n)
+    | Dynamic prev_end ->
         let off_fn buf base = prev_end buf base - base in
         (off_fn, Variable_dynamic { off_fn; size_fn }, -1)
   in
@@ -1508,7 +1506,7 @@ and compile_repeat : type elt seq r.
     field_access;
     size_delta = 0;
     next_off =
-      Dynamic_next (fun buf base -> base + off_fn buf base + size_fn buf base);
+      Dynamic (fun buf base -> base + off_fn buf base + size_fn buf base);
     bf_after = None;
     int_reader = null_int_reader;
     nested_readers = [];
@@ -1579,6 +1577,15 @@ and var_bytes_reader : type a.
   | Byte_slice _ -> Slice.make_or_eod buf ~first:(base + fo) ~length:sz
   | Byte_array _ -> Bytes.sub_string buf (base + fo) sz
   | Byte_array_where _ -> Bytes.sub_string buf (base + fo) sz
+  | All_bytes -> Bytes.sub_string buf (base + fo) sz
+  | All_zeros ->
+      let s = Bytes.sub_string buf (base + fo) sz in
+      String.iter
+        (fun c ->
+          if c <> '\000' then
+            invalid_arg "add_field: [all_zeros] field has a non-zero byte")
+        s;
+      s
   | _ -> assert false
 
 and var_bytes_writer : type a r.
@@ -1597,40 +1604,54 @@ and var_bytes_writer : type a r.
   | Byte_array_where _ ->
       let s = (value : string) in
       Bytes.blit_string s 0 buf (off + fo) (String.length s)
+  | All_bytes ->
+      let s = (value : string) in
+      Bytes.blit_string s 0 buf (off + fo) (String.length s)
+  | All_zeros ->
+      let s = (value : string) in
+      Bytes.blit_string s 0 buf (off + fo) (String.length s)
   | _ -> assert false
+
+and compile_var_size_fn : type a.
+    layout_ctx -> a typ -> off_fn:(bytes -> int -> int) -> bytes -> int -> int =
+ fun ctx typ ~off_fn ->
+  match typ with
+  | All_bytes | All_zeros ->
+      (* Trailing "rest of buffer": size is whatever bytes remain past the
+         current offset. The OCaml decoder gets the buffer length via
+         [Bytes.length buf]; the 3D projection emits [all_bytes], which
+         3D handles natively. *)
+      fun buf base -> Bytes.length buf - (base + off_fn buf base)
+  | _ ->
+      let size_expr =
+        match typ with
+        | Byte_slice { size } -> size
+        | Byte_array { size } -> size
+        | Byte_array_where { size; _ } -> size
+        | Uint_var { size; _ } -> size
+        | _ -> invalid_arg "add_field: unsupported variable-size field type"
+      in
+      let sizeof_this : bytes -> int -> int =
+        match ctx.lc_next_off with
+        | Static n -> fun _buf _base -> n
+        | Dynamic prev_end -> fun buf base -> prev_end buf base - base
+      in
+      compile_expr ~sizeof_this ctx.lc_field_readers size_expr
 
 and compile_var_bytes : type a r.
     layout_ctx -> (a, r) field -> (a, r) compiled_field =
  fun ctx fld ->
   let typ = fld.typ in
-  let size_expr =
-    match typ with
-    | Byte_slice { size } -> size
-    | Byte_array { size } -> size
-    | Byte_array_where { size; _ } -> size
-    | Uint_var { size; _ } -> size
-    | All_bytes | All_zeros ->
-        invalid_arg
-          "add_field: [all_bytes] / [all_zeros] are top-level decoders only; \
-           inside a record, use [byte_array ~size:Expr.(Param.expr total - \
-           sizeof_this)] with an explicit length param"
-    | _ -> invalid_arg "add_field: unsupported variable-size field type"
-  in
-  let sizeof_this : bytes -> int -> int =
+  let off_fn, validator_off =
     match ctx.lc_next_off with
-    | Static_next n -> fun _buf _base -> n
-    | Dynamic_next prev_end -> fun buf base -> prev_end buf base - base
+    | Static n -> ((fun (_buf : bytes) (_base : int) -> n), n)
+    | Dynamic prev_end -> ((fun buf base -> prev_end buf base - base), -1)
   in
-  let size_fn = compile_expr ~sizeof_this ctx.lc_field_readers size_expr in
-  let off_fn, (field_access : field_access), validator_off =
+  let size_fn = compile_var_size_fn ctx typ ~off_fn in
+  let field_access : field_access =
     match ctx.lc_next_off with
-    | Static_next n ->
-        ( (fun (_buf : bytes) (_base : int) -> n),
-          Variable { off = n; size_fn },
-          n )
-    | Dynamic_next prev_end ->
-        let off_fn buf base = prev_end buf base - base in
-        (off_fn, Variable_dynamic { off_fn; size_fn }, -1)
+    | Static n -> Variable { off = n; size_fn }
+    | Dynamic _ -> Variable_dynamic { off_fn; size_fn }
   in
   let raw_reader, raw_writer, int_reader =
     match typ with
@@ -1668,7 +1689,7 @@ and compile_var_bytes : type a r.
     field_access;
     size_delta = 0;
     next_off =
-      Dynamic_next
+      Dynamic
         (fun buf base ->
           let fo = off_fn buf base in
           base + fo + size_fn buf base);
@@ -1955,8 +1976,8 @@ let seal : type r. (r, r) record -> r t =
   let field_access = List.rev r.r_field_access_rev in
   let wire_size_info =
     match r.r_next_off with
-    | Static_next n -> Fixed n
-    | Dynamic_next f -> Variable { min_size = r.r_min_wire_size; compute = f }
+    | Static n -> Fixed n
+    | Dynamic f -> Variable { min_size = r.r_min_wire_size; compute = f }
   in
   let min_size = r.r_min_wire_size in
   let writers = Array.of_list (List.rev r.r_writers_rev) in
@@ -2043,7 +2064,7 @@ let empty_validator_acc =
     va_n_fields = 0;
     va_n_array_slots = 0;
     va_min_size = 0;
-    va_next_off = Static_next 0;
+    va_next_off = Static 0;
     va_bf = None;
   }
 
@@ -2071,13 +2092,13 @@ let layout_ctx_of_validator_acc acc =
    split. *)
 let acc_off_fn (acc : validator_acc) : bytes -> int -> int =
   match acc.va_next_off with
-  | Static_next n -> fun _buf _base -> n
-  | Dynamic_next f -> fun buf base -> f buf base - base
+  | Static n -> fun _buf _base -> n
+  | Dynamic f -> fun buf base -> f buf base - base
 
 let acc_prev_end (acc : validator_acc) : bytes -> int -> int =
   match acc.va_next_off with
-  | Static_next n -> fun _buf base -> base + n
-  | Dynamic_next f -> f
+  | Static n -> fun _buf base -> base + n
+  | Dynamic f -> f
 
 (* Validator step for a [Struct]-typed field. [compile_field] doesn't
    accept [Struct] (it has no [field_wire_size] without walking inner
@@ -2086,7 +2107,7 @@ let acc_prev_end (acc : validator_acc) : bytes -> int -> int =
 let rec apply_struct_field acc inner_struct =
   let inner_v = validator_of_struct inner_struct in
   let static_off =
-    match acc.va_next_off with Static_next n -> n | Dynamic_next _ -> -1
+    match acc.va_next_off with Static n -> n | Dynamic _ -> -1
   in
   let off_fn = acc_off_fn acc in
   let validator _arr buf base =
@@ -2095,11 +2116,10 @@ let rec apply_struct_field acc inner_struct =
   let prev_end = acc_prev_end acc in
   let size_delta, next_off =
     match (acc.va_next_off, inner_v.vt_wire_size) with
-    | Static_next n, Fixed sz -> (sz, Static_next (n + sz))
-    | _, Fixed sz -> (sz, Dynamic_next (fun buf base -> prev_end buf base + sz))
+    | Static n, Fixed sz -> (sz, Static (n + sz))
+    | _, Fixed sz -> (sz, Dynamic (fun buf base -> prev_end buf base + sz))
     | _, Variable { min_size; compute } ->
-        ( min_size,
-          Dynamic_next (fun buf base -> compute buf (prev_end buf base)) )
+        (min_size, Dynamic (fun buf base -> compute buf (prev_end buf base)))
   in
   {
     va_validators_rev = (static_off, validator) :: acc.va_validators_rev;
@@ -2194,8 +2214,8 @@ and validator_of_struct (s : Types.struct_) : validator =
   in
   let wire_size_info =
     match acc.va_next_off with
-    | Static_next n -> Fixed n
-    | Dynamic_next f -> Variable { min_size = acc.va_min_size; compute = f }
+    | Static n -> Fixed n
+    | Dynamic f -> Variable { min_size = acc.va_min_size; compute = f }
   in
   let param_handles = collect_param_handles s.fields s.where in
   let n_params = List.length param_handles in

--- a/lib/field.ml
+++ b/lib/field.ml
@@ -18,6 +18,25 @@ let v name ?constraint_ ?self_constraint ?action typ =
   in
   { name; typ; constraint_; action }
 
+(* Field decorations: produce a field directly from a typ + optional/
+   repeat metadata. Exposing these only at the field level keeps
+   [Wire.optional]/[Wire.repeat] off the typ-level surface so the
+   resulting decoration cannot be nested inside [array]/[where]/etc.
+   where 3D has no projection for it. *)
+let optional name ?constraint_ ?self_constraint ?action ~present typ =
+  v name ?constraint_ ?self_constraint ?action (Types.optional present typ)
+
+let optional_or name ?constraint_ ?self_constraint ?action ~present ~default typ
+    =
+  v name ?constraint_ ?self_constraint ?action
+    (Types.optional_or present ~default typ)
+
+let repeat name ?constraint_ ?self_constraint ?action ~size typ =
+  v name ?constraint_ ?self_constraint ?action (Types.repeat ~size typ)
+
+let repeat_seq name ?constraint_ ?self_constraint ?action ~seq ~size typ =
+  v name ?constraint_ ?self_constraint ?action (Types.repeat_seq seq ~size typ)
+
 let anon typ = { anon_typ = typ }
 let ref f = Types.Ref f.name
 let name f = f.name

--- a/lib/field.mli
+++ b/lib/field.mli
@@ -38,7 +38,56 @@ val v :
     projects to [UINT16BE Length {{ Length >= 7 }}], which EverParse's SMT can
     then use to discharge [byte-size (Length - 7)] on a later field. If both
     [?constraint_] and [?self_constraint] are given, the two are combined with
-    [And]. *)
+    [And].
+
+    For optional / repeating payloads use {!optional} / {!optional_or} /
+    {!repeat} -- those decorations only have a 3D projection at the top of a
+    struct field, never as a nested type. *)
+
+val optional :
+  string ->
+  ?constraint_:bool Types.expr ->
+  ?self_constraint:(int Types.expr -> bool Types.expr) ->
+  ?action:Types.action ->
+  present:bool Types.expr ->
+  'a Types.typ ->
+  'a option t
+(** [optional name ~present t] is a field present iff [present] evaluates to
+    [true]. Absent fields decode as [None] and consume zero bytes. *)
+
+val optional_or :
+  string ->
+  ?constraint_:bool Types.expr ->
+  ?self_constraint:(int Types.expr -> bool Types.expr) ->
+  ?action:Types.action ->
+  present:bool Types.expr ->
+  default:'a ->
+  'a Types.typ ->
+  'a t
+(** [optional_or name ~present ~default t] is a field that decodes to the inner
+    value when [present], or [default] when absent. No option wrapper. *)
+
+val repeat :
+  string ->
+  ?constraint_:bool Types.expr ->
+  ?self_constraint:(int Types.expr -> bool Types.expr) ->
+  ?action:Types.action ->
+  size:int Types.expr ->
+  'a Types.typ ->
+  'a list t
+(** [repeat name ~size t] parses elements of type [t] until [size] bytes have
+    been consumed. *)
+
+val repeat_seq :
+  string ->
+  ?constraint_:bool Types.expr ->
+  ?self_constraint:(int Types.expr -> bool Types.expr) ->
+  ?action:Types.action ->
+  seq:('a, 'seq) Types.seq_map ->
+  size:int Types.expr ->
+  'a Types.typ ->
+  'seq t
+(** Repeat with a custom sequence builder. *)
 
 val anon : 'a Types.typ -> 'a anon
 (** [anon typ] creates an anonymous (padding) field. *)

--- a/lib/test/everparse/test_wire_3d.ml
+++ b/lib/test/everparse/test_wire_3d.ml
@@ -347,6 +347,158 @@ let test_projection_filenames () =
     "raw schema name not used as filename" false
     (contains_exact "rpmsg_endpoint_info.h")
 
+(* -- Adversarial projection tests for 3D-shape transformations -- *)
+
+let to_3d_string s =
+  let m = Wire.Everparse.Raw.module_ [ Wire.Everparse.Raw.typedef s ] in
+  Wire.Everparse.Raw.to_3d m
+
+let contains s sub =
+  let lsub = String.length sub in
+  let n = String.length s - lsub in
+  let rec go i = i <= n && (String.sub s i lsub = sub || go (i + 1)) in
+  lsub = 0 || go 0
+
+(* [Action.var name e] must not project to [var name = e;] -- 3D's [var]
+   binds an atomic action, not a pure expression. The DSL combinator [Var]
+   has to be lowered by inlining the bound expression at every use site. *)
+let test_var_inlines () =
+  let f_a = field "Tag" uint8 in
+  let f_b = field "Value" uint16be in
+  let f_x = field "x" uint16be in
+  let s =
+    let out = Param.output "out" uint32be in
+    param_struct "VarTest"
+      [ Param.decl out ]
+      [
+        field "Tag" uint8;
+        field "Value"
+          ~action:
+            (Action.on_act
+               [
+                 Action.var "x" Expr.(field_ref f_a + field_ref f_b);
+                 Action.assign out Expr.(field_ref f_x + int 1);
+               ])
+          uint16be;
+      ]
+  in
+  let out = to_3d_string s in
+  Alcotest.(check bool)
+    "no [var x = ...] in 3D output" false (contains out "var x");
+  Alcotest.(check bool)
+    "x usage replaced by inlined expression" true
+    (contains out "(Tag + Value) + 1")
+
+(* Var bindings inside if-branches must not leak between sibling branches. *)
+let test_var_scoping_in_if () =
+  let f_a = field "Tag" uint8 in
+  let f_x = field "x" uint16be in
+  let s =
+    let out = Param.output "out" uint32be in
+    param_struct "VarIf"
+      [ Param.decl out ]
+      [
+        field "Tag" uint8;
+        field "Value"
+          ~action:
+            (Action.on_act
+               [
+                 Action.var "x" Expr.(field_ref f_a + int 7);
+                 Action.if_
+                   Expr.(field_ref f_x > int 100)
+                   [ Action.assign out (field_ref f_x) ]
+                   (Some [ Action.assign out (int 0) ]);
+               ])
+          uint8;
+      ]
+  in
+  let out = to_3d_string s in
+  Alcotest.(check bool) "no var leak" false (contains out "var x");
+  Alcotest.(check bool)
+    "inlined inside then-branch" true
+    (contains out "*out = (Tag + 7);");
+  Alcotest.(check bool)
+    "inlined inside cond" true
+    (contains out "(Tag + 7) > 100")
+
+(* Struct-level [where] referencing fields must lower to a constraint on
+   the latest referenced field, not stay at struct level. 3D's [where]
+   only sees parameters. *)
+let test_where_lowers_to_field () =
+  let f_len = field "Length" uint16be in
+  let f_max = field "max" uint16be in
+  let s =
+    param_struct "WhereTest"
+      [ param "max" uint16be ]
+      ~where:Expr.(field_ref f_len <= field_ref f_max)
+      [ field "Length" uint16be ]
+  in
+  let out = to_3d_string s in
+  Alcotest.(check bool) "no top-level where" false (contains out "where (");
+  Alcotest.(check bool)
+    "constraint moved onto the field" true
+    (contains out "Length <= max")
+
+(* A param-only [where] must remain at the struct level. *)
+let test_where_param_only_stays () =
+  let s =
+    let max_ = Param.input "max" uint16be in
+    let lim = Param.input "lim" uint16be in
+    param_struct "WhereParam"
+      [ Param.decl max_; Param.decl lim ]
+      ~where:Expr.(Param.expr max_ <= Param.expr lim)
+      [ field "Length" uint16be ]
+  in
+  let out = to_3d_string s in
+  Alcotest.(check bool)
+    "where stays at struct level" true (contains out "where (")
+
+(* The [where] must combine with any pre-existing field constraint via AND. *)
+let test_where_combines_field_constraint () =
+  let f_self = field "Length" uint16be in
+  let f_len =
+    field "Length" ~constraint_:Expr.(field_ref f_self > int 0) uint16be
+  in
+  let s =
+    param_struct "WhereAnd" []
+      ~where:Expr.(field_ref f_len < int 1024)
+      [ f_len ]
+  in
+  let out = to_3d_string s in
+  (* Both clauses must end up next to the field. *)
+  Alcotest.(check bool) "left clause present" true (contains out "Length > 0");
+  Alcotest.(check bool)
+    "right clause present" true
+    (contains out "Length < 1024")
+
+(* Param/field names that collide with 3D or F* keywords must be escaped
+   in the projected 3D output (not rejected at the API). The user keeps
+   writing [Param.input "total" ...], the 3D output reads [total_]. *)
+let test_keyword_param_escaped () =
+  let p = Param.input "total" uint32be in
+  let f = field "data" (byte_array ~size:(Param.expr p)) in
+  let s = param_struct "Esc" [ Param.decl p ] [ f ] in
+  let out = to_3d_string s in
+  Alcotest.(check bool)
+    "param decl uses escaped name" true
+    (contains out "UINT32BE total_");
+  Alcotest.(check bool)
+    "param ref uses escaped name" true
+    (contains out "byte-size total_");
+  Alcotest.(check bool)
+    "raw [total] keyword does not appear" false
+    (Re.execp (Re.compile (Re.seq [ Re.bow; Re.str "total"; Re.eow ])) out)
+
+let test_keyword_field_escaped () =
+  let s =
+    struct_ "Esc2"
+      [ field "let" uint8; field "match" uint8; field "type" uint16be ]
+  in
+  let out = to_3d_string s in
+  Alcotest.(check bool) "let_ field" true (contains out "let_");
+  Alcotest.(check bool) "match_ field" true (contains out "match_");
+  Alcotest.(check bool) "type_ field" true (contains out "type_")
+
 let suite =
   ( "wire_3d",
     [
@@ -362,6 +514,20 @@ let suite =
         test_projection_sizes;
       Alcotest.test_case "projection: filenames match EverParse output" `Quick
         test_projection_filenames;
+      Alcotest.test_case "projection: var inlines into uses" `Quick
+        test_var_inlines;
+      Alcotest.test_case "projection: var scoping inside if" `Quick
+        test_var_scoping_in_if;
+      Alcotest.test_case "projection: where lowers to field constraint" `Quick
+        test_where_lowers_to_field;
+      Alcotest.test_case "projection: param-only where stays at struct" `Quick
+        test_where_param_only_stays;
+      Alcotest.test_case "projection: where ANDs with field constraint" `Quick
+        test_where_combines_field_constraint;
+      Alcotest.test_case "projection: F*-keyword param escaped" `Quick
+        test_keyword_param_escaped;
+      Alcotest.test_case "projection: F*-keyword field escaped" `Quick
+        test_keyword_field_escaped;
       Alcotest.test_case "e2e: compile + run across naming conventions" `Slow
         test_e2e_compile_run;
     ] )

--- a/lib/test/everparse/test_wire_3d.ml
+++ b/lib/test/everparse/test_wire_3d.ml
@@ -489,6 +489,88 @@ let test_keyword_param_escaped () =
     "raw [total] keyword does not appear" false
     (Re.execp (Re.compile (Re.seq [ Re.bow; Re.str "total"; Re.eow ])) out)
 
+(* Field decorations [optional]/[optional_or]/[repeat] have no 3D
+   meaning outside a field's top-level type, so the smart constructors
+   for the wrapping combinators must reject them at the call site. *)
+let expect_invalid_arg ~combinator f =
+  match
+    try
+      let _ = f () in
+      Ok ()
+    with Invalid_argument msg -> Error msg
+  with
+  | Ok () ->
+      Alcotest.failf "%s should have rejected the construction" combinator
+  | Error _ -> ()
+
+let test_array_rejects_decoration () =
+  expect_invalid_arg ~combinator:"array (optional)" (fun () ->
+      array ~len:(int 4) (optional Expr.true_ uint8));
+  expect_invalid_arg ~combinator:"array (optional_or)" (fun () ->
+      array ~len:(int 4) (optional_or Expr.true_ ~default:0 uint8));
+  expect_invalid_arg ~combinator:"array (repeat)" (fun () ->
+      array ~len:(int 4) (repeat ~size:(int 8) uint8))
+
+(* [array ~len:N (byte_array ~size:M)] is valid -- it projects to
+   [UINT8 name[:byte-size (N * M)]]. The smart constructor only refuses
+   element types that have no derivable wire size expression at all. *)
+let test_array_accepts_sized_elem () =
+  let s =
+    struct_ "ArrSized"
+      [ field "Items" (array ~len:(int 3) (byte_array ~size:(int 5))) ]
+  in
+  let out = to_3d_string s in
+  Alcotest.(check bool)
+    "byte-size suffix uses len * elem_size" true (contains out "byte-size")
+
+let test_array_rejects_unsized_elem () =
+  expect_invalid_arg ~combinator:"array (all_bytes)" (fun () ->
+      array ~len:(int 4) all_bytes)
+
+(* [optional]/[optional_or] now accept any element with a derivable size --
+   plain scalars, fixed bitfields, AND already-sized payloads like
+   [byte_array {size}], so [field "Foo" (optional cond (byte_array ~size:N))]
+   projects to [UINT8 Foo[:byte-size if cond then N else 0]]. *)
+let test_optional_accepts_byte_array () =
+  let s =
+    let cond = Param.input "cond" uint8 in
+    param_struct "OptByteArr"
+      [ Param.decl cond ]
+      [
+        field "Hdr" uint8;
+        field "Body"
+          (optional Expr.(Param.expr cond <> int 0) (byte_array ~size:(int 8)));
+      ]
+  in
+  let out = to_3d_string s in
+  Alcotest.(check bool)
+    "byte-size suffix uses inner size" true (contains out "8")
+
+let test_optional_rejects_unsized () =
+  expect_invalid_arg ~combinator:"optional (all_bytes)" (fun () ->
+      optional Expr.true_ all_bytes)
+
+(* [repeat] is permissive: 3D's [<T>[:byte-size budget]] parses Ts until
+   the byte budget is exhausted, so variable-size T (struct, codec) is
+   fine. The only refusal is decoration nesting. *)
+let test_repeat_rejects_decoration () =
+  expect_invalid_arg ~combinator:"repeat (optional)" (fun () ->
+      repeat ~size:(int 32) (optional Expr.true_ uint8))
+
+let test_where_rejects_decoration () =
+  expect_invalid_arg ~combinator:"where (optional)" (fun () ->
+      where Expr.true_ (optional Expr.true_ uint8))
+
+let test_casetype_rejects_decoration () =
+  expect_invalid_arg ~combinator:"casetype (case = optional)" (fun () ->
+      casetype "Bad" uint8
+        [
+          case ~index:0
+            (optional Expr.true_ uint8)
+            ~inject:(fun x -> x)
+            ~project:(fun x -> Some x);
+        ])
+
 let test_keyword_field_escaped () =
   let s =
     struct_ "Esc2"
@@ -528,6 +610,22 @@ let suite =
         test_keyword_param_escaped;
       Alcotest.test_case "projection: F*-keyword field escaped" `Quick
         test_keyword_field_escaped;
+      Alcotest.test_case "ctor: array rejects decoration elem" `Quick
+        test_array_rejects_decoration;
+      Alcotest.test_case "ctor: array accepts sized variable elem" `Quick
+        test_array_accepts_sized_elem;
+      Alcotest.test_case "ctor: array rejects unsized elem" `Quick
+        test_array_rejects_unsized_elem;
+      Alcotest.test_case "ctor: optional accepts byte_array" `Quick
+        test_optional_accepts_byte_array;
+      Alcotest.test_case "ctor: optional rejects unsized inner" `Quick
+        test_optional_rejects_unsized;
+      Alcotest.test_case "ctor: repeat rejects decoration elem" `Quick
+        test_repeat_rejects_decoration;
+      Alcotest.test_case "ctor: where rejects decoration inner" `Quick
+        test_where_rejects_decoration;
+      Alcotest.test_case "ctor: casetype rejects decoration case" `Quick
+        test_casetype_rejects_decoration;
       Alcotest.test_case "e2e: compile + run across naming conventions" `Slow
         test_e2e_compile_run;
     ] )

--- a/lib/test/everparse/test_wire_3d.ml
+++ b/lib/test/everparse/test_wire_3d.ml
@@ -489,9 +489,6 @@ let test_keyword_param_escaped () =
     "raw [total] keyword does not appear" false
     (Re.execp (Re.compile (Re.seq [ Re.bow; Re.str "total"; Re.eow ])) out)
 
-(* Field decorations [optional]/[optional_or]/[repeat] have no 3D
-   meaning outside a field's top-level type, so the smart constructors
-   for the wrapping combinators must reject them at the call site. *)
 let expect_invalid_arg ~combinator f =
   match
     try
@@ -502,14 +499,6 @@ let expect_invalid_arg ~combinator f =
   | Ok () ->
       Alcotest.failf "%s should have rejected the construction" combinator
   | Error _ -> ()
-
-let test_array_rejects_decoration () =
-  expect_invalid_arg ~combinator:"array (optional)" (fun () ->
-      array ~len:(int 4) (optional Expr.true_ uint8));
-  expect_invalid_arg ~combinator:"array (optional_or)" (fun () ->
-      array ~len:(int 4) (optional_or Expr.true_ ~default:0 uint8));
-  expect_invalid_arg ~combinator:"array (repeat)" (fun () ->
-      array ~len:(int 4) (repeat ~size:(int 8) uint8))
 
 (* [array ~len:N (byte_array ~size:M)] is valid -- it projects to
    [UINT8 name[:byte-size (N * M)]]. The smart constructor only refuses
@@ -527,49 +516,26 @@ let test_array_rejects_unsized_elem () =
   expect_invalid_arg ~combinator:"array (all_bytes)" (fun () ->
       array ~len:(int 4) all_bytes)
 
-(* [optional]/[optional_or] now accept any element with a derivable size --
-   plain scalars, fixed bitfields, AND already-sized payloads like
-   [byte_array {size}], so [field "Foo" (optional cond (byte_array ~size:N))]
-   projects to [UINT8 Foo[:byte-size if cond then N else 0]]. *)
-let test_optional_accepts_byte_array () =
-  let s =
-    let cond = Param.input "cond" uint8 in
-    param_struct "OptByteArr"
-      [ Param.decl cond ]
-      [
-        field "Hdr" uint8;
-        field "Body"
-          (optional Expr.(Param.expr cond <> int 0) (byte_array ~size:(int 8)));
-      ]
+(* [Field.optional] accepts any element with a derivable size -- plain
+   scalars, fixed bitfields, AND already-sized payloads like
+   [byte_array {size}]. The projection emits a [byte-size if(cond, N, 0)]
+   suffix that uses the inner's size expression. *)
+let test_field_optional_byte_array () =
+  let f_present = Field.v "present" uint8 in
+  let cond = Expr.(Field.ref f_present <> int 0) in
+  let codec =
+    Codec.v "OptByteArr"
+      (fun present body -> (present, body))
+      Codec.
+        [
+          f_present $ fst;
+          Field.optional "Body" ~present:cond (byte_array ~size:(int 8)) $ snd;
+        ]
   in
+  let s = Everparse.struct_of_codec codec in
   let out = to_3d_string s in
   Alcotest.(check bool)
     "byte-size suffix uses inner size" true (contains out "8")
-
-let test_optional_rejects_unsized () =
-  expect_invalid_arg ~combinator:"optional (all_bytes)" (fun () ->
-      optional Expr.true_ all_bytes)
-
-(* [repeat] is permissive: 3D's [<T>[:byte-size budget]] parses Ts until
-   the byte budget is exhausted, so variable-size T (struct, codec) is
-   fine. The only refusal is decoration nesting. *)
-let test_repeat_rejects_decoration () =
-  expect_invalid_arg ~combinator:"repeat (optional)" (fun () ->
-      repeat ~size:(int 32) (optional Expr.true_ uint8))
-
-let test_where_rejects_decoration () =
-  expect_invalid_arg ~combinator:"where (optional)" (fun () ->
-      where Expr.true_ (optional Expr.true_ uint8))
-
-let test_casetype_rejects_decoration () =
-  expect_invalid_arg ~combinator:"casetype (case = optional)" (fun () ->
-      casetype "Bad" uint8
-        [
-          case ~index:0
-            (optional Expr.true_ uint8)
-            ~inject:(fun x -> x)
-            ~project:(fun x -> Some x);
-        ])
 
 let test_keyword_field_escaped () =
   let s =
@@ -610,22 +576,12 @@ let suite =
         test_keyword_param_escaped;
       Alcotest.test_case "projection: F*-keyword field escaped" `Quick
         test_keyword_field_escaped;
-      Alcotest.test_case "ctor: array rejects decoration elem" `Quick
-        test_array_rejects_decoration;
       Alcotest.test_case "ctor: array accepts sized variable elem" `Quick
         test_array_accepts_sized_elem;
       Alcotest.test_case "ctor: array rejects unsized elem" `Quick
         test_array_rejects_unsized_elem;
-      Alcotest.test_case "ctor: optional accepts byte_array" `Quick
-        test_optional_accepts_byte_array;
-      Alcotest.test_case "ctor: optional rejects unsized inner" `Quick
-        test_optional_rejects_unsized;
-      Alcotest.test_case "ctor: repeat rejects decoration elem" `Quick
-        test_repeat_rejects_decoration;
-      Alcotest.test_case "ctor: where rejects decoration inner" `Quick
-        test_where_rejects_decoration;
-      Alcotest.test_case "ctor: casetype rejects decoration case" `Quick
-        test_casetype_rejects_decoration;
+      Alcotest.test_case "Field.optional: byte_array inner projects" `Quick
+        test_field_optional_byte_array;
       Alcotest.test_case "e2e: compile + run across naming conventions" `Slow
         test_e2e_compile_run;
     ] )

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -265,7 +265,32 @@ let bf_uint32be = BF_U32 Big
 let bits ?(bit_order = Msb_first) ~width base = Bits { width; base; bit_order }
 let bit b = Bool.to_int b
 let is_set n = n <> 0
-let map decode encode inner = Map { inner; decode; encode }
+
+(* Field decorations [Optional], [Optional_or], [Repeat] only have a 3D
+   projection when they appear at the top of a struct field's type --
+   anywhere else (array elem, casetype case body, [where]/[map]/[apply]
+   wrapper) there is no 3D shape that captures the semantics. Reject the
+   construction at the user's call site so the error points at the
+   wrapping combinator rather than surfacing later inside [pp_typ]. *)
+let rec is_field_decoration : type a. a typ -> bool = function
+  | Optional _ | Optional_or _ | Repeat _ -> true
+  | Map { inner; _ } -> is_field_decoration inner
+  | Where { inner; _ } -> is_field_decoration inner
+  | Apply { typ; _ } -> is_field_decoration typ
+  | _ -> false
+
+let reject_decoration ~combinator t =
+  if is_field_decoration t then
+    Fmt.invalid_arg
+      "Wire.%s: [optional]/[optional_or]/[repeat] are field decorations and \
+       cannot appear nested inside [%s] -- attach them as the field type \
+       directly via [Field.v]."
+      combinator combinator
+
+let map decode encode inner =
+  reject_decoration ~combinator:"map" inner;
+  Map { inner; decode; encode }
+
 let bool inner = Map { inner; decode = is_set; encode = bit }
 
 (* Parse errors -- moved here so combinators like [cases] can raise them
@@ -303,7 +328,10 @@ let cases variants inner =
 let unit = Unit
 let all_bytes = All_bytes
 let all_zeros = All_zeros
-let where cond inner = Where { cond; inner }
+
+let where cond inner =
+  reject_decoration ~combinator:"where" inner;
+  Where { cond; inner }
 
 let seq_list : ('a, 'a list) seq_map =
   Seq_map
@@ -314,8 +342,47 @@ let seq_list : ('a, 'a list) seq_map =
       iter = List.iter;
     }
 
-let array ~len elem = Array { len; elem; seq = seq_list }
-let array_seq seq ~len elem = Array { len; elem; seq }
+(* The 3D projection of [array]/[optional]/[optional_or]/[repeat] turns
+   their length / predicate / byte budget into a [byte-size] suffix.
+   That works as long as the wrapped element exposes a wire size we can
+   plumb into the suffix expression -- either a fixed scalar width, an
+   already-sized payload like [byte_array {size}], or a codec with a
+   fixed [wire_size]. Reject everything else at the smart constructor
+   so the error fires at the user's call site. *)
+let rec has_wire_size_expr : type a. a typ -> bool = function
+  | Uint8 | Uint16 _ | Uint32 _ | Uint63 _ | Uint64 _ -> true
+  | Int8 | Int16 _ | Int32 _ | Int64 _ -> true
+  | Float32 _ | Float64 _ -> true
+  | Bits _ -> true
+  | Unit -> true
+  | Uint_var _ -> true
+  | Byte_array _ | Byte_slice _ | Byte_array_where _ -> true
+  | Single_elem _ -> true
+  | Map { inner; _ } -> has_wire_size_expr inner
+  | Enum { base; _ } -> has_wire_size_expr base
+  | Where { inner; _ } -> has_wire_size_expr inner
+  | Apply { typ; _ } -> has_wire_size_expr typ
+  | Array { elem; _ } -> has_wire_size_expr elem
+  | Codec { codec_fixed_size; _ } -> codec_fixed_size <> None
+  | _ -> false
+
+let reject_variable_size ~combinator t =
+  if not (has_wire_size_expr t) then
+    Fmt.invalid_arg
+      "Wire.%s: inner type must expose a wire size -- 3D projects %s through a \
+       [byte-size] suffix that needs the element width."
+      combinator combinator
+
+let array ~len elem =
+  reject_decoration ~combinator:"array" elem;
+  reject_variable_size ~combinator:"array" elem;
+  Array { len; elem; seq = seq_list }
+
+let array_seq seq ~len elem =
+  reject_decoration ~combinator:"array_seq" elem;
+  reject_variable_size ~combinator:"array_seq" elem;
+  Array { len; elem; seq }
+
 let byte_array ~size = Byte_array { size }
 let byte_array_where_counter = Stdlib.ref 0
 let elt_var_prefix = "__elt_"
@@ -338,10 +405,28 @@ let synth_name_of_elt_var ev =
   else "_RefByte_" ^ ev
 
 let byte_slice ~size = Byte_slice { size }
-let optional present inner = Optional { present; inner }
-let optional_or present ~default inner = Optional_or { present; inner; default }
-let repeat ~size elem = Repeat { size; elem; seq = seq_list }
-let repeat_seq seq ~size elem = Repeat { size; elem; seq }
+
+let optional present inner =
+  reject_variable_size ~combinator:"optional" inner;
+  Optional { present; inner }
+
+let optional_or present ~default inner =
+  reject_variable_size ~combinator:"optional_or" inner;
+  Optional_or { present; inner; default }
+
+(* [repeat ~size elem] is more permissive than [array]: 3D's
+   [<elem>[:byte-size <size>]] parses elements until the byte budget is
+   exhausted, so variable-size elements are fine as long as each one is
+   self-bounded by its 3D type (struct, codec, ...). The only thing we
+   refuse is a field decoration nested inside [elem]. *)
+let repeat ~size elem =
+  reject_decoration ~combinator:"repeat" elem;
+  Repeat { size; elem; seq = seq_list }
+
+let repeat_seq seq ~size elem =
+  reject_decoration ~combinator:"repeat_seq" elem;
+  Repeat { size; elem; seq }
+
 let nested ~size elem = Single_elem { size; elem; at_most = false }
 let nested_at_most ~size elem = Single_elem { size; elem; at_most = true }
 let enum name cases base = Enum { name; cases; base }
@@ -393,6 +478,7 @@ let casetype ?(first = 0) ?(step = 1) name tag defs =
   let counter = Stdlib.ref first in
   let resolve = function
     | Case_def { cd_index; cd_inner; cd_inject; cd_project } ->
+        reject_decoration ~combinator:"casetype" cd_inner;
         let idx =
           match cd_index with
           | Some i ->
@@ -411,6 +497,7 @@ let casetype ?(first = 0) ?(step = 1) name tag defs =
             cb_project = cd_project;
           }
     | Default_def { dd_inner; dd_inject; dd_project } ->
+        reject_decoration ~combinator:"casetype" dd_inner;
         Case_branch
           {
             cb_tag = None;
@@ -492,7 +579,10 @@ let mutable_param name typ =
   { param_name = name; param_typ = Pack_typ typ; mutable_ = true }
 
 let param_struct name params ?where fields = { name; params; where; fields }
-let apply typ args = Apply { typ; args = List.map (fun e -> Pack_expr e) args }
+
+let apply typ args =
+  reject_decoration ~combinator:"apply" typ;
+  Apply { typ; args = List.map (fun e -> Pack_expr e) args }
 
 (* Type references *)
 let type_ref name = Type_ref name
@@ -736,24 +826,18 @@ and pp_typ : type a. a typ Fmt.t =
       Fmt.pf ppf "%a(%a)" pp_typ typ Fmt.(list ~sep:comma pp_packed_expr) args
   | Map { inner; _ } -> pp_typ ppf inner
   | Codec { codec_name; _ } -> Fmt.string ppf codec_name
+  (* [Optional]/[Optional_or]/[Repeat] are field decorations: their
+     wrapping combinators ([map], [where], [array], [casetype], [apply])
+     reject them at construction, so reaching this branch from a typ
+     emitted by 3D projection means a struct field is being printed
+     standalone -- caller's job, never our pp_typ. The trivial-predicate
+     branches survive because they erase the decoration entirely. *)
   | Optional { present = Bool true; inner } -> pp_typ ppf inner
   | Optional { present = Bool false; _ } -> Fmt.string ppf "UINT8"
-  | Optional _ ->
-      invalid_arg
-        "Wire 3D projection: [optional] with a non-trivial predicate has no \
-         standalone 3D type; use it as a struct field so it projects via the \
-         field-suffix [byte-size] rule."
   | Optional_or { present = Bool true; inner; _ } -> pp_typ ppf inner
   | Optional_or { present = Bool false; _ } -> Fmt.string ppf "UINT8"
-  | Optional_or _ ->
-      invalid_arg
-        "Wire 3D projection: [optional_or] with a non-trivial predicate has no \
-         standalone 3D type; use it as a struct field so it projects via the \
-         field-suffix [byte-size] rule."
-  | Repeat _ ->
-      invalid_arg
-        "Wire 3D projection: [repeat] has no standalone 3D type; use it as a \
-         struct field so it projects via the field-suffix [byte-size] rule."
+  | Optional _ | Optional_or _ | Repeat _ ->
+      assert false (* unreachable: rejected by the wrapping combinator *)
 
 and pp_packed_expr ppf (Pack_expr e) = pp_expr ppf e
 
@@ -847,19 +931,38 @@ let rec inner_wire_size : type a. a typ -> int option = function
   | Map { inner; _ } -> inner_wire_size inner
   | Enum { base; _ } -> inner_wire_size base
   | Where { inner; _ } -> inner_wire_size inner
+  | Codec { codec_fixed_size = Some n; _ } -> Some n
   | _ -> None
+
+(* Like [inner_wire_size] but as an [int expr], so explicitly-sized
+   types ([byte_array], [byte_slice], [single_elem], etc.) can drive
+   the [byte-size] suffix of an enclosing [optional]/[array]. Returns
+   [None] only for shapes whose total wire size is genuinely not
+   expressible at projection time (variable-size codec without an
+   exposed [wire_size_expr], casetype, struct ref, all_bytes/all_zeros). *)
+and inner_wire_size_expr : type a. a typ -> int expr option = function
+  | Byte_array { size } | Byte_slice { size } | Byte_array_where { size; _ } ->
+      Some size
+  | Single_elem { size; _ } -> Some size
+  | Uint_var { size; _ } -> Some size
+  | Array { len; elem; _ } -> (
+      match inner_wire_size_expr elem with
+      | Some s -> Some (Mul (len, s))
+      | None -> None)
+  | Apply { typ; _ } -> inner_wire_size_expr typ
+  | t -> ( match inner_wire_size t with Some n -> Some (Int n) | None -> None)
 
 and optional_suffix : type a.
     bool expr -> a typ -> field_suffix * (Format.formatter -> unit) =
  fun present inner ->
-  match inner_wire_size inner with
-  | Some n ->
-      let size = If_then_else (present, Int n, Int 0) in
-      (Byte_array size, fun ppf -> pp_typ ppf inner)
+  match inner_wire_size_expr inner with
+  | Some s ->
+      ( Byte_array (If_then_else (present, s, Int 0)),
+        fun ppf -> pp_typ ppf inner )
   | None ->
-      invalid_arg
-        "Wire 3D projection: [optional]/[optional_or] requires a fixed-size \
-         inner type; the predicate compiles to a 0-or-N byte-size suffix."
+      (* Unreachable: [optional]/[optional_or] reject variable-size inner
+         at construction (smart constructor uses [has_wire_size_expr]). *)
+      assert false
 
 and field_suffix : type a. a typ -> field_suffix * (Format.formatter -> unit) =
  fun typ ->
@@ -876,15 +979,15 @@ and field_suffix : type a. a typ -> field_suffix * (Format.formatter -> unit) =
       (Single_elem { size; at_most }, fun ppf -> pp_typ ppf elem)
   | Array { len; elem; _ } -> (
       (* 3D's [name[len]] suffix only accepts byte-sized elements; for wider
-         elements the size in bytes must be made explicit via [:byte-size]. *)
-      match inner_wire_size elem with
-      | Some 1 -> (Array len, fun ppf -> pp_typ ppf elem)
-      | Some n -> (Byte_array (Mul (len, Int n)), fun ppf -> pp_typ ppf elem)
-      | None ->
-          invalid_arg
-            "Wire 3D projection: array element with no fixed wire size has no \
-             3D representation; use [byte_array]/[byte_slice] for variable \
-             sizes or wrap in a [Codec] with a fixed [wire_size].")
+         elements the size in bytes must be made explicit via [:byte-size].
+         [inner_wire_size_expr] handles fixed scalars, [byte_array]-style
+         sized payloads, codec-with-fixed-size, and nested arrays. *)
+      match (inner_wire_size elem, inner_wire_size_expr elem) with
+      | Some 1, _ -> (Array len, fun ppf -> pp_typ ppf elem)
+      | _, Some s -> (Byte_array (Mul (len, s)), fun ppf -> pp_typ ppf elem)
+      | _ ->
+          (* Unreachable: [array] rejects variable-size elem at construction. *)
+          assert false)
   | Map { inner; _ } -> field_suffix inner
   | Enum { base; _ } -> field_suffix base
   | Optional { present = Bool true; inner } -> field_suffix inner

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -618,13 +618,26 @@ module Reserved_3d = Set.Make (String)
 let reserved_3d =
   Reserved_3d.of_list
     (String.split_on_char ' '
+       (* 3D / EverParse keywords *)
        "typedef struct casetype switch case default enum extern mutable \
         entrypoint export output where if else return abort var unit bool true \
         false sizeof this int char void float double long short unsigned \
         signed static const volatile auto register union while for do break \
         continue goto type inline UINT8 UINT16 UINT16BE UINT32 UINT32BE UINT64 \
-        UINT64BE Bool PUINT8")
+        UINT64BE Bool PUINT8 abstract and as assert assume attributes begin by \
+        calc class decreases default downto effect eliminate ensures exception \
+        exists forall friend fun function ghost include inline_for_extraction \
+        instance introduce irreducible layered_effect let logic match module \
+        new new_effect noeq noextract opaque_to_smt open polymonadic_bind \
+        polymonadic_subcomp private range_of rec reflectable reifiable reify \
+        requires restart_solver returns set_range_of sub_effect synth then tot \
+        total try unfold unopteq val when with")
 
+(* Append a trailing underscore to names that 3D or F* reserves so the
+   projection always produces a parseable identifier even when the user
+   picks something like [total]. The same escaping is applied wherever a
+   user-chosen name reaches 3D output: param decls, [Param_ref], [Ref],
+   field names. The OCaml-side name is unchanged. *)
 let escape_3d name =
   if Reserved_3d.mem name reserved_3d then name ^ "_" else name
 
@@ -725,40 +738,94 @@ and pp_typ : type a. a typ Fmt.t =
   | Codec { codec_name; _ } -> Fmt.string ppf codec_name
   | Optional { present = Bool true; inner } -> pp_typ ppf inner
   | Optional { present = Bool false; _ } -> Fmt.string ppf "UINT8"
-  | Optional { inner; _ } -> Fmt.pf ppf "optional(%a)" pp_typ inner
+  | Optional _ ->
+      invalid_arg
+        "Wire 3D projection: [optional] with a non-trivial predicate has no \
+         standalone 3D type; use it as a struct field so it projects via the \
+         field-suffix [byte-size] rule."
   | Optional_or { present = Bool true; inner; _ } -> pp_typ ppf inner
   | Optional_or { present = Bool false; _ } -> Fmt.string ppf "UINT8"
-  | Optional_or { inner; _ } -> Fmt.pf ppf "optional(%a)" pp_typ inner
-  | Repeat { elem; _ } -> pp_typ ppf elem
+  | Optional_or _ ->
+      invalid_arg
+        "Wire 3D projection: [optional_or] with a non-trivial predicate has no \
+         standalone 3D type; use it as a struct field so it projects via the \
+         field-suffix [byte-size] rule."
+  | Repeat _ ->
+      invalid_arg
+        "Wire 3D projection: [repeat] has no standalone 3D type; use it as a \
+         struct field so it projects via the field-suffix [byte-size] rule."
 
 and pp_packed_expr ppf (Pack_expr e) = pp_expr ppf e
 
-let rec pp_action_stmt ppf = function
-  | Assign (p, e) -> Fmt.pf ppf "*%s = %a;" (escape_3d p.ph_name) pp_expr e
-  | Field_assign (ptr, field_name, e) ->
-      Fmt.pf ppf "%s->%s = %a;" ptr field_name pp_expr e
+(* 3D's [var x = a; p] requires [a] to be an atomic action (extern call,
+   field_ptr, ...), not an arbitrary expression. Wire's [Action.var name e]
+   binds a name to a pure expression, so we lower it by substituting
+   [Ref name -> e] in subsequent stmts and dropping the [var] emission. *)
+let rec subst_expr : type a. (string * int expr) list -> a expr -> a expr =
+ fun env e ->
+  let r e = subst_expr env e in
+  match e with
+  | Int _ | Int64 _ | Bool _ | Param_ref _ | Sizeof _ | Sizeof_this | Field_pos
+    ->
+      e
+  | Ref name -> ( try List.assoc name env with Not_found -> e)
+  | Add (a, b) -> Add (r a, r b)
+  | Sub (a, b) -> Sub (r a, r b)
+  | Mul (a, b) -> Mul (r a, r b)
+  | Div (a, b) -> Div (r a, r b)
+  | Mod (a, b) -> Mod (r a, r b)
+  | Land (a, b) -> Land (r a, r b)
+  | Lor (a, b) -> Lor (r a, r b)
+  | Lxor (a, b) -> Lxor (r a, r b)
+  | Lnot a -> Lnot (r a)
+  | Lsl (a, b) -> Lsl (r a, r b)
+  | Lsr (a, b) -> Lsr (r a, r b)
+  | Eq (a, b) -> Eq (r a, r b)
+  | Ne (a, b) -> Ne (r a, r b)
+  | Lt (a, b) -> Lt (r a, r b)
+  | Le (a, b) -> Le (r a, r b)
+  | Gt (a, b) -> Gt (r a, r b)
+  | Ge (a, b) -> Ge (r a, r b)
+  | And (a, b) -> And (r a, r b)
+  | Or (a, b) -> Or (r a, r b)
+  | Not a -> Not (r a)
+  | Cast (w, x) -> Cast (w, r x)
+  | If_then_else (c, a, b) -> If_then_else (r c, r a, r b)
+
+let pp_stmt env ppf stmt =
+  let e a = subst_expr env a in
+  match stmt with
+  | Assign (p, x) -> Fmt.pf ppf "*%s = %a;" (escape_3d p.ph_name) pp_expr (e x)
+  | Field_assign (ptr, field_name, x) ->
+      Fmt.pf ppf "%s->%s = %a;" ptr field_name pp_expr (e x)
   | Extern_call (fn, args) -> Fmt.pf ppf "%s(%s);" fn (String.concat ", " args)
-  | Return e -> Fmt.pf ppf "return %a;" pp_expr e
+  | Return x -> Fmt.pf ppf "return %a;" pp_expr (e x)
   | Abort -> Fmt.string ppf "abort;"
-  | If (cond, then_, None) ->
-      Fmt.pf ppf "if (%a) { %a }" pp_expr cond
-        Fmt.(list ~sep:sp pp_action_stmt)
-        then_
-  | If (cond, then_, Some else_) ->
-      Fmt.pf ppf "if (%a) { %a } else { %a }" pp_expr cond
-        Fmt.(list ~sep:sp pp_action_stmt)
-        then_
-        Fmt.(list ~sep:sp pp_action_stmt)
-        else_
-  | Var (name, e) -> Fmt.pf ppf "var %s = %a;" (escape_3d name) pp_expr e
+  | If _ | Var _ ->
+      (* Handled by [pp_stmts] which threads the substitution env. *)
+      assert false
+
+let rec pp_stmts env ppf = function
+  | [] -> ()
+  | Var (name, x) :: rest -> pp_stmts ((name, subst_expr env x) :: env) ppf rest
+  | If (cond, then_, else_opt) :: rest ->
+      let cond = subst_expr env cond in
+      (match else_opt with
+      | None -> Fmt.pf ppf "if (%a) { %a }" pp_expr cond (pp_stmts env) then_
+      | Some else_ ->
+          Fmt.pf ppf "if (%a) { %a } else { %a }" pp_expr cond (pp_stmts env)
+            then_ (pp_stmts env) else_);
+      if rest <> [] then Fmt.sp ppf ();
+      pp_stmts env ppf rest
+  | stmt :: rest ->
+      pp_stmt env ppf stmt;
+      if rest <> [] then Fmt.sp ppf ();
+      pp_stmts env ppf rest
 
 let pp_action ppf = function
   | On_success stmts ->
-      Fmt.pf ppf "@[<h>{:on-success %a }@]"
-        Fmt.(list ~sep:sp pp_action_stmt)
-        stmts
-  | On_act stmts ->
-      Fmt.pf ppf "@[<h>{:act %a }@]" Fmt.(list ~sep:sp pp_action_stmt) stmts
+      Fmt.pf ppf "@[<h>{:on-success %a }@]" (pp_stmts []) stmts
+  | On_act stmts -> Fmt.pf ppf "@[<h>{:act %a }@]" (pp_stmts []) stmts
 
 (* Extract field suffix for arrays - the modifier goes after the field name *)
 type field_suffix =
@@ -789,7 +856,10 @@ and optional_suffix : type a.
   | Some n ->
       let size = If_then_else (present, Int n, Int 0) in
       (Byte_array size, fun ppf -> pp_typ ppf inner)
-  | None -> (No_suffix, fun ppf -> Fmt.pf ppf "optional(%a)" pp_typ inner)
+  | None ->
+      invalid_arg
+        "Wire 3D projection: [optional]/[optional_or] requires a fixed-size \
+         inner type; the predicate compiles to a 0-or-N byte-size suffix."
 
 and field_suffix : type a. a typ -> field_suffix * (Format.formatter -> unit) =
  fun typ ->
@@ -804,7 +874,17 @@ and field_suffix : type a. a typ -> field_suffix * (Format.formatter -> unit) =
       (Byte_array size, fun ppf -> Fmt.string ppf synth)
   | Single_elem { size; elem; at_most } ->
       (Single_elem { size; at_most }, fun ppf -> pp_typ ppf elem)
-  | Array { len; elem; _ } -> (Array len, fun ppf -> pp_typ ppf elem)
+  | Array { len; elem; _ } -> (
+      (* 3D's [name[len]] suffix only accepts byte-sized elements; for wider
+         elements the size in bytes must be made explicit via [:byte-size]. *)
+      match inner_wire_size elem with
+      | Some 1 -> (Array len, fun ppf -> pp_typ ppf elem)
+      | Some n -> (Byte_array (Mul (len, Int n)), fun ppf -> pp_typ ppf elem)
+      | None ->
+          invalid_arg
+            "Wire 3D projection: array element with no fixed wire size has no \
+             3D representation; use [byte_array]/[byte_slice] for variable \
+             sizes or wrap in a [Codec] with a fixed [wire_size].")
   | Map { inner; _ } -> field_suffix inner
   | Enum { base; _ } -> field_suffix base
   | Optional { present = Bool true; inner } -> field_suffix inner
@@ -874,13 +954,91 @@ let pp_params ppf params =
   if not (List.is_empty params) then
     Fmt.pf ppf "(%a)" Fmt.(list ~sep:comma pp_param) params
 
+(* Collect every [Ref name] occurring in an expression. Used to detect
+   field references in struct-level [where] clauses, which 3D's grammar
+   does not allow (the [where] there sees only parameters). *)
+let rec collect_refs : type a. a expr -> string list = function
+  | Int _ | Int64 _ | Bool _ | Param_ref _ | Sizeof _ | Sizeof_this | Field_pos
+    ->
+      []
+  | Ref name -> [ name ]
+  | Add (a, b)
+  | Sub (a, b)
+  | Mul (a, b)
+  | Div (a, b)
+  | Mod (a, b)
+  | Land (a, b)
+  | Lor (a, b)
+  | Lxor (a, b)
+  | Lsl (a, b)
+  | Lsr (a, b) ->
+      collect_refs a @ collect_refs b
+  | Lnot a -> collect_refs a
+  | Lt (a, b) | Le (a, b) | Gt (a, b) | Ge (a, b) ->
+      collect_refs a @ collect_refs b
+  | And (a, b) | Or (a, b) -> collect_refs a @ collect_refs b
+  | Not a -> collect_refs a
+  | Cast (_, a) -> collect_refs a
+  | If_then_else (c, a, b) -> collect_refs c @ collect_refs a @ collect_refs b
+  | Eq (a, b) -> collect_refs_packed a @ collect_refs_packed b
+  | Ne (a, b) -> collect_refs_packed a @ collect_refs_packed b
+
+and collect_refs_packed : type a. a expr -> string list =
+ fun e -> collect_refs e
+
+(* If a struct-level [where] references fields (rather than only params),
+   attach it as the [constraint_] of the last referenced field instead --
+   3D's [where] clause only sees parameters. *)
+let lower_where_to_field_constraint where fields =
+  match where with
+  | None -> (None, fields)
+  | Some w ->
+      let refs = collect_refs w in
+      let field_names =
+        List.filter_map (fun (Field f) -> f.field_name) fields
+      in
+      let referenced_field_names =
+        List.filter (fun r -> List.mem r field_names) refs
+      in
+      if referenced_field_names = [] then (Some w, fields)
+      else
+        (* Attach to the last referenced field by struct position so every
+           name in the constraint is decoded by the time it runs. *)
+        let last_pos =
+          List.fold_left
+            (fun acc (Field f) ->
+              match f.field_name with
+              | Some n when List.mem n referenced_field_names -> Some n
+              | _ -> acc)
+            None fields
+        in
+        let target =
+          match last_pos with
+          | Some n -> n
+          | None -> List.hd (List.rev referenced_field_names)
+        in
+        let fields =
+          List.map
+            (fun (Field f as field) ->
+              match f.field_name with
+              | Some n when n = target ->
+                  let constraint_ =
+                    combine_constraints f.constraint_ (Some w)
+                  in
+                  Field { f with constraint_ }
+              | _ -> field)
+            fields
+        in
+        (None, fields)
+
 let pp_struct ppf (s : struct_) =
   anon_counter := 0;
   let name = escape_3d s.name in
+  let where, fields = lower_where_to_field_constraint s.where s.fields in
   Fmt.pf ppf "typedef struct _%s%a" name pp_params s.params;
-  Option.iter (Fmt.pf ppf "@,where (%a)" pp_expr) s.where;
+  Option.iter (Fmt.pf ppf "@,where (%a)" pp_expr) where;
   Fmt.pf ppf "@,{@[<v 2>";
-  List.iter (pp_field ppf) s.fields;
+  List.iter (pp_field ppf) fields;
   Fmt.pf ppf "@]@,} %s" name
 
 let pp_decl ppf = function
@@ -904,8 +1062,9 @@ let pp_decl ppf = function
         Fmt.(list ~sep:comma pp_param)
         params
   | Extern_probe { init; name } ->
-      if init then Fmt.pf ppf "extern probe (INIT) %s;@,@," name
-      else Fmt.pf ppf "extern probe %s;@,@," name
+      (* 3D's [EXTERN PROBE q? IDENT] rule has no terminator. *)
+      if init then Fmt.pf ppf "extern probe (INIT) %s@,@," name
+      else Fmt.pf ppf "extern probe %s@,@," name
   | Enum_decl { name; cases; base = Pack_typ base } ->
       Fmt.pf ppf "%a enum %s {@[<v 2>" pp_typ base name;
       List.iteri

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -101,11 +101,6 @@ let array_seq = Types.array_seq
 let rest_bytes (total : (int, _) Param.t) =
   Types.byte_array ~size:Types.(Sub (Param_ref total, Sizeof_this))
 
-let optional = Types.optional
-let optional_or = Types.optional_or
-let repeat = Types.repeat
-let repeat_seq = Types.repeat_seq
-
 let bits ?(bit_order = Types.Msb_first) ~width bf =
   let base =
     match bf with

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -348,7 +348,56 @@ module Field : sig
   (** [v name typ] creates a named field. [?self_constraint] receives the
       field's own ref and returns a constraint over it; useful for proving a
       later size-expression safe (e.g. [self >= int 7] when a later field uses
-      [byte_slice ~size:(ref len - int 7)]). *)
+      [byte_slice ~size:(ref len - int 7)]).
+
+      Use {!optional} / {!optional_or} / {!repeat} for optional and repeating
+      payloads -- they only project to 3D as the top of a struct field, never as
+      a nested type. *)
+
+  val optional :
+    string ->
+    ?constraint_:bool expr ->
+    ?self_constraint:(int expr -> bool expr) ->
+    ?action:Action.t ->
+    present:bool expr ->
+    'a typ ->
+    'a option t
+  (** [optional name ~present t] is a field present iff [present] evaluates to
+      [true]. Absent fields decode as [None] and consume zero bytes. *)
+
+  val optional_or :
+    string ->
+    ?constraint_:bool expr ->
+    ?self_constraint:(int expr -> bool expr) ->
+    ?action:Action.t ->
+    present:bool expr ->
+    default:'a ->
+    'a typ ->
+    'a t
+  (** [optional_or name ~present ~default t] is a field that decodes to the
+      inner value when [present], or [default] when absent. *)
+
+  val repeat :
+    string ->
+    ?constraint_:bool expr ->
+    ?self_constraint:(int expr -> bool expr) ->
+    ?action:Action.t ->
+    size:int expr ->
+    'a typ ->
+    'a list t
+  (** [repeat name ~size t] parses elements of type [t] until [size] bytes have
+      been consumed. *)
+
+  val repeat_seq :
+    string ->
+    ?constraint_:bool expr ->
+    ?self_constraint:(int expr -> bool expr) ->
+    ?action:Action.t ->
+    seq:('a, 'seq) Types.seq_map ->
+    size:int expr ->
+    'a typ ->
+    'seq t
+  (** Repeat with a custom sequence builder. *)
 
   val anon : 'a typ -> 'a anon
   (** [anon typ] creates an anonymous (padding) field. *)
@@ -863,22 +912,11 @@ val codec : 'r Codec.t -> 'r typ
 (** [codec c] embeds a sub-codec as a field type. The sub-codec's decode and
     encode functions are called at the appropriate offset. *)
 
-val optional : bool expr -> 'a typ -> 'a option typ
-(** [optional present t] is a field that is present when [present] evaluates to
-    [true], absent otherwise. Absent fields decode as [None] and consume zero
-    bytes. *)
-
-val optional_or : bool expr -> default:'a -> 'a typ -> 'a typ
-(** [optional_or present ~default t] is a field that decodes to the inner value
-    when [present] is true, or returns [default] when absent. No option wrapper
-    -- zero allocation for the absent case. *)
-
-val repeat : size:int expr -> 'a typ -> 'a list typ
-(** [repeat ~size t] parses elements of type [t] repeatedly until [size] bytes
-    have been consumed. *)
-
-val repeat_seq : ('a, 'seq) seq_map -> size:int expr -> 'a typ -> 'seq typ
-(** Repeat with custom builder. *)
+(** Optional and repeated payloads are field decorations only -- see
+    {!Field.optional} / {!Field.optional_or} / {!Field.repeat}. They are not
+    exposed at the typ level because there is no 3D projection for them outside
+    the top of a struct field (e.g. nested in [array] or [casetype] case
+    bodies). *)
 
 (** {1 Export}
 

--- a/test/cram/dune
+++ b/test/cram/dune
@@ -1,0 +1,4 @@
+(cram
+ (deps
+  (package wire)
+  ../fixtures/test_fixtures.ml))

--- a/test/cram/no_decoration_at_typ_level.t
+++ b/test/cram/no_decoration_at_typ_level.t
@@ -1,0 +1,80 @@
+Field decorations -- [optional], [optional_or], [repeat], [repeat_seq]
+-- are not exposed at the typ level. Anything that would project to
+invalid 3D (nested decoration in [array], [where], [casetype], ...)
+is therefore unreachable: the names simply do not exist as functions
+returning a typ.
+
+  $ cat > dune-project << 'EOF'
+  > (lang dune 3.0)
+  > EOF
+
+  $ cat > dune << 'EOF'
+  > (executable (name probe) (libraries wire))
+  > EOF
+
+[Wire.optional] does not exist:
+
+  $ cat > probe.ml << 'EOF'
+  > open Wire
+  > let _ = array ~len:(int 4) (Wire.optional Expr.true_ uint8)
+  > EOF
+  $ dune build probe.exe 2>&1
+  File "probe.ml", line 2, characters 28-41:
+  2 | let _ = array ~len:(int 4) (Wire.optional Expr.true_ uint8)
+                                  ^^^^^^^^^^^^^
+  Error: Unbound value Wire.optional
+  [1]
+
+[Wire.optional_or] does not exist:
+
+  $ cat > probe.ml << 'EOF'
+  > open Wire
+  > let _ = where Expr.true_ (Wire.optional_or Expr.true_ ~default:0 uint8)
+  > EOF
+  $ dune build probe.exe 2>&1
+  File "probe.ml", line 2, characters 26-42:
+  2 | let _ = where Expr.true_ (Wire.optional_or Expr.true_ ~default:0 uint8)
+                                ^^^^^^^^^^^^^^^^
+  Error: Unbound value Wire.optional_or
+  [1]
+
+[Wire.repeat] does not exist:
+
+  $ cat > probe.ml << 'EOF'
+  > open Wire
+  > let _ = casetype "Bad" uint8
+  >   [ case ~index:0 (Wire.repeat ~size:(int 8) uint8)
+  >       ~inject:(fun x -> x) ~project:(fun x -> Some x) ]
+  > EOF
+  $ dune build probe.exe 2>&1
+  File "probe.ml", line 3, characters 19-30:
+  3 |   [ case ~index:0 (Wire.repeat ~size:(int 8) uint8)
+                         ^^^^^^^^^^^
+  Error: Unbound value Wire.repeat
+  [1]
+
+[Wire.repeat_seq] does not exist:
+
+  $ cat > probe.ml << 'EOF'
+  > open Wire
+  > let _ = Wire.repeat_seq seq_list ~size:(int 8) uint8
+  > EOF
+  $ dune build probe.exe 2>&1
+  File "probe.ml", line 2, characters 8-23:
+  2 | let _ = Wire.repeat_seq seq_list ~size:(int 8) uint8
+              ^^^^^^^^^^^^^^^
+  Error: Unbound value Wire.repeat_seq
+  [1]
+
+The same operations are exposed at the field level and accept
+fixed-size scalars as well as sized payloads (e.g. [byte_array {size}]):
+
+  $ cat > probe.ml << 'EOF'
+  > open Wire
+  > let f_present = Field.v "present" uint8
+  > let _ =
+  >   Field.optional "Body"
+  >     ~present:Expr.(Field.ref f_present <> int 0)
+  >     (byte_array ~size:(int 8))
+  > EOF
+  $ dune build probe.exe 2>&1

--- a/test/fixtures/test_fixtures.ml
+++ b/test/fixtures/test_fixtures.ml
@@ -58,7 +58,7 @@ let opt_codec ~present =
     Codec.
       [
         (Field.v "Hdr" uint8 $ fun r -> r.opt_hdr);
-        ( Field.v "Payload" (optional (bool present) uint16be) $ fun r ->
+        ( Field.optional "Payload" ~present:(bool present) uint16be $ fun r ->
           r.opt_payload );
         (Field.v "Trail" uint8 $ fun r -> r.opt_trail);
       ]
@@ -76,8 +76,7 @@ let repeat_codec =
     Codec.
       [
         (f_cnt_length $ fun r -> r.cnt_length);
-        ( Field.v "Items"
-            (repeat ~size:(Field.ref f_cnt_length) (codec inner_codec))
+        ( Field.repeat "Items" ~size:(Field.ref f_cnt_length) (codec inner_codec)
         $ fun r -> r.cnt_items );
       ]
 

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -2486,7 +2486,7 @@ let opt_inner_codec ~present =
     Codec.
       [
         (Field.v "Hdr" uint8 $ fun r -> r.oc_hdr);
-        ( Field.v "Inner" (optional (bool present) (codec inner_codec))
+        ( Field.optional "Inner" ~present:(bool present) (codec inner_codec)
         $ fun r -> r.oc_inner );
         (Field.v "Trail" uint8 $ fun r -> r.oc_trail);
       ]
@@ -2531,10 +2531,12 @@ let multi_opt_codec ~ocf ~fecf =
     Codec.
       [
         (Field.v "Data" uint16be $ fun r -> r.mo_data);
-        ( Field.v "OCF"
-            (optional (if ocf then Expr.true_ else Expr.false_) uint32be)
+        ( Field.optional "OCF"
+            ~present:(if ocf then Expr.true_ else Expr.false_)
+            uint32be
         $ fun r -> r.mo_ocf );
-        (Field.v "FECF" (optional (bool fecf) uint16be) $ fun r -> r.mo_fecf);
+        ( Field.optional "FECF" ~present:(bool fecf) uint16be $ fun r ->
+          r.mo_fecf );
       ]
 
 let test_optional_both_present () =
@@ -2583,8 +2585,9 @@ let dyn_opt_codec =
     Codec.
       [
         (f_do_flags $ fun r -> r.do_flags);
-        ( Field.v "Payload"
-            (optional Expr.(Field.ref f_do_flags <> int 0) uint16be)
+        ( Field.optional "Payload"
+            ~present:Expr.(Field.ref f_do_flags <> int 0)
+            uint16be
         $ fun r -> r.do_payload );
         (Field.v "Trail" uint8 $ fun r -> r.do_trail);
       ]
@@ -2647,8 +2650,9 @@ let tm_opt_codec =
         (f_to_ocf_flag $ fun r -> r.to_ocf_flag);
         (Field.v "Pad" (bits ~width:7 U8) $ fun _ -> 0);
         (Field.v "Data" uint16be $ fun r -> r.to_data);
-        ( Field.v "OCF"
-            (optional Expr.(Field.ref f_to_ocf_flag <> int 0) uint32be)
+        ( Field.optional "OCF"
+            ~present:Expr.(Field.ref f_to_ocf_flag <> int 0)
+            uint32be
         $ fun r -> r.to_ocf );
         (Field.v "Trail" uint8 $ fun r -> r.to_trail);
       ]
@@ -2788,8 +2792,8 @@ let repeat_int_codec =
     Codec.
       [
         (f_ic_count $ fun r -> r.ic_count);
-        ( Field.v "Values" (repeat ~size:(Field.ref f_ic_count) uint16be)
-        $ fun r -> r.ic_values );
+        ( Field.repeat "Values" ~size:(Field.ref f_ic_count) uint16be $ fun r ->
+          r.ic_values );
       ]
 
 let test_repeat_primitive () =
@@ -2817,7 +2821,7 @@ let repeat_trailer_codec =
     Codec.
       [
         (f_rt_len $ fun r -> r.rt_len);
-        ( Field.v "Items" (repeat ~size:(Field.ref f_rt_len) (codec inner_codec))
+        ( Field.repeat "Items" ~size:(Field.ref f_rt_len) (codec inner_codec)
         $ fun r -> r.rt_items );
         (Field.v "Check" uint8 $ fun r -> r.rt_check);
       ]
@@ -2862,8 +2866,8 @@ let var_repeat_codec =
     Codec.
       [
         (f_vc_size $ fun r -> r.vc_size);
-        ( Field.v "Items"
-            (repeat ~size:(Field.ref f_vc_size) (codec var_inner_codec))
+        ( Field.repeat "Items" ~size:(Field.ref f_vc_size)
+            (codec var_inner_codec)
         $ fun r -> r.vc_items );
       ]
 
@@ -2915,13 +2919,15 @@ let tm_like_codec ~ocf ~fecf =
       [
         (Field.v "Hdr" uint16be $ fun r -> r.tm_hdr);
         (f_tm_data_len $ fun r -> r.tm_data_len);
-        ( Field.v "Packets"
-            (repeat ~size:(Field.ref f_tm_data_len) (codec packet_codec))
+        ( Field.repeat "Packets" ~size:(Field.ref f_tm_data_len)
+            (codec packet_codec)
         $ fun r -> r.tm_packets );
-        ( Field.v "OCF"
-            (optional (if ocf then Expr.true_ else Expr.false_) uint32be)
+        ( Field.optional "OCF"
+            ~present:(if ocf then Expr.true_ else Expr.false_)
+            uint32be
         $ fun r -> r.tm_ocf );
-        (Field.v "FECF" (optional (bool fecf) uint16be) $ fun r -> r.tm_fecf);
+        ( Field.optional "FECF" ~present:(bool fecf) uint16be $ fun r ->
+          r.tm_fecf );
       ]
 
 let test_tm_like_full () =
@@ -3224,9 +3230,7 @@ let test_repeat_after_var_slice () =
   let f_prefix_len = Field.v "prefix_len" uint8 in
   let f_prefix = Field.v "prefix" (byte_slice ~size:(Field.ref f_prefix_len)) in
   let f_count = Field.v "count" uint8 in
-  let f_items =
-    Field.v "items" (Wire.repeat ~size:(Field.ref f_count) Wire.uint16be)
-  in
+  let f_items = Field.repeat "items" ~size:(Field.ref f_count) Wire.uint16be in
   let codec =
     let open Codec in
     v "PrefixedItems"

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -204,7 +204,11 @@ let test_struct_of_codec_metadata () =
   let s = Everparse.struct_of_codec projection_codec in
   let m = module_ [ typedef s ] in
   let output = to_3d m in
-  Alcotest.(check bool) "contains where" true (contains ~sub:"where" output);
+  (* The struct-level [where] referencing the field [x] is lowered onto the
+     field as a [{ ... }] constraint -- 3D's [where] only sees params. *)
+  Alcotest.(check bool)
+    "contains lowered where expression" true
+    (contains ~sub:"x <= limit" output);
   Alcotest.(check bool)
     "contains on-success" true
     (contains ~sub:":on-success" output);

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -105,13 +105,14 @@ let tm_like_codec ~ocf ~fecf =
       [
         (Field.v "Hdr" uint16be $ fun r -> r.hdr);
         (f_tm_data_len $ fun r -> r.data_len);
-        ( Field.v "Packets"
-            (repeat ~size:(Field.ref f_tm_data_len) (codec packet_codec))
+        ( Field.repeat "Packets" ~size:(Field.ref f_tm_data_len)
+            (codec packet_codec)
         $ fun r -> r.packets );
-        ( Field.v "OCF"
-            (optional (if ocf then Expr.true_ else Expr.false_) uint32be)
+        ( Field.optional "OCF"
+            ~present:(if ocf then Expr.true_ else Expr.false_)
+            uint32be
         $ fun r -> r.ocf );
-        (Field.v "FECF" (optional (bool fecf) uint16be) $ fun r -> r.fecf);
+        (Field.optional "FECF" ~present:(bool fecf) uint16be $ fun r -> r.fecf);
       ]
 
 (* -- 3D extraction tests -- *)

--- a/test/test_param.ml
+++ b/test/test_param.ml
@@ -273,9 +273,11 @@ let test_3d_rendering () =
   Alcotest.(check bool)
     "contains mutable UINT32BE *out" true
     (Re.execp (Re.compile (Re.str "mutable")) output);
+  (* The struct-level [where] referencing fields is lowered to a field-level
+     [{ ... }] constraint -- 3D's struct [where] only sees parameters. *)
   Alcotest.(check bool)
-    "contains where" true
-    (Re.execp (Re.compile (Re.str "where")) output);
+    "contains lowered where expression" true
+    (Re.execp (Re.compile (Re.str "x <= limit")) output);
   Alcotest.(check bool)
     "contains on-success" true
     (Re.execp (Re.compile (Re.str ":on-success")) output);

--- a/test/test_wire.ml
+++ b/test/test_wire.ml
@@ -140,10 +140,8 @@ let test_finite_rejects_inf () =
   | _ -> Alcotest.fail "is_finite should have rejected +inf"
 
 let test_rest_of_buffer_codec () =
-  (* "Header then rest-of-buffer payload" idiom: the trailing payload's
-     size is [total - sizeof_this], where [total] is a length param
-     bound to [Bytes.length buf]. Works in OCaml and projects to 3D as
-     [UINT8[:byte-size (total - sizeof(this))]]. *)
+  (* "Header then rest-of-buffer payload" idiom -- both formulations
+     should work in a Codec field and round-trip OCaml decode/encode. *)
   let total = Param.input "total" uint32be in
   let f_h = Field.v "Header" uint8 in
   let f_d = Field.v "Data" (rest_bytes total) in
@@ -157,6 +155,41 @@ let test_rest_of_buffer_codec () =
       Alcotest.(check int) "header" 1 h;
       Alcotest.(check string) "data" "HELLO" d
   | Error e -> Alcotest.failf "%a" pp_parse_error e
+
+let test_all_bytes_in_codec () =
+  (* [field "Rest" all_bytes] inside a Codec must just work -- the
+     buffer length implicitly bounds the field. No length param needed. *)
+  let f_h = Field.v "Header" uint8 in
+  let f_d = Field.v "Data" all_bytes in
+  let codec =
+    Codec.v "Trailing" (fun h d -> (h, d)) Codec.[ f_h $ fst; f_d $ snd ]
+  in
+  let buf = Bytes.of_string "\x2AHello" in
+  match Codec.decode codec buf 0 with
+  | Ok (h, d) ->
+      Alcotest.(check int) "header" 0x2A h;
+      Alcotest.(check string) "data" "Hello" d
+  | Error e -> Alcotest.failf "%a" pp_parse_error e
+
+let test_all_zeros_in_codec () =
+  let f_h = Field.v "Tag" uint8 in
+  let f_p = Field.v "Pad" all_zeros in
+  let codec =
+    Codec.v "Padded" (fun h p -> (h, p)) Codec.[ f_h $ fst; f_p $ snd ]
+  in
+  let ok_buf = Bytes.of_string "\x55\x00\x00\x00" in
+  (match Codec.decode codec ok_buf 0 with
+  | Ok (h, p) ->
+      Alcotest.(check int) "tag" 0x55 h;
+      Alcotest.(check string) "padding" "\000\000\000" p
+  | Error e -> Alcotest.failf "%a" pp_parse_error e);
+  let bad_buf = Bytes.of_string "\x55\x00\x01\x00" in
+  match
+    try Ok (Codec.decode codec bad_buf 0)
+    with Invalid_argument _ -> Error `Bad
+  with
+  | Ok (Ok _) -> Alcotest.fail "all_zeros must reject non-zero pad byte"
+  | _ -> ()
 
 let printable_byte b = Expr.(b >= int 0x20 && b <= int 0x7e)
 
@@ -726,6 +759,10 @@ let suite =
       Alcotest.test_case "is_finite: rejects inf" `Quick test_finite_rejects_inf;
       Alcotest.test_case "codec: rest-of-buffer payload" `Quick
         test_rest_of_buffer_codec;
+      Alcotest.test_case "codec: all_bytes as field" `Quick
+        test_all_bytes_in_codec;
+      Alcotest.test_case "codec: all_zeros as field" `Quick
+        test_all_zeros_in_codec;
       Alcotest.test_case "parse: byte_array_where accepts" `Quick
         test_bawhere_accepts;
       Alcotest.test_case "parse: byte_array_where rejects" `Quick


### PR DESCRIPTION
Add [examples/validate_3d.ml](examples/validate_3d.ml), an Alcotest harness that emits and runs `3d.exe` on every demo / space / net schema, and fix the projection bugs it surfaces (multi-byte array element width, `extern probe` terminator, F* keyword escaping for params and fields, `Action.var` lowering by inlining at use sites, struct-level `where` clauses lowering onto the latest referenced field).

Tighten the API so the bad nested-decoration constructions can't be expressed: `Wire.optional` / `Wire.optional_or` / `Wire.repeat` / `Wire.repeat_seq` move off the typ-level surface and become field-level combinators (`Field.optional` / etc.) returning `_ Field.t`. Anything that would have projected to invalid 3D (`array (optional ...)`, `casetype` case = `optional`, `where` over a decoration, ...) is now an `Unbound value` at compile time. Locked in by [test/cram/no_decoration_at_typ_level.t](test/cram/no_decoration_at_typ_level.t) and six new fuzz cases in [fuzz_everparse.ml](fuzz/fuzz_everparse.ml) covering `Field.optional` / `Field.repeat` over random sizes, where-lowering, F* keywords, and `Action.var` over random expression shapes.

Breaking; for 0.10.