### PR TITLE
fuzz: encoder coverage for the full Wire DSL, plus three encoder fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,16 +2,9 @@
 
 ### Tests
 
-- Composable `'a gen = { codec; positive_cases; negative_cases; equal }`
-  in [fuzz_wire.ml](fuzz/fuzz_wire.ml) for the structured combinators
-  (parametric `byte_array`, variable-element `repeat`, codec with
-  `all_bytes` tail, string-tag casetype) plus a `gen_pair` cross-product
-  that mixes valid/invalid halves into "almost valid" byte streams.
-  Adds leaf gens for `byte_slice`, `byte_array_where`, `uint_var`,
-  `where`, `map`, `single_elem`, `all_zeros`, `optional`, `optional_or`
-  and a casetype with int tag, plus a meta-test that round-trips one
-  representative value per `Wire.typ` constructor through `Wire.to_string`
-  / `Wire.of_string` (#55, @samoht)
+- Fuzz coverage of every codec-targetable `Wire.typ` constructor, with
+  a meta-test that round-trips one value per constructor through
+  `Wire.to_string` / `Wire.of_string` (#55, @samoht)
 
 ### Added
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -84,6 +84,11 @@
   `Constraint_failed` decode error instead of raising `Invalid_argument`.
   The old behaviour broke the decoder's "never raise on adversarial
   input" contract (#55, @samoht)
+- `Wire.encode_into` on a `Single_elem` (`Wire.nested ~size:n inner`)
+  now pads zero bytes up to the declared `size` when `inner` writes
+  fewer than `n` bytes. `encode_direct` already padded; `encode_into`
+  silently dropped the padding, so `Wire.to_string` produced shorter
+  bytes than `Wire.of_string` expected (#55, @samoht)
 - `Wire.encode_into` on a `codec` field whose inner ends in `all_bytes`
   / `rest_bytes` / `all_zeros` no longer ships a 4096-byte scratch
   tail. The encoded size is now computed from the value via

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -80,6 +80,10 @@
   The previous code returned `0` for variable-element repeats and for
   casetypes, leading `Wire.to_string` to allocate too-small buffers
   (#55, @samoht)
+- Decoding an `all_zeros` field that contains a non-zero byte returns a
+  `Constraint_failed` decode error instead of raising `Invalid_argument`.
+  The old behaviour broke the decoder's "never raise on adversarial
+  input" contract (#55, @samoht)
 - `Wire.encode_into` on a `codec` field whose inner ends in `all_bytes`
   / `rest_bytes` / `all_zeros` no longer ships a 4096-byte scratch
   tail. The encoded size is now computed from the value via

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,18 @@
 ## unreleased
 
+### Tests
+
+- Composable `'a gen = { codec; positive_cases; negative_cases; equal }`
+  in [fuzz_wire.ml](fuzz/fuzz_wire.ml) for the structured combinators
+  (parametric `byte_array`, variable-element `repeat`, codec with
+  `all_bytes` tail, string-tag casetype) plus a `gen_pair` cross-product
+  that mixes valid/invalid halves into "almost valid" byte streams.
+  Adds leaf gens for `byte_slice`, `byte_array_where`, `uint_var`,
+  `where`, `map`, `single_elem`, `all_zeros`, `optional`, `optional_or`
+  and a casetype with int tag, plus a meta-test that round-trips one
+  representative value per `Wire.typ` constructor through `Wire.to_string`
+  / `Wire.of_string` (#55, @samoht)
+
 ### Added
 
 - `Wire.casetype` now accepts any tag typ (`'k typ`, not just `int`) and
@@ -62,6 +75,11 @@
   of using the dynamic gate as an encode-side size oracle; the gate
   remains the decode-side selector between the decoded inner and the
   default (#58, @samoht)
+- `size_of_typ_value` now walks `Repeat` (per-element from the value
+  sequence) and `Casetype` (tag size plus matched-branch body size).
+  The previous code returned `0` for variable-element repeats and for
+  casetypes, leading `Wire.to_string` to allocate too-small buffers
+  (#55, @samoht)
 - `Wire.encode_into` on a `codec` field whose inner ends in `all_bytes`
   / `rest_bytes` / `all_zeros` no longer ships a 4096-byte scratch
   tail. The encoded size is now computed from the value via

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -89,6 +89,12 @@
   fewer than `n` bytes. `encode_direct` already padded; `encode_into`
   silently dropped the padding, so `Wire.to_string` produced shorter
   bytes than `Wire.of_string` expected (#55, @samoht)
+- `Wire.default` now takes a required `~tag:'k`: the discriminator
+  the encoder writes when projecting the default branch back to bytes.
+  Previously encoding any default-branch value crashed with
+  `Failure "casetype encoding: cannot encode default case"`; the
+  decoder side still uses the default branch as the match-anything
+  fallback (#55, @samoht)
 - `Wire.encode_into` on a `codec` field whose inner ends in `all_bytes`
   / `rest_bytes` / `all_zeros` no longer ships a 4096-byte scratch
   tail. The encoded size is now computed from the value via

--- a/fuzz/fuzz_everparse.ml
+++ b/fuzz/fuzz_everparse.ml
@@ -158,7 +158,7 @@ let test_casetype_inline () =
           ~inject:(fun v -> `U32 (Wire.Private.UInt32.to_int v))
           ~project:(function
             | `U32 v -> Some (Wire.Private.UInt32.of_int v) | _ -> None);
-        Wire.default Wire.uint8
+        Wire.default ~tag:0xFF Wire.uint8
           ~inject:(fun v -> `Default v)
           ~project:(function `Default v -> Some v | _ -> None);
       ]

--- a/fuzz/fuzz_wire.ml
+++ b/fuzz/fuzz_wire.ml
@@ -962,7 +962,732 @@ let float_tests =
     test_case "float64 roundtrip" [ bytes ] test_float64_roundtrip;
   ]
 
+(* Composable [(codec, bytes list)] generators for the structured
+   combinators. Each [gen] packs an existentially-typed codec with a
+   list of [case]s: every [Valid v] carries wire bytes that should
+   decode to [v] (and re-encode byte-identically), while [Noise] bytes
+   are deliberately unrelated input that the decoder must handle
+   without crashing.
+
+   The four leaves cover the bug classes the encoder-coverage TODO
+   names (parametric byte_array #53, variable-element repeat #51,
+   codec-with-all_bytes tail #54, string-tag casetype #49/#50). The
+   [pair] combinator wraps two leaves into one tuple codec so a single
+   fuzz draw exercises a compound layout end to end. *)
+
+type 'a positive = { value : 'a; bytes : unit -> bytes }
+type negative = { bytes : unit -> bytes }
+
+type 'a gen = {
+  codec : 'a Wire.Codec.t;
+  env : Wire.Param.env option;
+  positive_cases : 'a positive list;
+      (* Bytes that should decode to [value] and re-encode byte-identically.*)
+  negative_cases : negative list;
+      (* Bytes the decoder must handle without crashing (return [Error] or
+         decode to some value -- either outcome is acceptable, but raising
+         is a bug). *)
+  equal : 'a -> 'a -> bool;
+}
+
+let mk_random buf =
+  let n = String.length buf in
+  if n = 0 then Bytes.empty
+  else
+    let out = Bytes.create n in
+    Bytes.blit_string buf 0 out 0 n;
+    out
+
+let run_gen label g =
+  List.iter
+    (fun (p : _ positive) ->
+      let bs = p.bytes () in
+      (match Wire.Codec.decode ?env:g.env g.codec bs 0 with
+      | Ok decoded ->
+          if not (g.equal decoded p.value) then
+            fail (label ^ ": positive decode mismatch")
+      | Error _ -> fail (label ^ ": positive decode failed"));
+      let out = Bytes.create (Bytes.length bs) in
+      (try Wire.Codec.encode ?env:g.env g.codec p.value out 0
+       with Invalid_argument _ -> fail (label ^ ": positive reencode raised"));
+      if Bytes.unsafe_to_string out <> Bytes.unsafe_to_string bs then
+        fail (label ^ ": positive reencode bytes mismatch");
+      (* Also exercise the top-level [Wire.to_string] path: this drives
+         [encode_into] -> [encode_codec], which uses [size_of_value] to
+         pre-size the scratch. A mismatch here surfaces encoder bugs that
+         [Codec.encode] doesn't hit (Codec.encode bypasses encode_codec). *)
+      if g.env = None then begin
+        let via_wire = Wire.to_string (Wire.codec g.codec) p.value in
+        if via_wire <> Bytes.unsafe_to_string bs then
+          fail (label ^ ": Wire.to_string mismatch")
+      end)
+    g.positive_cases;
+  List.iter
+    (fun (n : negative) ->
+      let bs = n.bytes () in
+      try ignore (Wire.Codec.decode ?env:g.env g.codec bs 0)
+      with Invalid_argument _ -> fail (label ^ ": negative crashed decoder"))
+    g.negative_cases
+
+(* Leaf generators *)
+
+type param_payload = { payload : string }
+
+let gen_param_byte_array n =
+  let len = abs n mod 64 in
+  let payload = String.init len (fun i -> Char.chr ((n + i) land 0xFF)) in
+  let p_len = Wire.Param.input "len" Wire.uint16be in
+  let codec =
+    Wire.Codec.v "Param"
+      (fun b -> { payload = b })
+      Wire.Codec.
+        [
+          ( Wire.Field.v "Data" (Wire.byte_array ~size:(Wire.Param.expr p_len))
+          $ fun r -> r.payload );
+        ]
+  in
+  let env = Wire.Codec.env codec |> Wire.Param.bind p_len len in
+  let valid = Bytes.of_string payload in
+  let noise = mk_random (String.make (max 0 (len - 1)) '\x00') in
+  {
+    codec;
+    env = Some env;
+    positive_cases = [ { value = { payload }; bytes = (fun () -> valid) } ];
+    negative_cases = [ { bytes = (fun () -> noise) } ];
+    equal = (fun a b -> a.payload = b.payload);
+  }
+
+type ext = { name : string }
+
+let ext_codec =
+  let f_len = Wire.Field.v "name_len" Wire.uint8 in
+  let f_name =
+    Wire.Field.v "name" (Wire.byte_array ~size:(Wire.Field.ref f_len))
+  in
+  Wire.Codec.v "Ext"
+    (fun _l n -> { name = n })
+    Wire.Codec.
+      [ (f_len $ fun e -> String.length e.name); (f_name $ fun e -> e.name) ]
+
+let gen_repeat_var_elem buf =
+  let buf = truncate buf in
+  let body = Buffer.create 64 in
+  let exts = Stdlib.ref [] in
+  let i = Stdlib.ref 0 in
+  while !i < String.length buf do
+    let take = max 1 (Char.code buf.[!i] land 0x0F) in
+    let take = min take (String.length buf - !i - 1) in
+    if take > 0 then begin
+      let name = String.sub buf (!i + 1) take in
+      Buffer.add_char body (Char.chr take);
+      Buffer.add_string body name;
+      exts := { name } :: !exts;
+      i := !i + 1 + take
+    end
+    else i := String.length buf
+  done;
+  let exts = List.rev !exts in
+  let total = Buffer.length body in
+  let f_total = Wire.Field.v "total" Wire.uint16be in
+  let f_exts =
+    Wire.Field.repeat "exts" ~size:(Wire.Field.ref f_total)
+      (Wire.codec ext_codec)
+  in
+  let codec =
+    Wire.Codec.v "Exts"
+      (fun _t xs -> xs)
+      Wire.Codec.[ (f_total $ fun _ -> total); (f_exts $ fun xs -> xs) ]
+  in
+  let framed = Bytes.create (2 + total) in
+  Bytes.set_uint16_be framed 0 total;
+  Bytes.blit_string (Buffer.contents body) 0 framed 2 total;
+  (* A noise byte stream that announces a length larger than the data
+     it carries: the decoder must surface EOF, not crash. *)
+  let noise = Bytes.of_string "\x00\xFF\x00" in
+  {
+    codec;
+    env = None;
+    positive_cases = [ { value = exts; bytes = (fun () -> framed) } ];
+    negative_cases = [ { bytes = (fun () -> noise) } ];
+    equal = ( = );
+  }
+
+type trailing = { header : int; tail : string }
+
+let trailing_codec =
+  Wire.Codec.v "Trailing"
+    (fun h t -> { header = h; tail = t })
+    Wire.Codec.
+      [
+        (Wire.Field.v "h" Wire.uint8 $ fun r -> r.header);
+        (Wire.Field.v "t" Wire.all_bytes $ fun r -> r.tail);
+      ]
+
+let outer_trailing =
+  Wire.Codec.v "Outer"
+    (fun p -> p)
+    Wire.Codec.[ (Wire.Field.v "p" (Wire.codec trailing_codec) $ fun p -> p) ]
+
+let gen_codec_all_bytes_tail buf =
+  let buf = truncate buf in
+  (* Pad with a sentinel when the fuzz input was empty so the [Valid]
+     case carries the header byte the codec requires. *)
+  let buf = if String.length buf = 0 then "\x00" else buf in
+  let header = Char.code buf.[0] in
+  let tail = String.sub buf 1 (String.length buf - 1) in
+  let framed = Bytes.of_string buf in
+  let noise = Bytes.empty in
+  {
+    codec = outer_trailing;
+    env = None;
+    positive_cases =
+      [ { value = { header; tail }; bytes = (fun () -> framed) } ];
+    negative_cases = [ { bytes = (fun () -> noise) } ];
+    equal = (fun a b -> a.header = b.header && a.tail = b.tail);
+  }
+
+type ssh_auth = [ `Publickey of int | `Other of int ]
+
+let ssh_auth_codec =
+  let body : ssh_auth Wire.typ =
+    Wire.casetype "AuthMethod"
+      (Wire.byte_array ~size:(Wire.int 9))
+      [
+        Wire.case ~index:"publickey" Wire.uint8
+          ~inject:(fun v -> `Publickey v)
+          ~project:(function `Publickey v -> Some v | _ -> None);
+        Wire.default Wire.uint8
+          ~inject:(fun v -> `Other v)
+          ~project:(function `Other v -> Some v | _ -> None);
+      ]
+  in
+  let f = Wire.Field.v "method" body in
+  Wire.Codec.v "SshAuth" (fun m -> m) Wire.Codec.[ (f $ fun m -> m) ]
+
+let gen_casetype_string_tag body_byte =
+  let v = abs body_byte mod 256 in
+  let framed = Bytes.create 10 in
+  Bytes.blit_string "publickey" 0 framed 0 9;
+  Bytes.set_uint8 framed 9 v;
+  let noise =
+    (* Method-name bytes that match no case; decoder hits the default
+       branch and yields [`Other], not a crash. *)
+    let n = Bytes.create 10 in
+    Bytes.blit_string "xxxxxxxxx" 0 n 0 9;
+    Bytes.set_uint8 n 9 (v lxor 0xFF);
+    n
+  in
+  {
+    codec = ssh_auth_codec;
+    env = None;
+    positive_cases = [ { value = `Publickey v; bytes = (fun () -> framed) } ];
+    negative_cases = [ { bytes = (fun () -> noise) } ];
+    equal = ( = );
+  }
+
+(* Combinator: glue two leaf gens into a pair-codec gen.
+
+   Cross-products produce four sets of bytes:
+   - positive x positive: clean tuples, the both-valid base case.
+   - positive x negative and negative x positive: "almost valid" -- one
+     side is well-shaped, the other isn't. These are the inputs that
+     stress decoder error paths most realistically.
+   - negative x negative: fully invalid; included for completeness so
+     the decoder isn't tested only on near-valid data.
+
+   The split keeps the positive/negative distribution from collapsing
+   into one direction: as long as both leaves contribute roughly
+   balanced positive/negative cases, the product stays roughly half
+   positive (1 of 4) and half negative (3 of 4). *)
+let cat_bytes_thunks a b () =
+  let av = a () and bv = b () in
+  let na = Bytes.length av and nb = Bytes.length bv in
+  let out = Bytes.create (na + nb) in
+  Bytes.blit av 0 out 0 na;
+  Bytes.blit bv 0 out na nb;
+  out
+
+let pair_positives g1 g2 =
+  List.concat_map
+    (fun (p1 : _ positive) ->
+      List.map
+        (fun (p2 : _ positive) ->
+          {
+            value = (p1.value, p2.value);
+            bytes = cat_bytes_thunks p1.bytes p2.bytes;
+          })
+        g2.positive_cases)
+    g1.positive_cases
+
+let pair_negatives g1 g2 =
+  let cross_pn =
+    List.concat_map
+      (fun (p1 : _ positive) ->
+        List.map
+          (fun (n2 : negative) ->
+            { bytes = cat_bytes_thunks p1.bytes n2.bytes })
+          g2.negative_cases)
+      g1.positive_cases
+  in
+  let cross_np =
+    List.concat_map
+      (fun (n1 : negative) ->
+        List.map
+          (fun (p2 : _ positive) ->
+            { bytes = cat_bytes_thunks n1.bytes p2.bytes })
+          g2.positive_cases)
+      g1.negative_cases
+  in
+  let cross_nn =
+    List.concat_map
+      (fun (n1 : negative) ->
+        List.map
+          (fun (n2 : negative) ->
+            { bytes = cat_bytes_thunks n1.bytes n2.bytes })
+          g2.negative_cases)
+      g1.negative_cases
+  in
+  cross_pn @ cross_np @ cross_nn
+
+let gen_pair name g1 g2 =
+  let f1 = Wire.Field.v "x" (Wire.codec g1.codec) in
+  let f2 = Wire.Field.v "y" (Wire.codec g2.codec) in
+  let codec =
+    Wire.Codec.v name (fun x y -> (x, y)) Wire.Codec.[ f1 $ fst; f2 $ snd ]
+  in
+  let env = match (g1.env, g2.env) with None, None -> None | _ -> None in
+  let equal (x1, y1) (x2, y2) = g1.equal x1 x2 && g2.equal y1 y2 in
+  {
+    codec;
+    env;
+    positive_cases = pair_positives g1 g2;
+    negative_cases = pair_negatives g1 g2;
+    equal;
+  }
+
+let test_gen_param_byte_array n =
+  run_gen "param_byte_array" (gen_param_byte_array n)
+
+let test_gen_repeat_var_elem buf =
+  run_gen "repeat_var_elem" (gen_repeat_var_elem buf)
+
+let test_gen_codec_tail buf =
+  run_gen "codec_all_bytes_tail" (gen_codec_all_bytes_tail buf)
+
+let test_gen_casetype_string_tag n =
+  run_gen "casetype_string_tag" (gen_casetype_string_tag n)
+
+(* Fixed-size leaf used for composition tests: an embedded sub-codec with
+   variable-size tail can't be the left half of a pair (the right half
+   has no way to find its starting offset). The string-tag casetype's
+   per-case body sizes are known (uint8 in both branches), so two of
+   them compose cleanly. *)
+let test_gen_pair m n =
+  run_gen "pair"
+    (gen_pair "Pair" (gen_casetype_string_tag m) (gen_casetype_string_tag n))
+
+(* Remaining leaves so every codec-targetable Wire.typ constructor has
+   at least one fuzz target. Each leaf wraps the constructor under test
+   in a one-field codec so the harness exercises decode + Codec.encode
+   + Wire.to_string in lockstep. Constructors only meaningful inside a
+   module of types (Type_ref / Qualified_ref / Struct / Apply) are not
+   standalone codec fields and stay out of scope. *)
+
+let gen_byte_slice buf =
+  let buf = truncate buf in
+  let buf = if buf = "" then "\x00" else buf in
+  let len = min (String.length buf) 32 in
+  let payload = String.sub buf 0 len in
+  let codec =
+    Wire.Codec.v "Slice"
+      (fun s -> s)
+      Wire.Codec.
+        [
+          (Wire.Field.v "s" (Wire.byte_slice ~size:(Wire.int len)) $ fun s -> s);
+        ]
+  in
+  let positive =
+    let bytes_payload = Bytes.of_string payload in
+    let slice = Bytesrw.Bytes.Slice.make bytes_payload ~first:0 ~length:len in
+    [ { value = slice; bytes = (fun () -> bytes_payload) } ]
+  in
+  let negative = [ { bytes = (fun () -> Bytes.empty) } ] in
+  {
+    codec;
+    env = None;
+    positive_cases = positive;
+    negative_cases = negative;
+    equal =
+      (fun a b ->
+        Bytesrw.Bytes.Slice.length a = Bytesrw.Bytes.Slice.length b
+        && Bytes.unsafe_to_string (Bytesrw.Bytes.Slice.bytes a)
+           = Bytes.unsafe_to_string (Bytesrw.Bytes.Slice.bytes b));
+  }
+
+let gen_uint_var n =
+  let len = (abs n mod 7) + 1 in
+  let value = abs n mod 256 in
+  let codec =
+    Wire.Codec.v "Uv"
+      (fun v -> v)
+      Wire.Codec.
+        [
+          ( Wire.Field.v "v" (Wire.uint ~endian:Wire.Big (Wire.int len))
+          $ fun v -> v );
+        ]
+  in
+  let buf = Bytes.create len in
+  Wire.Codec.encode codec value buf 0;
+  {
+    codec;
+    env = None;
+    positive_cases = [ { value; bytes = (fun () -> buf) } ];
+    negative_cases = [ { bytes = (fun () -> Bytes.empty) } ];
+    equal = Int.equal;
+  }
+
+let printable b =
+  let open Wire.Expr in
+  Wire.Expr.( >= ) b (Wire.int 0x20) && Wire.Expr.( <= ) b (Wire.int 0x7e)
+
+let gen_byte_array_where buf =
+  let buf = truncate buf in
+  let buf = if buf = "" then "x" else buf in
+  let len = min (String.length buf) 16 in
+  (* Sanitise into the predicate's accept set so the [Valid] case round-
+     trips; the predicate is per-byte [0x20..0x7e]. *)
+  let payload =
+    String.init len (fun i ->
+        let c = Char.code buf.[i] in
+        let c = if c < 0x20 || c > 0x7e then 0x20 + (c land 0x5f) else c in
+        Char.chr c)
+  in
+  let codec =
+    Wire.Codec.v "Baw"
+      (fun s -> s)
+      Wire.Codec.
+        [
+          ( Wire.Field.v "s"
+              (Wire.byte_array_where ~size:(Wire.int len) ~per_byte:printable)
+          $ fun s -> s );
+        ]
+  in
+  let bytes_in = Bytes.of_string payload in
+  let bad = Bytes.make len '\x00' in
+  {
+    codec;
+    env = None;
+    positive_cases = [ { value = payload; bytes = (fun () -> bytes_in) } ];
+    (* Noise: bytes that violate the per-byte predicate -- decoder must
+       surface [Constraint_failed], not crash. *)
+    negative_cases = [ { bytes = (fun () -> bad) } ];
+    equal = String.equal;
+  }
+
+let gen_where n =
+  let value = abs n mod 100 in
+  let f = Wire.Field.v "v" Wire.uint8 in
+  let codec =
+    Wire.Codec.v "W"
+      ~where:Wire.Expr.(Wire.Field.ref f <= Wire.int 100)
+      (fun v -> v)
+      Wire.Codec.[ (f $ fun v -> v) ]
+  in
+  let valid = Bytes.make 1 (Char.chr value) in
+  let bad = Bytes.make 1 '\xff' in
+  {
+    codec;
+    env = None;
+    positive_cases = [ { value; bytes = (fun () -> valid) } ];
+    negative_cases = [ { bytes = (fun () -> bad) } ];
+    equal = Int.equal;
+  }
+
+let gen_map n =
+  let value = abs n mod 128 in
+  let map_typ =
+    Wire.map ~decode:(fun n -> n * 2) ~encode:(fun n -> n / 2) Wire.uint8
+  in
+  let codec =
+    Wire.Codec.v "M"
+      (fun v -> v)
+      Wire.Codec.[ (Wire.Field.v "v" map_typ $ fun v -> v) ]
+  in
+  let raw = value in
+  let buf = Bytes.make 1 (Char.chr raw) in
+  let positive = [ { value = raw * 2; bytes = (fun () -> buf) } ] in
+  let negative = [ { bytes = (fun () -> Bytes.empty) } ] in
+  {
+    codec;
+    env = None;
+    positive_cases = positive;
+    negative_cases = negative;
+    equal = Int.equal;
+  }
+
+let gen_single_elem n =
+  let len = (abs n mod 3) + 1 in
+  let inner_v = abs n mod 256 in
+  let codec =
+    Wire.Codec.v "Se"
+      (fun v -> v)
+      Wire.Codec.
+        [
+          ( Wire.Field.v "v" (Wire.nested ~size:(Wire.int len) Wire.uint8)
+          $ fun v -> v );
+        ]
+  in
+  let buf = Bytes.make len '\x00' in
+  Bytes.set_uint8 buf 0 inner_v;
+  {
+    codec;
+    env = None;
+    positive_cases = [ { value = inner_v; bytes = (fun () -> buf) } ];
+    negative_cases = [ { bytes = (fun () -> Bytes.empty) } ];
+    equal = Int.equal;
+  }
+
+let gen_all_zeros n =
+  let len = abs n mod 16 in
+  let codec =
+    Wire.Codec.v "Az"
+      (fun s -> s)
+      Wire.Codec.[ (Wire.Field.v "z" Wire.all_zeros $ fun s -> s) ]
+  in
+  let zeros = Bytes.make len '\x00' in
+  let nonzero = Bytes.make (max 1 len) '\x01' in
+  {
+    codec;
+    env = None;
+    positive_cases =
+      [ { value = String.make len '\x00'; bytes = (fun () -> zeros) } ];
+    negative_cases = [ { bytes = (fun () -> nonzero) } ];
+    equal = String.equal;
+  }
+
+let gen_optional n =
+  (* Static-present optional: [present = Bool true] resolves the field
+     unconditionally to its inner shape. *)
+  let inner = abs n mod 256 in
+  let f = Wire.Field.optional ~present:Wire.Expr.true_ "v" Wire.uint8 in
+  let codec = Wire.Codec.v "Opt" (fun v -> v) Wire.Codec.[ (f $ fun v -> v) ] in
+  let buf = Bytes.make 1 (Char.chr inner) in
+  {
+    codec;
+    env = None;
+    positive_cases = [ { value = Some inner; bytes = (fun () -> buf) } ];
+    negative_cases = [ { bytes = (fun () -> Bytes.empty) } ];
+    equal = ( = );
+  }
+
+let gen_optional_or n =
+  let inner = abs n mod 256 in
+  let f =
+    Wire.Field.optional_or ~present:Wire.Expr.true_ ~default:0 "v" Wire.uint8
+  in
+  let codec =
+    Wire.Codec.v "OptOr" (fun v -> v) Wire.Codec.[ (f $ fun v -> v) ]
+  in
+  let buf = Bytes.make 1 (Char.chr inner) in
+  {
+    codec;
+    env = None;
+    positive_cases = [ { value = inner; bytes = (fun () -> buf) } ];
+    negative_cases = [ { bytes = (fun () -> Bytes.empty) } ];
+    equal = Int.equal;
+  }
+
+type int_case = U16 of int | Default of int
+
+let gen_casetype_int_tag n =
+  let pick = abs n mod 2 in
+  let body : int_case Wire.typ =
+    Wire.casetype "Cf" Wire.uint8
+      [
+        Wire.case ~index:1 Wire.uint16be
+          ~inject:(fun v -> U16 v)
+          ~project:(function U16 v -> Some v | _ -> None);
+        Wire.default Wire.uint8
+          ~inject:(fun v -> Default v)
+          ~project:(function Default v -> Some v | _ -> None);
+      ]
+  in
+  let codec =
+    Wire.Codec.v "Cm"
+      (fun m -> m)
+      Wire.Codec.[ (Wire.Field.v "m" body $ fun m -> m) ]
+  in
+  let v, buf =
+    if pick = 0 then (
+      let payload = (abs n + 256) mod 0xFFFF in
+      let b = Bytes.create 3 in
+      Bytes.set_uint8 b 0 1;
+      Bytes.set_uint16_be b 1 payload;
+      (U16 payload, b))
+    else
+      let payload = abs n mod 256 in
+      let b = Bytes.create 2 in
+      Bytes.set_uint8 b 0 0xFF;
+      Bytes.set_uint8 b 1 payload;
+      (Default payload, b)
+  in
+  {
+    codec;
+    env = None;
+    positive_cases = [ { value = v; bytes = (fun () -> buf) } ];
+    negative_cases = [ { bytes = (fun () -> Bytes.empty) } ];
+    equal = ( = );
+  }
+
+let test_gen_byte_slice buf = run_gen "byte_slice" (gen_byte_slice buf)
+let test_gen_uint_var n = run_gen "uint_var" (gen_uint_var n)
+
+let test_gen_byte_array_where buf =
+  run_gen "byte_array_where" (gen_byte_array_where buf)
+
+let test_gen_where n = run_gen "where" (gen_where n)
+let test_gen_map n = run_gen "map" (gen_map n)
+let test_gen_single_elem n = run_gen "single_elem" (gen_single_elem n)
+let test_gen_all_zeros n = run_gen "all_zeros" (gen_all_zeros n)
+let test_gen_optional n = run_gen "optional" (gen_optional n)
+let test_gen_optional_or n = run_gen "optional_or" (gen_optional_or n)
+
+let test_gen_casetype_int n =
+  run_gen "casetype_int_tag" (gen_casetype_int_tag n)
+
+(* Meta-test: assert every codec-targetable [Wire.typ] constructor has a
+   gen fuzz target. Drives a representative value of each constructor
+   into [size_of_typ_value] (the value-driven encode-size walk) -- any
+   constructor whose match arm we forget to teach falls into the
+   wildcard returning [0] or raises, both of which surface here. *)
+
+(* Walk a representative [a typ] for every constructor and require
+   [size_of_typ_value] to return a positive size (or 0 for nominally
+   zero-width forms). Calling this in the fuzz suite means adding a new
+   typ constructor without teaching [size_of_typ_value] about it makes
+   this test fail loudly. *)
+let meta_check label expected_ok matches =
+  if not matches then
+    fail (Fmt.str "typ constructor %s missing expected_ok=%d" label expected_ok)
+
+(* Meta cases assert each [Wire.typ] constructor round-trips via the
+   public [Wire.to_string] / [Wire.of_string]. Adding a constructor
+   without teaching the encoder / decoder makes one of these
+   roundtrips fail and signals the gen menu also needs an entry. *)
+
+let try_rt : type a. a Wire.typ -> a -> bool =
+ fun t v ->
+  let s = Wire.to_string t v in
+  match Wire.of_string t s with Ok v' -> v' = v | Error _ -> false
+
+let meta_scalar_cases =
+  [
+    ("Uint8", fun () -> try_rt Wire.uint8 0x42);
+    ("Uint16be", fun () -> try_rt Wire.uint16be 0xABCD);
+    ( "Uint32be",
+      fun () -> try_rt Wire.uint32be (Wire.Private.UInt32.of_int 0x12345678) );
+    ("Uint63be", fun () -> try_rt Wire.uint63be (Wire.Private.UInt63.of_int 7));
+    ("Uint64be", fun () -> try_rt Wire.uint64be 0x42L);
+    ("Int8", fun () -> try_rt Wire.int8 (-1));
+    ("Int16be", fun () -> try_rt Wire.int16be (-2));
+    ("Int32be", fun () -> try_rt Wire.int32be (-3));
+    ("Int64be", fun () -> try_rt Wire.int64be (-4L));
+    ("Float32be", fun () -> try_rt Wire.float32be 1.5);
+    ("Float64be", fun () -> try_rt Wire.float64be 1.5);
+    ("Bits", fun () -> try_rt (Wire.bits ~width:3 Wire.U8) 5);
+    ("Unit", fun () -> try_rt Wire.empty ());
+    ( "Uint_var",
+      fun () -> try_rt (Wire.uint ~endian:Wire.Big (Wire.int 3)) 0x123 );
+  ]
+
+let meta_byte_cases =
+  [
+    ("All_bytes", fun () -> try_rt Wire.all_bytes "abc");
+    ("All_zeros", fun () -> try_rt Wire.all_zeros "\000\000");
+    ("Byte_array", fun () -> try_rt (Wire.byte_array ~size:(Wire.int 3)) "xyz");
+    ( "Byte_array_where",
+      fun () ->
+        try_rt
+          (Wire.byte_array_where ~size:(Wire.int 3) ~per_byte:printable)
+          "abc" );
+    ( "Byte_slice",
+      fun () ->
+        let b = Bytes.of_string "abcd" in
+        let s = Bytesrw.Bytes.Slice.make b ~first:0 ~length:4 in
+        Wire.to_string (Wire.byte_slice ~size:(Wire.int 4)) s = "abcd" );
+  ]
+
+let meta_composite_cases =
+  [
+    ( "Map",
+      fun () ->
+        let t =
+          Wire.map ~decode:(fun n -> n + 1) ~encode:(fun n -> n - 1) Wire.uint8
+        in
+        try_rt t 5 );
+    ( "Variants/Enum",
+      fun () ->
+        let t = Wire.variants "E" [ ("A", `A); ("B", `B) ] Wire.uint8 in
+        try_rt t `A );
+    ( "Single_elem (nested)",
+      fun () -> try_rt (Wire.nested ~size:(Wire.int 2) Wire.uint8) 7 );
+    ( "Array",
+      fun () -> try_rt (Wire.array ~len:(Wire.int 3) Wire.uint8) [ 1; 2; 3 ] );
+    ( "Casetype",
+      fun () ->
+        let body : int_case Wire.typ =
+          Wire.casetype "Cf" Wire.uint8
+            [
+              Wire.case ~index:1 Wire.uint16be
+                ~inject:(fun v -> U16 v)
+                ~project:(function U16 v -> Some v | _ -> None);
+              Wire.default Wire.uint8
+                ~inject:(fun v -> Default v)
+                ~project:(function Default v -> Some v | _ -> None);
+            ]
+        in
+        try_rt body (U16 7) );
+    ( "Codec",
+      fun () ->
+        let inner =
+          Wire.Codec.v "I"
+            (fun v -> v)
+            Wire.Codec.[ (Wire.Field.v "v" Wire.uint8 $ fun v -> v) ]
+        in
+        try_rt (Wire.codec inner) 9 );
+  ]
+
+let test_meta_typs n =
+  ignore n;
+  let all = meta_scalar_cases @ meta_byte_cases @ meta_composite_cases in
+  List.iter (fun (name, run) -> meta_check name 1 (run ())) all
+
+let encoder_tests =
+  [
+    test_case "gen param byte_array" [ int ] test_gen_param_byte_array;
+    test_case "gen repeat var-elem" [ bytes ] test_gen_repeat_var_elem;
+    test_case "gen codec all_bytes-tail" [ bytes ] test_gen_codec_tail;
+    test_case "gen casetype string-tag" [ int ] test_gen_casetype_string_tag;
+    test_case "gen pair (casetype + casetype)" [ int; int ] test_gen_pair;
+    test_case "gen uint_var" [ int ] test_gen_uint_var;
+    test_case "gen where" [ int ] test_gen_where;
+    test_case "gen map" [ int ] test_gen_map;
+    test_case "gen single_elem" [ int ] test_gen_single_elem;
+    test_case "gen optional" [ int ] test_gen_optional;
+    test_case "gen optional_or" [ int ] test_gen_optional_or;
+    (* The five tests below currently fail. Each is a fuzz reproducer for
+       a real Wire bug documented in [todo/fuzz-known-failing-gens.md];
+       leaving them in the suite keeps the bugs visible until they're
+       fixed. *)
+    test_case "gen byte_slice" [ bytes ] test_gen_byte_slice;
+    test_case "gen byte_array_where" [ bytes ] test_gen_byte_array_where;
+    test_case "gen all_zeros" [ int ] test_gen_all_zeros;
+    test_case "gen casetype int-tag" [ int ] test_gen_casetype_int;
+    test_case "meta: every typ has a size_of_typ_value arm" [ int ]
+      test_meta_typs;
+  ]
+
 let suite =
   ( "wire",
     parse_tests @ roundtrip_tests @ record_tests @ stream_tests @ depsize_tests
-    @ float_tests )
+    @ float_tests @ encoder_tests )

--- a/fuzz/fuzz_wire.ml
+++ b/fuzz/fuzz_wire.ml
@@ -990,6 +990,16 @@ type 'a gen = {
   equal : 'a -> 'a -> bool;
 }
 
+(* A [leaf] is a gen exposed as its bare typ -- usable as one field of
+   a flat record codec built with [record] below. *)
+type 'a leaf = {
+  typ : 'a Wire.typ;
+  env : Wire.Param.env option;
+  positive_cases : 'a positive list;
+  negative_cases : negative list;
+  equal : 'a -> 'a -> bool;
+}
+
 let mk_random buf =
   let n = String.length buf in
   if n = 0 then Bytes.empty
@@ -998,7 +1008,7 @@ let mk_random buf =
     Bytes.blit_string buf 0 out 0 n;
     out
 
-let run_gen label g =
+let run_gen label (g : _ gen) =
   List.iter
     (fun (p : _ positive) ->
       let bs = p.bytes () in
@@ -1148,21 +1158,41 @@ let gen_codec_all_bytes_tail buf =
 
 type ssh_auth = [ `Publickey of int | `Other of int ]
 
+let ssh_auth_body : ssh_auth Wire.typ =
+  Wire.casetype "AuthMethod"
+    (Wire.byte_array ~size:(Wire.int 9))
+    [
+      Wire.case ~index:"publickey" Wire.uint8
+        ~inject:(fun v -> `Publickey v)
+        ~project:(function `Publickey v -> Some v | _ -> None);
+      Wire.default ~tag:"xxxxxxxxx" Wire.uint8
+        ~inject:(fun v -> `Other v)
+        ~project:(function `Other v -> Some v | _ -> None);
+    ]
+
 let ssh_auth_codec =
-  let body : ssh_auth Wire.typ =
-    Wire.casetype "AuthMethod"
-      (Wire.byte_array ~size:(Wire.int 9))
-      [
-        Wire.case ~index:"publickey" Wire.uint8
-          ~inject:(fun v -> `Publickey v)
-          ~project:(function `Publickey v -> Some v | _ -> None);
-        Wire.default ~tag:"xxxxxxxxx" Wire.uint8
-          ~inject:(fun v -> `Other v)
-          ~project:(function `Other v -> Some v | _ -> None);
-      ]
-  in
-  let f = Wire.Field.v "method" body in
+  let f = Wire.Field.v "method" ssh_auth_body in
   Wire.Codec.v "SshAuth" (fun m -> m) Wire.Codec.[ (f $ fun m -> m) ]
+
+let leaf_casetype_string_tag body_byte =
+  let v = abs body_byte mod 256 in
+  let framed = Bytes.create 10 in
+  Bytes.blit_string "publickey" 0 framed 0 9;
+  Bytes.set_uint8 framed 9 v;
+  let noise =
+    let n = Bytes.create 10 in
+    Bytes.blit_string "xxxxxxxxx" 0 n 0 9;
+    Bytes.set_uint8 n 9 (v lxor 0xFF);
+    n
+  in
+  ({
+     typ = ssh_auth_body;
+     env = None;
+     positive_cases = [ { value = `Publickey v; bytes = (fun () -> framed) } ];
+     negative_cases = [ { bytes = (fun () -> noise) } ];
+     equal = ( = );
+   }
+    : ssh_auth leaf)
 
 let gen_casetype_string_tag body_byte =
   let v = abs body_byte mod 256 in
@@ -1170,8 +1200,6 @@ let gen_casetype_string_tag body_byte =
   Bytes.blit_string "publickey" 0 framed 0 9;
   Bytes.set_uint8 framed 9 v;
   let noise =
-    (* Method-name bytes that match no case; decoder hits the default
-       branch and yields [`Other], not a crash. *)
     let n = Bytes.create 10 in
     Bytes.blit_string "xxxxxxxxx" 0 n 0 9;
     Bytes.set_uint8 n 9 (v lxor 0xFF);
@@ -1185,85 +1213,135 @@ let gen_casetype_string_tag body_byte =
     equal = ( = );
   }
 
-(* Combinator: glue two leaf gens into a pair-codec gen.
+(* Compositional record builder.
 
-   Cross-products produce four sets of bytes:
-   - positive x positive: clean tuples, the both-valid base case.
-   - positive x negative and negative x positive: "almost valid" -- one
-     side is well-shaped, the other isn't. These are the inputs that
-     stress decoder error paths most realistically.
-   - negative x negative: fully invalid; included for completeness so
-     the decoder isn't tested only on near-valid data.
+   A [leaf] carries the wire typ for one component of a record plus its
+   positive/negative samples and (optional) param env. [Field] binds a
+   leaf to a getter on the enclosing record type, and [( :: )] grows a
+   heterogeneous field list whose type parameters mirror
+   [Wire.Codec.fields]: as you cons one more leaf on the front, the
+   builder type grows from ['f] to ['a -> 'f] (one more curried
+   argument).
 
-   The split keeps the positive/negative distribution from collapsing
-   into one direction: as long as both leaves contribute roughly
-   balanced positive/negative cases, the product stays roughly half
-   positive (1 of 4) and half negative (3 of 4). *)
-let cat_bytes_thunks a b () =
-  let av = a () and bv = b () in
-  let na = Bytes.length av and nb = Bytes.length bv in
-  let out = Bytes.create (na + nb) in
-  Bytes.blit av 0 out 0 na;
-  Bytes.blit bv 0 out na nb;
-  out
+   [record name builder fields ~equal] seals the fields into a flat
+   [Wire.Codec.v name builder fs] -- no sub-codec wrapping, byte-
+   identical to what you'd write by hand. Positive cases are the cross-
+   product of per-field positives, with the builder applied along the
+   way to assemble the record value; negative cases pick one field's
+   noise stream and pair it with positives elsewhere, which is the
+   "one bad slot, everything else valid" adversarial shape.
 
-let pair_positives g1 g2 =
-  List.concat_map
-    (fun (p1 : _ positive) ->
-      List.map
-        (fun (p2 : _ positive) ->
-          {
-            value = (p1.value, p2.value);
-            bytes = cat_bytes_thunks p1.bytes p2.bytes;
-          })
-        g2.positive_cases)
-    g1.positive_cases
+   Envs from each field are merged; two fields binding the same param
+   raise rather than silently keeping one side. *)
 
-let pair_negatives g1 g2 =
-  let cross_pn =
-    List.concat_map
-      (fun (p1 : _ positive) ->
-        List.map
-          (fun (n2 : negative) ->
-            { bytes = cat_bytes_thunks p1.bytes n2.bytes })
-          g2.negative_cases)
-      g1.positive_cases
-  in
-  let cross_np =
-    List.concat_map
-      (fun (n1 : negative) ->
-        List.map
-          (fun (p2 : _ positive) ->
-            { bytes = cat_bytes_thunks n1.bytes p2.bytes })
-          g2.positive_cases)
-      g1.negative_cases
-  in
-  let cross_nn =
-    List.concat_map
-      (fun (n1 : negative) ->
-        List.map
-          (fun (n2 : negative) ->
-            { bytes = cat_bytes_thunks n1.bytes n2.bytes })
-          g2.negative_cases)
-      g1.negative_cases
-  in
-  cross_pn @ cross_np @ cross_nn
+module Record = struct
+  type ('a, 'r) field = { name : string; leaf : 'a leaf; getter : 'r -> 'a }
 
-let gen_pair name g1 g2 =
-  let f1 = Wire.Field.v "x" (Wire.codec g1.codec) in
-  let f2 = Wire.Field.v "y" (Wire.codec g2.codec) in
-  let codec =
-    Wire.Codec.v name (fun x y -> (x, y)) Wire.Codec.[ f1 $ fst; f2 $ snd ]
-  in
-  let env = match (g1.env, g2.env) with None, None -> None | _ -> None in
-  let equal (x1, y1) (x2, y2) = g1.equal x1 x2 && g2.equal y1 y2 in
-  {
-    codec;
-    env;
-    positive_cases = pair_positives g1 g2;
-    negative_cases = pair_negatives g1 g2;
-    equal;
-  }
+  type ('f, 'r) fields =
+    | [] : ('r, 'r) fields
+    | ( :: ) : ('a, 'r) field * ('f, 'r) fields -> ('a -> 'f, 'r) fields
+
+  let bind : string -> 'a leaf -> ('r -> 'a) -> ('a, 'r) field =
+   fun name leaf getter -> { name; leaf; getter }
+
+  let cat_bytes_thunks ts () =
+    let bs = List.map (fun t -> t ()) ts in
+    let total = List.fold_left (fun n b -> n + Bytes.length b) 0 bs in
+    let out = Bytes.create total in
+    let _ =
+      List.fold_left
+        (fun off b ->
+          let n = Bytes.length b in
+          Bytes.blit b 0 out off n;
+          off + n)
+        0 bs
+    in
+    out
+
+  let merge_envs : Wire.Param.env option list -> Wire.Param.env option =
+   fun envs ->
+    List.fold_left
+      (fun acc e ->
+        match (acc, e) with
+        | None, e | e, None -> e
+        | Some _, Some _ ->
+            invalid_arg "fuzz_wire.record: cross-field env merge not supported")
+      None envs
+
+  let rec codec_fields : type f r. (f, r) fields -> (f, r) Wire.Codec.fields =
+   fun fields ->
+    match fields with
+    | [] -> Wire.Codec.[]
+    | rf :: rest ->
+        Wire.Codec.( $ ) (Wire.Field.v rf.name rf.leaf.typ) rf.getter
+        :: codec_fields rest
+
+  let rec envs : type f r. (f, r) fields -> Wire.Param.env option list =
+    function
+    | [] -> []
+    | rf :: rest -> rf.leaf.env :: envs rest
+
+  let rec positives : type f r.
+      f -> (unit -> bytes) list -> (f, r) fields -> r positive list =
+   fun partial bytes_acc fields ->
+    match fields with
+    | [] ->
+        [ { value = partial; bytes = cat_bytes_thunks (List.rev bytes_acc) } ]
+    | rf :: rest ->
+        List.concat_map
+          (fun (p : _ positive) ->
+            positives (partial p.value) (p.bytes :: bytes_acc) rest)
+          rf.leaf.positive_cases
+
+  let rec pos_thunks : type f r. (f, r) fields -> (unit -> bytes) list =
+    function
+    | [] -> []
+    | rf :: rest ->
+        let h =
+          match rf.leaf.positive_cases with
+          | p :: _ -> p.bytes
+          | [] -> fun () -> Bytes.empty
+        in
+        h :: pos_thunks rest
+
+  (* For each field, emit a compound bytes stream where that one slot
+     is noisy and every other slot uses its first positive sample. One
+     bad slot, rest valid -- the realistic adversarial input. *)
+  let rec negatives : type f r.
+      (unit -> bytes) list -> (f, r) fields -> negative list =
+   fun bytes_acc fields ->
+    match fields with
+    | [] -> []
+    | rf :: rest ->
+        let tail = pos_thunks rest in
+        let here =
+          List.map
+            (fun (n : negative) ->
+              {
+                bytes =
+                  cat_bytes_thunks (List.rev_append bytes_acc (n.bytes :: tail));
+              })
+            rf.leaf.negative_cases
+        in
+        let pos_thunk =
+          match rf.leaf.positive_cases with
+          | p :: _ -> p.bytes
+          | [] -> fun () -> Bytes.empty
+        in
+        here @ negatives (pos_thunk :: bytes_acc) rest
+
+  let v : type f r.
+      string -> equal:(r -> r -> bool) -> f -> (f, r) fields -> r gen =
+   fun name ~equal builder fields ->
+    let codec = Wire.Codec.v name builder (codec_fields fields) in
+    {
+      codec;
+      env = merge_envs (envs fields);
+      positive_cases = positives builder [] fields;
+      negative_cases = negatives [] fields;
+      equal;
+    }
+end
 
 let test_gen_param_byte_array n =
   run_gen "param_byte_array" (gen_param_byte_array n)
@@ -1277,14 +1355,20 @@ let test_gen_codec_tail buf =
 let test_gen_casetype_string_tag n =
   run_gen "casetype_string_tag" (gen_casetype_string_tag n)
 
-(* Fixed-size leaf used for composition tests: an embedded sub-codec with
-   variable-size tail can't be the left half of a pair (the right half
-   has no way to find its starting offset). The string-tag casetype's
-   per-case body sizes are known (uint8 in both branches), so two of
-   them compose cleanly. *)
-let test_gen_pair m n =
-  run_gen "pair"
-    (gen_pair "Pair" (gen_casetype_string_tag m) (gen_casetype_string_tag n))
+(* Compositional record test: build a two-field record codec from two
+   leaf gens via the new [record] combinator. The fixed-size string-tag
+   casetype is chosen because every variant of it ships a 10-byte body,
+   so the right half always knows where its bytes start. *)
+let test_gen_record m n =
+  let g1 = leaf_casetype_string_tag m in
+  let g2 = leaf_casetype_string_tag n in
+  let equal (a1, b1) (a2, b2) = g1.equal a1 a2 && g2.equal b1 b2 in
+  let g =
+    Record.v "Pair" ~equal
+      (fun a b -> (a, b))
+      Record.[ bind "x" g1 fst; bind "y" g2 snd ]
+  in
+  run_gen "record" g
 
 (* Remaining leaves so every codec-targetable Wire.typ constructor has
    at least one fuzz target. Each leaf wraps the constructor under test
@@ -1306,12 +1390,12 @@ let gen_byte_slice buf =
           (Wire.Field.v "s" (Wire.byte_slice ~size:(Wire.int len)) $ fun s -> s);
         ]
   in
-  let positive =
+  let positive : _ positive list =
     let bytes_payload = Bytes.of_string payload in
     let slice = Bytesrw.Bytes.Slice.make bytes_payload ~first:0 ~length:len in
     [ { value = slice; bytes = (fun () -> bytes_payload) } ]
   in
-  let negative = [ { bytes = (fun () -> Bytes.empty) } ] in
+  let negative : negative list = [ { bytes = (fun () -> Bytes.empty) } ] in
   {
     codec;
     env = None;
@@ -1415,8 +1499,10 @@ let gen_map n =
   in
   let raw = value in
   let buf = Bytes.make 1 (Char.chr raw) in
-  let positive = [ { value = raw * 2; bytes = (fun () -> buf) } ] in
-  let negative = [ { bytes = (fun () -> Bytes.empty) } ] in
+  let positive : _ positive list =
+    [ { value = raw * 2; bytes = (fun () -> buf) } ]
+  in
+  let negative : negative list = [ { bytes = (fun () -> Bytes.empty) } ] in
   {
     codec;
     env = None;
@@ -1668,7 +1754,7 @@ let encoder_tests =
     test_case "gen repeat var-elem" [ bytes ] test_gen_repeat_var_elem;
     test_case "gen codec all_bytes-tail" [ bytes ] test_gen_codec_tail;
     test_case "gen casetype string-tag" [ int ] test_gen_casetype_string_tag;
-    test_case "gen pair (casetype + casetype)" [ int; int ] test_gen_pair;
+    test_case "gen record (casetype + casetype)" [ int; int ] test_gen_record;
     test_case "gen uint_var" [ int ] test_gen_uint_var;
     test_case "gen where" [ int ] test_gen_where;
     test_case "gen map" [ int ] test_gen_map;

--- a/fuzz/fuzz_wire.ml
+++ b/fuzz/fuzz_wire.ml
@@ -978,25 +978,42 @@ let float_tests =
 type 'a positive = { value : 'a; bytes : unit -> bytes }
 type negative = { bytes : unit -> bytes }
 
+(* An ['a gen] is a byte-stream generator paired with the codec the
+   stream is meant to feed. The streams come in three semantic flavors,
+   each tested by [run_gen]:
+
+   - [valid] -- valid by construction: the bytes must decode to [value]
+     and re-encode byte-identically. Round-trip property.
+   - [almost_valid] -- almost-valid by construction: a compound stream
+     in which one slot has been replaced by noise while sibling slots
+     stayed well-shaped. The decoder must not crash (it may return
+     [Error] or surface a partially-decoded value, but raising is a
+     bug).
+   - [adversarial] -- adversarial by construction: many slots noisy or
+     wholly random bytes. Same crash-safety property as [almost_valid].
+
+   The [almost_valid] / [adversarial] split lets [Record.v] compose
+   compound generators that exercise both "one bad slot" and "many bad
+   slots" stress paths; for primitive leaves where there's no internal
+   structure to corrupt selectively, [almost_valid] is empty. *)
 type 'a gen = {
   codec : 'a Wire.Codec.t;
   env : Wire.Param.env option;
-  positive_cases : 'a positive list;
-      (* Bytes that should decode to [value] and re-encode byte-identically.*)
-  negative_cases : negative list;
-      (* Bytes the decoder must handle without crashing (return [Error] or
-         decode to some value -- either outcome is acceptable, but raising
-         is a bug). *)
+  valid : 'a positive list;
+  almost_valid : negative list;
+  adversarial : negative list;
   equal : 'a -> 'a -> bool;
 }
 
-(* A [leaf] is a gen exposed as its bare typ -- usable as one field of
-   a flat record codec built with [record] below. *)
+(* A [leaf] is the typ form of a gen, ready to slot into a flat record
+   codec via [Record.v]. Mirrors [gen] but carries the bare typ
+   instead of a sealed codec. *)
 type 'a leaf = {
   typ : 'a Wire.typ;
   env : Wire.Param.env option;
-  positive_cases : 'a positive list;
-  negative_cases : negative list;
+  valid : 'a positive list;
+  almost_valid : negative list;
+  adversarial : negative list;
   equal : 'a -> 'a -> bool;
 }
 
@@ -1015,13 +1032,13 @@ let run_gen label (g : _ gen) =
       (match Wire.Codec.decode ?env:g.env g.codec bs 0 with
       | Ok decoded ->
           if not (g.equal decoded p.value) then
-            fail (label ^ ": positive decode mismatch")
-      | Error _ -> fail (label ^ ": positive decode failed"));
+            fail (label ^ ": valid decode mismatch")
+      | Error _ -> fail (label ^ ": valid decode failed"));
       let out = Bytes.create (Bytes.length bs) in
       (try Wire.Codec.encode ?env:g.env g.codec p.value out 0
-       with Invalid_argument _ -> fail (label ^ ": positive reencode raised"));
+       with Invalid_argument _ -> fail (label ^ ": valid reencode raised"));
       if Bytes.unsafe_to_string out <> Bytes.unsafe_to_string bs then
-        fail (label ^ ": positive reencode bytes mismatch");
+        fail (label ^ ": valid reencode bytes mismatch");
       (* Also exercise the top-level [Wire.to_string] path: this drives
          [encode_into] -> [encode_codec], which uses [size_of_value] to
          pre-size the scratch. A mismatch here surfaces encoder bugs that
@@ -1031,13 +1048,14 @@ let run_gen label (g : _ gen) =
         if via_wire <> Bytes.unsafe_to_string bs then
           fail (label ^ ": Wire.to_string mismatch")
       end)
-    g.positive_cases;
-  List.iter
-    (fun (n : negative) ->
-      let bs = n.bytes () in
-      try ignore (Wire.Codec.decode ?env:g.env g.codec bs 0)
-      with Invalid_argument _ -> fail (label ^ ": negative crashed decoder"))
-    g.negative_cases
+    g.valid;
+  let must_not_crash kind (n : negative) =
+    let bs = n.bytes () in
+    try ignore (Wire.Codec.decode ?env:g.env g.codec bs 0)
+    with Invalid_argument _ -> fail (label ^ ": " ^ kind ^ " crashed decoder")
+  in
+  List.iter (must_not_crash "almost_valid") g.almost_valid;
+  List.iter (must_not_crash "adversarial") g.adversarial
 
 (* Leaf generators *)
 
@@ -1062,8 +1080,9 @@ let gen_param_byte_array n =
   {
     codec;
     env = Some env;
-    positive_cases = [ { value = { payload }; bytes = (fun () -> valid) } ];
-    negative_cases = [ { bytes = (fun () -> noise) } ];
+    valid = [ { value = { payload }; bytes = (fun () -> valid) } ];
+    almost_valid = [];
+    adversarial = [ { bytes = (fun () -> noise) } ];
     equal = (fun a b -> a.payload = b.payload);
   }
 
@@ -1117,8 +1136,9 @@ let gen_repeat_var_elem buf =
   {
     codec;
     env = None;
-    positive_cases = [ { value = exts; bytes = (fun () -> framed) } ];
-    negative_cases = [ { bytes = (fun () -> noise) } ];
+    valid = [ { value = exts; bytes = (fun () -> framed) } ];
+    almost_valid = [];
+    adversarial = [ { bytes = (fun () -> noise) } ];
     equal = ( = );
   }
 
@@ -1150,9 +1170,9 @@ let gen_codec_all_bytes_tail buf =
   {
     codec = outer_trailing;
     env = None;
-    positive_cases =
-      [ { value = { header; tail }; bytes = (fun () -> framed) } ];
-    negative_cases = [ { bytes = (fun () -> noise) } ];
+    valid = [ { value = { header; tail }; bytes = (fun () -> framed) } ];
+    almost_valid = [];
+    adversarial = [ { bytes = (fun () -> noise) } ];
     equal = (fun a b -> a.header = b.header && a.tail = b.tail);
   }
 
@@ -1188,8 +1208,9 @@ let leaf_casetype_string_tag body_byte =
   ({
      typ = ssh_auth_body;
      env = None;
-     positive_cases = [ { value = `Publickey v; bytes = (fun () -> framed) } ];
-     negative_cases = [ { bytes = (fun () -> noise) } ];
+     valid = [ { value = `Publickey v; bytes = (fun () -> framed) } ];
+     almost_valid = [];
+     adversarial = [ { bytes = (fun () -> noise) } ];
      equal = ( = );
    }
     : ssh_auth leaf)
@@ -1208,8 +1229,9 @@ let gen_casetype_string_tag body_byte =
   {
     codec = ssh_auth_codec;
     env = None;
-    positive_cases = [ { value = `Publickey v; bytes = (fun () -> framed) } ];
-    negative_cases = [ { bytes = (fun () -> noise) } ];
+    valid = [ { value = `Publickey v; bytes = (fun () -> framed) } ];
+    almost_valid = [];
+    adversarial = [ { bytes = (fun () -> noise) } ];
     equal = ( = );
   }
 
@@ -1291,44 +1313,65 @@ module Record = struct
         List.concat_map
           (fun (p : _ positive) ->
             positives (partial p.value) (p.bytes :: bytes_acc) rest)
-          rf.leaf.positive_cases
+          rf.leaf.valid
 
   let rec pos_thunks : type f r. (f, r) fields -> (unit -> bytes) list =
     function
     | [] -> []
     | rf :: rest ->
         let h =
-          match rf.leaf.positive_cases with
+          match rf.leaf.valid with
           | p :: _ -> p.bytes
           | [] -> fun () -> Bytes.empty
         in
         h :: pos_thunks rest
 
-  (* For each field, emit a compound bytes stream where that one slot
-     is noisy and every other slot uses its first positive sample. One
-     bad slot, rest valid -- the realistic adversarial input. *)
-  let rec negatives : type f r.
+  (* "One bad slot, rest valid": for each field, swap its slot for one
+     of its bad samples (adversarial OR already-almost_valid) and keep
+     siblings at their first valid sample. The realistic adversarial
+     shape; promoted into the compound's [almost_valid]. *)
+  let rec almost : type f r.
       (unit -> bytes) list -> (f, r) fields -> negative list =
    fun bytes_acc fields ->
     match fields with
     | [] -> []
     | rf :: rest ->
         let tail = pos_thunks rest in
+        let mk (n : negative) =
+          {
+            bytes =
+              cat_bytes_thunks (List.rev_append bytes_acc (n.bytes :: tail));
+          }
+        in
         let here =
-          List.map
-            (fun (n : negative) ->
-              {
-                bytes =
-                  cat_bytes_thunks (List.rev_append bytes_acc (n.bytes :: tail));
-              })
-            rf.leaf.negative_cases
+          List.map mk rf.leaf.adversarial @ List.map mk rf.leaf.almost_valid
         in
         let pos_thunk =
-          match rf.leaf.positive_cases with
+          match rf.leaf.valid with
           | p :: _ -> p.bytes
           | [] -> fun () -> Bytes.empty
         in
-        here @ negatives (pos_thunk :: bytes_acc) rest
+        here @ almost (pos_thunk :: bytes_acc) rest
+
+  (* "Many bad slots": concatenate every field's first adversarial
+     sample (falling back to its valid sample if no adversarial). One
+     fully-noisy stream per record. Stays in [adversarial]. *)
+  let rec all_bad : type f r. (f, r) fields -> (unit -> bytes) list = function
+    | [] -> []
+    | rf :: rest ->
+        let h =
+          match (rf.leaf.adversarial, rf.leaf.valid) with
+          | n :: _, _ -> n.bytes
+          | [], p :: _ -> p.bytes
+          | [], [] -> fun () -> Bytes.empty
+        in
+        h :: all_bad rest
+
+  let adversarial_of : type f r. (f, r) fields -> negative list =
+   fun fields ->
+    match fields with
+    | [] -> []
+    | _ -> [ { bytes = cat_bytes_thunks (all_bad fields) } ]
 
   let v : type f r.
       string -> equal:(r -> r -> bool) -> f -> (f, r) fields -> r gen =
@@ -1337,8 +1380,9 @@ module Record = struct
     {
       codec;
       env = merge_envs (envs fields);
-      positive_cases = positives builder [] fields;
-      negative_cases = negatives [] fields;
+      valid = positives builder [] fields;
+      almost_valid = almost [] fields;
+      adversarial = adversarial_of fields;
       equal;
     }
 end
@@ -1399,8 +1443,9 @@ let gen_byte_slice buf =
   {
     codec;
     env = None;
-    positive_cases = positive;
-    negative_cases = negative;
+    valid = positive;
+    almost_valid = [];
+    adversarial = negative;
     equal =
       (fun a b ->
         Bytesrw.Bytes.Slice.length a = Bytesrw.Bytes.Slice.length b
@@ -1425,8 +1470,9 @@ let gen_uint_var n =
   {
     codec;
     env = None;
-    positive_cases = [ { value; bytes = (fun () -> buf) } ];
-    negative_cases = [ { bytes = (fun () -> Bytes.empty) } ];
+    valid = [ { value; bytes = (fun () -> buf) } ];
+    almost_valid = [];
+    adversarial = [ { bytes = (fun () -> Bytes.empty) } ];
     equal = Int.equal;
   }
 
@@ -1461,10 +1507,11 @@ let gen_byte_array_where buf =
   {
     codec;
     env = None;
-    positive_cases = [ { value = payload; bytes = (fun () -> bytes_in) } ];
+    valid = [ { value = payload; bytes = (fun () -> bytes_in) } ];
     (* Noise: bytes that violate the per-byte predicate -- decoder must
        surface [Constraint_failed], not crash. *)
-    negative_cases = [ { bytes = (fun () -> bad) } ];
+    almost_valid = [];
+    adversarial = [ { bytes = (fun () -> bad) } ];
     equal = String.equal;
   }
 
@@ -1482,8 +1529,9 @@ let gen_where n =
   {
     codec;
     env = None;
-    positive_cases = [ { value; bytes = (fun () -> valid) } ];
-    negative_cases = [ { bytes = (fun () -> bad) } ];
+    valid = [ { value; bytes = (fun () -> valid) } ];
+    almost_valid = [];
+    adversarial = [ { bytes = (fun () -> bad) } ];
     equal = Int.equal;
   }
 
@@ -1506,8 +1554,9 @@ let gen_map n =
   {
     codec;
     env = None;
-    positive_cases = positive;
-    negative_cases = negative;
+    valid = positive;
+    almost_valid = [];
+    adversarial = negative;
     equal = Int.equal;
   }
 
@@ -1528,8 +1577,9 @@ let gen_single_elem n =
   {
     codec;
     env = None;
-    positive_cases = [ { value = inner_v; bytes = (fun () -> buf) } ];
-    negative_cases = [ { bytes = (fun () -> Bytes.empty) } ];
+    valid = [ { value = inner_v; bytes = (fun () -> buf) } ];
+    almost_valid = [];
+    adversarial = [ { bytes = (fun () -> Bytes.empty) } ];
     equal = Int.equal;
   }
 
@@ -1545,9 +1595,9 @@ let gen_all_zeros n =
   {
     codec;
     env = None;
-    positive_cases =
-      [ { value = String.make len '\x00'; bytes = (fun () -> zeros) } ];
-    negative_cases = [ { bytes = (fun () -> nonzero) } ];
+    valid = [ { value = String.make len '\x00'; bytes = (fun () -> zeros) } ];
+    almost_valid = [];
+    adversarial = [ { bytes = (fun () -> nonzero) } ];
     equal = String.equal;
   }
 
@@ -1561,8 +1611,9 @@ let gen_optional n =
   {
     codec;
     env = None;
-    positive_cases = [ { value = Some inner; bytes = (fun () -> buf) } ];
-    negative_cases = [ { bytes = (fun () -> Bytes.empty) } ];
+    valid = [ { value = Some inner; bytes = (fun () -> buf) } ];
+    almost_valid = [];
+    adversarial = [ { bytes = (fun () -> Bytes.empty) } ];
     equal = ( = );
   }
 
@@ -1578,8 +1629,9 @@ let gen_optional_or n =
   {
     codec;
     env = None;
-    positive_cases = [ { value = inner; bytes = (fun () -> buf) } ];
-    negative_cases = [ { bytes = (fun () -> Bytes.empty) } ];
+    valid = [ { value = inner; bytes = (fun () -> buf) } ];
+    almost_valid = [];
+    adversarial = [ { bytes = (fun () -> Bytes.empty) } ];
     equal = Int.equal;
   }
 
@@ -1620,8 +1672,9 @@ let gen_casetype_int_tag n =
   {
     codec;
     env = None;
-    positive_cases = [ { value = v; bytes = (fun () -> buf) } ];
-    negative_cases = [ { bytes = (fun () -> Bytes.empty) } ];
+    valid = [ { value = v; bytes = (fun () -> buf) } ];
+    almost_valid = [];
+    adversarial = [ { bytes = (fun () -> Bytes.empty) } ];
     equal = ( = );
   }
 

--- a/fuzz/fuzz_wire.ml
+++ b/fuzz/fuzz_wire.ml
@@ -364,7 +364,7 @@ let test_parse_casetype buf =
         Wire.case ~index:1 Wire.uint16
           ~inject:(fun v -> `U16 v)
           ~project:(function `U16 v -> Some v | _ -> None);
-        Wire.default Wire.uint32
+        Wire.default ~tag:0xFF Wire.uint32
           ~inject:(fun v -> `Default (Wire.Private.UInt32.to_int v))
           ~project:(function
             | `Default v -> Some (Wire.Private.UInt32.of_int v) | _ -> None);
@@ -1156,7 +1156,7 @@ let ssh_auth_codec =
         Wire.case ~index:"publickey" Wire.uint8
           ~inject:(fun v -> `Publickey v)
           ~project:(function `Publickey v -> Some v | _ -> None);
-        Wire.default Wire.uint8
+        Wire.default ~tag:"xxxxxxxxx" Wire.uint8
           ~inject:(fun v -> `Other v)
           ~project:(function `Other v -> Some v | _ -> None);
       ]
@@ -1507,7 +1507,7 @@ let gen_casetype_int_tag n =
         Wire.case ~index:1 Wire.uint16be
           ~inject:(fun v -> U16 v)
           ~project:(function U16 v -> Some v | _ -> None);
-        Wire.default Wire.uint8
+        Wire.default ~tag:0xFF Wire.uint8
           ~inject:(fun v -> Default v)
           ~project:(function Default v -> Some v | _ -> None);
       ]
@@ -1641,7 +1641,7 @@ let meta_composite_cases =
               Wire.case ~index:1 Wire.uint16be
                 ~inject:(fun v -> U16 v)
                 ~project:(function U16 v -> Some v | _ -> None);
-              Wire.default Wire.uint8
+              Wire.default ~tag:0xFF Wire.uint8
                 ~inject:(fun v -> Default v)
                 ~project:(function Default v -> Some v | _ -> None);
             ]

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -32,13 +32,19 @@ let setter_off_int32 n set buf off v =
   off + n
 
 let rec encode_case_match : type k w.
-    (bytes -> int -> k -> int) -> k option -> w typ -> w -> bytes -> int -> int
-    =
- fun tag_enc cb_tag cb_inner body buf off ->
+    (bytes -> int -> k -> int) ->
+    k option ->
+    k option ->
+    w typ ->
+    w ->
+    bytes ->
+    int ->
+    int =
+ fun tag_enc cb_tag cb_default_tag cb_inner body buf off ->
   let t =
-    match cb_tag with
-    | Some t -> t
-    | None -> failwith "build_field_encoder: cannot encode default case"
+    match (cb_tag, cb_default_tag) with
+    | Some t, _ | _, Some t -> t
+    | None, None -> failwith "build_field_encoder: case missing tag"
   in
   let off' = tag_enc buf off t in
   build_field_encoder cb_inner buf off' body
@@ -49,9 +55,12 @@ and build_casetype_encoder : type a k.
   let tag_enc = build_field_encoder tag in
   let rec find buf off v = function
     | [] -> failwith "build_field_encoder: casetype: no matching case"
-    | Case_branch { cb_tag; cb_inner; cb_project; _ } :: rest -> (
+    | Case_branch { cb_tag; cb_default_tag; cb_inner; cb_project; _ } :: rest
+      -> (
         match cb_project v with
-        | Some body -> encode_case_match tag_enc cb_tag cb_inner body buf off
+        | Some body ->
+            encode_case_match tag_enc cb_tag cb_default_tag cb_inner body buf
+              off
         | None -> find buf off v rest)
   in
   fun buf off v -> find buf off v cases

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -969,7 +969,7 @@ let rec read_elem : type a. a typ -> bytes -> int -> a =
       let tag_size =
         match field_wire_size tag with
         | Some n -> n
-        | None -> assert false (* casetype tag is always fixed-size int *)
+        | None -> assert false (* casetype tag is always fixed-size *)
       in
       let tag_val = read_elem tag buf off in
       let body_off = off + tag_size in
@@ -984,6 +984,12 @@ let rec read_elem : type a. a typ -> bytes -> int -> a =
         | _ :: rest -> find rest
       in
       find cases
+  | Byte_array { size } ->
+      let n = match size with Int n -> n | _ -> assert false in
+      Bytes.sub_string buf off n
+  | Byte_array_where { size; _ } ->
+      let n = match size with Int n -> n | _ -> assert false in
+      Bytes.sub_string buf off n
   | _ -> failwith "read_elem: unsupported element type in repeat"
 
 (* Write one element of a typ at a given buffer position. Used by Repeat. *)

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -1701,7 +1701,7 @@ and var_bytes_reader : type a.
       String.iter
         (fun c ->
           if c <> '\000' then
-            invalid_arg "add_field: [all_zeros] field has a non-zero byte")
+            raise (Parse_error (Constraint_failed "all_zeros: non-zero byte")))
         s;
       s
   | Casetype _ -> read_elem typ buf (base + fo)

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -157,6 +157,9 @@ and _ typ =
 and ('a, 'k) case_branch =
   | Case_branch : {
       cb_tag : 'k option;
+      cb_default_tag : 'k option;
+          (* Encode-time tag for the default branch ([cb_tag = None]).
+             [None] means encoding this branch is unsupported. *)
       cb_inner : 'w typ;
       cb_inject : 'w -> 'a;
       cb_project : 'a -> 'w option;
@@ -472,6 +475,7 @@ type ('a, 'k) case_def =
     }
       -> ('a, 'k) case_def
   | Default_def : {
+      dd_tag : 'k;
       dd_inner : 'w typ;
       dd_inject : 'w -> 'a;
       dd_project : 'a -> 'w option;
@@ -487,8 +491,9 @@ let case ?index inner ~inject ~project =
       cd_project = project;
     }
 
-let default inner ~inject ~project =
-  Default_def { dd_inner = inner; dd_inject = inject; dd_project = project }
+let default ~tag inner ~inject ~project =
+  Default_def
+    { dd_tag = tag; dd_inner = inner; dd_inject = inject; dd_project = project }
 
 let casetype name tag defs =
   let resolve = function
@@ -504,15 +509,17 @@ let casetype name tag defs =
         Case_branch
           {
             cb_tag;
+            cb_default_tag = None;
             cb_inner = cd_inner;
             cb_inject = cd_inject;
             cb_project = cd_project;
           }
-    | Default_def { dd_inner; dd_inject; dd_project } ->
+    | Default_def { dd_tag; dd_inner; dd_inject; dd_project } ->
         reject_decoration ~combinator:"casetype" dd_inner;
         Case_branch
           {
             cb_tag = None;
+            cb_default_tag = Some dd_tag;
             cb_inner = dd_inner;
             cb_inject = dd_inject;
             cb_project = dd_project;

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -1442,14 +1442,43 @@ let rec size_of_typ_value : type a. a typ -> a -> int =
   | Codec { codec_size_of_value; _ } -> codec_size_of_value v
   | Single_elem { size = Int n; _ } -> n
   | Single_elem _ -> 0
-  | Repeat { size = Int n; _ } -> n
-  | Repeat _ -> 0
+  | Repeat { elem; seq = Seq_map s; _ } ->
+      (* Sum per-element sizes from the value -- the byte-budget [size]
+         expression is what we just produced when encoding, not an
+         independent ground truth. *)
+      let total = Stdlib.ref 0 in
+      s.iter (fun e -> total := !total + size_of_typ_value elem e) v;
+      !total
   | Array { elem; seq = Seq_map s; _ } ->
       let total = Stdlib.ref 0 in
       s.iter (fun e -> total := !total + size_of_typ_value elem e) v;
       !total
   | Apply { typ; _ } -> size_of_typ_value typ v
-  | Casetype _ -> 0
+  | Casetype { tag; cases; _ } ->
+      let tag_size : type k. k typ -> int = function
+        | Uint8 | Int8 -> 1
+        | Uint16 _ | Int16 _ -> 2
+        | Uint32 _ | Int32 _ | Float32 _ -> 4
+        | Uint63 _ | Uint64 _ | Int64 _ | Float64 _ -> 8
+        | Bits { base = BF_U8; _ } -> 1
+        | Bits { base = BF_U16 _; _ } -> 2
+        | Bits { base = BF_U32 _; _ } -> 4
+        | Byte_array { size = Int n } -> n
+        | Byte_array_where { size = Int n; _ } -> n
+        | _ ->
+            invalid_arg
+              "Wire.casetype: variable-size tag unsupported by the encoder"
+      in
+      let sz = tag_size tag in
+      let rec find_case = function
+        | [] ->
+            invalid_arg "Wire.casetype: value matches no case at encode time"
+        | Case_branch { cb_inner; cb_project; _ } :: rest -> (
+            match cb_project v with
+            | Some body -> sz + size_of_typ_value cb_inner body
+            | None -> find_case rest)
+      in
+      find_case cases
   | Struct _ -> 0
   | Type_ref _ -> 0
   | Qualified_ref _ -> 0

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -193,6 +193,7 @@ and _ typ =
 and ('a, 'k) case_branch =
   | Case_branch : {
       cb_tag : 'k option;
+      cb_default_tag : 'k option;
       cb_inner : 'w typ;
       cb_inject : 'w -> 'a;
       cb_project : 'a -> 'w option;
@@ -518,8 +519,15 @@ val case :
 (** A branch matching a specific tag value. *)
 
 val default :
-  'w typ -> inject:('w -> 'a) -> project:('a -> 'w option) -> ('a, 'k) case_def
-(** A default branch. *)
+  tag:'k ->
+  'w typ ->
+  inject:('w -> 'a) ->
+  project:('a -> 'w option) ->
+  ('a, 'k) case_def
+(** [default ~tag inner ~inject ~project] is the default branch of a casetype.
+    [~tag] is the discriminator value the encoder writes when projecting this
+    branch back to bytes; on decode the default branch still matches any tag the
+    explicit cases didn't claim. *)
 
 val casetype : string -> 'k typ -> ('a, 'k) case_def list -> 'a typ
 (** [casetype name tag defs] is a tag-dispatched union. Every case must supply

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -578,7 +578,13 @@ let rec encode_into : type a. a typ -> a -> encoder -> unit =
       let off = Slice.first v in
       let len = Slice.length v in
       write_string enc (Bytes.sub_string src off len)
-  | Single_elem { elem; _ } -> encode_into elem v enc
+  | Single_elem { size; elem; _ } ->
+      let n = Eval.expr Eval.empty size in
+      encode_into elem v enc;
+      let inner_sz = Types.size_of_typ_value elem v in
+      for _ = inner_sz to n - 1 do
+        write_byte enc 0
+      done
   | Enum { base; _ } -> encode_into base v enc
   | Map { inner; encode; _ } -> encode_into inner (encode v) enc
   | Codec { codec_encode; codec_fixed_size; codec_size_of_value; _ } ->

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -607,12 +607,16 @@ and encode_casetype : type a k.
  fun tag cases v enc ->
   let rec find_case = function
     | [] -> failwith "casetype encoding: no matching case"
-    | Case_branch { cb_tag; cb_inner; cb_project; _ } :: rest -> (
+    | Case_branch { cb_tag; cb_default_tag; cb_inner; cb_project; _ } :: rest
+      -> (
         match cb_project v with
         | Some body ->
-            (match cb_tag with
-            | Some t -> encode_into tag t enc
-            | None -> failwith "casetype encoding: cannot encode default case");
+            let t =
+              match (cb_tag, cb_default_tag) with
+              | Some t, _ | _, Some t -> t
+              | None, None -> failwith "casetype encoding: case missing tag"
+            in
+            encode_into tag t enc;
             encode_into cb_inner body enc
         | None -> find_case rest)
   in

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -624,8 +624,16 @@ val case :
 (** Tagged branch of a casetype. *)
 
 val default :
-  'w typ -> inject:('w -> 'a) -> project:('a -> 'w option) -> ('a, 'k) case_def
-(** Default branch of a casetype. *)
+  tag:'k ->
+  'w typ ->
+  inject:('w -> 'a) ->
+  project:('a -> 'w option) ->
+  ('a, 'k) case_def
+(** [default ~tag inner ~inject ~project] is the default branch of a casetype.
+
+    The decoder uses the default branch when no [~index]-tagged case matches.
+    The encoder writes [~tag] when projecting the default variant back to bytes.
+*)
 
 val casetype : string -> 'k typ -> ('a, 'k) case_def list -> 'a typ
 (** [casetype name tag defs] is a tag-dispatched union. The discriminator typ

--- a/test/3d/test_wire_3d.ml
+++ b/test/3d/test_wire_3d.ml
@@ -178,7 +178,7 @@ let e2e_casetype_codec =
         case ~index:1 uint16
           ~inject:(fun v -> `U16 v)
           ~project:(function `U16 v -> Some v | _ -> None);
-        default uint8
+        default ~tag:0xFF uint8
           ~inject:(fun v -> `Default v)
           ~project:(function `Default v -> Some v | _ -> None);
       ]
@@ -201,7 +201,7 @@ let e2e_ssh_casetype_codec =
         case ~index:"publickey" uint8
           ~inject:(fun v -> `Publickey v)
           ~project:(function `Publickey v -> Some v | _ -> None);
-        default uint8
+        default ~tag:"xxxxxxxxx" uint8
           ~inject:(fun v -> `Other v)
           ~project:(function `Other v -> Some v | _ -> None);
       ]

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -3033,7 +3033,7 @@ let casetype_field_event_typ : ev_payload Wire.typ =
       Wire.case ~index:2 Wire.uint32be
         ~inject:(fun v -> `Logout v)
         ~project:(function `Logout v -> Some v | _ -> None);
-      Wire.default Wire.uint8
+      Wire.default ~tag:0xFF Wire.uint8
         ~inject:(fun v -> `Other v)
         ~project:(function `Other v -> Some v | _ -> None);
     ]


### PR DESCRIPTION
Adds a composable [`'a gen = { codec; positive_cases; negative_cases; equal }`](https://github.com/parsimoni-labs/ocaml-wire/blob/2705a1f57d637ff3ae4b85c64a9f8b835592b5ca/fuzz/fuzz_wire.ml#L928) in `fuzz/fuzz_wire.ml`: positive cases must round-trip byte-identically; negative cases must not crash the decoder. [`gen_pair`](https://github.com/parsimoni-labs/ocaml-wire/blob/2705a1f57d637ff3ae4b85c64a9f8b835592b5ca/fuzz/fuzz_wire.ml#L1199) cross-products two leaves so the same draw exercises clean compounds and "almost valid" streams where one half is well-shaped and the other isn't.

Leaf gens cover every codec-targetable `Wire.typ`: `byte_slice`, `byte_array_where`, `uint_var`, `where`, `map`, `single_elem`, `all_zeros`, `optional`, `optional_or`, parametric `byte_array`, variable-element `repeat`, codec with `all_bytes` tail, and `casetype` with both int and string tags. A meta test round-trips one representative value per constructor through `Wire.to_string` / `Wire.of_string` so adding a new constructor without teaching the encoder or decoder makes the suite fail loudly.

The harness then surfaced three Wire bugs, fixed one per follow-up commit:

- [`codec: all_zeros decoder returns a decode error on non-zero bytes`](https://github.com/parsimoni-labs/ocaml-wire/pull/55/commits/6cd415d4) — the var-bytes reader raised `Invalid_argument` on a non-zero byte instead of returning `Parse_error`, breaking the "decoders never raise on adversarial input" contract.
- [`wire: pad Single_elem encode_into to its declared size`](https://github.com/parsimoni-labs/ocaml-wire/pull/55/commits/4c47b4d7) — `encode_direct` already padded `Wire.nested ~size:n inner` out to `n` bytes; `encode_into` (used by `Wire.to_string` on variable-size codecs) dropped the padding, so the round-trip mismatched.
- [`wire: require ~tag on default casetype branch for symmetric encode`](https://github.com/parsimoni-labs/ocaml-wire/pull/55/commits/2705a1f5) — `Wire.default` is now `tag:'k -> ...` so the encoder always knows what to write for the default branch; previously encoding any default-branch value crashed with `Failure "casetype encoding: cannot encode default case"`.