### PR TITLE
Project Field.repeat over variable-size elements to 3D

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,9 @@
   separate 3D struct. Sub-codecs may end in `all_bytes`; the
   declaration order places the sub-codec before the dispatch decl
   that names it (#50, @samoht)
+- `Field.repeat` now projects to 3D for variable-size elements (e.g.
+  a sub-codec with its own length-prefixed bytes), emitting
+  `<Elem> name[:byte-size budget]` (#51, @samoht)
 - Support `Wire.casetype` and `Wire.nested ~size` as `Codec` fields
   (#47, @samoht)
 - Add `Field.optional` / `Field.optional_or` / `Field.repeat` /

--- a/lib/everparse.ml
+++ b/lib/everparse.ml
@@ -33,6 +33,9 @@ let rec is_byte_field : type a. a Types.typ -> bool = function
      actions. Treat it like a byte span: the SetBytes setter receives an
      offset into the buffer, and the C side decodes if it wants to. *)
   | Types.Casetype _ -> true
+  (* A repeat-into-list field has no single value 3D can read; expose its
+     bytes via the [SetBytes] offset just like other variable-size fields. *)
+  | Types.Repeat _ -> true
   | _ -> false
 
 type setter_info = { setter_name : string; setter_val_typ : Types.packed_typ }

--- a/lib/test/everparse/test_wire_3d.ml
+++ b/lib/test/everparse/test_wire_3d.ml
@@ -244,6 +244,36 @@ let e2e_codec_in_casetype =
   let f = Field.v "msg" body in
   Codec.v "ChannelOpen" (fun m -> m) [ Codec.( $ ) f (fun m -> m) ]
 
+(* [Field.repeat] over a sub-codec whose own size is dynamic (here a
+   length-prefixed name). Projects to a byte-budget repeat
+   [Ext exts[:byte-size total]] in 3D. *)
+type ext = { name : string }
+
+let ext_codec =
+  let open Wire in
+  let f_len = Field.v "name_len" uint8 in
+  let f_name = Field.v "name" (byte_array ~size:(Field.ref f_len)) in
+  Codec.v "Ext"
+    (fun _l n -> { name = n })
+    [
+      Codec.( $ ) f_len (fun e -> String.length e.name);
+      Codec.( $ ) f_name (fun e -> e.name);
+    ]
+
+let e2e_repeat_var_elem =
+  let open Wire in
+  let f_total = Field.v "total" uint8 in
+  let f_exts =
+    Field.repeat "exts" ~size:(Field.ref f_total) (codec ext_codec)
+  in
+  Codec.v "Exts"
+    (fun _t xs -> xs)
+    [
+      Codec.( $ ) f_total (fun xs ->
+          List.fold_left (fun a e -> a + 1 + String.length e.name) 0 xs);
+      Codec.( $ ) f_exts (fun xs -> xs);
+    ]
+
 let test_e2e_compile_run () =
   compile_and_run ~name:"Demo" e2e_simple_codec;
   compile_and_run ~name:"CLCW" e2e_allcaps_codec;
@@ -251,6 +281,7 @@ let test_e2e_compile_run () =
   compile_and_run ~name:"Ctt" e2e_casetype_codec;
   compile_and_run ~name:"Sshauth" e2e_ssh_casetype_codec;
   compile_and_run ~name:"ChannelOpen" e2e_codec_in_casetype;
+  compile_and_run ~name:"Exts" e2e_repeat_var_elem;
   compile_and_run ~name:"rpmsg_endpoint_info" e2e_snake_codec;
   compile_and_run ~name:"EP_Header" e2e_mixed_codec;
   compile_and_run ~name:"UnderflowCheck" e2e_underflow_codec


### PR DESCRIPTION
A `Field.repeat` whose element is itself variable-size (e.g. a sub-codec with a length-prefixed bytes field) now compiles end-to-end. The OCaml side already handled it; this makes the 3D projection treat the repeat field as a byte-budget span (`<Elem> name[:byte-size budget]`).

Unlocks SSH `EXT_INFO`-style messages: a count-prefixed list of extensions where each extension carries a variable-length name + value.