### PR TITLE
codec: size encoded buffers from the value, not from a scratch read

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,6 +53,11 @@
 
 ### Fixed
 
+- `Wire.encode_into` on a `codec` field whose inner ends in `all_bytes`
+  / `rest_bytes` / `all_zeros` no longer ships a 4096-byte scratch
+  tail. The encoded size is now computed from the value via
+  `Codec.size_of_value`; the buffer-driven `size_of` mismeasured
+  variable tails as "remaining buffer space" (#54, @samoht)
 - `Codec.encode` / `Codec.raw_encode` accept `?env:Param.env`, mirroring
   `Codec.decode`. Encoding a parametric codec without an env (or with an
   env that left an input param unbound) now raises `Invalid_argument`

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -618,6 +618,12 @@ type ('f, 'r) record =
       r_make : 'full;
       r_readers : ('full, 'f) readers;
       r_writers_rev : ('r -> bytes -> int -> unit) list;
+      r_size_of_value_rev : ('r -> int) list;
+          (* Per-field value-driven size functions (one per writer). At
+             seal we sum them into [t_size_of_value]; encode uses that
+             instead of the buffer-driven [t_wire_size.compute] when sizing
+             scratch buffers, because the latter misreads variable tails
+             (all_bytes / rest_bytes / all_zeros) as "remaining buffer". *)
       r_min_wire_size : int;
           (* sum of all fixed-size fields -- minimum buffer size *)
       r_next_off : next_off; (* where the next field starts *)
@@ -646,6 +652,7 @@ let id_counter = Atomic.make 0
 type 'r t = {
   t_id : int;
   t_name : string;
+  t_size_of_value : 'r -> int;
   t_field_access : (string * field_access) list;
   t_field_readers : field_reader list;
   t_field_actions : (string * compiled_action) list;
@@ -670,6 +677,7 @@ let record_start ?where name make =
       r_make = make;
       r_readers = Nil;
       r_writers_rev = [];
+      r_size_of_value_rev = [];
       r_min_wire_size = 0;
       r_next_off = Static 0;
       r_fields_rev = [];
@@ -1850,12 +1858,16 @@ let apply_compiled : type a f r.
   let new_field_readers =
     cf.nested_readers @ ((fld.name, cf.int_reader) :: r.r_field_readers)
   in
+  let field_typ = fld.typ in
+  let field_get = fld.get in
+  let field_size_of_value v = size_of_typ_value field_typ (field_get v) in
   Record
     {
       r_name = r.r_name;
       r_make = r.r_make;
       r_readers = Snoc (r.r_readers, cf.raw_reader);
       r_writers_rev = new_writers_rev;
+      r_size_of_value_rev = field_size_of_value :: r.r_size_of_value_rev;
       r_min_wire_size = r.r_min_wire_size + cf.size_delta;
       r_next_off = cf.next_off;
       r_fields_rev = struct_field fld :: r.r_fields_rev;
@@ -2097,9 +2109,19 @@ let seal : type r. (r, r) record -> r t =
   in
   (* Per-field action runners *)
   let field_actions = List.rev r.r_field_actions_rev in
+  let size_funcs = Array.of_list (List.rev r.r_size_of_value_rev) in
+  let n_size_funcs = Array.length size_funcs in
+  let size_of_value v =
+    let total = Stdlib.ref 0 in
+    for i = 0 to n_size_funcs - 1 do
+      total := !total + size_funcs.(i) v
+    done;
+    !total
+  in
   {
     t_id = codec_id;
     t_name = r.r_name;
+    t_size_of_value = size_of_value;
     t_field_access = field_access;
     t_field_readers = List.rev r.r_field_readers;
     t_field_actions = field_actions;
@@ -2388,6 +2410,8 @@ let wire_size_at t buf off =
   match t.t_wire_size with
   | Fixed n -> n
   | Variable { compute; _ } -> compute buf off - off
+
+let size_of_value t v = t.t_size_of_value v
 
 let is_fixed t =
   match t.t_wire_size with Fixed _ -> true | Variable _ -> false

--- a/lib/codec.mli
+++ b/lib/codec.mli
@@ -42,6 +42,13 @@ val min_wire_size : 'r t -> int
 val wire_size_at : 'r t -> bytes -> int -> int
 (** Compute the actual wire size from a buffer at a given offset. *)
 
+val size_of_value : 'r t -> 'r -> int
+(** [size_of_value c v] returns the number of bytes that [encode c v] will
+    write. Computed from [v], not from a buffer: works for variable-size codecs
+    whose tail is [all_bytes] / [rest_bytes] / [all_zeros], where the
+    buffer-driven {!wire_size_at} cannot distinguish "value's tail" from
+    "remaining buffer space". *)
+
 val is_fixed : 'r t -> bool
 (** [is_fixed c] is [true] iff the codec [c] has a fixed wire size. *)
 

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -128,6 +128,12 @@ and _ typ =
       codec_encode : 'r -> bytes -> int -> unit;
       codec_fixed_size : int option;
       codec_size_of : bytes -> int -> int;
+      codec_size_of_value : 'r -> int;
+          (* Encoded byte length of a value, computed from the value rather
+             than by re-reading the buffer. The buffer-driven [codec_size_of]
+             is wrong for variable-size codecs ending in [all_bytes] /
+             [rest_bytes] / [all_zeros]: it reads "remaining buffer space",
+             not the value's actual tail length. *)
       codec_field_readers : (string * (bytes -> int -> int)) list;
       codec_struct : struct_;
           (** Structural representation of the codec. Mirrors [codec_decode] /
@@ -1377,7 +1383,67 @@ let pp_parse_error ppf = function
   | All_zeros_failed { offset } ->
       Fmt.pf ppf "non-zero byte at offset %d" offset
 
+(* Encoded byte size of [v] under [typ], computed from the value rather
+   than from a buffer. Mirrors [field_wire_size] for fixed cases and
+   reads the value for variable byte fields. Sub-codecs delegate to the
+   value-driven [codec_size_of_value] baked in at codec construction.
+
+   Typs whose size depends on a parameter or sibling field ([Uint_var]
+   with non-constant size, dynamic [Optional]/[Optional_or], parametric
+   [Repeat] / [Single_elem]) are not handled here -- they only appear
+   inside a codec, which threads its own value-driven size at seal. *)
+
 (** Compute wire size of a type (None for variable-size types). *)
+let rec size_of_typ_value : type a. a typ -> a -> int =
+ fun typ v ->
+  match typ with
+  | Uint8 -> 1
+  | Uint16 _ -> 2
+  | Uint32 _ -> 4
+  | Uint63 _ -> 8
+  | Uint64 _ -> 8
+  | Int8 -> 1
+  | Int16 _ -> 2
+  | Int32 _ -> 4
+  | Int64 _ -> 8
+  | Float32 _ -> 4
+  | Float64 _ -> 8
+  | Bits { base = BF_U8; _ } -> 1
+  | Bits { base = BF_U16 _; _ } -> 2
+  | Bits { base = BF_U32 _; _ } -> 4
+  | Unit -> 0
+  | All_bytes -> String.length v
+  | All_zeros -> String.length v
+  | Byte_array _ -> String.length v
+  | Byte_array_where _ -> String.length v
+  | Byte_slice _ -> Bytesrw.Bytes.Slice.length v
+  | Uint_var { size = Int n; _ } -> n
+  | Uint_var _ -> 0
+  | Map { inner; encode; _ } -> size_of_typ_value inner (encode v)
+  | Where { inner; _ } -> size_of_typ_value inner v
+  | Enum { base; _ } -> size_of_typ_value base v
+  | Optional { present = Bool true; inner } ->
+      size_of_typ_value inner (Option.get v)
+  | Optional { present = Bool false; _ } -> 0
+  | Optional _ -> 0
+  | Optional_or { present = Bool true; inner; _ } -> size_of_typ_value inner v
+  | Optional_or { present = Bool false; _ } -> 0
+  | Optional_or _ -> 0
+  | Codec { codec_size_of_value; _ } -> codec_size_of_value v
+  | Single_elem { size = Int n; _ } -> n
+  | Single_elem _ -> 0
+  | Repeat { size = Int n; _ } -> n
+  | Repeat _ -> 0
+  | Array { elem; seq = Seq_map s; _ } ->
+      let total = Stdlib.ref 0 in
+      s.iter (fun e -> total := !total + size_of_typ_value elem e) v;
+      !total
+  | Apply { typ; _ } -> size_of_typ_value typ v
+  | Casetype _ -> 0
+  | Struct _ -> 0
+  | Type_ref _ -> 0
+  | Qualified_ref _ -> 0
+
 let rec field_wire_size : type a. a typ -> int option = function
   | Uint8 -> Some 1
   | Uint16 _ -> Some 2

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -167,6 +167,9 @@ and _ typ =
       codec_encode : 'r -> bytes -> int -> unit;
       codec_fixed_size : int option;
       codec_size_of : bytes -> int -> int;
+      codec_size_of_value : 'r -> int;
+          (** Encoded byte length of a value, computed from the value rather
+              than by re-reading the buffer. *)
       codec_field_readers : (string * (bytes -> int -> int)) list;
       codec_struct : struct_;
           (** Structural form of the codec, used by the 3D projection. *)
@@ -711,6 +714,13 @@ val pp_parse_error : Format.formatter -> parse_error -> unit
 
 val field_wire_size : 'a typ -> int option
 (** Fixed wire size of a field type, if determinable. *)
+
+val size_of_typ_value : 'a typ -> 'a -> int
+(** [size_of_typ_value typ v] is the encoded byte size of [v] under [typ],
+    computed from the value rather than from a buffer. Falls back to [0] for
+    typs whose size depends on an out-of-band parameter or sibling field --
+    those only appear inside a codec, where {!Codec.size_of_value} sums per-
+    field projections instead. *)
 
 val c_type_of : 'a typ -> string
 (** [c_type_of typ] returns the C type name (e.g., ["uint8_t"], ["uint32_t"]).

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -65,6 +65,7 @@ let codec (c : 'r Codec.t) : 'r typ =
   let codec_encode = Codec.raw_encode c in
   let codec_field_readers = Codec.field_readers c in
   let codec_struct = Codec.to_struct c in
+  let codec_size_of_value = Codec.size_of_value c in
   match Codec.wire_size_info c with
   | `Fixed n ->
       Codec
@@ -74,6 +75,7 @@ let codec (c : 'r Codec.t) : 'r typ =
           codec_encode;
           codec_fixed_size = Some n;
           codec_size_of = (fun _buf _off -> n);
+          codec_size_of_value;
           codec_field_readers;
           codec_struct;
         }
@@ -85,6 +87,7 @@ let codec (c : 'r Codec.t) : 'r typ =
           codec_encode;
           codec_fixed_size = None;
           codec_size_of = size_of;
+          codec_size_of_value;
           codec_field_readers;
           codec_struct;
         }
@@ -506,15 +509,8 @@ let write_string enc s =
     Writer.write_string enc.writer s
   end
 
-let encode_codec ~encode ~fixed_size ~size_of v enc =
-  let sz =
-    match fixed_size with
-    | Some n -> n
-    | None ->
-        let tmp = Bytes.create 4096 in
-        encode v tmp 0;
-        size_of tmp 0
-  in
+let encode_codec ~encode ~fixed_size ~size_of_value v enc =
+  let sz = match fixed_size with Some n -> n | None -> size_of_value v in
   let tmp = Bytes.create sz in
   encode v tmp 0;
   write_string enc (Bytes.unsafe_to_string tmp)
@@ -585,9 +581,9 @@ let rec encode_into : type a. a typ -> a -> encoder -> unit =
   | Single_elem { elem; _ } -> encode_into elem v enc
   | Enum { base; _ } -> encode_into base v enc
   | Map { inner; encode; _ } -> encode_into inner (encode v) enc
-  | Codec { codec_encode; codec_fixed_size; codec_size_of; _ } ->
+  | Codec { codec_encode; codec_fixed_size; codec_size_of_value; _ } ->
       encode_codec ~encode:codec_encode ~fixed_size:codec_fixed_size
-        ~size_of:codec_size_of v enc
+        ~size_of_value:codec_size_of_value v enc
   | Optional { present; inner } ->
       if Eval.expr Eval.empty present then encode_into inner (Option.get v) enc
   | Optional_or { present; inner; _ } ->

--- a/test/test_wire.ml
+++ b/test/test_wire.ml
@@ -171,6 +171,38 @@ let test_all_bytes_in_codec () =
       Alcotest.(check string) "data" "Hello" d
   | Error e -> Alcotest.failf "%a" pp_parse_error e
 
+(* Regression: encoding a codec-as-typ-field whose inner codec ends in
+   [all_bytes] used to size the scratch via a 4096-byte buffer, then ask
+   the buffer-driven size_of for the encoded size -- which for an
+   all_bytes tail returns "remaining buffer" (4096), so the encoder
+   shipped 4096 bytes including uninitialised scratch. Now the size is
+   computed from the value. Cover payloads spanning < 4096, = 4096 and
+   > 4096 to catch the scratch ceiling as well. *)
+let test_codec_all_bytes_tail () =
+  let f_h = Field.v "Header" uint8 in
+  let f_d = Field.v "Data" all_bytes in
+  let inner =
+    Codec.v "Inner" (fun h d -> (h, d)) Codec.[ f_h $ fst; f_d $ snd ]
+  in
+  let f_payload = Field.v "Payload" (codec inner) in
+  let outer = Codec.v "Outer" (fun p -> p) Codec.[ (f_payload $ fun p -> p) ] in
+  let roundtrip label tail =
+    let v = (0x42, tail) in
+    let sz = 1 + String.length tail in
+    let buf = Bytes.create sz in
+    Codec.encode outer v buf 0;
+    Alcotest.(check int) (label ^ ": buf length") sz (Bytes.length buf);
+    match Codec.decode outer buf 0 with
+    | Ok (h, d) ->
+        Alcotest.(check int) (label ^ ": header") 0x42 h;
+        Alcotest.(check string) (label ^ ": tail") tail d
+    | Error e -> Alcotest.failf "%s decode: %a" label pp_parse_error e
+  in
+  roundtrip "small" "Hello";
+  roundtrip "<4096" (String.make 1024 'A');
+  roundtrip "=4095" (String.make 4095 'B');
+  roundtrip ">4096" (String.make 8192 'C')
+
 let test_all_zeros_in_codec () =
   let f_h = Field.v "Tag" uint8 in
   let f_p = Field.v "Pad" all_zeros in
@@ -830,6 +862,8 @@ let suite =
         test_rest_of_buffer_codec;
       Alcotest.test_case "codec: all_bytes as field" `Quick
         test_all_bytes_in_codec;
+      Alcotest.test_case "encode: codec-with-all_bytes tail roundtrip" `Quick
+        test_codec_all_bytes_tail;
       Alcotest.test_case "codec: all_zeros as field" `Quick
         test_all_zeros_in_codec;
       Alcotest.test_case "parse: byte_array_where accepts" `Quick


### PR DESCRIPTION
[`Wire.encode_into`](lib/wire.ml#L509) on a codec field used to allocate a 4096-byte scratch, encode into it, then ask the buffer-driven [`codec_size_of`](lib/types.ml#L130) how many bytes the encoded form occupied. For codecs ending in `all_bytes` / `rest_bytes` / `all_zeros` that answer is "remaining buffer", so the encoder shipped 4096 bytes (uninitialised tail included). Values larger than 4096 silently overran.

[`Codec.size_of_value`](lib/codec.mli#L45) is now built at seal-time and used to size the scratch exactly; one encode pass instead of two.