### PR TITLE
Satisfy new merlint rules + dedup parallel test scaffolding

### DIFF
--- a/fuzz/fuzz_everparse.ml
+++ b/fuzz/fuzz_everparse.ml
@@ -174,48 +174,39 @@ let test_casetype_inline () =
   let _ = Wire.Everparse.Raw.to_3d m in
   ()
 
-(** Test constraint expression generation. *)
-let test_constraint_expr a =
-  let v = abs a mod 1000 in
-  let f_x = Wire.Everparse.Raw.field "x" Wire.uint16 in
-  let cond = Wire.Expr.(Wire.Everparse.Raw.field_ref f_x <= Wire.int v) in
+(* Render a one-field struct constrained by [build_cond f_x] through the
+   3D emitter. The fuzz target is "does this typecheck and produce output";
+   the actual rendered string is dropped. *)
+let render_constrained_x ~name typ build_cond =
+  let f_x = Wire.Everparse.Raw.field "x" typ in
+  let cond = build_cond f_x in
   let s =
-    Wire.Everparse.Raw.struct_ "Constrained"
-      [ Wire.Everparse.Raw.field "x" ~constraint_:cond Wire.uint16 ]
+    Wire.Everparse.Raw.struct_ name
+      [ Wire.Everparse.Raw.field "x" ~constraint_:cond typ ]
   in
   let m = Wire.Everparse.Raw.module_ [ Wire.Everparse.Raw.typedef s ] in
   let _ = Wire.Everparse.Raw.to_3d m in
   ()
+
+(** Test constraint expression generation. *)
+let test_constraint_expr a =
+  let v = abs a mod 1000 in
+  render_constrained_x ~name:"Constrained" Wire.uint16 (fun f_x ->
+      Wire.Expr.(Wire.Everparse.Raw.field_ref f_x <= Wire.int v))
 
 (** Test bitfield constraints. *)
 let test_bitfield_constraint width =
   let width = (width mod 16) + 1 in
   let t = Wire.bits ~width Wire.U16 in
-  let f_x = Wire.Everparse.Raw.field "x" t in
-  let cond = Wire.Expr.(Wire.Everparse.Raw.field_ref f_x <= Wire.int 100) in
-  let s =
-    Wire.Everparse.Raw.struct_ "BFConstrained"
-      [ Wire.Everparse.Raw.field "x" ~constraint_:cond t ]
-  in
-  let m = Wire.Everparse.Raw.module_ [ Wire.Everparse.Raw.typedef s ] in
-  let _ = Wire.Everparse.Raw.to_3d m in
-  ()
+  render_constrained_x ~name:"BFConstrained" t (fun f_x ->
+      Wire.Expr.(Wire.Everparse.Raw.field_ref f_x <= Wire.int 100))
 
 (** Test bitwise expression operators in 3D output. *)
 let test_bitwise_expr a =
   let v = abs a mod 256 in
-  let f_x = Wire.Everparse.Raw.field "x" Wire.uint16 in
-  let open Wire.Expr in
-  let cond =
-    Wire.Everparse.Raw.field_ref f_x land Wire.int 0xFF <= Wire.int v
-  in
-  let s =
-    Wire.Everparse.Raw.struct_ "Bitwise"
-      [ Wire.Everparse.Raw.field "x" ~constraint_:cond Wire.uint16 ]
-  in
-  let m = Wire.Everparse.Raw.module_ [ Wire.Everparse.Raw.typedef s ] in
-  let _ = Wire.Everparse.Raw.to_3d m in
-  ()
+  render_constrained_x ~name:"Bitwise" Wire.uint16 (fun f_x ->
+      let open Wire.Expr in
+      Wire.Everparse.Raw.field_ref f_x land Wire.int 0xFF <= Wire.int v)
 
 (** Test logical expression operators. *)
 let test_logical_expr () =
@@ -285,49 +276,36 @@ let test_sizeof_expr () =
   let _ = Wire.field_pos in
   ()
 
-(** Test array types. *)
-let test_array_type len =
-  let len = (abs len mod 100) + 1 in
-  let arr = Wire.array ~len:(Wire.int len) Wire.uint8 in
+let render_single_field_struct ~struct_name ~field_name typ =
   let s =
-    Wire.Everparse.Raw.struct_ "WithArray"
-      [ Wire.Everparse.Raw.field "arr" arr ]
+    Wire.Everparse.Raw.struct_ struct_name
+      [ Wire.Everparse.Raw.field field_name typ ]
   in
   let m = Wire.Everparse.Raw.module_ [ Wire.Everparse.Raw.typedef s ] in
   let _ = Wire.Everparse.Raw.to_3d m in
   ()
+
+(** Test array types. *)
+let test_array_type len =
+  let len = (abs len mod 100) + 1 in
+  render_single_field_struct ~struct_name:"WithArray" ~field_name:"arr"
+    (Wire.array ~len:(Wire.int len) Wire.uint8)
 
 (** Test byte_array types. *)
 let test_byte_array size =
   let size = (abs size mod 1000) + 1 in
-  let ba = Wire.byte_array ~size:(Wire.int size) in
-  let s =
-    Wire.Everparse.Raw.struct_ "WithByteArray"
-      [ Wire.Everparse.Raw.field "data" ba ]
-  in
-  let m = Wire.Everparse.Raw.module_ [ Wire.Everparse.Raw.typedef s ] in
-  let _ = Wire.Everparse.Raw.to_3d m in
-  ()
+  render_single_field_struct ~struct_name:"WithByteArray" ~field_name:"data"
+    (Wire.byte_array ~size:(Wire.int size))
 
 (** Test nested. *)
 let test_nested () =
-  let t = Wire.nested ~size:(Wire.int 4) Wire.uint32 in
-  let s =
-    Wire.Everparse.Raw.struct_ "WithSingle" [ Wire.Everparse.Raw.field "x" t ]
-  in
-  let m = Wire.Everparse.Raw.module_ [ Wire.Everparse.Raw.typedef s ] in
-  let _ = Wire.Everparse.Raw.to_3d m in
-  ()
+  render_single_field_struct ~struct_name:"WithSingle" ~field_name:"x"
+    (Wire.nested ~size:(Wire.int 4) Wire.uint32)
 
 (** Test nested_at_most. *)
 let test_single_elem_at_most () =
-  let t = Wire.nested_at_most ~size:(Wire.int 8) Wire.uint32 in
-  let s =
-    Wire.Everparse.Raw.struct_ "WithAtMost" [ Wire.Everparse.Raw.field "x" t ]
-  in
-  let m = Wire.Everparse.Raw.module_ [ Wire.Everparse.Raw.typedef s ] in
-  let _ = Wire.Everparse.Raw.to_3d m in
-  ()
+  render_single_field_struct ~struct_name:"WithAtMost" ~field_name:"x"
+    (Wire.nested_at_most ~size:(Wire.int 8) Wire.uint32)
 
 (** Test anon_field (padding). *)
 let test_anon_field () =
@@ -386,18 +364,18 @@ let test_apply () =
 (** Test type_ref. *)
 let test_type_ref () =
   let t : int Wire.typ = Wire.Everparse.Raw.type_ref "SomeType" in
-  let s =
-    Wire.Everparse.Raw.struct_ "WithRef" [ Wire.Everparse.Raw.field "x" t ]
-  in
-  let m = Wire.Everparse.Raw.module_ [ Wire.Everparse.Raw.typedef s ] in
-  let _ = Wire.Everparse.Raw.to_3d m in
-  ()
+  render_single_field_struct ~struct_name:"WithRef" ~field_name:"x" t
 
 (** Test qualified_ref. *)
 let test_qualified_ref () =
   let t : int Wire.typ = Wire.Everparse.Raw.qualified_ref "Other" "SomeType" in
+  render_single_field_struct ~struct_name:"WithQRef" ~field_name:"x" t
+
+let render_action_struct ~name ptr act =
   let s =
-    Wire.Everparse.Raw.struct_ "WithQRef" [ Wire.Everparse.Raw.field "x" t ]
+    Wire.Everparse.Raw.param_struct name
+      [ Wire.Param.decl ptr ]
+      [ Wire.Everparse.Raw.field "x" ~action:act Wire.uint8 ]
   in
   let m = Wire.Everparse.Raw.module_ [ Wire.Everparse.Raw.typedef s ] in
   let _ = Wire.Everparse.Raw.to_3d m in
@@ -413,27 +391,13 @@ let test_action () =
         Wire.Action.return_bool Wire.Expr.true_;
       ]
   in
-  let s =
-    Wire.Everparse.Raw.param_struct "WithAction"
-      [ Wire.Param.decl ptr ]
-      [ Wire.Everparse.Raw.field "x" ~action:act Wire.uint8 ]
-  in
-  let m = Wire.Everparse.Raw.module_ [ Wire.Everparse.Raw.typedef s ] in
-  let _ = Wire.Everparse.Raw.to_3d m in
-  ()
+  render_action_struct ~name:"WithAction" ptr act
 
 (** Test Action.on_act action. *)
 let test_on_act () =
   let ptr = Wire.Param.output "ptr" Wire.uint32 in
   let act = Wire.Action.on_act [ Wire.Action.assign ptr (Wire.int 0) ] in
-  let s =
-    Wire.Everparse.Raw.param_struct "WithOnAct"
-      [ Wire.Param.decl ptr ]
-      [ Wire.Everparse.Raw.field "x" ~action:act Wire.uint8 ]
-  in
-  let m = Wire.Everparse.Raw.module_ [ Wire.Everparse.Raw.typedef s ] in
-  let _ = Wire.Everparse.Raw.to_3d m in
-  ()
+  render_action_struct ~name:"WithOnAct" ptr act
 
 (** Test Action.abort action. *)
 let test_abort () =

--- a/fuzz/fuzz_wire.ml
+++ b/fuzz/fuzz_wire.ml
@@ -548,6 +548,11 @@ let test_stream_roundtrip_uint64be_chunk5 n =
   | Ok decoded -> if n <> decoded then fail "stream uint64be chunk=5 mismatch"
   | Error _ -> fail "stream uint64be chunk=5 parse failed"
 
+let stream_check_field ~label ~expected typ slice =
+  match parse_chunked ~chunk_size:1 typ slice with
+  | Error _ -> fail (label ^ " parse failed")
+  | Ok v -> if expected <> v then fail (label ^ " mismatch")
+
 let test_stream_roundtrip_record x y z =
   let x = abs x mod 256 in
   let y = abs y mod 65536 in
@@ -555,23 +560,13 @@ let test_stream_roundtrip_record x y z =
   let original = { x; y; z } in
   match string_of_record test_record_codec original with
   | Error _ -> fail "stream record encode failed"
-  | Ok encoded -> (
-      (* Parse individual fields through chunked reader *)
-      match parse_chunked ~chunk_size:1 Wire.uint8 (String.sub encoded 0 1) with
-      | Error _ -> fail "stream record x parse failed"
-      | Ok vx -> (
-          if x <> vx then fail "stream record x mismatch";
-          match
-            parse_chunked ~chunk_size:1 Wire.uint16 (String.sub encoded 1 2)
-          with
-          | Error _ -> fail "stream record y parse failed"
-          | Ok vy -> (
-              if y <> vy then fail "stream record y mismatch";
-              match
-                parse_chunked ~chunk_size:1 Wire.uint32 (String.sub encoded 3 4)
-              with
-              | Error _ -> fail "stream record z parse failed"
-              | Ok vz -> if z <> vz then fail "stream record z mismatch")))
+  | Ok encoded ->
+      stream_check_field ~label:"stream record x" ~expected:x Wire.uint8
+        (String.sub encoded 0 1);
+      stream_check_field ~label:"stream record y" ~expected:y Wire.uint16
+        (String.sub encoded 1 2);
+      stream_check_field ~label:"stream record z" ~expected:z Wire.uint32
+        (String.sub encoded 3 4)
 
 (** {1 Dependent-size Field Tests} *)
 

--- a/fuzz/fuzz_wire.ml
+++ b/fuzz/fuzz_wire.ml
@@ -308,66 +308,40 @@ let test_parse_nested_struct buf =
 
 (** {1 Roundtrip Tests} *)
 
+let roundtrip_uint label ~equal typ n =
+  let encoded = Wire.to_string typ n in
+  match Wire.of_string typ encoded with
+  | Ok decoded ->
+      if not (equal n decoded) then fail (label ^ " roundtrip mismatch")
+  | Error _ -> fail (label ^ " roundtrip parse failed")
+
 let test_roundtrip_uint8 n =
-  let n = abs n mod 256 in
-  let encoded = Wire.to_string Wire.uint8 n in
-  match Wire.of_string Wire.uint8 encoded with
-  | Ok decoded -> if n <> decoded then fail "uint8 roundtrip mismatch"
-  | Error _ -> fail "uint8 roundtrip parse failed"
+  roundtrip_uint "uint8" ~equal:Int.equal Wire.uint8 (abs n mod 256)
 
 let test_roundtrip_uint16 n =
-  let n = abs n mod 65536 in
-  let encoded = Wire.to_string Wire.uint16 n in
-  match Wire.of_string Wire.uint16 encoded with
-  | Ok decoded -> if n <> decoded then fail "uint16 roundtrip mismatch"
-  | Error _ -> fail "uint16 roundtrip parse failed"
+  roundtrip_uint "uint16" ~equal:Int.equal Wire.uint16 (abs n mod 65536)
 
 let test_roundtrip_uint16be n =
-  let n = abs n mod 65536 in
-  let encoded = Wire.to_string Wire.uint16be n in
-  match Wire.of_string Wire.uint16be encoded with
-  | Ok decoded -> if n <> decoded then fail "uint16be roundtrip mismatch"
-  | Error _ -> fail "uint16be roundtrip parse failed"
+  roundtrip_uint "uint16be" ~equal:Int.equal Wire.uint16be (abs n mod 65536)
 
 let test_roundtrip_uint32 n =
-  let n = n land ((1 lsl 32) - 1) in
-  let encoded = Wire.to_string Wire.uint32 n in
-  match Wire.of_string Wire.uint32 encoded with
-  | Ok decoded -> if n <> decoded then fail "uint32 roundtrip mismatch"
-  | Error _ -> fail "uint32 roundtrip parse failed"
+  roundtrip_uint "uint32" ~equal:Int.equal Wire.uint32 (n land ((1 lsl 32) - 1))
 
 let test_roundtrip_uint32be n =
-  let n = n land ((1 lsl 32) - 1) in
-  let encoded = Wire.to_string Wire.uint32be n in
-  match Wire.of_string Wire.uint32be encoded with
-  | Ok decoded -> if n <> decoded then fail "uint32be roundtrip mismatch"
-  | Error _ -> fail "uint32be roundtrip parse failed"
+  roundtrip_uint "uint32be" ~equal:Int.equal Wire.uint32be
+    (n land ((1 lsl 32) - 1))
 
 let test_roundtrip_uint63 n =
-  let n = abs n in
-  let encoded = Wire.to_string Wire.uint63 n in
-  match Wire.of_string Wire.uint63 encoded with
-  | Ok decoded -> if n <> decoded then fail "uint63 roundtrip mismatch"
-  | Error _ -> fail "uint63 roundtrip parse failed"
+  roundtrip_uint "uint63" ~equal:Int.equal Wire.uint63 (abs n)
 
 let test_roundtrip_uint63be n =
-  let n = abs n in
-  let encoded = Wire.to_string Wire.uint63be n in
-  match Wire.of_string Wire.uint63be encoded with
-  | Ok decoded -> if n <> decoded then fail "uint63be roundtrip mismatch"
-  | Error _ -> fail "uint63be roundtrip parse failed"
+  roundtrip_uint "uint63be" ~equal:Int.equal Wire.uint63be (abs n)
 
 let test_roundtrip_uint64 n =
-  let encoded = Wire.to_string Wire.uint64 n in
-  match Wire.of_string Wire.uint64 encoded with
-  | Ok decoded -> if n <> decoded then fail "uint64 roundtrip mismatch"
-  | Error _ -> fail "uint64 roundtrip parse failed"
+  roundtrip_uint "uint64" ~equal:Int64.equal Wire.uint64 n
 
 let test_roundtrip_uint64be n =
-  let encoded = Wire.to_string Wire.uint64be n in
-  match Wire.of_string Wire.uint64be encoded with
-  | Ok decoded -> if n <> decoded then fail "uint64be roundtrip mismatch"
-  | Error _ -> fail "uint64be roundtrip parse failed"
+  roundtrip_uint "uint64be" ~equal:Int64.equal Wire.uint64be n
 
 let test_roundtrip_map n =
   let n = abs n mod 256 in
@@ -508,47 +482,40 @@ let parse_chunked ~chunk_size typ s =
   let reader = Bytesrw.Bytes.Reader.of_string ~slice_length:chunk_size s in
   Wire.of_reader typ reader
 
+let stream_roundtrip label ~chunk_size ~equal typ n =
+  let encoded = Wire.to_string typ n in
+  match parse_chunked ~chunk_size typ encoded with
+  | Ok decoded -> if not (equal n decoded) then fail (label ^ " mismatch")
+  | Error _ -> fail (label ^ " parse failed")
+
 let test_stream_roundtrip_uint16 n =
-  let n = abs n mod 65536 in
-  let encoded = Wire.to_string Wire.uint16 n in
-  match parse_chunked ~chunk_size:1 Wire.uint16 encoded with
-  | Ok decoded -> if n <> decoded then fail "stream uint16 mismatch"
-  | Error _ -> fail "stream uint16 parse failed"
+  stream_roundtrip "stream uint16" ~chunk_size:1 ~equal:Int.equal Wire.uint16
+    (abs n mod 65536)
 
 let test_stream_roundtrip_uint16be n =
-  let n = abs n mod 65536 in
-  let encoded = Wire.to_string Wire.uint16be n in
-  match parse_chunked ~chunk_size:1 Wire.uint16be encoded with
-  | Ok decoded -> if n <> decoded then fail "stream uint16be mismatch"
-  | Error _ -> fail "stream uint16be parse failed"
+  stream_roundtrip "stream uint16be" ~chunk_size:1 ~equal:Int.equal
+    Wire.uint16be
+    (abs n mod 65536)
 
 let test_stream_roundtrip_uint32 n =
-  let n = n land ((1 lsl 32) - 1) in
-  let encoded = Wire.to_string Wire.uint32 n in
-  match parse_chunked ~chunk_size:1 Wire.uint32 encoded with
-  | Ok decoded -> if n <> decoded then fail "stream uint32 chunk=1 mismatch"
-  | Error _ -> fail "stream uint32 chunk=1 parse failed"
+  stream_roundtrip "stream uint32 chunk=1" ~chunk_size:1 ~equal:Int.equal
+    Wire.uint32
+    (n land ((1 lsl 32) - 1))
 
 let test_stream_roundtrip_uint32be_chunk3 n =
-  let n = n land ((1 lsl 32) - 1) in
-  let encoded = Wire.to_string Wire.uint32be n in
-  match parse_chunked ~chunk_size:3 Wire.uint32be encoded with
-  | Ok decoded -> if n <> decoded then fail "stream uint32be chunk=3 mismatch"
-  | Error _ -> fail "stream uint32be chunk=3 parse failed"
+  stream_roundtrip "stream uint32be chunk=3" ~chunk_size:3 ~equal:Int.equal
+    Wire.uint32be
+    (n land ((1 lsl 32) - 1))
 
 let test_stream_roundtrip_uint64 n =
-  let encoded = Wire.to_string Wire.uint64 n in
-  match parse_chunked ~chunk_size:1 Wire.uint64 encoded with
-  | Ok decoded -> if n <> decoded then fail "stream uint64 chunk=1 mismatch"
-  | Error _ -> fail "stream uint64 chunk=1 parse failed"
+  stream_roundtrip "stream uint64 chunk=1" ~chunk_size:1 ~equal:Int64.equal
+    Wire.uint64 n
 
 let test_stream_roundtrip_uint64be_chunk5 n =
-  let encoded = Wire.to_string Wire.uint64be n in
-  match parse_chunked ~chunk_size:5 Wire.uint64be encoded with
-  | Ok decoded -> if n <> decoded then fail "stream uint64be chunk=5 mismatch"
-  | Error _ -> fail "stream uint64be chunk=5 parse failed"
+  stream_roundtrip "stream uint64be chunk=5" ~chunk_size:5 ~equal:Int64.equal
+    Wire.uint64be n
 
-let stream_check_field ~label ~expected typ slice =
+let stream_check_field label ~expected typ slice =
   match parse_chunked ~chunk_size:1 typ slice with
   | Error _ -> fail (label ^ " parse failed")
   | Ok v -> if expected <> v then fail (label ^ " mismatch")
@@ -561,11 +528,11 @@ let test_stream_roundtrip_record x y z =
   match string_of_record test_record_codec original with
   | Error _ -> fail "stream record encode failed"
   | Ok encoded ->
-      stream_check_field ~label:"stream record x" ~expected:x Wire.uint8
+      stream_check_field "stream record x" ~expected:x Wire.uint8
         (String.sub encoded 0 1);
-      stream_check_field ~label:"stream record y" ~expected:y Wire.uint16
+      stream_check_field "stream record y" ~expected:y Wire.uint16
         (String.sub encoded 1 2);
-      stream_check_field ~label:"stream record z" ~expected:z Wire.uint32
+      stream_check_field "stream record z" ~expected:z Wire.uint32
         (String.sub encoded 3 4)
 
 (** {1 Dependent-size Field Tests} *)

--- a/lib/ascii.ml
+++ b/lib/ascii.ml
@@ -102,6 +102,31 @@ let annotate_fixed name typ constraint_ bits =
   | None -> base
 
 (* Extract segment info from a Types.field. *)
+let variable_annotation : type a. string -> a Types.typ -> string =
+ fun name typ ->
+  match typ with
+  | Types.Byte_array { size } ->
+      Fmt.str "%s (%s bytes)" name (string_of_expr size)
+  | Types.Byte_slice { size } ->
+      Fmt.str "%s (%s bytes)" name (string_of_expr size)
+  | Byte_array_where { size; _ } ->
+      Fmt.str "%s (%s bytes, refined)" name (string_of_expr size)
+  | Array { len; elem; _ } ->
+      let elem_info =
+        match Types.field_wire_size elem with
+        | Some n -> Fmt.str "%d-byte elems" n
+        | None -> "var elems"
+      in
+      Fmt.str "%s (%s x %s)" name (string_of_expr len) elem_info
+  | Where { inner; cond } ->
+      let inner_label =
+        match Types.field_wire_size inner with
+        | Some n -> Fmt.str "%s (%d)" name (n * 8)
+        | None -> name
+      in
+      Fmt.str "%s [%s]" inner_label (string_of_expr cond)
+  | _ -> if name = "" then "(variable)" else Fmt.str "%s (variable)" name
+
 let field_segment (Types.Field { field_name; field_typ; constraint_; _ }) =
   let name = Option.value field_name ~default:"" in
   match field_typ with
@@ -117,29 +142,7 @@ let field_segment (Types.Field { field_name; field_typ; constraint_; _ }) =
               bits = n * 8;
             }
       | None ->
-          let annotation =
-            match field_typ with
-            | Byte_array { size } | Byte_slice { size } ->
-                Fmt.str "%s (%s bytes)" name (string_of_expr size)
-            | Byte_array_where { size; _ } ->
-                Fmt.str "%s (%s bytes, refined)" name (string_of_expr size)
-            | Array { len; elem; _ } ->
-                let elem_info =
-                  match Types.field_wire_size elem with
-                  | Some n -> Fmt.str "%d-byte elems" n
-                  | None -> "var elems"
-                in
-                Fmt.str "%s (%s x %s)" name (string_of_expr len) elem_info
-            | Where { inner; cond } ->
-                let inner_label =
-                  match Types.field_wire_size inner with
-                  | Some n -> Fmt.str "%s (%d)" name (n * 8)
-                  | None -> name
-                in
-                Fmt.str "%s [%s]" inner_label (string_of_expr cond)
-            | _ ->
-                if name = "" then "(variable)" else Fmt.str "%s (variable)" name
-          in
+          let annotation = variable_annotation name field_typ in
           let label =
             match constraint_ with
             | None -> annotation
@@ -249,6 +252,20 @@ let layout segments =
   flush ();
   List.rev !rows
 
+let row_bits_used = function
+  | Fixed_row fields -> List.fold_left (fun acc (_, b) -> acc + b) 0 fields
+  | Variable_row _ -> row_bits
+
+let render_row buf last_bits row =
+  let used = row_bits_used row in
+  Buffer.add_string buf (sep (max !last_bits used));
+  Buffer.add_char buf '\n';
+  (match row with
+  | Fixed_row fields -> Buffer.add_string buf (render_fixed_row fields)
+  | Variable_row label -> Buffer.add_string buf (render_variable_row label));
+  Buffer.add_char buf '\n';
+  last_bits := used
+
 let render_struct (s : Types.struct_) =
   let segments = List.map field_segment s.fields in
   let rows = layout segments in
@@ -261,24 +278,7 @@ let render_struct (s : Types.struct_) =
     Buffer.add_string buf ones;
     Buffer.add_char buf '\n';
     let last_bits = ref row_bits in
-    List.iter
-      (fun row ->
-        let row_bits_used =
-          match row with
-          | Fixed_row fields ->
-              List.fold_left (fun acc (_, b) -> acc + b) 0 fields
-          | Variable_row _ -> row_bits
-        in
-        (* Separator matches the wider of previous row and current row *)
-        Buffer.add_string buf (sep (max !last_bits row_bits_used));
-        Buffer.add_char buf '\n';
-        (match row with
-        | Fixed_row fields -> Buffer.add_string buf (render_fixed_row fields)
-        | Variable_row label ->
-            Buffer.add_string buf (render_variable_row label));
-        Buffer.add_char buf '\n';
-        last_bits := row_bits_used)
-      rows;
+    List.iter (render_row buf last_bits) rows;
     Buffer.add_string buf (sep !last_bits);
     Buffer.add_char buf '\n';
     Buffer.contents buf

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -31,7 +31,32 @@ let setter_off_int32 n set buf off v =
   set buf off (Int32.of_int v);
   off + n
 
-let rec build_field_encoder : type a. a typ -> bytes -> int -> a -> int =
+let rec encode_case_match : type k w.
+    (bytes -> int -> k -> int) -> k option -> w typ -> w -> bytes -> int -> int
+    =
+ fun tag_enc cb_tag cb_inner body buf off ->
+  let t =
+    match cb_tag with
+    | Some t -> t
+    | None -> failwith "build_field_encoder: cannot encode default case"
+  in
+  let off' = tag_enc buf off t in
+  build_field_encoder cb_inner buf off' body
+
+and build_casetype_encoder : type a k.
+    k typ -> (a, k) case_branch list -> bytes -> int -> a -> int =
+ fun tag cases ->
+  let tag_enc = build_field_encoder tag in
+  let rec find buf off v = function
+    | [] -> failwith "build_field_encoder: casetype: no matching case"
+    | Case_branch { cb_tag; cb_inner; cb_project; _ } :: rest -> (
+        match cb_project v with
+        | Some body -> encode_case_match tag_enc cb_tag cb_inner body buf off
+        | None -> find buf off v rest)
+  in
+  fun buf off v -> find buf off v cases
+
+and build_field_encoder : type a. a typ -> bytes -> int -> a -> int =
  fun typ ->
   match typ with
   | Uint8 ->
@@ -111,25 +136,7 @@ let rec build_field_encoder : type a. a typ -> bytes -> int -> a -> int =
       let enc = build_field_encoder inner in
       fun buf off v -> enc buf off (encode v)
   | Unit -> fun _buf off () -> off
-  | Casetype { tag; cases; _ } ->
-      let tag_enc = build_field_encoder tag in
-      fun buf off v ->
-        let rec find = function
-          | [] -> failwith "build_field_encoder: casetype: no matching case"
-          | Case_branch { cb_tag; cb_inner; cb_project; _ } :: rest -> (
-              match cb_project v with
-              | Some body ->
-                  let off' =
-                    match cb_tag with
-                    | Some t -> tag_enc buf off t
-                    | None ->
-                        failwith
-                          "build_field_encoder: cannot encode default case"
-                  in
-                  build_field_encoder cb_inner buf off' body
-              | None -> find rest)
-        in
-        find cases
+  | Casetype { tag; cases; _ } -> build_casetype_encoder tag cases
   | _ ->
       (* Fallback for complex types - not specialized *)
       fun _buf _off _v -> failwith "build_field_encoder: unsupported type"
@@ -1488,6 +1495,44 @@ and compile_optional_or : type a r.
         "add_field: dynamic optional_or with variable-size inner not yet \
          supported"
 
+and repeat_raw_fixed : type elt seq.
+    (elt, seq) seq_map ->
+    elt typ ->
+    int ->
+    off_fn:(bytes -> int -> int) ->
+    size_fn:(bytes -> int -> int) ->
+    bytes ->
+    int ->
+    seq =
+ fun (Seq_map seq) elem esz ~off_fn ~size_fn buf base ->
+  let budget = size_fn buf base in
+  let n = if esz > 0 then budget / esz else 0 in
+  let start = base + off_fn buf base in
+  let rec loop acc i =
+    if i >= n then seq.finish acc
+    else loop (seq.add acc (read_elem elem buf (start + (i * esz)))) (i + 1)
+  in
+  loop seq.empty 0
+
+and repeat_raw_variable : type elt seq.
+    (elt, seq) seq_map ->
+    elt typ ->
+    off_fn:(bytes -> int -> int) ->
+    size_fn:(bytes -> int -> int) ->
+    bytes ->
+    int ->
+    seq =
+ fun (Seq_map seq) elem ~off_fn ~size_fn buf base ->
+  let budget = size_fn buf base in
+  let rec loop acc pos remaining =
+    if remaining <= 0 then seq.finish acc
+    else
+      let v = read_elem elem buf pos in
+      let esz = elem_size_of elem buf pos in
+      loop (seq.add acc v) (pos + esz) (remaining - esz)
+  in
+  loop seq.empty (base + off_fn buf base) budget
+
 and repeat_raw_reader : type elt seq.
     (elt, seq) seq_map ->
     elt typ ->
@@ -1497,32 +1542,10 @@ and repeat_raw_reader : type elt seq.
     bytes ->
     int ->
     seq =
- fun (Seq_map seq) elem ~elem_size ~off_fn ~size_fn ->
+ fun seq elem ~elem_size ~off_fn ~size_fn ->
   match elem_size with
-  | Some esz ->
-      (* Fixed-size elements: direct fill via builder. *)
-      fun buf base ->
-        let budget = size_fn buf base in
-        let n = if esz > 0 then budget / esz else 0 in
-        let start = base + off_fn buf base in
-        let rec loop acc i =
-          if i >= n then seq.finish acc
-          else
-            loop (seq.add acc (read_elem elem buf (start + (i * esz)))) (i + 1)
-        in
-        loop seq.empty 0
-  | None ->
-      (* Variable-size elements: builder accumulation. *)
-      fun buf base ->
-        let budget = size_fn buf base in
-        let rec loop acc pos remaining =
-          if remaining <= 0 then seq.finish acc
-          else
-            let v = read_elem elem buf pos in
-            let esz = elem_size_of elem buf pos in
-            loop (seq.add acc v) (pos + esz) (remaining - esz)
-        in
-        loop seq.empty (base + off_fn buf base) budget
+  | Some esz -> repeat_raw_fixed seq elem esz ~off_fn ~size_fn
+  | None -> repeat_raw_variable seq elem ~off_fn ~size_fn
 
 and compile_repeat : type elt seq r.
     layout_ctx ->
@@ -1992,19 +2015,20 @@ let build_decode : type full r. full -> (full, r) readers -> bytes -> int -> r =
       let fwd = to_fwd readers in
       fun buf off -> apply_fwd make fwd buf off
 
+let lookup_reader_idx rev_readers name =
+  let rec find i = function
+    | [] -> failwith ("unbound field: " ^ name)
+    | (n, _) :: _ when n = name -> i
+    | _ :: rest -> find (i + 1) rest
+  in
+  find 0 rev_readers
+
 let compile_where_clause field_readers where =
   match where with
   | None -> None
   | Some cond ->
       let rev_readers = List.rev field_readers in
-      let idx name =
-        let rec find i = function
-          | [] -> failwith ("unbound field: " ^ name)
-          | (n, _) :: _ when n = name -> i
-          | _ :: rest -> find (i + 1) rest
-        in
-        find 0 rev_readers
-      in
+      let idx name = lookup_reader_idx rev_readers name in
       let cc = { idx; sizeof_this = 0; field_pos = 0 } in
       Some (compile_bool_arr cc cond)
 

--- a/lib/diff/wire_diff.ml
+++ b/lib/diff/wire_diff.ml
@@ -69,24 +69,31 @@ let write_test (Harness h) value =
       | None -> Only_c_ok "OCaml rejected external bytes")
   | None -> Only_ocaml_ok "External write failed"
 
+let check_after_external_write ~ocaml_read ~equal c_value c_bytes =
+  match ocaml_read c_bytes with
+  | Some final ->
+      if equal c_value final then Match
+      else Value_mismatch "values differ after full roundtrip"
+  | None -> Only_c_ok "OCaml rejected external bytes"
+
+let roundtrip_after_external_read ~write ~ocaml_read ~equal c_value =
+  match write c_value with
+  | None -> Only_ocaml_ok "External write failed"
+  | Some c_bytes ->
+      check_after_external_write ~ocaml_read ~equal c_value c_bytes
+
 let roundtrip_test (Harness h) value =
   let ocaml_bytes = string_of_record h.codec value in
   match (h.read ocaml_bytes, h.ocaml_read ocaml_bytes) with
   | None, Some _ -> Only_ocaml_ok "External read failed on OCaml-encoded bytes"
   | Some _, None -> Only_c_ok "OCaml rejected OCaml-encoded bytes"
   | None, None -> Both_failed
-  | Some c_value, Some ocaml_value -> (
+  | Some c_value, Some ocaml_value ->
       if not (h.equal c_value ocaml_value) then
         Value_mismatch "values differ during external read"
       else
-        match h.write c_value with
-        | None -> Only_ocaml_ok "External write failed"
-        | Some c_bytes -> (
-            match h.ocaml_read c_bytes with
-            | Some final ->
-                if h.equal c_value final then Match
-                else Value_mismatch "values differ after full roundtrip"
-            | None -> Only_c_ok "OCaml rejected external bytes"))
+        roundtrip_after_external_read ~write:h.write ~ocaml_read:h.ocaml_read
+          ~equal:h.equal c_value
 
 type t = {
   name : string;

--- a/lib/everparse.ml
+++ b/lib/everparse.ml
@@ -204,58 +204,59 @@ let rec unwrap_bits : type a.
   | Types.Where { inner; _ } -> unwrap_bits inner
   | _ -> None
 
+let is_same_bit_group base bit_order (Types.Field f) =
+  match unwrap_bits f.field_typ with
+  | Some (b2, bo2, _) -> b2 = base && bo2 = bit_order
+  | None -> false
+
+let bit_width (Types.Field f) =
+  match unwrap_bits f.field_typ with Some (_, _, w) -> w | None -> 0
+
+let collect_bit_group base bit_order total f0 rest =
+  let rec collect used group = function
+    | f :: rest' when is_same_bit_group base bit_order f ->
+        let w = bit_width f in
+        if used + w <= total then collect (used + w) (f :: group) rest'
+        else (used, List.rev group, f :: rest')
+    | rest' -> (used, List.rev group, rest')
+  in
+  collect (bit_width f0) [ f0 ] rest
+
+let pad_reversed_group total used base native reversed =
+  let padding = total - used in
+  if padding > 0 then
+    let pad_typ = Types.Bits { width = padding; base; bit_order = native } in
+    Types.Field
+      {
+        field_name = None;
+        field_typ = pad_typ;
+        constraint_ = None;
+        action = None;
+      }
+    :: reversed
+  else reversed
+
+let reorder_bit_group base bit_order f0 rest =
+  let total = Bitfield.total_bits base in
+  let native = Bitfield.native_bit_order base in
+  let used, group, rest' = collect_bit_group base bit_order total f0 rest in
+  let emitted =
+    if bit_order = native then group
+    else
+      let reversed = collapse_constraints_into_last (List.rev group) in
+      pad_reversed_group total used base native reversed
+  in
+  (emitted, rest')
+
 let reorder_bit_groups_for_3d fields =
-  let is_same_bit_group base bit_order (Types.Field f) =
-    match unwrap_bits f.field_typ with
-    | Some (b2, bo2, _) -> b2 = base && bo2 = bit_order
-    | None -> false
-  in
-  let bit_width (Types.Field f) =
-    match unwrap_bits f.field_typ with Some (_, _, w) -> w | None -> 0
-  in
   let rec go acc = function
     | [] -> List.rev acc
-    | (Types.Field f as f0) :: rest
-      when Option.is_some (unwrap_bits f.field_typ) ->
-        let base, bit_order, _ = Option.get (unwrap_bits f.field_typ) in
-        let total = Bitfield.total_bits base in
-        let native = Bitfield.native_bit_order base in
-        (* Greedy: collect consecutive Bits with the same (base, bit_order)
-           that still fit in one base word. *)
-        let rec collect used group = function
-          | f :: rest' when is_same_bit_group base bit_order f ->
-              let w = bit_width f in
-              if used + w <= total then collect (used + w) (f :: group) rest'
-              else (used, List.rev group, f :: rest')
-          | rest' -> (used, List.rev group, rest')
-        in
-        let used, group, rest' = collect (bit_width f0) [ f0 ] rest in
-        if bit_order = native then go (List.rev_append group acc) rest'
-        else begin
-          let reversed = List.rev group in
-          (* Backward references in reversed order would break: fields now
-             come before the values their constraints read. Collapse all
-             constraints onto the last reversed field. *)
-          let reversed = collapse_constraints_into_last reversed in
-          let padded =
-            let padding = total - used in
-            if padding > 0 then
-              let pad_typ =
-                Types.Bits { width = padding; base; bit_order = native }
-              in
-              Types.Field
-                {
-                  field_name = None;
-                  field_typ = pad_typ;
-                  constraint_ = None;
-                  action = None;
-                }
-              :: reversed
-            else reversed
-          in
-          go (List.rev_append padded acc) rest'
-        end
-    | other :: rest -> go (other :: acc) rest
+    | (Types.Field f as f0) :: rest -> (
+        match unwrap_bits f.field_typ with
+        | Some (base, bit_order, _) ->
+            let emitted, rest' = reorder_bit_group base bit_order f0 rest in
+            go (List.rev_append emitted acc) rest'
+        | None -> go (f0 :: acc) rest)
   in
   go [] fields
 
@@ -408,32 +409,32 @@ type plug_field = {
   pf_val_c_type : string;
 }
 
+let plug_field s idx (Types.Field f) =
+  match f.field_name with
+  | None -> None
+  | Some name ->
+      let i = !idx in
+      incr idx;
+      let setter =
+        if is_byte_field f.field_typ then bytes_setter s.name
+        else setter_of s.name f.field_typ
+      in
+      let (Types.Pack_typ val_typ) = setter.setter_val_typ in
+      Some
+        {
+          pf_name = name;
+          pf_idx = i;
+          pf_c_type = Types.c_type_of f.field_typ;
+          pf_setter = setter.setter_name;
+          pf_val_c_type = Types.c_type_of val_typ;
+        }
+
 let plug_fields s =
   match s.source with
   | None -> []
   | Some src ->
       let idx = ref 0 in
-      List.filter_map
-        (fun (Types.Field f) ->
-          match f.field_name with
-          | None -> None
-          | Some name ->
-              let i = !idx in
-              incr idx;
-              let setter =
-                if is_byte_field f.field_typ then bytes_setter s.name
-                else setter_of s.name f.field_typ
-              in
-              let (Types.Pack_typ val_typ) = setter.setter_val_typ in
-              Some
-                {
-                  pf_name = name;
-                  pf_idx = i;
-                  pf_c_type = Types.c_type_of f.field_typ;
-                  pf_setter = setter.setter_name;
-                  pf_val_c_type = Types.c_type_of val_typ;
-                })
-        src.fields
+      List.filter_map (plug_field s idx) src.fields
 
 let plug_setters s =
   let seen = Hashtbl.create 8 in
@@ -516,13 +517,13 @@ module Raw = struct
     | Field.Named f -> Types.Ref (Field.name f)
     | Field.Anon _ -> invalid_arg "Everparse.Raw.field_ref: anonymous field"
 
-  let unpack_fields fields = List.map Field.to_decl fields
+  let unpack_fields fields = List.map Field.decl_of_packed fields
   let struct_ name fields = Types.struct_ name (unpack_fields fields)
   let struct_name = Types.struct_name
   let field_names = Types.field_names
 
   let struct_project s ~name ~keep =
-    Types.struct_project s ~name ~keep:(List.map Field.to_decl keep)
+    Types.struct_project s ~name ~keep:(List.map Field.decl_of_packed keep)
 
   type ocaml_kind = Types.ocaml_kind =
     | Int

--- a/lib/field.ml
+++ b/lib/field.ml
@@ -46,7 +46,7 @@ let action f = f.action
 
 type packed = Named : 'a t -> packed | Anon : 'a anon -> packed
 
-let to_decl = function
+let decl_of_packed = function
   | Named f ->
       Types.field f.name ?constraint_:f.constraint_ ?action:f.action f.typ
   | Anon a -> Types.anon_field a.anon_typ

--- a/lib/field.mli
+++ b/lib/field.mli
@@ -114,5 +114,5 @@ type packed =
   | Anon : 'a anon -> packed
       (** Existentially packed field for heterogeneous lists. *)
 
-val to_decl : packed -> Types.field
-(** Convert a packed field to a {!Types.field} declaration. *)
+val decl_of_packed : packed -> Types.field
+(** [decl_of_packed p] is the {!Types.field} declaration of [p]. *)

--- a/lib/test/bitfield/test_bitfield.ml
+++ b/lib/test/bitfield/test_bitfield.ml
@@ -72,50 +72,32 @@ let test_native_bit_order () =
     "u32be native msb" true
     (Bitfield.native_bit_order bf_u32_be = Types.Msb_first)
 
+let check_extract label ~expected ~bit_order ~total ~bits_used ~width word =
+  Alcotest.(check int)
+    label expected
+    (Bitfield.extract ~bit_order ~total ~bits_used ~width word)
+
 let test_extract_lsb_first () =
-  (* LSBFirst: first declared field at bit 0 *)
-  (* Word 0b11010110 = 0xD6, extract 4 bits at offset 0 -> 0b0110 = 6 *)
   let word = 0xD6 in
-  Alcotest.(check int)
-    "lsb bits 0..3" 6
-    (Bitfield.extract ~bit_order:Types.Lsb_first ~total:8 ~bits_used:0 ~width:4
-       word);
-  (* Extract 4 bits at offset 4 -> 0b1101 = 13 *)
-  Alcotest.(check int)
-    "lsb bits 4..7" 13
-    (Bitfield.extract ~bit_order:Types.Lsb_first ~total:8 ~bits_used:4 ~width:4
-       word)
+  check_extract "lsb bits 0..3" ~expected:6 ~bit_order:Types.Lsb_first ~total:8
+    ~bits_used:0 ~width:4 word;
+  check_extract "lsb bits 4..7" ~expected:13 ~bit_order:Types.Lsb_first ~total:8
+    ~bits_used:4 ~width:4 word
 
 let test_extract_msb_first () =
-  (* MSBFirst: first declared field at MSB *)
-  (* Word 0xD600 = 0b1101011000000000 in 16-bit context *)
   let word = 0xD600 in
-  (* Extract 4 bits at offset 0 (MSB side) -> 0b1101 = 13 *)
-  Alcotest.(check int)
-    "msb bits 0..3" 13
-    (Bitfield.extract ~bit_order:Types.Msb_first ~total:16 ~bits_used:0 ~width:4
-       word);
-  (* Extract 4 bits at offset 4 -> 0b0110 = 6 *)
-  Alcotest.(check int)
-    "msb bits 4..7" 6
-    (Bitfield.extract ~bit_order:Types.Msb_first ~total:16 ~bits_used:4 ~width:4
-       word)
+  check_extract "msb bits 0..3" ~expected:13 ~bit_order:Types.Msb_first
+    ~total:16 ~bits_used:0 ~width:4 word;
+  check_extract "msb bits 4..7" ~expected:6 ~bit_order:Types.Msb_first ~total:16
+    ~bits_used:4 ~width:4 word
 
-(* Independence: bit_order is orthogonal to the base's byte order. Show that
-   an LSB-first extraction on a BE base and MSB-first extraction on a LE base
-   both behave according to the bit_order choice, not the base endian. *)
+(* Independence: bit_order is orthogonal to the base's byte order. *)
 let test_extract_bit_order_independent () =
-  (* LSB-first extraction on a BE base: still operates on the low bits. *)
   let word = 0xD6 in
-  Alcotest.(check int)
-    "lsb-first on u16be base" 6
-    (Bitfield.extract ~bit_order:Types.Lsb_first ~total:16 ~bits_used:0 ~width:4
-       word);
-  (* MSB-first extraction on an 8-bit LE base: operates on the top bits. *)
-  Alcotest.(check int)
-    "msb-first on u8 base" 13
-    (Bitfield.extract ~bit_order:Types.Msb_first ~total:8 ~bits_used:0 ~width:4
-       word)
+  check_extract "lsb-first on u16be base" ~expected:6 ~bit_order:Types.Lsb_first
+    ~total:16 ~bits_used:0 ~width:4 word;
+  check_extract "msb-first on u8 base" ~expected:13 ~bit_order:Types.Msb_first
+    ~total:8 ~bits_used:0 ~width:4 word
 
 let suite =
   ( "bitfield",

--- a/lib/test/diff-gen/test_wire_diff_gen.ml
+++ b/lib/test/diff-gen/test_wire_diff_gen.ml
@@ -15,18 +15,22 @@ let test_schema_creation () =
   in
   Alcotest.(check bool) "some" true (Option.is_some s)
 
-let test_generate_3d_files () =
-  let tmpdir = Filename.temp_dir "diff_gen_test" "" in
-  let s =
-    Wire_diff_gen.schema ~name:"TestDiffGen" ~struct_:simple_struct
-      ~module_:simple_module
-    |> Option.get
-  in
-  Wire_diff_gen.generate_3d_files ~outdir:tmpdir [ s ];
-  let path = Filename.concat tmpdir "TestDiffGen.3d" in
-  Alcotest.(check bool) "3d file exists" true (Sys.file_exists path);
+let schema_for name =
+  Wire_diff_gen.schema ~name ~struct_:simple_struct ~module_:simple_module
+  |> Option.get
+
+let run_generator label ~tag ~generate ~filename =
+  let outdir = Filename.temp_dir tag "" in
+  let s = schema_for "TestDiffGen" in
+  generate ~outdir [ s ];
+  let path = Filename.concat outdir filename in
+  Alcotest.(check bool) label true (Sys.file_exists path);
   Sys.remove path;
-  Unix.rmdir tmpdir
+  Unix.rmdir outdir
+
+let test_generate_3d_files () =
+  run_generator "3d file exists" ~tag:"diff_gen_test"
+    ~generate:Wire_diff_gen.generate_3d_files ~filename:"TestDiffGen.3d"
 
 let has_everparse () =
   let ic = Unix.open_process_in "command -v 3d.exe 2>/dev/null" in
@@ -63,30 +67,13 @@ let test_generate_c_stubs () =
   end
 
 let test_generate_ml_stubs () =
-  let outdir = Filename.temp_dir "diff_gen_ml_stubs" "" in
-  let s =
-    Wire_diff_gen.schema ~name:"TestDiffGen" ~struct_:simple_struct
-      ~module_:simple_module
-    |> Option.get
-  in
-  Wire_diff_gen.generate_ml_stubs ~outdir [ s ];
-  let path = Filename.concat outdir "stubs.ml" in
-  Alcotest.(check bool) "stubs.ml exists" true (Sys.file_exists path);
-  Sys.remove path;
-  Unix.rmdir outdir
+  run_generator "stubs.ml exists" ~tag:"diff_gen_ml_stubs"
+    ~generate:Wire_diff_gen.generate_ml_stubs ~filename:"stubs.ml"
 
 let test_generate_test_runner () =
-  let outdir = Filename.temp_dir "diff_gen_test_runner" "" in
-  let s =
-    Wire_diff_gen.schema ~name:"TestDiffGen" ~struct_:simple_struct
-      ~module_:simple_module
-    |> Option.get
-  in
-  Wire_diff_gen.generate_test_runner ~outdir [ s ];
-  let path = Filename.concat outdir "diff_test.ml" in
-  Alcotest.(check bool) "diff_test.ml exists" true (Sys.file_exists path);
-  Sys.remove path;
-  Unix.rmdir outdir
+  run_generator "diff_test.ml exists" ~tag:"diff_gen_test_runner"
+    ~generate:(fun ~outdir s -> Wire_diff_gen.generate_test_runner ~outdir s)
+    ~filename:"diff_test.ml"
 
 let suite =
   ( "wire_diff_gen",

--- a/lib/test/diff/test_wire_diff.ml
+++ b/lib/test/diff/test_wire_diff.ml
@@ -53,11 +53,15 @@ let test_read_ocaml_override () =
   let result = s.Wire_diff.test_read (encode_simple (7, 1000)) in
   Alcotest.(check bool) "read uses override" true (result = Wire_diff.Match)
 
+let check_result label ~expected ~f s buf =
+  Alcotest.(check bool) label true (f s buf = expected)
+
 let test_write () =
   let s = mk_schema () in
-  let buf = encode_simple (7, 1000) in
-  let result = s.Wire_diff.test_write buf in
-  Alcotest.(check bool) "write result" true (result = Wire_diff.Match)
+  check_result "write result" ~expected:Wire_diff.Match
+    ~f:(fun s buf -> s.Wire_diff.test_write buf)
+    s
+    (encode_simple (7, 1000))
 
 let test_write_ocaml_override () =
   let c_write _ = Some "abc" in
@@ -73,33 +77,29 @@ let test_write_ocaml_override () =
 
 let test_full_roundtrip () =
   let s = mk_schema () in
-  let buf = encode_simple (3, 512) in
-  let result = s.Wire_diff.test_roundtrip buf in
-  Alcotest.(check bool) "full_roundtrip result" true (result = Wire_diff.Match)
+  check_result "full_roundtrip result" ~expected:Wire_diff.Match
+    ~f:(fun s buf -> s.Wire_diff.test_roundtrip buf)
+    s
+    (encode_simple (3, 512))
+
+let c_reject_schema name =
+  let c_write_reject _ = None in
+  v ~name ~read:mock_c_read ~write:c_write_reject ~project:encode_simple
+    ~equal:String.equal ()
 
 let test_full_roundtrip_c_rejects () =
-  let c_write_reject _ = None in
-  let s =
-    v ~name:"CReject" ~read:mock_c_read ~write:c_write_reject
-      ~project:encode_simple ~equal:String.equal ()
-  in
-  let buf = encode_simple (3, 512) in
-  let result = s.Wire_diff.test_roundtrip buf in
-  Alcotest.(check bool)
-    "c rejects -> Only_ocaml_ok" true
-    (result = Wire_diff.Only_ocaml_ok "External write failed")
+  check_result "c rejects -> Only_ocaml_ok"
+    ~expected:(Wire_diff.Only_ocaml_ok "External write failed")
+    ~f:(fun s buf -> s.Wire_diff.test_roundtrip buf)
+    (c_reject_schema "CReject")
+    (encode_simple (3, 512))
 
 let test_write_c_rejects () =
-  let c_write_reject _ = None in
-  let s =
-    v ~name:"CRejectW" ~read:mock_c_read ~write:c_write_reject
-      ~project:encode_simple ~equal:String.equal ()
-  in
-  let buf = encode_simple (3, 512) in
-  let result = s.Wire_diff.test_write buf in
-  Alcotest.(check bool)
-    "write c rejects -> Only_ocaml_ok" true
-    (result = Wire_diff.Only_ocaml_ok "External write failed")
+  check_result "write c rejects -> Only_ocaml_ok"
+    ~expected:(Wire_diff.Only_ocaml_ok "External write failed")
+    ~f:(fun s buf -> s.Wire_diff.test_write buf)
+    (c_reject_schema "CRejectW")
+    (encode_simple (3, 512))
 
 let projection_codec =
   let open Codec in
@@ -128,10 +128,10 @@ let test_projection_read () =
   Alcotest.(check bool) "projection read" true (result = Wire_diff.Match)
 
 let test_projection_roundtrip () =
-  let s = mk_projection () in
-  let buf = encode_simple (7, 0) in
-  let result = s.Wire_diff.test_roundtrip buf in
-  Alcotest.(check bool) "projection roundtrip" true (result = Wire_diff.Match)
+  check_result "projection roundtrip" ~expected:Wire_diff.Match
+    ~f:(fun s buf -> s.Wire_diff.test_roundtrip buf)
+    (mk_projection ())
+    (encode_simple (7, 0))
 
 let test_harness () =
   let s =

--- a/lib/test/everparse/test_wire_3d.ml
+++ b/lib/test/everparse/test_wire_3d.ml
@@ -325,39 +325,34 @@ let check_size ~name ~expected codec =
     (Fmt.str "%s: schema.wire_size = %d" name expected)
     (Some expected) schema.Everparse.wire_size
 
+let pack_four_u8 name ta tb tc td =
+  let fa = Field.v "a" ta in
+  let fb = Field.v "b" tb in
+  let fc = Field.v "c" tc in
+  let fd = Field.v "d" td in
+  let open Codec in
+  v name
+    (fun a b c d -> (a, b, c, d))
+    [
+      (fa $ fun (a, _, _, _) -> a);
+      (fb $ fun (_, b, _, _) -> b);
+      (fc $ fun (_, _, c, _) -> c);
+      (fd $ fun (_, _, _, d) -> d);
+    ]
+
 (* SSID-like layout: mix of [bit (bits 1 U8)] and bare [bits N U8] summing to
    exactly one U8. Historical bug: the Map-wrapped fields fell out of the bit
    group and produced spurious anon padding. *)
 let ssid_style_codec =
-  let f1 = Field.v "a" (bit (bits ~width:1 U8)) in
-  let f2 = Field.v "b" (bits ~width:2 U8) in
-  let f3 = Field.v "c" (bits ~width:4 U8) in
-  let f4 = Field.v "d" (bit (bits ~width:1 U8)) in
-  let open Codec in
-  v "SsidStyle"
-    (fun a b c d -> (a, b, c, d))
-    [
-      (f1 $ fun (a, _, _, _) -> a);
-      (f2 $ fun (_, b, _, _) -> b);
-      (f3 $ fun (_, _, c, _) -> c);
-      (f4 $ fun (_, _, _, d) -> d);
-    ]
+  pack_four_u8 "SsidStyle"
+    (bit (bits ~width:1 U8))
+    (bits ~width:2 U8) (bits ~width:4 U8)
+    (bit (bits ~width:1 U8))
 
 (* All [bit] (Map-wrapped), packed into one U8. *)
 let all_bool_codec =
-  let f1 = Field.v "a" (bit (bits ~width:1 U8)) in
-  let f2 = Field.v "b" (bit (bits ~width:1 U8)) in
-  let f3 = Field.v "c" (bit (bits ~width:1 U8)) in
-  let f4 = Field.v "d" (bit (bits ~width:1 U8)) in
-  let open Codec in
-  v "AllBool"
-    (fun a b c d -> (a, b, c, d))
-    [
-      (f1 $ fun (a, _, _, _) -> a);
-      (f2 $ fun (_, b, _, _) -> b);
-      (f3 $ fun (_, _, c, _) -> c);
-      (f4 $ fun (_, _, _, d) -> d);
-    ]
+  let b = bit (bits ~width:1 U8) in
+  pack_four_u8 "AllBool" b b b b
 
 (* Spilling across a base-word boundary: 5+5 bits on U8 must roll into two U8s. *)
 let spill_u8_codec =

--- a/lib/test/field/test_field.ml
+++ b/lib/test/field/test_field.ml
@@ -27,7 +27,7 @@ let test_pp_prints_name () =
 let test_to_decl_named () =
   let f = Field.v "Flags" Types.uint8 in
   let packed = Field.Named f in
-  match Field.to_decl packed with
+  match Field.decl_of_packed packed with
   | Types.Field { field_name = Some name; _ } ->
       Alcotest.(check string) "decl name" "Flags" name
   | _ -> Alcotest.fail "expected named field declaration"
@@ -35,7 +35,7 @@ let test_to_decl_named () =
 let test_to_decl_anon () =
   let a = Field.anon Types.uint8 in
   let packed = Field.Anon a in
-  match Field.to_decl packed with
+  match Field.decl_of_packed packed with
   | Types.Field { field_name = None; _ } -> ()
   | _ -> Alcotest.fail "expected anonymous field declaration"
 

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -813,17 +813,30 @@ let split_string_casetype_fields (s : struct_) : struct_ =
   in
   { s with fields = List.concat_map split s.fields }
 
+let decl_name = function
+  | Enum_decl { name; _ } -> Some name
+  | Casetype_decl { name; _ } -> Some name
+  | Typedef { struct_ = { name; _ }; _ } -> Some name
+  | _ -> None
+
+let absorb_candidate (acc_rev, seen) e =
+  match decl_name e with
+  | None -> (acc_rev, seen)
+  | Some n when List.mem n seen -> (acc_rev, seen)
+  | Some n -> (e :: acc_rev, n :: seen)
+
+let absorb_typedef_dependencies acc d =
+  match d with
+  | Typedef { struct_; _ } ->
+      let candidates = enum_decls struct_ @ casetype_decls_of_struct struct_ in
+      List.fold_left absorb_candidate acc candidates
+  | _ -> acc
+
 let module_ ?doc decls =
   (* Auto-prepend enum and casetype declarations needed by typedefs in
      [decls] but not already declared in the module. Output order matches
      the order [casetype_decls_of_struct] returns: dispatch before
      wrapper, since the wrapper applies the dispatch. *)
-  let decl_name = function
-    | Enum_decl { name; _ } -> Some name
-    | Casetype_decl { name; _ } -> Some name
-    | Typedef { struct_ = { name; _ }; _ } -> Some name
-    | _ -> None
-  in
   let already_declared =
     List.filter_map decl_name decls |> List.fold_left (fun acc n -> n :: acc) []
   in
@@ -839,22 +852,8 @@ let module_ ?doc decls =
       decls
   in
   let extra_rev, _ =
-    List.fold_left
-      (fun (acc_rev, seen) d ->
-        match d with
-        | Typedef { struct_; _ } ->
-            let candidates =
-              enum_decls struct_ @ casetype_decls_of_struct struct_
-            in
-            List.fold_left
-              (fun (acc_rev, seen) e ->
-                match decl_name e with
-                | None -> (acc_rev, seen)
-                | Some n when List.mem n seen -> (acc_rev, seen)
-                | Some n -> (e :: acc_rev, n :: seen))
-              (acc_rev, seen) candidates
-        | _ -> (acc_rev, seen))
-      ([], already_declared) split_decls
+    List.fold_left absorb_typedef_dependencies ([], already_declared)
+      split_decls
   in
   { doc; decls = List.rev extra_rev @ split_decls }
 
@@ -1248,6 +1247,24 @@ and collect_refs_packed : type a. a expr -> string list =
 (* If a struct-level [where] references fields (rather than only params),
    attach it as the [constraint_] of the last referenced field instead --
    3D's [where] clause only sees parameters. *)
+let attach_where_to_target w target fields =
+  List.map
+    (fun (Field f as field) ->
+      if f.field_name = Some target then
+        let constraint_ = combine_constraints f.constraint_ (Some w) in
+        Field { f with constraint_ }
+      else field)
+    fields
+
+(* Last [field_name] that occurs in [names], by struct position. *)
+let last_referenced_field names fields =
+  List.fold_left
+    (fun acc (Field f) ->
+      match f.field_name with
+      | Some n when List.mem n names -> Some n
+      | _ -> acc)
+    None fields
+
 let lower_where_to_field_constraint where fields =
   match where with
   | None -> (None, fields)
@@ -1256,39 +1273,17 @@ let lower_where_to_field_constraint where fields =
       let field_names =
         List.filter_map (fun (Field f) -> f.field_name) fields
       in
-      let referenced_field_names =
-        List.filter (fun r -> List.mem r field_names) refs
-      in
-      if referenced_field_names = [] then (Some w, fields)
+      let referenced = List.filter (fun r -> List.mem r field_names) refs in
+      if referenced = [] then (Some w, fields)
       else
         (* Attach to the last referenced field by struct position so every
            name in the constraint is decoded by the time it runs. *)
-        let last_pos =
-          List.fold_left
-            (fun acc (Field f) ->
-              match f.field_name with
-              | Some n when List.mem n referenced_field_names -> Some n
-              | _ -> acc)
-            None fields
-        in
         let target =
-          match last_pos with
+          match last_referenced_field referenced fields with
           | Some n -> n
-          | None -> List.hd (List.rev referenced_field_names)
+          | None -> List.hd (List.rev referenced)
         in
-        let fields =
-          List.map
-            (fun (Field f as field) ->
-              match f.field_name with
-              | Some n when n = target ->
-                  let constraint_ =
-                    combine_constraints f.constraint_ (Some w)
-                  in
-                  Field { f with constraint_ }
-              | _ -> field)
-            fields
-        in
-        (None, fields)
+        (None, attach_where_to_target w target fields)
 
 let pp_struct ppf (s : struct_) =
   anon_counter := 0;
@@ -1300,11 +1295,27 @@ let pp_struct ppf (s : struct_) =
   List.iter (pp_field ppf) fields;
   Fmt.pf ppf "@]@,} %s" name
 
+let pp_enum_cases ppf cases =
+  List.iteri
+    (fun i (cname, value) ->
+      if not (Int.equal i 0) then Fmt.string ppf ",";
+      Fmt.pf ppf "@,%s = %d" cname value)
+    cases
+
+let pp_casetype_cases ppf cases =
+  List.iteri
+    (fun i (tag_opt, Pack_typ typ) ->
+      let field_name = Fmt.str "v%d" i in
+      match tag_opt with
+      | Some e ->
+          Fmt.pf ppf "@,case %a: %a %s;" pp_packed_expr e pp_typ typ field_name
+      | None -> Fmt.pf ppf "@,default: %a %s;" pp_typ typ field_name)
+    cases
+
 let pp_decl ppf = function
   | Typedef { entrypoint; export; output; extern_; doc; struct_ = st } ->
       Option.iter (Fmt.pf ppf "/*++ %s --*/@,") doc;
       if extern_ then
-        (* extern typedef struct _Name Name *)
         let n = escape_3d st.name in
         Fmt.pf ppf "extern typedef struct _%s %s@,@," n n
       else begin
@@ -1321,23 +1332,16 @@ let pp_decl ppf = function
         Fmt.(list ~sep:comma pp_param)
         params
   | Extern_probe { init; name } ->
-      (* 3D's [EXTERN PROBE q? IDENT] rule has no terminator. *)
       if init then Fmt.pf ppf "extern probe (INIT) %s@,@," name
       else Fmt.pf ppf "extern probe %s@,@," name
   | Enum_decl { name; cases; base = Pack_typ base } ->
       Fmt.pf ppf "%a enum %s {@[<v 2>" pp_typ base name;
-      List.iteri
-        (fun i (cname, value) ->
-          if not (Int.equal i 0) then Fmt.string ppf ",";
-          Fmt.pf ppf "@,%s = %d" cname value)
-        cases;
+      pp_enum_cases ppf cases;
       Fmt.pf ppf "@]@,}@,@,"
   | Casetype_decl { name; params; tag = Pack_typ _; cases } ->
-      (* First param is the switch discriminant *)
       let disc_name =
         match params with p :: _ -> p.param_name | [] -> "tag"
       in
-      (* Internal name has underscore prefix, public name doesn't *)
       let internal_name, public_name =
         if String.length name > 0 && name.[0] = '_' then
           (name, String.sub name 1 (String.length name - 1))
@@ -1345,15 +1349,7 @@ let pp_decl ppf = function
       in
       Fmt.pf ppf "casetype %s%a {@[<v 2>@,switch (%s) {" internal_name pp_params
         params disc_name;
-      List.iteri
-        (fun i (tag_opt, Pack_typ typ) ->
-          let field_name = Fmt.str "v%d" i in
-          match tag_opt with
-          | Some e ->
-              Fmt.pf ppf "@,case %a: %a %s;" pp_packed_expr e pp_typ typ
-                field_name
-          | None -> Fmt.pf ppf "@,default: %a %s;" pp_typ typ field_name)
-        cases;
+      pp_casetype_cases ppf cases;
       Fmt.pf ppf "@,}@]@,} %s;@,@," public_name
 
 let pp_module ppf m =


### PR DESCRIPTION
Brings the tree back in line with merlint's stricter nesting-depth and naming-convention rules, and threads a small dedup pass through the test files that dupfind has been flagging. The only user-visible change is the public rename [Field.to_decl -> Field.decl_of_packed](lib/field.mli#L117).