### PR TITLE
Project sub-codecs embedded in casetype cases to 3D

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,10 @@
   `byte_array ~size`) project as two adjacent byte spans so dispatch
   happens in caller code, matching how OpenSSH and similar protocol
   parsers handle string-discriminated messages (#49, @samoht)
+- Project a casetype case whose body is an embedded sub-codec to a
+  separate 3D struct. Sub-codecs may end in `all_bytes`; the
+  declaration order places the sub-codec before the dispatch decl
+  that names it (#50, @samoht)
 - Support `Wire.casetype` and `Wire.nested ~size` as `Codec` fields
   (#47, @samoht)
 - Add `Field.optional` / `Field.optional_or` / `Field.repeat` /

--- a/lib/test/everparse/test_wire_3d.ml
+++ b/lib/test/everparse/test_wire_3d.ml
@@ -209,12 +209,48 @@ let e2e_ssh_casetype_codec =
   let f = Field.v "method" body in
   Codec.v "Sshauth" (fun m -> m) [ Codec.( $ ) f (fun m -> m) ]
 
+(* Casetype with a sub-codec body that itself contains a trailing
+   [all_bytes]. The 3D projection emits the sub-codec as its own typedef
+   before the casetype's dispatch decl, and [all_bytes] inside the
+   sub-codec consumes through end-of-buffer -- correct because the
+   casetype is constrained to be the last field of its parent. *)
+type session = { recipient : int; rest : string }
+type channel_confirm = Session of session | Tcpip of int
+
+let session_codec =
+  let open Wire in
+  let f_recip = Field.v "recipient" uint32be in
+  let f_rest = Field.v "rest" all_bytes in
+  Codec.v "Session"
+    (fun r b -> { recipient = Wire.Private.UInt32.to_int r; rest = b })
+    [
+      Codec.( $ ) f_recip (fun s -> Wire.Private.UInt32.of_int s.recipient);
+      Codec.( $ ) f_rest (fun s -> s.rest);
+    ]
+
+let e2e_codec_in_casetype =
+  let open Wire in
+  let body : channel_confirm typ =
+    casetype "Confirm" uint8
+      [
+        case ~index:1 (codec session_codec)
+          ~inject:(fun s -> Session s)
+          ~project:(function Session s -> Some s | _ -> None);
+        case ~index:2 uint16be
+          ~inject:(fun n -> Tcpip n)
+          ~project:(function Tcpip n -> Some n | _ -> None);
+      ]
+  in
+  let f = Field.v "msg" body in
+  Codec.v "ChannelOpen" (fun m -> m) [ Codec.( $ ) f (fun m -> m) ]
+
 let test_e2e_compile_run () =
   compile_and_run ~name:"Demo" e2e_simple_codec;
   compile_and_run ~name:"CLCW" e2e_allcaps_codec;
   compile_and_run ~name:"TMFrame" e2e_tm_codec;
   compile_and_run ~name:"Ctt" e2e_casetype_codec;
   compile_and_run ~name:"Sshauth" e2e_ssh_casetype_codec;
+  compile_and_run ~name:"ChannelOpen" e2e_codec_in_casetype;
   compile_and_run ~name:"rpmsg_endpoint_info" e2e_snake_codec;
   compile_and_run ~name:"EP_Header" e2e_mixed_codec;
   compile_and_run ~name:"UnderflowCheck" e2e_underflow_codec

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -129,6 +129,9 @@ and _ typ =
       codec_fixed_size : int option;
       codec_size_of : bytes -> int -> int;
       codec_field_readers : (string * (bytes -> int -> int)) list;
+      codec_struct : struct_;
+          (** Structural representation of the codec. Mirrors [codec_decode] /
+              [codec_encode] but in a form 3D projection can walk. *)
     }
       -> 'r typ
   | Optional : { present : bool expr; inner : 'a typ } -> 'a option typ
@@ -743,13 +746,24 @@ let casetype_decls_of_struct (s : struct_) : decl list =
     | Casetype { name; tag; cases }
       when is_int_dispatch_typ tag && not (Hashtbl.mem seen name) ->
         Hashtbl.add seen name ();
+        (* Visit case inners first so any sub-codecs / nested casetypes they
+           reference are declared before the dispatch that names them. *)
+        List.iter (fun (Case_branch { cb_inner; _ }) -> extract cb_inner) cases;
         let dispatch, wrapper = casetype_pair name tag cases in
-        acc := wrapper :: dispatch :: !acc;
-        List.iter (fun (Case_branch { cb_inner; _ }) -> extract cb_inner) cases
+        acc := wrapper :: dispatch :: !acc
     | Casetype { cases; _ } ->
         (* String-tagged casetype: handled by [split_string_casetype_fields].
            Still walk inner case typs for nested int-tagged casetypes. *)
         List.iter (fun (Case_branch { cb_inner; _ }) -> extract cb_inner) cases
+    | Codec { codec_name; codec_struct; _ }
+      when not (Hashtbl.mem seen codec_name) ->
+        (* Embedded sub-codec: emit its struct alongside the parent so 3D
+           references to [codec_name] resolve. Recurse into the sub-codec's
+           own fields to catch nested casetype / sub-codec dependencies. *)
+        Hashtbl.add seen codec_name ();
+        acc := typedef codec_struct :: !acc;
+        List.iter (fun (Field f) -> extract f.field_typ) codec_struct.fields
+    | Codec _ -> ()
     | Map { inner; _ } -> extract inner
     | Where { inner; _ } -> extract inner
     | Optional { inner; _ } -> extract inner

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -168,6 +168,8 @@ and _ typ =
       codec_fixed_size : int option;
       codec_size_of : bytes -> int -> int;
       codec_field_readers : (string * (bytes -> int -> int)) list;
+      codec_struct : struct_;
+          (** Structural form of the codec, used by the 3D projection. *)
     }
       -> 'r typ  (** Embedded sub-codec. *)
   | Optional : { present : bool expr; inner : 'a typ } -> 'a option typ

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -64,6 +64,7 @@ let codec (c : 'r Codec.t) : 'r typ =
   let codec_decode = Codec.raw_decode c in
   let codec_encode = Codec.raw_encode c in
   let codec_field_readers = Codec.field_readers c in
+  let codec_struct = Codec.to_struct c in
   match Codec.wire_size_info c with
   | `Fixed n ->
       Codec
@@ -74,6 +75,7 @@ let codec (c : 'r Codec.t) : 'r typ =
           codec_fixed_size = Some n;
           codec_size_of = (fun _buf _off -> n);
           codec_field_readers;
+          codec_struct;
         }
   | `Variable size_of ->
       Codec
@@ -84,6 +86,7 @@ let codec (c : 'r Codec.t) : 'r typ =
           codec_fixed_size = None;
           codec_size_of = size_of;
           codec_field_readers;
+          codec_struct;
         }
 
 type ('elt, 'seq) seq_map = ('elt, 'seq) Types.seq_map =


### PR DESCRIPTION
A `Wire.casetype` case whose body is a sub-codec (`Wire.codec c`) now projects to a 3D struct alongside the parent. The `Codec` typ now carries its source struct; `casetype_decls_of_struct` walks the case bodies, emits each unique sub-codec as a typedef, and orders the output so the sub-codec is declared before the dispatch that names it.

Unlocks `CHANNEL_OPEN_CONFIRMATION`-style SSH messages where each case body is a record ending in `all_bytes`. The trailing-rest semantics already worked on the OCaml side; this PR makes the 3D side accept the same shape.