### PR TITLE
Project Wire.casetype to 3D (int + string discriminators)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,12 @@
 
 ### Added
 
+- `Wire.casetype` now accepts any tag typ (`'k typ`, not just `int`) and
+  projects cleanly to 3D: int-tagged casetypes get an auto-emitted
+  `casetype_decl` + wrapper typedef; byte-tagged casetypes (e.g.
+  `byte_array ~size`) project as two adjacent byte spans so dispatch
+  happens in caller code, matching how OpenSSH and similar protocol
+  parsers handle string-discriminated messages (#49, @samoht)
 - Support `Wire.casetype` and `Wire.nested ~size` as `Codec` fields
   (#47, @samoht)
 - Add `Field.optional` / `Field.optional_or` / `Field.repeat` /

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,14 @@ All bench/prof/memtrace targets use `--profile=release`.
 - `test/` -- Alcotest unit tests and differential tests (`test/diff/`)
 - `.github/workflows/ci.yml` -- CI workflow
 
+## Feature shippability
+
+Every feature in `ocaml-wire` must project cleanly to EverParse 3D. A
+feature that decodes/encodes on the OCaml side but has no clean 3D
+projection is **not shipped**. The OCaml side and the 3D side are part
+of the same release-shaped unit; partial work goes in a branch but
+does not merge until both halves land.
+
 ## Code generation pipeline
 
 All C code generation flows through `Wire.Everparse` (no duplication):

--- a/fuzz/fuzz_everparse.ml
+++ b/fuzz/fuzz_everparse.ml
@@ -151,10 +151,10 @@ let test_casetype_inline () =
   let t : ep_case_val Wire.typ =
     Wire.casetype "Tag" Wire.uint8
       [
-        Wire.case Wire.uint16
+        Wire.case ~index:0 Wire.uint16
           ~inject:(fun v -> `U16 v)
           ~project:(function `U16 v -> Some v | _ -> None);
-        Wire.case Wire.uint32
+        Wire.case ~index:1 Wire.uint32
           ~inject:(fun v -> `U32 (Wire.Private.UInt32.to_int v))
           ~project:(function
             | `U32 v -> Some (Wire.Private.UInt32.of_int v) | _ -> None);

--- a/fuzz/fuzz_wire.ml
+++ b/fuzz/fuzz_wire.ml
@@ -271,10 +271,10 @@ let test_parse_casetype buf =
   let t : test_case_val Wire.typ =
     Wire.casetype "Tag" Wire.uint8
       [
-        Wire.case Wire.uint8
+        Wire.case ~index:0 Wire.uint8
           ~inject:(fun v -> `U8 v)
           ~project:(function `U8 v -> Some v | _ -> None);
-        Wire.case Wire.uint16
+        Wire.case ~index:1 Wire.uint16
           ~inject:(fun v -> `U16 v)
           ~project:(function `U16 v -> Some v | _ -> None);
         Wire.default Wire.uint32

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -949,7 +949,8 @@ let rec read_elem : type a. a typ -> bytes -> int -> a =
       let tag_val = read_elem tag buf off in
       let body_off = off + tag_size in
       let rec find = function
-        | [] -> raise (Parse_error (Invalid_tag tag_val))
+        | [] ->
+            raise (Parse_error (Constraint_failed "casetype: no matching case"))
         | Case_branch { cb_tag = Some t; cb_inner; cb_inject; _ } :: _
           when t = tag_val ->
             cb_inject (read_elem cb_inner buf body_off)
@@ -1004,7 +1005,8 @@ let rec elem_size_of : type a. a typ -> bytes -> int -> int =
       let tag_val = read_elem tag buf off in
       let body_off = off + tag_size in
       let rec find = function
-        | [] -> raise (Parse_error (Invalid_tag tag_val))
+        | [] ->
+            raise (Parse_error (Constraint_failed "casetype: no matching case"))
         | Case_branch { cb_tag = Some t; cb_inner; _ } :: _ when t = tag_val ->
             tag_size + elem_size_of cb_inner buf body_off
         | Case_branch { cb_tag = None; cb_inner; _ } :: _ ->

--- a/lib/everparse.ml
+++ b/lib/everparse.ml
@@ -23,11 +23,16 @@ let rec is_byte_field : type a. a Types.typ -> bool = function
   | Types.Byte_array _ | Types.Byte_array_where _ | Types.Byte_slice _
   | Types.Uint_var _ ->
       true
+  | Types.All_bytes | Types.All_zeros -> true
   | Types.Optional { present = Types.Bool _; _ } -> false
   | Types.Optional _ -> true
   | Types.Optional_or { present = Types.Bool _; _ } -> false
   | Types.Optional_or _ -> true
   | Types.Map { inner; _ } -> is_byte_field inner
+  (* Casetype projects to a struct value, which is not "readable" in 3D
+     actions. Treat it like a byte span: the SetBytes setter receives an
+     offset into the buffer, and the C side decodes if it wants to. *)
+  | Types.Casetype _ -> true
   | _ -> false
 
 type setter_info = { setter_name : string; setter_val_typ : Types.packed_typ }
@@ -367,6 +372,11 @@ let coalesced_wire_size fields =
   with Bail -> None
 
 let schema_of_struct (s : Types.struct_) : t =
+  (* Split string-tagged casetype fields up-front so [source] and
+     [with_output] see the same field list. Downstream codegen
+     (plug fields, stubs) walks [source] to expose every named field --
+     it must include the synthesised body field of each casetype. *)
+  let s = Types.split_string_casetype_fields s in
   let name = Types.struct_name s in
   let wire_size = coalesced_wire_size s.fields in
   let decls = with_output s in

--- a/lib/test/everparse/test_wire_3d.ml
+++ b/lib/test/everparse/test_wire_3d.ml
@@ -163,10 +163,58 @@ let e2e_underflow_codec =
   let open Codec in
   v "UnderflowCheck" (fun len data -> (len, data)) [ f_len $ fst; f_data $ snd ]
 
+(* [Wire.casetype] in a codec field. The Everparse projection auto-emits
+   a [casetype_decl] dispatch + wrapper typedef per unique int-tagged
+   [Casetype], then references the wrapper as the field type. End-to-end
+   check that 3d.exe accepts the synthesised module and the generated C
+   compiles. *)
+type ep_case_v = [ `U16 of int | `Default of int ]
+
+let e2e_casetype_codec =
+  let open Wire in
+  let body : ep_case_v typ =
+    casetype "CtBody" uint8
+      [
+        case ~index:1 uint16
+          ~inject:(fun v -> `U16 v)
+          ~project:(function `U16 v -> Some v | _ -> None);
+        default uint8
+          ~inject:(fun v -> `Default v)
+          ~project:(function `Default v -> Some v | _ -> None);
+      ]
+  in
+  let f = Field.v "msg" body in
+  Codec.v "Ctt" (fun m -> m) [ Codec.( $ ) f (fun m -> m) ]
+
+(* String-tagged casetype: the 3D projection rewrites the casetype field
+   into two adjacent byte spans (tag and body) so dispatch happens in
+   caller code, mirroring OpenSSH's two-step pattern. No 3D-side extern,
+   scratch slot or runtime helper -- just two SetBytes setters. *)
+type ssh_auth = [ `Publickey of int | `Other of int ]
+
+let e2e_ssh_casetype_codec =
+  let open Wire in
+  let body : ssh_auth typ =
+    casetype "AuthMethod"
+      (byte_array ~size:(int 9))
+      [
+        case ~index:"publickey" uint8
+          ~inject:(fun v -> `Publickey v)
+          ~project:(function `Publickey v -> Some v | _ -> None);
+        default uint8
+          ~inject:(fun v -> `Other v)
+          ~project:(function `Other v -> Some v | _ -> None);
+      ]
+  in
+  let f = Field.v "method" body in
+  Codec.v "Sshauth" (fun m -> m) [ Codec.( $ ) f (fun m -> m) ]
+
 let test_e2e_compile_run () =
   compile_and_run ~name:"Demo" e2e_simple_codec;
   compile_and_run ~name:"CLCW" e2e_allcaps_codec;
   compile_and_run ~name:"TMFrame" e2e_tm_codec;
+  compile_and_run ~name:"Ctt" e2e_casetype_codec;
+  compile_and_run ~name:"Sshauth" e2e_ssh_casetype_codec;
   compile_and_run ~name:"rpmsg_endpoint_info" e2e_snake_codec;
   compile_and_run ~name:"EP_Header" e2e_mixed_codec;
   compile_and_run ~name:"UnderflowCheck" e2e_underflow_codec

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -113,8 +113,8 @@ and _ typ =
       -> int typ
   | Casetype : {
       name : string;
-      tag : int typ;
-      cases : 'a case_branch list;
+      tag : 'k typ;
+      cases : ('a, 'k) case_branch list;
     }
       -> 'a typ
   | Struct : struct_ -> unit typ
@@ -145,14 +145,14 @@ and _ typ =
     }
       -> 'seq typ
 
-and 'a case_branch =
+and ('a, 'k) case_branch =
   | Case_branch : {
-      cb_tag : int option;
+      cb_tag : 'k option;
       cb_inner : 'w typ;
       cb_inject : 'w -> 'a;
       cb_project : 'a -> 'w option;
     }
-      -> 'a case_branch
+      -> ('a, 'k) case_branch
 
 and packed_expr = Pack_expr : 'a expr -> packed_expr
 
@@ -447,20 +447,20 @@ let variants name cases base =
   map decode encode (enum name enum_cases base)
 
 (* Casetype *)
-type 'a case_def =
+type ('a, 'k) case_def =
   | Case_def : {
-      cd_index : int option;
+      cd_index : 'k option;
       cd_inner : 'w typ;
       cd_inject : 'w -> 'a;
       cd_project : 'a -> 'w option;
     }
-      -> 'a case_def
+      -> ('a, 'k) case_def
   | Default_def : {
       dd_inner : 'w typ;
       dd_inject : 'w -> 'a;
       dd_project : 'a -> 'w option;
     }
-      -> 'a case_def
+      -> ('a, 'k) case_def
 
 let case ?index inner ~inject ~project =
   Case_def
@@ -474,24 +474,20 @@ let case ?index inner ~inject ~project =
 let default inner ~inject ~project =
   Default_def { dd_inner = inner; dd_inject = inject; dd_project = project }
 
-let casetype ?(first = 0) ?(step = 1) name tag defs =
-  let counter = Stdlib.ref first in
+let casetype name tag defs =
   let resolve = function
     | Case_def { cd_index; cd_inner; cd_inject; cd_project } ->
         reject_decoration ~combinator:"casetype" cd_inner;
-        let idx =
+        let cb_tag =
           match cd_index with
-          | Some i ->
-              counter := i + step;
-              i
+          | Some _ as k -> k
           | None ->
-              let i = !counter in
-              counter := i + step;
-              i
+              invalid_arg
+                "Wire.casetype: every case must supply an explicit [~index]"
         in
         Case_branch
           {
-            cb_tag = Some idx;
+            cb_tag;
             cb_inner = cd_inner;
             cb_inject = cd_inject;
             cb_project = cd_project;
@@ -669,38 +665,171 @@ let enum_decls (s : struct_) : decl list =
     s.fields;
   List.rev !decls
 
-let module_ ?doc decls =
-  (* Auto-prepend enum declarations for any enum types used in typedefs
-     that aren't already declared in the module. *)
-  let already_declared =
-    List.fold_left
-      (fun acc d ->
-        match d with Enum_decl { name; _ } -> name :: acc | _ -> acc)
-      [] decls
+(* True for tag types that the 3D side can dispatch on natively: integer-
+   shaped scalars plus enums. String/byte tags use the two-step shape
+   (split into adjacent fields, dispatch in caller code) instead. *)
+let is_int_dispatch_typ : type a. a typ -> bool = function
+  | Uint8 | Uint16 _ | Uint32 _ | Uint63 _ | Uint_var _ | Int8 | Int16 _
+  | Int32 _ | Bits _ | Enum _ ->
+      true
+  | _ -> false
+
+(* Project a case-branch discriminator value of type ['k] to a 3D constant
+   expression. Only called for int-shaped tags; non-int tags don't reach
+   here because their casetype field is rewritten away before
+   [casetype_decls_of_struct] walks it. *)
+let case_index_to_expr : type k. k typ -> k -> packed_expr =
+ fun tag_typ k ->
+  match tag_typ with
+  | Uint8 -> Pack_expr (Int k)
+  | Uint16 _ -> Pack_expr (Int k)
+  | Uint32 _ -> Pack_expr (Int k)
+  | Uint63 _ -> Pack_expr (Int k)
+  | Uint_var _ -> Pack_expr (Int k)
+  | Int8 -> Pack_expr (Int k)
+  | Int16 _ -> Pack_expr (Int k)
+  | Int32 _ -> Pack_expr (Int k)
+  | Bits _ -> Pack_expr (Int k)
+  | Enum _ -> Pack_expr (Int k)
+  | _ -> assert false (* guarded by [is_int_dispatch_typ] *)
+
+(* Auto-emit a dispatch + wrapper for each [Casetype] used in a struct.
+
+   [Wire.casetype "Foo" tag cases] parses the tag inline in OCaml; the 3D
+   side has no equivalent (its [casetype_decl] takes the tag as a
+   parameter, leaving the caller to supply it). To project cleanly we
+   synthesise two declarations per unique casetype name:
+
+   - [Casetype_decl "Foo_Body"] -- the dispatch table, parameterised on
+     the tag value.
+   - [Typedef "Foo"] -- a small wrapper struct holding [tag; body] where
+     [body] is [Foo_Body(tag)].
+
+   The user's [Casetype] typ then prints as the wrapper's name (already
+   the existing [pp_typ] behaviour) and references the wrapper. *)
+let decl_case_of_branch : type a k. k typ -> (a, k) case_branch -> decl_case =
+ fun tag (Case_branch { cb_tag; cb_inner; _ }) ->
+  let tag_expr =
+    match cb_tag with None -> None | Some k -> Some (case_index_to_expr tag k)
   in
-  let extra =
+  (tag_expr, Pack_typ cb_inner)
+
+let casetype_pair : type a k.
+    string -> k typ -> (a, k) case_branch list -> decl * decl =
+ fun name tag cases ->
+  let body_name = name ^ "_Body" in
+  let decl_cases = List.map (decl_case_of_branch tag) cases in
+  let dispatch =
+    Casetype_decl
+      {
+        name = body_name;
+        params = [ param "tag" tag ];
+        tag = Pack_typ tag;
+        cases = decl_cases;
+      }
+  in
+  let tag_field = field "tag" tag in
+  let body_field =
+    field "body"
+      (Apply { typ = Type_ref body_name; args = [ Pack_expr (Ref "tag") ] })
+  in
+  let wrapper = typedef (struct_ name [ tag_field; body_field ]) in
+  (dispatch, wrapper)
+
+let casetype_decls_of_struct (s : struct_) : decl list =
+  let seen = Hashtbl.create 4 in
+  let acc = Stdlib.ref [] in
+  let rec extract : type a. a typ -> unit = function
+    | Casetype { name; tag; cases }
+      when is_int_dispatch_typ tag && not (Hashtbl.mem seen name) ->
+        Hashtbl.add seen name ();
+        let dispatch, wrapper = casetype_pair name tag cases in
+        acc := wrapper :: dispatch :: !acc;
+        List.iter (fun (Case_branch { cb_inner; _ }) -> extract cb_inner) cases
+    | Casetype { cases; _ } ->
+        (* String-tagged casetype: handled by [split_string_casetype_fields].
+           Still walk inner case typs for nested int-tagged casetypes. *)
+        List.iter (fun (Case_branch { cb_inner; _ }) -> extract cb_inner) cases
+    | Map { inner; _ } -> extract inner
+    | Where { inner; _ } -> extract inner
+    | Optional { inner; _ } -> extract inner
+    | Optional_or { inner; _ } -> extract inner
+    | Apply { typ; _ } -> extract typ
+    | Repeat { elem; _ } -> extract elem
+    | Array { elem; _ } -> extract elem
+    | Single_elem { elem; _ } -> extract elem
+    | _ -> ()
+  in
+  List.iter (fun (Field f) -> extract f.field_typ) s.fields;
+  List.rev !acc
+
+(* Two-step projection for string-tagged casetype: split the field into
+   two adjacent fields, the tag bytes and the body bytes.
+
+   The 3D side validates wire framing only; case dispatch is the caller's
+   job (OCaml [parse_casetype] already does this on its side, and C
+   consumers receive both spans through the plug and dispatch with their
+   own [strcmp] table -- exactly what real protocol implementations like
+   OpenSSH do). No 3D-side extern, no scratch slot, no runtime helper.
+
+   The body field uses [All_bytes] ("rest of buffer"), so the casetype
+   must be the trailing field of its parent struct -- matching the
+   existing codec.ml constraint for variable-size casetype fields. *)
+let split_string_casetype_fields (s : struct_) : struct_ =
+  let split (Field f) =
+    match (f.field_name, f.field_typ) with
+    | Some fname, Casetype { tag; _ } when not (is_int_dispatch_typ tag) ->
+        let tag_field = Field { f with field_typ = tag } in
+        let body_field = field (fname ^ "_body") All_bytes in
+        [ tag_field; body_field ]
+    | _ -> [ Field f ]
+  in
+  { s with fields = List.concat_map split s.fields }
+
+let module_ ?doc decls =
+  (* Auto-prepend enum and casetype declarations needed by typedefs in
+     [decls] but not already declared in the module. Output order matches
+     the order [casetype_decls_of_struct] returns: dispatch before
+     wrapper, since the wrapper applies the dispatch. *)
+  let decl_name = function
+    | Enum_decl { name; _ } -> Some name
+    | Casetype_decl { name; _ } -> Some name
+    | Typedef { struct_ = { name; _ }; _ } -> Some name
+    | _ -> None
+  in
+  let already_declared =
+    List.filter_map decl_name decls |> List.fold_left (fun acc n -> n :: acc) []
+  in
+  (* First pass: split string-tagged casetype fields in every typedef.
+     This must happen before [casetype_decls_of_struct] runs so the
+     wrapper-and-dispatch projection only sees int-tagged casetypes. *)
+  let split_decls =
+    List.map
+      (function
+        | Typedef ({ struct_; _ } as t) ->
+            Typedef { t with struct_ = split_string_casetype_fields struct_ }
+        | d -> d)
+      decls
+  in
+  let extra_rev, _ =
     List.fold_left
-      (fun acc d ->
+      (fun (acc_rev, seen) d ->
         match d with
         | Typedef { struct_; _ } ->
-            List.filter
-              (fun e ->
-                match e with
-                | Enum_decl { name; _ } ->
-                    not
-                      (List.mem name already_declared
-                      || List.exists
-                           (function
-                             | Enum_decl { name = n; _ } -> String.equal n name
-                             | _ -> false)
-                           acc)
-                | _ -> false)
-              (enum_decls struct_)
-            @ acc
-        | _ -> acc)
-      [] decls
+            let candidates =
+              enum_decls struct_ @ casetype_decls_of_struct struct_
+            in
+            List.fold_left
+              (fun (acc_rev, seen) e ->
+                match decl_name e with
+                | None -> (acc_rev, seen)
+                | Some n when List.mem n seen -> (acc_rev, seen)
+                | Some n -> (e :: acc_rev, n :: seen))
+              (acc_rev, seen) candidates
+        | _ -> (acc_rev, seen))
+      ([], already_declared) split_decls
   in
-  { doc; decls = List.rev extra @ decls }
+  { doc; decls = List.rev extra_rev @ split_decls }
 
 (* 3D and C reserved words that cannot be used as field/param names. *)
 module Reserved_3d = Set.Make (String)

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -149,8 +149,8 @@ and _ typ =
       -> int typ  (** Named enumeration. *)
   | Casetype : {
       name : string;
-      tag : int typ;
-      cases : 'a case_branch list;
+      tag : 'k typ;
+      cases : ('a, 'k) case_branch list;
     }
       -> 'a typ  (** Tag-dispatched union. *)
   | Struct : struct_ -> unit typ  (** Nested struct. *)
@@ -185,14 +185,14 @@ and _ typ =
     }
       -> 'seq typ  (** Repeated elements filling a byte budget. *)
 
-and 'a case_branch =
+and ('a, 'k) case_branch =
   | Case_branch : {
-      cb_tag : int option;
+      cb_tag : 'k option;
       cb_inner : 'w typ;
       cb_inject : 'w -> 'a;
       cb_project : 'a -> 'w option;
     }
-      -> 'a case_branch
+      -> ('a, 'k) case_branch
 
 and packed_expr =
   | Pack_expr : 'a expr -> packed_expr  (** Existentially packed expression. *)
@@ -495,24 +495,33 @@ val enum : string -> (string * int) list -> int typ -> int typ
 val variants : string -> (string * 'a) list -> int typ -> 'a typ
 (** Named variant mapping over an integer base. *)
 
-type 'a case_def
-(** A casetype branch definition. *)
+type ('a, 'k) case_def
+(** A casetype branch definition. ['k] is the discriminator type. *)
 
 val case :
-  ?index:int ->
+  ?index:'k ->
   'w typ ->
   inject:('w -> 'a) ->
   project:('a -> 'w option) ->
-  'a case_def
+  ('a, 'k) case_def
 (** A branch matching a specific tag value. *)
 
 val default :
-  'w typ -> inject:('w -> 'a) -> project:('a -> 'w option) -> 'a case_def
+  'w typ -> inject:('w -> 'a) -> project:('a -> 'w option) -> ('a, 'k) case_def
 (** A default branch. *)
 
-val casetype :
-  ?first:int -> ?step:int -> string -> int typ -> 'a case_def list -> 'a typ
-(** Tag-dispatched union type. *)
+val casetype : string -> 'k typ -> ('a, 'k) case_def list -> 'a typ
+(** [casetype name tag defs] is a tag-dispatched union. Every case must supply
+    an explicit [~index]; the discriminator type ['k] can be [int], [string], or
+    any other typ with decidable equality. *)
+
+val split_string_casetype_fields : struct_ -> struct_
+(** [split_string_casetype_fields s] rewrites each [Casetype] field of [s] whose
+    tag is not an int-shaped typ into two adjacent byte fields: the tag bytes
+    and a trailing [all_bytes] body. Used by the 3D projection so string-tagged
+    casetype dispatch becomes caller code instead of parser code, matching how
+    real protocol implementations like OpenSSH split the parse and dispatch
+    steps. *)
 
 (** {1 Struct Constructors} *)
 

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -297,12 +297,12 @@ let rec parse_direct : type a. a typ -> bytes -> int -> int -> a * int =
   | Qualified_ref _ -> failwith "qualified_ref requires a type registry"
   | Apply _ -> failwith "apply requires a type registry"
 
-and parse_casetype : type a.
-    int typ -> a case_branch list -> bytes -> int -> int -> a * int =
+and parse_casetype : type a k.
+    k typ -> (a, k) case_branch list -> bytes -> int -> int -> a * int =
  fun tag cases buf off len ->
   let tag_val, off' = parse_direct tag buf off len in
   let rec find_case = function
-    | [] -> raise (Parse_exn (Invalid_tag tag_val))
+    | [] -> raise (Parse_exn (Constraint_failed "casetype: no matching case"))
     | Case_branch { cb_tag = Some expected; cb_inner; cb_inject; _ } :: rest ->
         if expected = tag_val then
           let body, off'' = parse_direct cb_inner buf off' len in
@@ -597,8 +597,8 @@ let rec encode_into : type a. a typ -> a -> encoder -> unit =
   | Qualified_ref _ -> failwith "qualified_ref requires a type registry"
   | Apply _ -> failwith "apply requires a type registry"
 
-and encode_casetype : type a.
-    int typ -> a case_branch list -> a -> encoder -> unit =
+and encode_casetype : type a k.
+    k typ -> (a, k) case_branch list -> a -> encoder -> unit =
  fun tag cases v enc ->
   let rec find_case = function
     | [] -> failwith "casetype encoding: no matching case"

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -613,23 +613,24 @@ val variants : string -> (string * 'a) list -> int typ -> 'a typ
 (** [variants name cases base] maps integer values to OCaml values via a named
     enumeration. Unlike {!enum}, this converts to proper OCaml values. *)
 
-type 'a case_def
+type ('a, 'k) case_def
 
 val case :
-  ?index:int ->
+  ?index:'k ->
   'w typ ->
   inject:('w -> 'a) ->
   project:('a -> 'w option) ->
-  'a case_def
+  ('a, 'k) case_def
 (** Tagged branch of a casetype. *)
 
 val default :
-  'w typ -> inject:('w -> 'a) -> project:('a -> 'w option) -> 'a case_def
+  'w typ -> inject:('w -> 'a) -> project:('a -> 'w option) -> ('a, 'k) case_def
 (** Default branch of a casetype. *)
 
-val casetype :
-  ?first:int -> ?step:int -> string -> int typ -> 'a case_def list -> 'a typ
-(** Tag-dispatched choice between several descriptions. *)
+val casetype : string -> 'k typ -> ('a, 'k) case_def list -> 'a typ
+(** [casetype name tag defs] is a tag-dispatched union. The discriminator typ
+    ['k] can be [int], [string], or any other typ with decidable equality; every
+    case must supply an explicit [~index]. *)
 
 val size : 'a typ -> int option
 (** [size t] is the fixed wire size of a description, if known statically. *)


### PR DESCRIPTION
Generalises `Wire.casetype` to a parametric discriminator type `'k typ` and makes both shapes project cleanly to EverParse 3D.

**Int-tagged casetype** auto-emits a `casetype_decl` dispatch plus a small wrapper typedef holding the tag + body. The user's `Casetype` typ then references the wrapper. Mirrors the existing `enum_decls` auto-extraction.

**String-tagged casetype** (e.g. `byte_array ~size`) splits into two adjacent byte spans -- the tag bytes and a trailing `all_bytes` body. Case dispatch happens in caller code, the way OpenSSH (`auth2.c`), Go `x/crypto/ssh`, libssh and wolfSSH all handle string-discriminated messages: read the bytes, `strcmp` against a known method table, then parse the body. No 3D-side extern callback, no scratch slot, no runtime helper -- the C plug exposes both spans through the existing `SetBytes` mechanism.

The wire data is unchanged in either case; only the validator surface differs.

Test coverage: both shapes go through the same `compile_and_run` flow as every other schema (`Ctt` for int tag, `Sshauth` for string tag). 21/21 wire_3d tests pass.