### PR TITLE
codec: casetype and nested as Codec fields

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,10 @@
 
 ### Added
 
+- Support `Wire.casetype` and `Wire.nested ~size` as `Codec` fields
+  (#47, @samoht)
 - Add `Field.optional` / `Field.optional_or` / `Field.repeat` /
-  `Field.repeat_seq` (@samoht)
+  `Field.repeat_seq` (#46, @samoht)
 - Add `Wire.rest_bytes` for trailing "rest of buffer" fields, plus
   direct `all_bytes` / `all_zeros` support as `Codec` fields
   (#44, @samoht)
@@ -17,13 +19,13 @@
   / `struct_min_size` (#37, @samoht)
 - Add `Codec.slice_offset` / `Codec.slice_length` (#37, @samoht)
 - Add `Wire.codec` type alias for `'r Codec.t` and `Wire.pp_value`
-  (@samoht)
+  (#39, @samoht)
 
 ### Changed
 
 - Remove `Wire.optional` / `Wire.optional_or` / `Wire.repeat` /
   `Wire.repeat_seq` from the typ-level surface; use the matching
-  `Field.*` combinators instead (@samoht)
+  `Field.*` combinators instead (#46, @samoht)
 - Rename `Wire.decode_*` / `Wire.encode_*` to `of_string` / `of_bytes` /
   `of_reader` / `to_string` / `to_bytes` / `to_writer`; add `_exn` twins
   that raise on parse error (#39, @samoht)
@@ -33,7 +35,8 @@
 
 ### Documentation
 
-- Type-check `README.md` and every public `.mli` under `mdx` (@samoht)
+- Type-check `README.md` and every public `.mli` under `mdx`
+  (#39, @samoht)
 
 ### Fixed
 

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -925,6 +925,24 @@ let rec read_elem : type a. a typ -> bytes -> int -> a =
   | Map { inner; decode; _ } -> decode (read_elem inner buf off)
   | Where { inner; _ } -> read_elem inner buf off
   | Enum { base; _ } -> read_elem base buf off
+  | Casetype { tag; cases; _ } ->
+      let tag_size =
+        match field_wire_size tag with
+        | Some n -> n
+        | None -> assert false (* casetype tag is always fixed-size int *)
+      in
+      let tag_val = read_elem tag buf off in
+      let body_off = off + tag_size in
+      let rec find = function
+        | [] -> raise (Parse_error (Invalid_tag tag_val))
+        | Case_branch { cb_tag = Some t; cb_inner; cb_inject; _ } :: _
+          when t = tag_val ->
+            cb_inject (read_elem cb_inner buf body_off)
+        | Case_branch { cb_tag = None; cb_inner; cb_inject; _ } :: _ ->
+            cb_inject (read_elem cb_inner buf body_off)
+        | _ :: rest -> find rest
+      in
+      find cases
   | _ -> failwith "read_elem: unsupported element type in repeat"
 
 (* Write one element of a typ at a given buffer position. Used by Repeat. *)
@@ -960,10 +978,27 @@ let rec write_elem : type a. a typ -> bytes -> int -> a -> unit =
 
 (* Compute the wire size of one element at a buffer position. Used by Repeat
    for variable-size elements. *)
-let elem_size_of : type a. a typ -> bytes -> int -> int =
+let rec elem_size_of : type a. a typ -> bytes -> int -> int =
  fun typ buf off ->
   match typ with
   | Codec { codec_size_of; _ } -> codec_size_of buf off
+  | Casetype { tag; cases; _ } ->
+      let tag_size =
+        match field_wire_size tag with Some n -> n | None -> assert false
+      in
+      let tag_val = read_elem tag buf off in
+      let body_off = off + tag_size in
+      let rec find = function
+        | [] -> raise (Parse_error (Invalid_tag tag_val))
+        | Case_branch { cb_tag = Some t; cb_inner; _ } :: _ when t = tag_val ->
+            tag_size + elem_size_of cb_inner buf body_off
+        | Case_branch { cb_tag = None; cb_inner; _ } :: _ ->
+            tag_size + elem_size_of cb_inner buf body_off
+        | _ :: rest -> find rest
+      in
+      find cases
+  | Map { inner; _ } -> elem_size_of inner buf off
+  | Where { inner; _ } -> elem_size_of inner buf off
   | _ -> (
       match field_wire_size typ with
       | Some n -> n
@@ -1586,6 +1621,8 @@ and var_bytes_reader : type a.
             invalid_arg "add_field: [all_zeros] field has a non-zero byte")
         s;
       s
+  | Casetype _ -> read_elem typ buf (base + fo)
+  | Single_elem { elem; _ } -> read_elem elem buf (base + fo)
   | _ -> assert false
 
 and var_bytes_writer : type a r.
@@ -1610,6 +1647,9 @@ and var_bytes_writer : type a r.
   | All_zeros ->
       let s = (value : string) in
       Bytes.blit_string s 0 buf (off + fo) (String.length s)
+  | Casetype _ -> ignore (build_field_encoder typ buf (off + fo) value)
+  | Single_elem { elem; _ } ->
+      ignore (build_field_encoder elem buf (off + fo) value)
   | _ -> assert false
 
 and compile_var_size_fn : type a.
@@ -1622,6 +1662,10 @@ and compile_var_size_fn : type a.
          [Bytes.length buf]; the 3D projection emits [all_bytes], which
          3D handles natively. *)
       fun buf base -> Bytes.length buf - (base + off_fn buf base)
+  | Casetype _ ->
+      (* Tag is decoded first; the case body's size is whatever the
+         selected case's inner typ reports. *)
+      fun buf base -> elem_size_of typ buf (base + off_fn buf base)
   | _ ->
       let size_expr =
         match typ with
@@ -1629,6 +1673,7 @@ and compile_var_size_fn : type a.
         | Byte_array { size } -> size
         | Byte_array_where { size; _ } -> size
         | Uint_var { size; _ } -> size
+        | Single_elem { size; _ } -> size
         | _ -> invalid_arg "add_field: unsupported variable-size field type"
       in
       let sizeof_this : bytes -> int -> int =

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -2891,6 +2891,101 @@ let test_repeat_variable_size_elements () =
   Alcotest.(check int) "item1.len" 3 i1.vi_len;
   Alcotest.(check string) "item1.data" "cde" i1.vi_data
 
+(* -- Casetype as a trailing variable-size codec field -- *)
+
+type ev_payload = [ `Login of int | `Logout of int | `Other of int ]
+
+let casetype_field_event_typ : ev_payload Wire.typ =
+  Wire.casetype "EvPayload" Wire.uint8
+    [
+      Wire.case ~index:1 Wire.uint16be
+        ~inject:(fun v -> `Login v)
+        ~project:(function `Login v -> Some v | _ -> None);
+      Wire.case ~index:2 Wire.uint32be
+        ~inject:(fun v -> `Logout v)
+        ~project:(function `Logout v -> Some v | _ -> None);
+      Wire.default Wire.uint8
+        ~inject:(fun v -> `Other v)
+        ~project:(function `Other v -> Some v | _ -> None);
+    ]
+
+type ev_event = { ev_ts : int64; ev_data : ev_payload }
+
+let casetype_field_codec =
+  Codec.v "CasetypeFieldEvt"
+    (fun ts data -> { ev_ts = ts; ev_data = data })
+    Codec.
+      [
+        (Field.v "Timestamp" int64be $ fun e -> e.ev_ts);
+        (Field.v "Data" casetype_field_event_typ $ fun e -> e.ev_data);
+      ]
+
+let test_casetype_field_login () =
+  let buf = Bytes.create 11 in
+  Bytes.set_int64_be buf 0 42L;
+  Bytes.set_uint8 buf 8 1;
+  Bytes.set_uint16_be buf 9 0x1234;
+  let r = decode_ok (Codec.decode casetype_field_codec buf 0) in
+  Alcotest.(check int64) "ts" 42L r.ev_ts;
+  Alcotest.(check bool) "Login 0x1234" true (r.ev_data = `Login 0x1234)
+
+let test_casetype_field_logout () =
+  let buf = Bytes.create 13 in
+  Bytes.set_int64_be buf 0 99L;
+  Bytes.set_uint8 buf 8 2;
+  Bytes.set_int32_be buf 9 0x55667788l;
+  let r = decode_ok (Codec.decode casetype_field_codec buf 0) in
+  Alcotest.(check bool) "Logout" true (r.ev_data = `Logout 0x55667788)
+
+let test_casetype_field_default () =
+  let buf = Bytes.create 10 in
+  Bytes.set_int64_be buf 0 0L;
+  Bytes.set_uint8 buf 8 99;
+  Bytes.set_uint8 buf 9 7;
+  let r = decode_ok (Codec.decode casetype_field_codec buf 0) in
+  Alcotest.(check bool) "Other 7" true (r.ev_data = `Other 7)
+
+let test_casetype_field_roundtrip () =
+  let buf = Bytes.create 11 in
+  let original = { ev_ts = 123L; ev_data = `Login 0xabcd } in
+  Codec.encode casetype_field_codec original buf 0;
+  let decoded = decode_ok (Codec.decode casetype_field_codec buf 0) in
+  Alcotest.(check int64) "ts roundtrip" original.ev_ts decoded.ev_ts;
+  Alcotest.(check bool)
+    "data roundtrip" true
+    (original.ev_data = decoded.ev_data)
+
+(* Length-prefixed casetype dispatch: [tag][length][body] where length
+   bounds the inner casetype's tag + body. *)
+
+type lp_event = { lp_tag : int; lp_len : int; lp_data : ev_payload }
+
+let lp_event_len = Field.v "Length" uint16be
+
+let lp_event_codec =
+  Codec.v "LpEvent"
+    (fun tag len data -> { lp_tag = tag; lp_len = len; lp_data = data })
+    Codec.
+      [
+        (Field.v "Tag" uint8 $ fun e -> e.lp_tag);
+        (lp_event_len $ fun e -> e.lp_len);
+        ( Field.v "Data"
+            (Wire.nested ~size:(Field.ref lp_event_len) casetype_field_event_typ)
+        $ fun e -> e.lp_data );
+      ]
+
+let test_length_prefixed_casetype () =
+  (* tag=0xAA, len=3 (1 byte casetype tag + 2 bytes uint16be), inner tag=1, body=0x4242 *)
+  let buf = Bytes.create 6 in
+  Bytes.set_uint8 buf 0 0xAA;
+  Bytes.set_uint16_be buf 1 3;
+  Bytes.set_uint8 buf 3 1;
+  Bytes.set_uint16_be buf 4 0x4242;
+  let r = decode_ok (Codec.decode lp_event_codec buf 0) in
+  Alcotest.(check int) "tag" 0xAA r.lp_tag;
+  Alcotest.(check int) "len" 3 r.lp_len;
+  Alcotest.(check bool) "data" true (r.lp_data = `Login 0x4242)
+
 (* -- Nested: Composition: optional + repeat + codec --
    TM-frame-like structure: header + data zone (repeat of packets) + optional
    OCF + optional FECF. [packet] / [packet_codec] live in {!Test_fixtures}. *)
@@ -3703,6 +3798,16 @@ let suite =
       Alcotest.test_case "repeat: encode" `Quick test_repeat_encode;
       Alcotest.test_case "repeat: roundtrip" `Quick test_repeat_roundtrip;
       Alcotest.test_case "repeat: primitive" `Quick test_repeat_primitive;
+      Alcotest.test_case "casetype field: login" `Quick
+        test_casetype_field_login;
+      Alcotest.test_case "casetype field: logout" `Quick
+        test_casetype_field_logout;
+      Alcotest.test_case "casetype field: default" `Quick
+        test_casetype_field_default;
+      Alcotest.test_case "casetype field: roundtrip" `Quick
+        test_casetype_field_roundtrip;
+      Alcotest.test_case "casetype field: length-prefixed" `Quick
+        test_length_prefixed_casetype;
       Alcotest.test_case "repeat: with trailer" `Quick test_repeat_with_trailer;
       Alcotest.test_case "repeat: variable size elements" `Quick
         test_repeat_variable_size_elements;


### PR DESCRIPTION
`Wire.casetype` and `Wire.nested ~size` could be parsed at the top level but not as fields of a `Wire.Codec.t` -- [`compile_var_bytes`](lib/codec.ml#L1641) only handled byte arrays, slices, and the rest-of-buffer helpers. Extend it to read the tag, dispatch on the case, and decode the case body, plus the single-element variant that wraps an arbitrary inner type bounded by a size expression. The 3D projection already had this shape, only the OCaml side was missing.

[`read_elem`](lib/codec.ml#L900) and [`elem_size_of`](lib/codec.ml#L979) pick up `casetype` too, so a `Wire.repeat` over a casetype element works as well. Length-prefixed dispatch -- `nested ~size:(Field.ref f_len) (casetype ...)` -- is now expressible as a single field.