### PR TITLE
codec: fix silent miscompile of optional predicates and refs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,7 +39,8 @@
 
 - Fix silent always-true compilation of `Field.optional` /
   `Field.optional_or` predicates that use bitwise / shift / mod
-  operators (#48, @samoht)
+  operators, and fix `Field.ref` on an `optional` field reading 0
+  instead of the decoded inner value (#48, @samoht)
 - Allow variable-size sub-codecs and `Field.repeat` after a
   variable-size field (#38, @samoht)
 - Fix C stub generator for schema names with 2+ leading capitals

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,9 @@
 
 ### Fixed
 
+- Fix silent always-true compilation of `Field.optional` /
+  `Field.optional_or` predicates that use bitwise / shift / mod
+  operators (#48, @samoht)
 - Allow variable-size sub-codecs and `Field.repeat` after a
   variable-size field (#38, @samoht)
 - Fix C stub generator for schema names with 2+ leading capitals

--- a/fuzz/fuzz_param.ml
+++ b/fuzz/fuzz_param.ml
@@ -242,6 +242,52 @@ let test_optional_predicate_operator op_idx k flags =
              k flags expected_present actual_present)
   | Error e -> fail (Fmt.str "decode error: %a" Wire.pp_parse_error e)
 
+(* Property: [Field.ref f] reads the same int the codec decoded for
+   [f], for every typ shape that can host a ref. *)
+let test_field_ref_matches_decode typ_idx v =
+  let v = abs v mod 256 in
+  let buf = Bytes.create 2 in
+  Bytes.set_uint8 buf 0 v;
+  Bytes.set_uint8 buf 1 v;
+  let check_int_pair name (f : int Wire.Field.t) =
+    let constraint_ =
+      Wire.Expr.(
+        Wire.Field.ref f = Wire.Field.ref (Wire.Field.v "Guard" Wire.uint8))
+    in
+    let f_g = Wire.Field.v "Guard" Wire.uint8 ~constraint_ in
+    let c =
+      Wire.Codec.v ("R_" ^ name)
+        (fun x g -> (x, g))
+        Wire.Codec.[ f $ fst; f_g $ snd ]
+    in
+    match Wire.Codec.decode c buf 0 with
+    | Ok _ -> ()
+    | Error _ -> fail (Fmt.str "%s: decoded != ref for v=0x%02x" name v)
+  in
+  match abs typ_idx mod 4 with
+  | 0 -> check_int_pair "u8" (Wire.Field.v "F" Wire.uint8)
+  | 1 ->
+      let m = Wire.map ~decode:(fun x -> x) ~encode:(fun x -> x) Wire.uint8 in
+      check_int_pair "map" (Wire.Field.v "F" m)
+  | 2 ->
+      let bit = Wire.bits ~width:8 Wire.U8 in
+      check_int_pair "bits" (Wire.Field.v "F" bit)
+  | _ -> (
+      let opt = Wire.Field.optional "F" ~present:Wire.Expr.true_ Wire.uint8 in
+      let constraint_ =
+        Wire.Expr.(
+          Wire.Field.ref opt = Wire.Field.ref (Wire.Field.v "Guard" Wire.uint8))
+      in
+      let f_g = Wire.Field.v "Guard" Wire.uint8 ~constraint_ in
+      let c =
+        Wire.Codec.v "R_opt"
+          (fun x g -> (x, g))
+          Wire.Codec.[ opt $ fst; f_g $ snd ]
+      in
+      match Wire.Codec.decode c buf 0 with
+      | Ok _ -> ()
+      | Error _ -> fail (Fmt.str "opt: decoded != ref for v=0x%02x" v))
+
 (** {1 Test Registration} *)
 
 let parse_tests =
@@ -265,6 +311,8 @@ let predicate_tests =
   [
     test_case "optional predicate matches OCaml eval" [ int; int; int ]
       test_optional_predicate_operator;
+    test_case "Field.ref matches decoded value" [ int; int ]
+      test_field_ref_matches_decode;
   ]
 
 let suite = ("param", parse_tests @ param_ref_tests @ predicate_tests)

--- a/fuzz/fuzz_param.ml
+++ b/fuzz/fuzz_param.ml
@@ -172,6 +172,76 @@ let test_typed_assign buf =
   let _ = Wire.Param.get env out in
   ()
 
+(* Property: an [optional] predicate built from any [int expr] operator
+   must agree with the same operator evaluated in plain OCaml. Catches
+   the silent-true fallback that [compile_bool_expr] used for operators
+   missing from its dispatch (Land, Lor, Lxor, Lsr, Lsl, Mod, Cast,
+   If_then_else). *)
+
+type opt_rec = { ovr_flags : int; ovr_body : int option }
+
+let f_ovr_flags = Wire.Field.v "Flags" Wire.uint8
+
+let build_predicate ~op_idx ~k =
+  let module E = Wire.Expr in
+  let lhs = E.( land ) (Wire.Field.ref f_ovr_flags) (Wire.int 0xFF) in
+  let r =
+    match abs op_idx mod 7 with
+    | 0 -> E.( land ) lhs (Wire.int k)
+    | 1 -> E.( lor ) lhs (Wire.int k)
+    | 2 -> E.( lxor ) lhs (Wire.int k)
+    | 3 -> E.( lsr ) lhs (Wire.int (abs k mod 8))
+    | 4 -> E.( lsl ) lhs (Wire.int (abs k mod 8))
+    | 5 -> E.( mod ) lhs (Wire.int ((abs k mod 7) + 1))
+    | _ -> E.( + ) lhs (Wire.int k)
+  in
+  E.( <> ) r (Wire.int 0)
+
+let eval_predicate ~op_idx ~k ~flags =
+  let l = flags land 0xFF in
+  match abs op_idx mod 7 with
+  | 0 -> l land k <> 0
+  | 1 -> l lor k <> 0
+  | 2 -> l lxor k <> 0
+  | 3 -> l lsr (abs k mod 8) <> 0
+  | 4 -> l lsl (abs k mod 8) <> 0
+  | 5 -> l mod ((abs k mod 7) + 1) <> 0
+  | _ -> l + k <> 0
+
+let test_optional_predicate_operator op_idx k flags =
+  let flags = abs flags mod 256 in
+  let present = build_predicate ~op_idx ~k in
+  let c =
+    Wire.Codec.v "OptVar"
+      (fun flags body -> { ovr_flags = flags; ovr_body = body })
+      Wire.Codec.
+        [
+          (f_ovr_flags $ fun r -> r.ovr_flags);
+          (Wire.Field.optional "Body" ~present Wire.uint8 $ fun r -> r.ovr_body);
+        ]
+  in
+  let expected_present = eval_predicate ~op_idx ~k ~flags in
+  let buf =
+    if expected_present then (
+      let b = Bytes.create 2 in
+      Bytes.set_uint8 b 0 flags;
+      Bytes.set_uint8 b 1 0x42;
+      b)
+    else
+      let b = Bytes.create 1 in
+      Bytes.set_uint8 b 0 flags;
+      b
+  in
+  match Wire.Codec.decode c buf 0 with
+  | Ok r ->
+      let actual_present = r.ovr_body <> None in
+      if actual_present <> expected_present then
+        fail
+          (Fmt.str "op=%d k=%d flags=0x%02x: expected present=%b got present=%b"
+             (abs op_idx mod 7)
+             k flags expected_present actual_present)
+  | Error e -> fail (Fmt.str "decode error: %a" Wire.pp_parse_error e)
+
 (** {1 Test Registration} *)
 
 let parse_tests =
@@ -191,4 +261,10 @@ let param_ref_tests =
     test_case "typed assign" [ bytes ] test_typed_assign;
   ]
 
-let suite = ("param", parse_tests @ param_ref_tests)
+let predicate_tests =
+  [
+    test_case "optional predicate matches OCaml eval" [ int; int; int ]
+      test_optional_predicate_operator;
+  ]
+
+let suite = ("param", parse_tests @ param_ref_tests @ predicate_tests)

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -218,11 +218,28 @@ let rec build_populate : type a.
   | Where { inner; _ } -> build_populate inner idx reader
   | Enum { base; _ } -> build_populate base idx reader
   | Map { inner; encode; _ } ->
+      build_populate inner idx (fun buf base -> encode (reader buf base))
+  | Optional_or { inner; _ } ->
+      (* [Optional_or] returns the inner type directly (no [option] wrapper),
+         so the reader is already of the inner's value type. *)
+      build_populate inner idx reader
+  | Optional { inner; _ } -> (
+      (* The optional decodes as ['inner option]; populate from the inner
+         value when present, leave the slot at 0 when absent. *)
       let inner_populate =
-        build_populate inner idx (fun buf base -> encode (reader buf base))
+        build_populate inner idx (fun buf base ->
+            match reader buf base with Some v -> v | None -> assert false)
       in
-      inner_populate
-  | _ -> fun _arr _buf _base -> ()
+      fun arr buf base ->
+        match reader buf base with
+        | Some _ -> inner_populate arr buf base
+        | None -> ())
+  | _ ->
+      (* Aggregate / string-valued types have no scalar int projection.
+         [Field.ref] over them reads 0; treat as deliberate (no slot
+         write) rather than an error since [ref] currently accepts any
+         field type. *)
+      fun _arr _buf _base -> ()
 
 (* Bitfield extraction descriptor: word reader + packed shift/mask.
    Packing shift and mask into a single int lets [extract] be a direct
@@ -1449,9 +1466,11 @@ and compile_optional : type a r.
     (a option, r) compiled_field =
  fun ctx fld present inner ->
   let inner_size = field_wire_size inner in
+  let nfields = ctx.lc_n_fields in
   match (present, inner_size) with
   | Bool true, Some fsize ->
       let inner_reader, inner_writer = inner_codec_accessors inner ctx in
+      let inner_populate = build_populate inner nfields inner_reader in
       let get = fld.get in
       optional_compiled ctx
         ~raw_reader:(fun buf base -> Some (inner_reader buf base))
@@ -1459,7 +1478,7 @@ and compile_optional : type a r.
           match get v with Some iv -> inner_writer buf off iv | None -> ())
         ~size_delta:fsize
         ~next_off:(advance_next_off ctx.lc_next_off fsize)
-        ~populate:no_populate
+        ~populate:inner_populate
   | Bool false, _ ->
       optional_compiled ctx
         ~raw_reader:(fun _buf _base -> None)
@@ -1468,6 +1487,7 @@ and compile_optional : type a r.
   | _, Some fsize ->
       let present_fn = compile_bool_expr ctx.lc_field_readers present in
       let inner_reader, inner_writer = inner_codec_accessors inner ctx in
+      let inner_populate = build_populate inner nfields inner_reader in
       let get = fld.get in
       optional_compiled ctx
         ~raw_reader:(fun buf base ->
@@ -1476,7 +1496,8 @@ and compile_optional : type a r.
           match get v with Some iv -> inner_writer buf off iv | None -> ())
         ~size_delta:0
         ~next_off:(dynamic_optional_next_off ctx present_fn fsize)
-        ~populate:no_populate
+        ~populate:(fun arr buf base ->
+          if present_fn buf base then inner_populate arr buf base)
   | _ ->
       invalid_arg
         "add_field: dynamic optional with variable-size inner not yet supported"

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -322,84 +322,83 @@ type next_off = Static of int | Dynamic of (bytes -> int -> int)
 type field_reader = string * (bytes -> int -> int)
 (* Name + buffer-and-base reader for a previously-declared int field. *)
 
-(* Compile an [int expr] into a closure that evaluates it at runtime by
-   reading previously-declared fields from the buffer. Built once at [add_field]
-   time, called at every [get]/[set]/[decode]. [?sizeof_this] is the byte
-   offset of the field currently being compiled, expressed as a function of
-   the buffer; defaults to [0] when [Sizeof_this] cannot meaningfully resolve
-   (e.g. inside a top-level wire description). *)
-let rec compile_expr ?(sizeof_this : bytes -> int -> int = fun _ _ -> 0)
-    (env : field_reader list) (e : int expr) : bytes -> int -> int =
-  let rec_ e = compile_expr ~sizeof_this env e in
+(* Single GADT walker for [a expr] used by both call surfaces (closure
+   over bytes for variable-size sizing; int_array lookup for constraint
+   evaluation). The two surfaces share every operator dispatch and only
+   differ in how leaves ([Ref], [Param_ref], [Sizeof], [Sizeof_this],
+   [Field_pos]) resolve. *)
+
+type packed_param = Pack_param : ('a, 'k) param_handle -> packed_param
+
+(* Leaves resolution strategy for a given access layer. *)
+type 'ctx leaves = {
+  ref_ : string -> 'ctx -> int;
+  param_ref : packed_param -> 'ctx -> int;
+  sizeof_typ : packed_typ -> 'ctx -> int;
+  sizeof_this : 'ctx -> int;
+  field_pos : 'ctx -> int;
+}
+
+let rec compile_int : type ctx. ctx leaves -> int expr -> ctx -> int =
+ fun l e ->
+  let rec_ = compile_int l in
   match e with
-  | Int n -> fun _buf _base -> n
-  | Ref name -> (
-      match List.assoc_opt name env with
-      | Some reader -> reader
-      | None ->
-          Fmt.invalid_arg "Codec: unbound field ref %S in size expression" name)
+  | Int n -> fun _ -> n
+  | Ref name -> l.ref_ name
+  | Param_ref p -> l.param_ref (Pack_param p)
+  | Sizeof t -> l.sizeof_typ (Pack_typ t)
+  | Sizeof_this -> l.sizeof_this
+  | Field_pos -> l.field_pos
   | Add (a, b) ->
       let fa = rec_ a and fb = rec_ b in
-      fun buf base -> fa buf base + fb buf base
+      fun c -> fa c + fb c
   | Sub (a, b) ->
       let fa = rec_ a and fb = rec_ b in
-      fun buf base -> fa buf base - fb buf base
+      fun c -> fa c - fb c
   | Mul (a, b) ->
       let fa = rec_ a and fb = rec_ b in
-      fun buf base -> fa buf base * fb buf base
+      fun c -> fa c * fb c
   | Div (a, b) ->
       let fa = rec_ a and fb = rec_ b in
-      fun buf base -> fa buf base / fb buf base
+      fun c -> fa c / fb c
   | Mod (a, b) ->
       let fa = rec_ a and fb = rec_ b in
-      fun buf base -> fa buf base mod fb buf base
+      fun c -> fa c mod fb c
   | Land (a, b) ->
       let fa = rec_ a and fb = rec_ b in
-      fun buf base -> fa buf base land fb buf base
+      fun c -> fa c land fb c
   | Lor (a, b) ->
       let fa = rec_ a and fb = rec_ b in
-      fun buf base -> fa buf base lor fb buf base
+      fun c -> fa c lor fb c
   | Lxor (a, b) ->
       let fa = rec_ a and fb = rec_ b in
-      fun buf base -> fa buf base lxor fb buf base
+      fun c -> fa c lxor fb c
   | Lnot a ->
       let fa = rec_ a in
-      fun buf base -> lnot (fa buf base)
+      fun c -> lnot (fa c)
   | Lsl (a, b) ->
       let fa = rec_ a and fb = rec_ b in
-      fun buf base -> fa buf base lsl fb buf base
+      fun c -> fa c lsl fb c
   | Lsr (a, b) ->
       let fa = rec_ a and fb = rec_ b in
-      fun buf base -> fa buf base lsr fb buf base
+      fun c -> fa c lsr fb c
   | Cast (w, a) -> (
       let fa = rec_ a in
       match w with
-      | `U8 -> fun buf base -> fa buf base land 0xFF
-      | `U16 -> fun buf base -> fa buf base land 0xFFFF
-      | `U32 -> fun buf base -> fa buf base land 0xFFFF_FFFF
+      | `U8 -> fun c -> fa c land 0xFF
+      | `U16 -> fun c -> fa c land 0xFFFF
+      | `U32 -> fun c -> fa c land 0xFFFF_FFFF
       | `U64 -> fa)
   | If_then_else (c, t, e) ->
-      let fc = compile_bool_expr ~sizeof_this env c in
+      let fc = compile_bool l c in
       let ft = rec_ t and fe = rec_ e in
-      fun buf base -> if fc buf base then ft buf base else fe buf base
-  | Param_ref p -> fun _buf _base -> !(p.ph_cell)
-  | Sizeof t -> (
-      match field_wire_size t with
-      | Some n -> fun _buf _base -> n
-      | None -> invalid_arg "Codec: sizeof on variable-size type")
-  | Sizeof_this -> sizeof_this
-  | Field_pos -> invalid_arg "Codec: [field_pos] only valid inside an action"
+      fun c' -> if fc c' then ft c' else fe c'
 
-(* Try compiling [a expr] as an [int expr] reader. Pattern matches each
-   int constructor so the GADT refines the type to [int expr] in each
-   arm. Used by [compile_bool_expr] to dispatch typed equality. *)
-and try_compile_int_reader : type a.
-    sizeof_this:(bytes -> int -> int) ->
-    field_reader list ->
-    a expr ->
-    (bytes -> int -> int) option =
- fun ~sizeof_this env e ->
-  let go e = Some (compile_expr ~sizeof_this env e) in
+(* Typed-GADT projector: refines [a expr] to [int expr] / [bool expr]
+   so [Eq] / [Ne] can dispatch to the right compiler at the right type. *)
+and try_int : type a ctx. ctx leaves -> a expr -> (ctx -> int) option =
+ fun l e ->
+  let go e = Some (compile_int l e) in
   match e with
   | Int _ as e -> go e
   | Ref _ as e -> go e
@@ -422,13 +421,9 @@ and try_compile_int_reader : type a.
   | If_then_else _ as e -> go e
   | _ -> None
 
-and try_compile_bool_reader : type a.
-    sizeof_this:(bytes -> int -> int) ->
-    field_reader list ->
-    a expr ->
-    (bytes -> int -> bool) option =
- fun ~sizeof_this env e ->
-  let go e = Some (compile_bool_expr ~sizeof_this env e) in
+and try_bool : type a ctx. ctx leaves -> a expr -> (ctx -> bool) option =
+ fun l e ->
+  let go e = Some (compile_bool l e) in
   match e with
   | Bool _ as e -> go e
   | Eq _ as e -> go e
@@ -442,212 +437,103 @@ and try_compile_bool_reader : type a.
   | Not _ as e -> go e
   | _ -> None
 
-and compile_bool_expr ?(sizeof_this : bytes -> int -> int = fun _ _ -> 0)
-    (env : field_reader list) (e : bool expr) : bytes -> int -> bool =
-  let bool_rec e = compile_bool_expr ~sizeof_this env e in
-  let int_rec e = compile_expr ~sizeof_this env e in
-  let try_int : type a. a expr -> (bytes -> int -> int) option =
-   fun e -> try_compile_int_reader ~sizeof_this env e
-  in
-  let try_bool : type a. a expr -> (bytes -> int -> bool) option =
-   fun e -> try_compile_bool_reader ~sizeof_this env e
-  in
-  match e with
-  | Bool b -> fun _buf _base -> b
-  | Eq (a, b) -> (
-      match (try_int a, try_int b, try_bool a, try_bool b) with
-      | Some fa, Some fb, _, _ -> fun buf base -> fa buf base = fb buf base
-      | _, _, Some fa, Some fb -> fun buf base -> fa buf base = fb buf base
-      | _ -> assert false)
-  | Ne (a, b) -> (
-      match (try_int a, try_int b, try_bool a, try_bool b) with
-      | Some fa, Some fb, _, _ -> fun buf base -> fa buf base <> fb buf base
-      | _, _, Some fa, Some fb -> fun buf base -> fa buf base <> fb buf base
-      | _ -> assert false)
-  | Lt (a, b) ->
-      let fa = int_rec a and fb = int_rec b in
-      fun buf base -> fa buf base < fb buf base
-  | Le (a, b) ->
-      let fa = int_rec a and fb = int_rec b in
-      fun buf base -> fa buf base <= fb buf base
-  | Gt (a, b) ->
-      let fa = int_rec a and fb = int_rec b in
-      fun buf base -> fa buf base > fb buf base
-  | Ge (a, b) ->
-      let fa = int_rec a and fb = int_rec b in
-      fun buf base -> fa buf base >= fb buf base
-  | And (a, b) ->
-      let fa = bool_rec a and fb = bool_rec b in
-      fun buf base -> fa buf base && fb buf base
-  | Or (a, b) ->
-      let fa = bool_rec a and fb = bool_rec b in
-      fun buf base -> fa buf base || fb buf base
-  | Not e ->
-      let fe = bool_rec e in
-      fun buf base -> not (fe buf base)
-
-(* Compile expressions to read from a per-decode int array instead of a Map.
-   The [idx] function maps field names to array indices. Built at [seal] time,
-   used at every [decode]. Zero allocation per decode. *)
-type idx = string -> int
-
-(* Per-field compile context: field name->index mapping plus sizeof_this
-   and field_pos constants (known at seal time for each field). *)
-type compile_ctx = { idx : idx; sizeof_this : int; field_pos : int }
-
-let rec compile_int_arr (cc : compile_ctx) (e : int expr) : int array -> int =
-  match e with
-  | Int n -> fun _ -> n
-  | Ref name ->
-      let i = cc.idx name in
-      fun a -> a.(i)
-  | Param_ref p ->
-      fun a ->
-        let i = p.ph_slot in
-        if i >= 0 then a.(i) else !(p.ph_cell)
-  | Sizeof t ->
-      let n = field_wire_size t |> Option.value ~default:0 in
-      fun _ -> n
-  | Sizeof_this ->
-      let n = cc.sizeof_this in
-      fun _ -> n
-  | Field_pos ->
-      let n = cc.field_pos in
-      fun _ -> n
-  | Add (a, b) ->
-      let fa = compile_int_arr cc a and fb = compile_int_arr cc b in
-      fun a -> fa a + fb a
-  | Sub (a, b) ->
-      let fa = compile_int_arr cc a and fb = compile_int_arr cc b in
-      fun a -> fa a - fb a
-  | Mul (a, b) ->
-      let fa = compile_int_arr cc a and fb = compile_int_arr cc b in
-      fun a -> fa a * fb a
-  | Div (a, b) ->
-      let fa = compile_int_arr cc a and fb = compile_int_arr cc b in
-      fun a -> fa a / fb a
-  | Mod (a, b) ->
-      let fa = compile_int_arr cc a and fb = compile_int_arr cc b in
-      fun a -> fa a mod fb a
-  | Land (a, b) ->
-      let fa = compile_int_arr cc a and fb = compile_int_arr cc b in
-      fun a -> fa a land fb a
-  | Lor (a, b) ->
-      let fa = compile_int_arr cc a and fb = compile_int_arr cc b in
-      fun a -> fa a lor fb a
-  | Lxor (a, b) ->
-      let fa = compile_int_arr cc a and fb = compile_int_arr cc b in
-      fun a -> fa a lxor fb a
-  | Lnot e ->
-      let fe = compile_int_arr cc e in
-      fun a -> lnot (fe a)
-  | Lsl (a, b) ->
-      let fa = compile_int_arr cc a and fb = compile_int_arr cc b in
-      fun a -> fa a lsl fb a
-  | Lsr (a, b) ->
-      let fa = compile_int_arr cc a and fb = compile_int_arr cc b in
-      fun a -> fa a lsr fb a
-  | Cast (w, e) -> (
-      let fe = compile_int_arr cc e in
-      match w with
-      | `U8 -> fun a -> fe a land 0xFF
-      | `U16 -> fun a -> fe a land 0xFFFF
-      | `U32 -> fun a -> fe a land 0xFFFF_FFFF
-      | `U64 -> fun a -> fe a)
-  | If_then_else (c, t, e) ->
-      let fc = compile_bool_arr cc c in
-      let ft = compile_int_arr cc t and fe = compile_int_arr cc e in
-      fun a -> if fc a then ft a else fe a
-
-(* Try to compile an expression of unknown type as int.
-   Returns None if the expression is not an int expr. *)
-and try_compile_int : type a. compile_ctx -> a expr -> (int array -> int) option
-    =
- fun cc e ->
-  let go e = Some (compile_int_arr cc e) in
-  match e with
-  | Int _ as e -> go e
-  | Ref _ as e -> go e
-  | Param_ref _ as e -> go e
-  | Sizeof _ as e -> go e
-  | Sizeof_this as e -> go e
-  | Field_pos as e -> go e
-  | Add _ as e -> go e
-  | Sub _ as e -> go e
-  | Mul _ as e -> go e
-  | Div _ as e -> go e
-  | Mod _ as e -> go e
-  | Land _ as e -> go e
-  | Lor _ as e -> go e
-  | Lxor _ as e -> go e
-  | Lnot _ as e -> go e
-  | Lsl _ as e -> go e
-  | Lsr _ as e -> go e
-  | Cast _ as e -> go e
-  | If_then_else _ as e -> go e
-  | _ -> None
-
-and try_compile_bool : type a.
-    compile_ctx -> a expr -> (int array -> bool) option =
- fun cc e ->
-  let go e = Some (compile_bool_arr cc e) in
-  match e with
-  | Bool _ as e -> go e
-  | Eq _ as e -> go e
-  | Ne _ as e -> go e
-  | Lt _ as e -> go e
-  | Le _ as e -> go e
-  | Gt _ as e -> go e
-  | Ge _ as e -> go e
-  | And _ as e -> go e
-  | Or _ as e -> go e
-  | Not _ as e -> go e
-  | _ -> None
-
-and compile_bool_arr (cc : compile_ctx) (e : bool expr) : int array -> bool =
+and compile_bool : type ctx. ctx leaves -> bool expr -> ctx -> bool =
+ fun l e ->
+  let int_rec = compile_int l in
+  let bool_rec = compile_bool l in
   match e with
   | Bool b -> fun _ -> b
   | Eq (a, b) -> (
-      match
-        ( try_compile_int cc a,
-          try_compile_int cc b,
-          try_compile_bool cc a,
-          try_compile_bool cc b )
-      with
-      | Some fa, Some fb, _, _ -> fun arr -> fa arr = fb arr
-      | _, _, Some fa, Some fb -> fun arr -> fa arr = fb arr
+      match (try_int l a, try_int l b, try_bool l a, try_bool l b) with
+      | Some fa, Some fb, _, _ -> fun c -> fa c = fb c
+      | _, _, Some fa, Some fb -> fun c -> fa c = fb c
       | _ -> assert false)
   | Ne (a, b) -> (
-      match
-        ( try_compile_int cc a,
-          try_compile_int cc b,
-          try_compile_bool cc a,
-          try_compile_bool cc b )
-      with
-      | Some fa, Some fb, _, _ -> fun arr -> fa arr <> fb arr
-      | _, _, Some fa, Some fb -> fun arr -> fa arr <> fb arr
+      match (try_int l a, try_int l b, try_bool l a, try_bool l b) with
+      | Some fa, Some fb, _, _ -> fun c -> fa c <> fb c
+      | _, _, Some fa, Some fb -> fun c -> fa c <> fb c
       | _ -> assert false)
   | Lt (a, b) ->
-      let fa = compile_int_arr cc a and fb = compile_int_arr cc b in
-      fun arr -> fa arr < fb arr
+      let fa = int_rec a and fb = int_rec b in
+      fun c -> fa c < fb c
   | Le (a, b) ->
-      let fa = compile_int_arr cc a and fb = compile_int_arr cc b in
-      fun arr -> fa arr <= fb arr
+      let fa = int_rec a and fb = int_rec b in
+      fun c -> fa c <= fb c
   | Gt (a, b) ->
-      let fa = compile_int_arr cc a and fb = compile_int_arr cc b in
-      fun arr -> fa arr > fb arr
+      let fa = int_rec a and fb = int_rec b in
+      fun c -> fa c > fb c
   | Ge (a, b) ->
-      let fa = compile_int_arr cc a and fb = compile_int_arr cc b in
-      fun arr -> fa arr >= fb arr
+      let fa = int_rec a and fb = int_rec b in
+      fun c -> fa c >= fb c
   | And (a, b) ->
-      let fa = compile_bool_arr cc a and fb = compile_bool_arr cc b in
-      fun arr -> fa arr && fb arr
+      let fa = bool_rec a and fb = bool_rec b in
+      fun c -> fa c && fb c
   | Or (a, b) ->
-      let fa = compile_bool_arr cc a and fb = compile_bool_arr cc b in
-      fun arr -> fa arr || fb arr
+      let fa = bool_rec a and fb = bool_rec b in
+      fun c -> fa c || fb c
   | Not e ->
-      let fe = compile_bool_arr cc e in
-      fun arr -> not (fe arr)
+      let fe = bool_rec e in
+      fun c -> not (fe c)
+
+(* Closure-based access layer: [ctx = bytes * int]. The pair is
+   re-allocated per call site; profile if this becomes hot. *)
+let bytes_leaves ?(sizeof_this : bytes -> int -> int = fun _ _ -> 0)
+    (env : field_reader list) : (bytes * int) leaves =
+  {
+    ref_ =
+      (fun name ->
+        match List.assoc_opt name env with
+        | Some reader -> fun (buf, base) -> reader buf base
+        | None ->
+            Fmt.invalid_arg "Codec: unbound field ref %S in size expression"
+              name);
+    param_ref = (fun (Pack_param p) _ -> !(p.ph_cell));
+    sizeof_typ =
+      (fun (Pack_typ t) ->
+        match field_wire_size t with
+        | Some n -> fun _ -> n
+        | None -> invalid_arg "Codec: sizeof on variable-size type");
+    sizeof_this = (fun (buf, base) -> sizeof_this buf base);
+    field_pos =
+      (fun _ -> invalid_arg "Codec: [field_pos] only valid inside an action");
+  }
+
+let compile_expr ?sizeof_this env e =
+  let l = bytes_leaves ?sizeof_this env in
+  let f = compile_int l e in
+  fun buf base -> f (buf, base)
+
+let compile_bool_expr ?sizeof_this env e =
+  let l = bytes_leaves ?sizeof_this env in
+  let f = compile_bool l e in
+  fun buf base -> f (buf, base)
+
+(* Int-array access layer: zero-alloc per decode. Used by field
+   constraints / where clauses where the validator has already populated
+   the per-decode int_array. *)
+type idx = string -> int
+type compile_ctx = { idx : idx; sizeof_this : int; field_pos : int }
+
+let array_leaves (cc : compile_ctx) : int array leaves =
+  {
+    ref_ =
+      (fun name ->
+        let i = cc.idx name in
+        fun a -> a.(i));
+    param_ref =
+      (fun (Pack_param p) a ->
+        let i = p.ph_slot in
+        if i >= 0 then a.(i) else !(p.ph_cell));
+    sizeof_typ =
+      (fun (Pack_typ t) ->
+        let n = field_wire_size t |> Option.value ~default:0 in
+        fun _ -> n);
+    sizeof_this = (fun _ -> cc.sizeof_this);
+    field_pos = (fun _ -> cc.field_pos);
+  }
+
+let compile_int_arr cc e = compile_int (array_leaves cc) e
+let compile_bool_arr cc e = compile_bool (array_leaves cc) e
 
 (* Compile action statements to operate on an int array instead of Eval.ctx.
    Assign writes to ph_cell (mutable param) and updates the array.

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -572,16 +572,18 @@ let rec compile_stmt (cc : compile_ctx) (s : Types.action_stmt) :
         | None -> fun _ -> ()
       in
       fun arr -> if fc arr then ft arr else fe arr
-  | Var (name, e) -> (
-      (* Extend index for subsequent statements -- but since Var only affects
-         later statements in the same block, we handle it at the block level *)
+  | Var (name, e) ->
+      (* [Action.var name e] writes [e]'s value to the int_array slot for
+         [name]. The slot is auto-registered by [action_vars] before the
+         index is built, so [cc.idx name] always resolves; the
+         out-of-bounds and [Failure] catches that used to live here were
+         dead defensive code, and matched the silent-default shape that
+         hid the predicate / [Field.ref] bugs in the parallel compilers.
+         Drop the catches -- if [cc.idx name] ever raises here we want it
+         to surface, not write to nowhere. *)
+      let i = cc.idx name in
       let fe = compile_int_arr cc e in
-      fun arr ->
-        (* Store in array if name is a known field *)
-        match cc.idx name with
-        | i when i < Array.length arr -> arr.(i) <- fe arr
-        | _ -> ()
-        | exception Failure _ -> ())
+      fun arr -> arr.(i) <- fe arr
 
 and compile_stmts (cc : compile_ctx) (stmts : Types.action_stmt list) :
     compiled_action =

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -322,73 +322,151 @@ let rec compile_expr ?(sizeof_this : bytes -> int -> int = fun _ _ -> 0)
       | None ->
           Fmt.invalid_arg "Codec: unbound field ref %S in size expression" name)
   | Add (a, b) ->
-      let fa = rec_ a in
-      let fb = rec_ b in
+      let fa = rec_ a and fb = rec_ b in
       fun buf base -> fa buf base + fb buf base
   | Sub (a, b) ->
-      let fa = rec_ a in
-      let fb = rec_ b in
+      let fa = rec_ a and fb = rec_ b in
       fun buf base -> fa buf base - fb buf base
   | Mul (a, b) ->
-      let fa = rec_ a in
-      let fb = rec_ b in
+      let fa = rec_ a and fb = rec_ b in
       fun buf base -> fa buf base * fb buf base
   | Div (a, b) ->
-      let fa = rec_ a in
-      let fb = rec_ b in
+      let fa = rec_ a and fb = rec_ b in
       fun buf base -> fa buf base / fb buf base
+  | Mod (a, b) ->
+      let fa = rec_ a and fb = rec_ b in
+      fun buf base -> fa buf base mod fb buf base
+  | Land (a, b) ->
+      let fa = rec_ a and fb = rec_ b in
+      fun buf base -> fa buf base land fb buf base
+  | Lor (a, b) ->
+      let fa = rec_ a and fb = rec_ b in
+      fun buf base -> fa buf base lor fb buf base
+  | Lxor (a, b) ->
+      let fa = rec_ a and fb = rec_ b in
+      fun buf base -> fa buf base lxor fb buf base
+  | Lnot a ->
+      let fa = rec_ a in
+      fun buf base -> lnot (fa buf base)
+  | Lsl (a, b) ->
+      let fa = rec_ a and fb = rec_ b in
+      fun buf base -> fa buf base lsl fb buf base
+  | Lsr (a, b) ->
+      let fa = rec_ a and fb = rec_ b in
+      fun buf base -> fa buf base lsr fb buf base
+  | Cast (w, a) -> (
+      let fa = rec_ a in
+      match w with
+      | `U8 -> fun buf base -> fa buf base land 0xFF
+      | `U16 -> fun buf base -> fa buf base land 0xFFFF
+      | `U32 -> fun buf base -> fa buf base land 0xFFFF_FFFF
+      | `U64 -> fa)
+  | If_then_else (c, t, e) ->
+      let fc = compile_bool_expr ~sizeof_this env c in
+      let ft = rec_ t and fe = rec_ e in
+      fun buf base -> if fc buf base then ft buf base else fe buf base
   | Param_ref p -> fun _buf _base -> !(p.ph_cell)
   | Sizeof t -> (
       match field_wire_size t with
       | Some n -> fun _buf _base -> n
       | None -> invalid_arg "Codec: sizeof on variable-size type")
   | Sizeof_this -> sizeof_this
-  | _ -> invalid_arg "Codec: unsupported expression in dependent size"
+  | Field_pos -> invalid_arg "Codec: [field_pos] only valid inside an action"
 
-let try_compile_int_reader : type a.
-    field_reader list -> a expr -> (bytes -> int -> int) option =
- fun env -> function
-  | Int _ as e -> Some (compile_expr env e)
-  | Ref _ as e -> Some (compile_expr env e)
-  | Param_ref _ as e -> Some (compile_expr env e)
-  | Add _ as e -> Some (compile_expr env e)
-  | Sub _ as e -> Some (compile_expr env e)
-  | Mul _ as e -> Some (compile_expr env e)
-  | Div _ as e -> Some (compile_expr env e)
+(* Try compiling [a expr] as an [int expr] reader. Pattern matches each
+   int constructor so the GADT refines the type to [int expr] in each
+   arm. Used by [compile_bool_expr] to dispatch typed equality. *)
+and try_compile_int_reader : type a.
+    sizeof_this:(bytes -> int -> int) ->
+    field_reader list ->
+    a expr ->
+    (bytes -> int -> int) option =
+ fun ~sizeof_this env e ->
+  let go e = Some (compile_expr ~sizeof_this env e) in
+  match e with
+  | Int _ as e -> go e
+  | Ref _ as e -> go e
+  | Param_ref _ as e -> go e
+  | Sizeof _ as e -> go e
+  | Sizeof_this as e -> go e
+  | Field_pos as e -> go e
+  | Add _ as e -> go e
+  | Sub _ as e -> go e
+  | Mul _ as e -> go e
+  | Div _ as e -> go e
+  | Mod _ as e -> go e
+  | Land _ as e -> go e
+  | Lor _ as e -> go e
+  | Lxor _ as e -> go e
+  | Lnot _ as e -> go e
+  | Lsl _ as e -> go e
+  | Lsr _ as e -> go e
+  | Cast _ as e -> go e
+  | If_then_else _ as e -> go e
   | _ -> None
 
-let rec compile_bool_expr (env : field_reader list) (e : bool expr) :
-    bytes -> int -> bool =
+and try_compile_bool_reader : type a.
+    sizeof_this:(bytes -> int -> int) ->
+    field_reader list ->
+    a expr ->
+    (bytes -> int -> bool) option =
+ fun ~sizeof_this env e ->
+  let go e = Some (compile_bool_expr ~sizeof_this env e) in
+  match e with
+  | Bool _ as e -> go e
+  | Eq _ as e -> go e
+  | Ne _ as e -> go e
+  | Lt _ as e -> go e
+  | Le _ as e -> go e
+  | Gt _ as e -> go e
+  | Ge _ as e -> go e
+  | And _ as e -> go e
+  | Or _ as e -> go e
+  | Not _ as e -> go e
+  | _ -> None
+
+and compile_bool_expr ?(sizeof_this : bytes -> int -> int = fun _ _ -> 0)
+    (env : field_reader list) (e : bool expr) : bytes -> int -> bool =
+  let bool_rec e = compile_bool_expr ~sizeof_this env e in
+  let int_rec e = compile_expr ~sizeof_this env e in
+  let try_int : type a. a expr -> (bytes -> int -> int) option =
+   fun e -> try_compile_int_reader ~sizeof_this env e
+  in
+  let try_bool : type a. a expr -> (bytes -> int -> bool) option =
+   fun e -> try_compile_bool_reader ~sizeof_this env e
+  in
   match e with
   | Bool b -> fun _buf _base -> b
   | Eq (a, b) -> (
-      match (try_compile_int_reader env a, try_compile_int_reader env b) with
-      | Some fa, Some fb -> fun buf base -> fa buf base = fb buf base
-      | _ -> fun _buf _base -> true)
+      match (try_int a, try_int b, try_bool a, try_bool b) with
+      | Some fa, Some fb, _, _ -> fun buf base -> fa buf base = fb buf base
+      | _, _, Some fa, Some fb -> fun buf base -> fa buf base = fb buf base
+      | _ -> assert false)
   | Ne (a, b) -> (
-      match (try_compile_int_reader env a, try_compile_int_reader env b) with
-      | Some fa, Some fb -> fun buf base -> fa buf base <> fb buf base
-      | _ -> fun _buf _base -> true)
+      match (try_int a, try_int b, try_bool a, try_bool b) with
+      | Some fa, Some fb, _, _ -> fun buf base -> fa buf base <> fb buf base
+      | _, _, Some fa, Some fb -> fun buf base -> fa buf base <> fb buf base
+      | _ -> assert false)
   | Lt (a, b) ->
-      let fa = compile_expr env a and fb = compile_expr env b in
+      let fa = int_rec a and fb = int_rec b in
       fun buf base -> fa buf base < fb buf base
   | Le (a, b) ->
-      let fa = compile_expr env a and fb = compile_expr env b in
+      let fa = int_rec a and fb = int_rec b in
       fun buf base -> fa buf base <= fb buf base
   | Gt (a, b) ->
-      let fa = compile_expr env a and fb = compile_expr env b in
+      let fa = int_rec a and fb = int_rec b in
       fun buf base -> fa buf base > fb buf base
   | Ge (a, b) ->
-      let fa = compile_expr env a and fb = compile_expr env b in
+      let fa = int_rec a and fb = int_rec b in
       fun buf base -> fa buf base >= fb buf base
   | And (a, b) ->
-      let fa = compile_bool_expr env a and fb = compile_bool_expr env b in
+      let fa = bool_rec a and fb = bool_rec b in
       fun buf base -> fa buf base && fb buf base
   | Or (a, b) ->
-      let fa = compile_bool_expr env a and fb = compile_bool_expr env b in
+      let fa = bool_rec a and fb = bool_rec b in
       fun buf base -> fa buf base || fb buf base
   | Not e ->
-      let fe = compile_bool_expr env e in
+      let fe = bool_rec e in
       fun buf base -> not (fe buf base)
 
 (* Compile expressions to read from a per-decode int array instead of a Map.
@@ -468,38 +546,70 @@ let rec compile_int_arr (cc : compile_ctx) (e : int expr) : int array -> int =
    Returns None if the expression is not an int expr. *)
 and try_compile_int : type a. compile_ctx -> a expr -> (int array -> int) option
     =
- fun cc -> function
-  | Int _ as e -> Some (compile_int_arr cc e)
-  | Ref _ as e -> Some (compile_int_arr cc e)
-  | Param_ref _ as e -> Some (compile_int_arr cc e)
-  | Sizeof _ as e -> Some (compile_int_arr cc e)
-  | Sizeof_this as e -> Some (compile_int_arr cc e)
-  | Field_pos as e -> Some (compile_int_arr cc e)
-  | Add _ as e -> Some (compile_int_arr cc e)
-  | Sub _ as e -> Some (compile_int_arr cc e)
-  | Mul _ as e -> Some (compile_int_arr cc e)
-  | Div _ as e -> Some (compile_int_arr cc e)
-  | Mod _ as e -> Some (compile_int_arr cc e)
-  | Land _ as e -> Some (compile_int_arr cc e)
-  | Lor _ as e -> Some (compile_int_arr cc e)
-  | Lxor _ as e -> Some (compile_int_arr cc e)
-  | Lnot _ as e -> Some (compile_int_arr cc e)
-  | Lsl _ as e -> Some (compile_int_arr cc e)
-  | Lsr _ as e -> Some (compile_int_arr cc e)
-  | Cast _ as e -> Some (compile_int_arr cc e)
+ fun cc e ->
+  let go e = Some (compile_int_arr cc e) in
+  match e with
+  | Int _ as e -> go e
+  | Ref _ as e -> go e
+  | Param_ref _ as e -> go e
+  | Sizeof _ as e -> go e
+  | Sizeof_this as e -> go e
+  | Field_pos as e -> go e
+  | Add _ as e -> go e
+  | Sub _ as e -> go e
+  | Mul _ as e -> go e
+  | Div _ as e -> go e
+  | Mod _ as e -> go e
+  | Land _ as e -> go e
+  | Lor _ as e -> go e
+  | Lxor _ as e -> go e
+  | Lnot _ as e -> go e
+  | Lsl _ as e -> go e
+  | Lsr _ as e -> go e
+  | Cast _ as e -> go e
+  | If_then_else _ as e -> go e
+  | _ -> None
+
+and try_compile_bool : type a.
+    compile_ctx -> a expr -> (int array -> bool) option =
+ fun cc e ->
+  let go e = Some (compile_bool_arr cc e) in
+  match e with
+  | Bool _ as e -> go e
+  | Eq _ as e -> go e
+  | Ne _ as e -> go e
+  | Lt _ as e -> go e
+  | Le _ as e -> go e
+  | Gt _ as e -> go e
+  | Ge _ as e -> go e
+  | And _ as e -> go e
+  | Or _ as e -> go e
+  | Not _ as e -> go e
   | _ -> None
 
 and compile_bool_arr (cc : compile_ctx) (e : bool expr) : int array -> bool =
   match e with
   | Bool b -> fun _ -> b
   | Eq (a, b) -> (
-      match (try_compile_int cc a, try_compile_int cc b) with
-      | Some fa, Some fb -> fun arr -> fa arr = fb arr
-      | _ -> fun _ -> true)
+      match
+        ( try_compile_int cc a,
+          try_compile_int cc b,
+          try_compile_bool cc a,
+          try_compile_bool cc b )
+      with
+      | Some fa, Some fb, _, _ -> fun arr -> fa arr = fb arr
+      | _, _, Some fa, Some fb -> fun arr -> fa arr = fb arr
+      | _ -> assert false)
   | Ne (a, b) -> (
-      match (try_compile_int cc a, try_compile_int cc b) with
-      | Some fa, Some fb -> fun arr -> fa arr <> fb arr
-      | _ -> fun _ -> true)
+      match
+        ( try_compile_int cc a,
+          try_compile_int cc b,
+          try_compile_bool cc a,
+          try_compile_bool cc b )
+      with
+      | Some fa, Some fb, _, _ -> fun arr -> fa arr <> fb arr
+      | _, _, Some fa, Some fb -> fun arr -> fa arr <> fb arr
+      | _ -> assert false)
   | Lt (a, b) ->
       let fa = compile_int_arr cc a and fb = compile_int_arr cc b in
       fun arr -> fa arr < fb arr

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -2731,6 +2731,32 @@ let test_optional_lor_predicate () =
   let r = decode_ok (Codec.decode c (Bytes.of_string "\xFF") 0) in
   Alcotest.(check (option int)) "lor no match" None r.bg_body
 
+(* [Field.ref] on an [optional] field must read the inner value, not 0.
+   The codec engine used to skip populating the int_array slot for
+   [Optional] fields, so any constraint or size expression referring to
+   the optional silently saw 0. *)
+
+type ref_opt = { ro_x : int option; ro_check : int }
+
+let f_ro_x = Field.optional "X" ~present:Expr.true_ uint8
+
+let ref_opt_codec =
+  let f_check =
+    Field.v "Check" uint8 ~constraint_:Expr.(Field.ref f_ro_x > int 0)
+  in
+  Codec.v "RefOpt"
+    (fun x check -> { ro_x = x; ro_check = check })
+    Codec.[ (f_ro_x $ fun r -> r.ro_x); (f_check $ fun r -> r.ro_check) ]
+
+let test_field_ref_through_optional () =
+  (* x=0x80 (present); the constraint reads ref(x) and asserts it's
+     non-zero. With the populate bug, ref(x) read 0 and the constraint
+     failed; with the fix it reads 0x80 and the decode succeeds. *)
+  let buf = Bytes.of_string "\x80\x7F" in
+  let r = decode_ok (Codec.decode ref_opt_codec buf 0) in
+  Alcotest.(check (option int)) "x" (Some 0x80) r.ro_x;
+  Alcotest.(check int) "check" 0x7F r.ro_check
+
 let test_uint64_ref_in_size () =
   let f_len = Field.v "Len" uint64be in
   let codec =
@@ -3752,6 +3778,8 @@ let suite =
         test_optional_mod_predicate;
       Alcotest.test_case "optional: lor predicate" `Quick
         test_optional_lor_predicate;
+      Alcotest.test_case "optional: Field.ref reads inner value" `Quick
+        test_field_ref_through_optional;
       Alcotest.test_case "ref: uint64 in size expr" `Quick
         test_uint64_ref_in_size;
       (* repeat *)

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -2680,6 +2680,57 @@ let test_dyn_opt_anyref_absent () =
   Alcotest.(check (option int)) "ocf" None r.to_ocf;
   Alcotest.(check int) "trail" 0xFF r.to_trail
 
+(* -- Predicates with bitwise/shift/mod operators in [optional] --
+   Reproduces the silent miscompile where [compile_bool_expr]'s
+   [try_compile_int_reader] fell back to [fun _ -> true] for any
+   predicate using [Land] / [Lor] / [Lsr] / [Mod] / [Cast] / etc.,
+   so a high-bit-gated optional would always read its payload. *)
+
+type bit_gated = { bg_flags : int; bg_body : int option }
+
+let f_bg_flags = Field.v "Flags" uint8
+
+let bg_codec ~present =
+  Codec.v "BgRec"
+    (fun flags body -> { bg_flags = flags; bg_body = body })
+    Codec.
+      [
+        (f_bg_flags $ fun r -> r.bg_flags);
+        (Field.optional "Body" ~present uint8 $ fun r -> r.bg_body);
+      ]
+
+let test_optional_land_predicate () =
+  let c =
+    bg_codec ~present:Expr.(Field.ref f_bg_flags land int 0x80 <> int 0)
+  in
+  let r = decode_ok (Codec.decode c (Bytes.of_string "\x80\x2A") 0) in
+  Alcotest.(check (option int)) "high bit set" (Some 0x2A) r.bg_body;
+  let r = decode_ok (Codec.decode c (Bytes.of_string "\x00") 0) in
+  Alcotest.(check (option int)) "high bit clear" None r.bg_body
+
+let test_optional_lsr_predicate () =
+  let c = bg_codec ~present:Expr.(Field.ref f_bg_flags lsr int 4 <> int 0) in
+  let r = decode_ok (Codec.decode c (Bytes.of_string "\x10\x2A") 0) in
+  Alcotest.(check (option int)) "top nibble set" (Some 0x2A) r.bg_body;
+  let r = decode_ok (Codec.decode c (Bytes.of_string "\x0F") 0) in
+  Alcotest.(check (option int)) "top nibble clear" None r.bg_body
+
+let test_optional_mod_predicate () =
+  let c = bg_codec ~present:Expr.(Field.ref f_bg_flags mod int 2 <> int 0) in
+  let r = decode_ok (Codec.decode c (Bytes.of_string "\x03\x2A") 0) in
+  Alcotest.(check (option int)) "odd" (Some 0x2A) r.bg_body;
+  let r = decode_ok (Codec.decode c (Bytes.of_string "\x02") 0) in
+  Alcotest.(check (option int)) "even" None r.bg_body
+
+let test_optional_lor_predicate () =
+  let c =
+    bg_codec ~present:Expr.(Field.ref f_bg_flags lor int 0x01 = int 0x01)
+  in
+  let r = decode_ok (Codec.decode c (Bytes.of_string "\x01\x2A") 0) in
+  Alcotest.(check (option int)) "lor matches" (Some 0x2A) r.bg_body;
+  let r = decode_ok (Codec.decode c (Bytes.of_string "\xFF") 0) in
+  Alcotest.(check (option int)) "lor no match" None r.bg_body
+
 let test_uint64_ref_in_size () =
   let f_len = Field.v "Len" uint64be in
   let codec =
@@ -3693,6 +3744,14 @@ let suite =
         test_dyn_opt_anyref_present;
       Alcotest.test_case "optional: bool ref absent" `Quick
         test_dyn_opt_anyref_absent;
+      Alcotest.test_case "optional: land predicate" `Quick
+        test_optional_land_predicate;
+      Alcotest.test_case "optional: lsr predicate" `Quick
+        test_optional_lsr_predicate;
+      Alcotest.test_case "optional: mod predicate" `Quick
+        test_optional_mod_predicate;
+      Alcotest.test_case "optional: lor predicate" `Quick
+        test_optional_lor_predicate;
       Alcotest.test_case "ref: uint64 in size expr" `Quick
         test_uint64_ref_in_size;
       (* repeat *)


### PR DESCRIPTION
Two parallel implementations of the same GADT walker (`compile_expr` / `compile_int_arr`, `compile_bool_expr` / `compile_bool_arr`) silently drifted: predicates with bitwise / shift / mod operators in `Field.optional` / `Field.optional_or` decoded as always-present, and `Field.ref` on an optional field read 0 because [`compile_optional`](lib/codec.ml) skipped populating the int_array slot.

Both fixed. The compilers are now a single GADT walker parameterised by a leaves record, with thin backend wrappers -- net -113 lines and no more drift surface. Regression tests in [`test_codec.ml`](test/test_codec.ml) and a Crowbar property in [`fuzz_param.ml`](fuzz/fuzz_param.ml) lock in the predicate / `ref` semantics.