### PR TITLE
codec: encode takes Param.env, with totality check

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,6 +53,12 @@
 
 ### Fixed
 
+- `Codec.encode` / `Codec.raw_encode` accept `?env:Param.env`, mirroring
+  `Codec.decode`. Encoding a parametric codec without an env (or with an
+  env that left an input param unbound) now raises `Invalid_argument`
+  naming the offending param instead of silently writing zero-sized
+  regions. A parametric byte field whose value length disagrees with its
+  env-bound size also raises rather than truncating (#53, @samoht)
 - Fix silent always-true compilation of `Field.optional` /
   `Field.optional_or` predicates that use bitwise / shift / mod
   operators, and fix `Field.ref` on an `optional` field reading 0

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -1647,20 +1647,38 @@ and var_bytes_reader : type a.
   | _ -> assert false
 
 and var_bytes_writer : type a r.
-    a typ -> (r -> a) -> (bytes -> int -> int) -> r -> bytes -> int -> unit =
- fun typ get off_fn v buf off ->
+    a typ ->
+    (r -> a) ->
+    (bytes -> int -> int) ->
+    (bytes -> int -> int) ->
+    r ->
+    bytes ->
+    int ->
+    unit =
+ fun typ get off_fn size_fn v buf off ->
   let fo = off_fn buf off in
   let value = get v in
+  let check_len ~actual =
+    let expected = size_fn buf off in
+    if actual <> expected then
+      Fmt.invalid_arg
+        "Codec.encode: byte field length %d does not match expected %d \
+         (parametric size, bind via ?env)"
+        actual expected
+  in
   match typ with
   | Byte_slice _ ->
       let src = (value : Slice.t) in
+      check_len ~actual:(Slice.length src);
       Bytes.blit (Slice.bytes src) (Slice.first src) buf (off + fo)
         (Slice.length src)
   | Byte_array _ ->
       let s = (value : string) in
+      check_len ~actual:(String.length s);
       Bytes.blit_string s 0 buf (off + fo) (String.length s)
   | Byte_array_where _ ->
       let s = (value : string) in
+      check_len ~actual:(String.length s);
       Bytes.blit_string s 0 buf (off + fo) (String.length s)
   | All_bytes ->
       let s = (value : string) in
@@ -1739,7 +1757,7 @@ and compile_var_bytes : type a r.
         (raw_reader, raw_writer, int_reader)
     | _ ->
         let raw_reader = var_bytes_reader typ off_fn size_fn in
-        let raw_writer = var_bytes_writer typ fld.get off_fn in
+        let raw_writer = var_bytes_writer typ fld.get off_fn size_fn in
         let int_reader buf base =
           match int_of_typ_value typ (raw_reader buf base) with
           | Some v -> v
@@ -2365,7 +2383,54 @@ let is_fixed t =
   match t.t_wire_size with Fixed _ -> true | Variable _ -> false
 
 let raw_decode t buf off = t.t_decode buf off
-let raw_encode t v buf off = t.t_encode v buf off
+
+(* Copy each input param's env value into its [ph_cell]. The encode
+   closures read [Param_ref p] via [!(p.ph_cell)] (see [bytes_leaves]
+   in [compile_expr]), so the cells are the runtime backing for
+   parametric field sizes. Mirror of the env -> array blit in
+   [decode_exn]. *)
+let load_env_into_cells (t : 'r t) (env : Param.env) =
+  List.iter
+    (fun (Param.Pack p) ->
+      if p.ph_env_idx >= 0 then p.ph_cell := env.pe_slots.(p.ph_env_idx))
+    t.t_param_handles
+
+(* Reject [encode] on a parametric codec without an env, and reject envs
+   that left an input param unbound. Either case would silently resolve
+   parametric sizes to 0 (the ph_cell init value), producing zero-byte
+   regions for byte_array / byte_slice / uint_var fields and writing the
+   rest of the record at the wrong offsets. *)
+let unbound_params (t : 'r t) (env : Param.env) : string list =
+  List.filter_map
+    (fun (Param.Pack p) ->
+      if
+        (not p.Types.ph_mutable) && p.ph_env_idx >= 0
+        && not env.pe_bound.(p.ph_env_idx)
+      then Some p.ph_name
+      else None)
+    t.t_param_handles
+
+let require_env t = function
+  | None when t.t_n_params = 0 -> ()
+  | None ->
+      Fmt.invalid_arg
+        "Codec.encode: codec %s has parameters; pass ?env (e.g. [Codec.env c \
+         |> Param.bind p N])."
+        t.t_name
+  | Some env -> (
+      match unbound_params t env with
+      | [] -> ()
+      | missing ->
+          Fmt.invalid_arg
+            "Codec.encode: codec %s has unbound input params [%s]; bind every \
+             one before encoding."
+            t.t_name
+            (String.concat ", " missing))
+
+let raw_encode ?env:e t v buf off =
+  require_env t e;
+  (match e with Some env -> load_env_into_cells t env | None -> ());
+  t.t_encode v buf off
 
 let wire_size_info t =
   match t.t_wire_size with
@@ -2373,7 +2438,11 @@ let wire_size_info t =
   | Variable { compute; _ } -> `Variable (fun buf off -> compute buf off - off)
 
 let env t : Param.env =
-  { Types.pe_codec_id = t.t_id; pe_slots = Array.make t.t_n_params 0 }
+  {
+    Types.pe_codec_id = t.t_id;
+    pe_slots = Array.make t.t_n_params 0;
+    pe_bound = Array.make t.t_n_params false;
+  }
 
 let decode_exn ?env:e t buf off =
   let v = t.t_decode buf off in
@@ -2397,7 +2466,10 @@ let decode_exn ?env:e t buf off =
 let decode ?env t buf off =
   try Ok (decode_exn ?env t buf off) with Types.Parse_error e -> Error e
 
-let encode t v buf off = t.t_encode v buf off
+let encode ?env:e t v buf off =
+  require_env t e;
+  (match e with Some env -> load_env_into_cells t env | None -> ());
+  t.t_encode v buf off
 
 let collect_params (fields : Types.field list) where =
   let seen = Hashtbl.create 4 in

--- a/lib/codec.mli
+++ b/lib/codec.mli
@@ -60,10 +60,43 @@ val decode_exn : ?env:Param.env -> 'r t -> bytes -> int -> 'r
 (** [decode_exn ?env c buf off] is like {!decode} but raises
     {!Types.Parse_error} on failure. *)
 
-val encode : 'r t -> 'r -> bytes -> int -> unit
-(** [encode c r buf off] encodes record [r] into [buf] at offset [off].
+val encode : ?env:Param.env -> 'r t -> 'r -> bytes -> int -> unit
+(** [encode ?env c r buf off] encodes record [r] into [buf] at offset [off].
 
-    Raises [Invalid_argument] if the destination buffer is too short. *)
+    For codecs with input parameters (e.g. [byte_array ~size:(Param.expr p)]),
+    the caller decides the width of each parametric field and tells the encoder
+    via [?env]:
+
+    {[
+    open Wire
+
+    let p_iv_len = Param.input "iv_len" uint8
+
+    let codec =
+      Codec.v "Hdr"
+        (fun iv -> iv)
+        Codec.
+          [
+            (Field.v "iv" (byte_array ~size:(Param.expr p_iv_len)) $ fun s -> s);
+          ]
+
+    let buf = Bytes.create 12
+    let env = Codec.env codec |> Param.bind p_iv_len 12
+
+    let () =
+      Codec.encode ~env codec (String.make 12 'a') buf 0;
+      assert (Bytes.to_string buf = String.make 12 'a')
+    ]}
+
+    Each bound width must match the length of the corresponding field value in
+    [record] -- the encoder cross-checks them. The same env shape works for
+    {!decode} when reading the bytes back, but [encode] does not need a prior
+    decode to obtain it.
+
+    Raises [Invalid_argument] when the codec has parameters and no env is
+    supplied, when the env left any input param unbound (the error names the
+    offending param), when the destination buffer is too short, or when a
+    parametric byte field's value length does not match its env-bound size. *)
 
 val to_struct : 'r t -> Types.struct_
 (** Project to a {!Types.struct_} declaration. *)
@@ -90,8 +123,9 @@ val set : 'r t -> ('a, 'r) field -> (bytes -> int -> 'a -> unit) Staged.t
 val raw_decode : 'r t -> bytes -> int -> 'r
 (** [raw_decode c buf off] decodes without validation. Internal use. *)
 
-val raw_encode : 'r t -> 'r -> bytes -> int -> unit
-(** [raw_encode c r buf off] encodes a record. Internal use. *)
+val raw_encode : ?env:Param.env -> 'r t -> 'r -> bytes -> int -> unit
+(** [raw_encode ?env c r buf off] encodes a record without [where]-clause
+    validation. Same env semantics as {!encode}. Internal use. *)
 
 val wire_size_info : 'r t -> [ `Fixed of int | `Variable of bytes -> int -> int ]
 (** Wire size information for embedding. *)

--- a/lib/param.ml
+++ b/lib/param.ml
@@ -110,9 +110,13 @@ type env = Types.param_env
 let bind (p : ('a, input) t) (v : 'a) (env : env) : env =
   let iv = to_int p.Types.ph_typ v in
   let slots = Array.copy env.pe_slots in
-  if p.ph_env_idx >= 0 then slots.(p.ph_env_idx) <- iv;
+  let bound = Array.copy env.pe_bound in
+  if p.ph_env_idx >= 0 then begin
+    slots.(p.ph_env_idx) <- iv;
+    bound.(p.ph_env_idx) <- true
+  end;
   p.ph_cell := iv;
-  { Types.pe_codec_id = env.pe_codec_id; pe_slots = slots }
+  { Types.pe_codec_id = env.pe_codec_id; pe_slots = slots; pe_bound = bound }
 
 let get (env : env) (p : ('a, 'k) t) : 'a =
   if p.Types.ph_env_idx < 0 then of_int p.ph_typ !(p.ph_cell)

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -192,7 +192,14 @@ and action_stmt =
   | If of bool expr * action_stmt list * action_stmt list option
   | Var of string * int expr
 
-type param_env = { pe_codec_id : int; pe_slots : int array }
+type param_env = {
+  pe_codec_id : int;
+  pe_slots : int array;
+  pe_bound : bool array;
+      (* Parallel to [pe_slots]: one bit per slot, set by [Param.bind] so
+         encoders can reject envs that left an input param at its
+         default-zero value. *)
+}
 
 (* Expression constructors *)
 let int n = Int n

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -232,7 +232,13 @@ and action_stmt =
   | If of bool expr * action_stmt list * action_stmt list option
   | Var of string * int expr  (** Action statement. *)
 
-type param_env = { pe_codec_id : int; pe_slots : int array }
+type param_env = {
+  pe_codec_id : int;
+  pe_slots : int array;
+  pe_bound : bool array;
+      (** Parallel to [pe_slots]; set by [Param.bind] so consumers can detect
+          unbound input params. *)
+}
 
 (** {1 Expression Constructors} *)
 

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -796,10 +796,19 @@ module Codec : sig
   val decode_exn : ?env:Param.env -> 'r t -> bytes -> int -> 'r
   (** Like {!decode} but raises {!exception:Parse_error} on failure. *)
 
-  val encode : 'r t -> 'r -> bytes -> int -> unit
-  (** Encodes one record value into a buffer at the given base offset.
+  val encode : ?env:Param.env -> 'r t -> 'r -> bytes -> int -> unit
+  (** [encode ?env c r buf off] encodes one record value into a buffer at the
+      given base offset.
 
-      Raises [Invalid_argument] if the destination buffer is too short. *)
+      For codecs with input parameters (e.g. [byte_array ~size:(Param.expr p)]),
+      the caller picks each parametric field's width and tells the encoder via
+      [?env] (built with [Codec.env c |> Param.bind p N]). The bound widths must
+      match the field values in [r]; the encoder cross-checks them.
+
+      Raises [Invalid_argument] when the codec has parameters and no env is
+      supplied, when the env left any input param unbound (the error names it),
+      when the destination buffer is too short, or when a parametric byte
+      field's value length does not match its env-bound size. *)
 
   val validate : 'r t -> bytes -> int -> unit
   (** [validate c buf off] checks field [~constraint_] and [~where] clauses

--- a/test/test_wire.ml
+++ b/test/test_wire.ml
@@ -394,6 +394,75 @@ let test_parse_param_with_params () =
   | Ok _ -> Alcotest.(check int) "out_len" 3 (Param.get env out_len)
   | Error e -> Alcotest.failf "%a" pp_parse_error e
 
+(* Encoding a parametric [byte_array ~size:(Param.expr p)] field must use
+   the env-bound size, not the (zero) default. Same env shape that
+   [decode ~env] accepts on the other side. *)
+type param_payload = { payload : string }
+
+let param_codec () =
+  let p_len = Param.input "len" uint8 in
+  let c =
+    Codec.v "ParamPayload"
+      (fun b -> { payload = b })
+      Codec.
+        [
+          ( Field.v "Data" (byte_array ~size:(Param.expr p_len)) $ fun r ->
+            r.payload );
+        ]
+  in
+  (c, p_len)
+
+let test_param_size_encode () =
+  let c, p_len = param_codec () in
+  List.iter
+    (fun n ->
+      let env = Codec.env c |> Param.bind p_len n in
+      let payload = String.make n 'A' in
+      let buf = Bytes.create 32 in
+      Codec.encode ~env c { payload } buf 0;
+      let actual = Bytes.sub_string buf 0 n in
+      Alcotest.(check string) (Fmt.str "encode len=%d" n) payload actual;
+      match Codec.decode ~env c buf 0 with
+      | Ok { payload = decoded } ->
+          Alcotest.(check string) (Fmt.str "roundtrip len=%d" n) payload decoded
+      | Error e -> Alcotest.failf "decode after encode: %a" pp_parse_error e)
+    [ 0; 1; 7; 32 ]
+
+let test_param_encode_length_mismatch () =
+  let c, p_len = param_codec () in
+  let env = Codec.env c |> Param.bind p_len 4 in
+  let buf = Bytes.create 16 in
+  match Codec.encode ~env c { payload = "ab" } buf 0 with
+  | () -> Alcotest.fail "expected Invalid_argument"
+  | exception Invalid_argument _ -> ()
+
+let test_param_encode_no_env () =
+  let c, _ = param_codec () in
+  let buf = Bytes.create 16 in
+  match Codec.encode c { payload = "" } buf 0 with
+  | () -> Alcotest.fail "expected Invalid_argument for missing env"
+  | exception Invalid_argument _ -> ()
+
+let test_param_encode_unbound () =
+  let c, _ = param_codec () in
+  let env =
+    Codec.env c
+    (* p_len never bound *)
+  in
+  let buf = Bytes.create 16 in
+  match Codec.encode ~env c { payload = "" } buf 0 with
+  | () -> Alcotest.fail "expected Invalid_argument for unbound param"
+  | exception Invalid_argument msg ->
+      if not (String.length msg > 0) then Alcotest.fail "empty error message";
+      (* Error must name the offending param so the user can fix it. *)
+      let needle = "len" in
+      let found = ref false in
+      let limit = String.length msg - String.length needle in
+      for i = 0 to limit do
+        if String.sub msg i (String.length needle) = needle then found := true
+      done;
+      Alcotest.(check bool) "error names missing param" true !found
+
 let test_parse_param_where_fail () =
   let max_len = Param.input "max_len" uint16be in
   let out_len = Param.output "out_len" uint16be in
@@ -797,6 +866,14 @@ let suite =
         test_parse_param_with_params;
       Alcotest.test_case "parse: param struct where fail" `Quick
         test_parse_param_where_fail;
+      Alcotest.test_case "encode: param size threads env" `Quick
+        test_param_size_encode;
+      Alcotest.test_case "encode: param size length mismatch" `Quick
+        test_param_encode_length_mismatch;
+      Alcotest.test_case "encode: param codec without env rejected" `Quick
+        test_param_encode_no_env;
+      Alcotest.test_case "encode: env with unbound param rejected" `Quick
+        test_param_encode_unbound;
       (* sizeof / sizeof_this / field_pos *)
       Alcotest.test_case "sizeof" `Quick test_sizeof;
       Alcotest.test_case "sizeof_this" `Quick test_sizeof_this;


### PR DESCRIPTION
[`Codec.encode`](lib/codec.mli#L63) had no way to take a [`Param.env`](lib/param.mli#L26), so parametric `byte_array` / `byte_slice` / `uint_var` fields silently encoded zero-sized regions and the bytes did not round-trip. Same env shape [`Codec.decode`](lib/codec.mli#L52) already accepted; encode just lacked the hook.