### PR TITLE
Fold duplicate helpers surfaced by dupfind

### DIFF
--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -2,13 +2,23 @@ open Types
 module Slice = Bytesrw.Bytes.Slice
 module Param = Param
 
-(** Build a specialized field encoder: writes field value to bytes at offset.
-    Returns the new offset. Works directly on the slice's underlying bytes. *)
-let blit_string_padded n buf off v =
-  let len = min n (String.length v) in
-  Bytes.blit_string v 0 buf off len;
+(** Generic blit-with-padding into a fixed [n]-byte window. The caller supplies
+    the source length and a copy callback that writes exactly [len] bytes
+    starting at the given destination offset; this helper handles bounding by
+    [n] and zeroing the tail. *)
+let blit_padded n buf off ~src_len ~blit =
+  let len = min n src_len in
+  blit ~dst_off:off ~len;
   if len < n then Bytes.fill buf (off + len) (n - len) '\x00';
   off + n
+
+let blit_string_padded n buf off v =
+  blit_padded n buf off ~src_len:(String.length v) ~blit:(fun ~dst_off ~len ->
+      Bytes.blit_string v 0 buf dst_off len)
+
+let blit_slice_padded n buf off src =
+  blit_padded n buf off ~src_len:(Slice.length src) ~blit:(fun ~dst_off ~len ->
+      Bytes.blit (Slice.bytes src) (Slice.first src) buf dst_off len)
 
 (* Pack a fixed-width integer setter into a [bytes -> int -> int -> int]
    field encoder that returns the offset advance. Used by the scalar cases
@@ -2400,22 +2410,13 @@ let decode ?env t buf off =
 let encode t v buf off = t.t_encode v buf off
 
 let collect_params (fields : Types.field list) where =
-  let seen = Hashtbl.create 4 in
-  let params = Stdlib.ref ([] : param list) in
-  let visit (Param.Pack p) =
-    if not (Hashtbl.mem seen p.ph_name) then begin
-      Hashtbl.add seen p.ph_name ();
-      params :=
-        {
-          param_name = p.ph_name;
-          param_typ = p.ph_packed_typ;
-          mutable_ = p.ph_mutable;
-        }
-        :: !params
-    end
-  in
-  iter_param_refs_fields visit fields where;
-  List.rev !params
+  collect_param_handles fields where
+  |> List.map (fun (Param.Pack p) ->
+      {
+        param_name = p.ph_name;
+        param_typ = p.ph_packed_typ;
+        mutable_ = p.ph_mutable;
+      })
 
 let to_struct t =
   let formals = collect_params t.t_struct_fields t.t_where in

--- a/lib/codec.mli
+++ b/lib/codec.mli
@@ -172,3 +172,13 @@ val load_word : bitfield -> (bytes -> int -> int) Staged.t
 val extract : bitfield -> int -> int
 (** [extract bf word] extracts the field from a pre-loaded word value. Pure
     shift+mask, no memory access. *)
+
+val blit_string_padded : int -> bytes -> int -> string -> int
+(** [blit_string_padded n buf off s] writes [s] into [buf] at [off], zero-pads
+    the trailing bytes if [String.length s < n], and returns [off + n]. Shared
+    helper for both record and top-level encoders. *)
+
+val blit_slice_padded : int -> bytes -> int -> Bytesrw.Bytes.Slice.t -> int
+(** [blit_slice_padded n buf off src] is like {!blit_string_padded} but copies
+    from a {!Bytesrw.Bytes.Slice.t}. Top-level [encode_direct] uses it for
+    [byte_slice] fields. *)

--- a/lib/param.ml
+++ b/lib/param.ml
@@ -2,57 +2,47 @@ type input = Types.param_input
 type output = Types.param_output
 type ('a, 'k) t = ('a, 'k) Types.param_handle
 
-let rec to_int : type a. a Types.typ -> a -> int =
- fun typ v ->
+(* Per-typ converter from the OCaml representation to [int] and back. One
+   match dispatches both directions; [to_int] and [of_int] just project
+   the relevant field. Avoids drift between the parallel cases. *)
+type 'a int_cvt = { fwd : 'a -> int; bwd : int -> 'a }
+
+let rec int_cvt : type a. a Types.typ -> a int_cvt =
+ fun typ ->
+  let id : 'a int_cvt = { fwd = (fun v -> v); bwd = (fun v -> v) } in
   match typ with
-  | Uint8 -> v
-  | Uint16 _ -> v
-  | Uint_var _ -> v
-  | Uint32 _ -> UInt32.to_int v
-  | Uint63 _ -> UInt63.to_int v
-  | Uint64 _ -> Int64.unsigned_to_int v |> Option.value ~default:max_int
-  | Int8 -> v
-  | Int16 _ -> v
-  | Int32 _ -> v
-  | Int64 _ -> Int64.to_int v
+  | Uint8 -> id
+  | Uint16 _ -> id
+  | Uint_var _ -> id
+  | Uint32 _ -> { fwd = UInt32.to_int; bwd = UInt32.of_int }
+  | Uint63 _ -> { fwd = UInt63.to_int; bwd = UInt63.of_int }
+  | Uint64 _ ->
+      {
+        fwd =
+          (fun v -> Int64.unsigned_to_int v |> Option.value ~default:max_int);
+        bwd = Int64.of_int;
+      }
+  | Int8 -> id
+  | Int16 _ -> id
+  | Int32 _ -> id
+  | Int64 _ -> { fwd = Int64.to_int; bwd = Int64.of_int }
   | Float32 _ -> invalid_arg "Param: floats are not integer-representable"
   | Float64 _ -> invalid_arg "Param: floats are not integer-representable"
-  | Bits _ -> v
-  | Enum { base; _ } -> to_int base v
-  | Where { inner; _ } -> to_int inner v
-  | Single_elem { elem; _ } -> to_int elem v
-  | Map { inner; encode; _ } -> to_int inner (encode v)
-  | Apply { typ; _ } -> to_int typ v
+  | Bits _ -> id
+  | Enum { base; _ } -> int_cvt base
+  | Where { inner; _ } -> int_cvt inner
+  | Single_elem { elem; _ } -> int_cvt elem
+  | Map { inner; encode; decode } ->
+      let c = int_cvt inner in
+      { fwd = (fun v -> c.fwd (encode v)); bwd = (fun v -> decode (c.bwd v)) }
+  | Apply { typ; _ } -> int_cvt typ
   | Unit | All_bytes | All_zeros | Array _ | Byte_array _ | Byte_array_where _
   | Byte_slice _ | Casetype _ | Struct _ | Type_ref _ | Qualified_ref _
   | Codec _ | Optional _ | Optional_or _ | Repeat _ ->
       invalid_arg "Param: unsupported parameter type"
 
-let rec of_int : type a. a Types.typ -> int -> a =
- fun typ v ->
-  match typ with
-  | Uint8 -> v
-  | Uint16 _ -> v
-  | Uint_var _ -> v
-  | Uint32 _ -> UInt32.of_int v
-  | Uint63 _ -> UInt63.of_int v
-  | Uint64 _ -> Int64.of_int v
-  | Int8 -> v
-  | Int16 _ -> v
-  | Int32 _ -> v
-  | Int64 _ -> Int64.of_int v
-  | Float32 _ -> invalid_arg "Param: floats are not integer-representable"
-  | Float64 _ -> invalid_arg "Param: floats are not integer-representable"
-  | Bits _ -> v
-  | Enum { base; _ } -> of_int base v
-  | Where { inner; _ } -> of_int inner v
-  | Single_elem { elem; _ } -> of_int elem v
-  | Map { inner; decode; _ } -> decode (of_int inner v)
-  | Apply { typ; _ } -> of_int typ v
-  | Unit | All_bytes | All_zeros | Array _ | Byte_array _ | Byte_array_where _
-  | Byte_slice _ | Casetype _ | Struct _ | Type_ref _ | Qualified_ref _
-  | Codec _ | Optional _ | Optional_or _ | Repeat _ ->
-      invalid_arg "Param: unsupported parameter type"
+let to_int typ v = (int_cvt typ).fwd v
+let of_int typ v = (int_cvt typ).bwd v
 
 let rec is_int_representable : type a. a Types.typ -> bool = function
   | Types.Uint8 | Types.Uint16 _ | Types.Uint_var _ | Types.Uint32 _

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -647,18 +647,6 @@ let encode_bits buf off v width base bit_order =
       Bytes.set_int32_be buf off (Int32.of_int masked);
       off + 4
 
-let encode_padded_string buf off n s =
-  let len = min n (String.length s) in
-  Bytes.blit_string s 0 buf off len;
-  if len < n then Bytes.fill buf (off + len) (n - len) '\x00';
-  off + n
-
-let encode_padded_slice buf off n src =
-  let len = min n (Slice.length src) in
-  Bytes.blit (Slice.bytes src) (Slice.first src) buf off len;
-  if len < n then Bytes.fill buf (off + len) (n - len) '\x00';
-  off + n
-
 (* Variable-size fallback: encode via the writer kernel into a Buffer,
    then blit. Used by [encode_direct]'s catch-all. *)
 let encode_via_writer typ buf off v =
@@ -717,8 +705,8 @@ let rec encode_direct : type a. a typ -> bytes -> int -> a -> int =
       let n = String.length v in
       Bytes.blit_string v 0 buf off n;
       off + n
-  | Byte_array { size = Int n } -> encode_padded_string buf off n v
-  | Byte_slice { size = Int n } -> encode_padded_slice buf off n v
+  | Byte_array { size = Int n } -> Codec.blit_string_padded n buf off v
+  | Byte_slice { size = Int n } -> Codec.blit_slice_padded n buf off v
   | Single_elem { size = Int n; elem; at_most = _ } ->
       let off' = encode_direct elem buf off v in
       if off' < off + n then Bytes.fill buf off' (off + n - off') '\x00';
@@ -748,17 +736,7 @@ let to_bytes typ v =
       to_writer typ v writer;
       Buffer.to_bytes buf
 
-let to_string typ v =
-  match field_wire_size typ with
-  | Some n ->
-      let buf = Bytes.create n in
-      ignore (encode_direct typ buf 0 v);
-      Bytes.unsafe_to_string buf
-  | None ->
-      let buf = Buffer.create 64 in
-      let writer = Writer.of_buffer buf in
-      to_writer typ v writer;
-      Buffer.contents buf
+let to_string typ v = Bytes.unsafe_to_string (to_bytes typ v)
 
 type 'r codec = 'r Codec.t
 


### PR DESCRIPTION
`dupfind scan lib/` was flagging five accidental duplicates across the encoder helpers, `to_bytes`/`to_string`, the codec's parameter collectors, and `Param.{to_int,of_int}`. Folding each into a shared form drops the duplication and removes the drift surface; net −21 lines.

`dupfind scan lib/ | grep -v /test/` is empty after this PR.