### PR TITLE
Dynamic Field.optional / optional_or are value-driven on encode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@
 - `Field.repeat` now projects to 3D for variable-size elements (e.g.
   a sub-codec with its own length-prefixed bytes), emitting
   `<Elem> name[:byte-size budget]` (#51, @samoht)
+- `Wire.Codec.size_of_value` (#58, @samoht)
 - Support `Wire.casetype` and `Wire.nested ~size` as `Codec` fields
   (#47, @samoht)
 - Add `Field.optional` / `Field.optional_or` / `Field.repeat` /
@@ -53,6 +54,14 @@
 
 ### Fixed
 
+- `Field.optional` with a dynamic gate no longer ships a silent phantom
+  byte or overruns the buffer on inconsistent input; the encoder raises
+  `Invalid_argument` when the gate and the option value disagree
+  (#58, @samoht)
+- Dynamic `Field.optional_or` now sizes and writes from the value instead
+  of using the dynamic gate as an encode-side size oracle; the gate
+  remains the decode-side selector between the decoded inner and the
+  default (#58, @samoht)
 - `Wire.encode_into` on a `codec` field whose inner ends in `all_bytes`
   / `rest_bytes` / `all_zeros` no longer ships a 4096-byte scratch
   tail. The encoded size is now computed from the value via

--- a/fuzz/fuzz_wire.ml
+++ b/fuzz/fuzz_wire.ml
@@ -249,6 +249,93 @@ let test_bf_encode_overflow a b c d =
           if v.bf_d <> decoded.bf_d then fail "bf_d mismatch"
       | Error _ -> fail "bf roundtrip decode failed")
 
+type optional_struct = {
+  os_gate : int;
+  os_payload : int option;
+  os_trail : int;
+}
+
+let f_os_gate = Wire.Field.v "Gate" Wire.uint8
+
+let optional_static_codec =
+  Wire.Codec.v "OptionalStatic"
+    (fun gate payload trail ->
+      { os_gate = gate; os_payload = payload; os_trail = trail })
+    Wire.Codec.
+      [
+        (f_os_gate $ fun r -> r.os_gate);
+        ( Wire.Field.optional "Payload" ~present:Wire.Expr.true_ Wire.uint8
+        $ fun r -> r.os_payload );
+        (Wire.Field.v "Trail" Wire.uint8 $ fun r -> r.os_trail);
+      ]
+
+let optional_dynamic_codec =
+  Wire.Codec.v "OptionalDynamic"
+    (fun gate payload trail ->
+      { os_gate = gate; os_payload = payload; os_trail = trail })
+    Wire.Codec.
+      [
+        (f_os_gate $ fun r -> r.os_gate);
+        ( Wire.Field.optional "Payload"
+            ~present:Wire.Expr.(Wire.Field.ref f_os_gate <> Wire.int 0)
+            Wire.uint8
+        $ fun r -> r.os_payload );
+        (Wire.Field.v "Trail" Wire.uint8 $ fun r -> r.os_trail);
+      ]
+
+let option_is_some = function Some _ -> true | None -> false
+
+let optional_equal a b =
+  a.os_gate = b.os_gate
+  && a.os_payload = b.os_payload
+  && a.os_trail = b.os_trail
+
+let check_optional_encode_totality label codec ~roundtrip original =
+  let len = Wire.Codec.size_of_value codec original in
+  let buf = Bytes.create len in
+  match Wire.Codec.encode codec original buf 0 with
+  | exception Invalid_argument _ ->
+      if roundtrip then fail (label ^ " rejected a consistent value")
+  | () ->
+      if not roundtrip then fail (label ^ " accepted an inconsistent value");
+      let ws = Wire.Codec.wire_size_at codec buf 0 in
+      if ws <> len then
+        fail (Fmt.str "%s wire size: expected %d got %d" label len ws);
+      let decoded =
+        match Wire.Codec.decode codec buf 0 with
+        | Ok v -> v
+        | Error e -> fail (Fmt.str "%s decode: %a" label Wire.pp_parse_error e)
+      in
+      if not (optional_equal original decoded) then
+        fail (label ^ " roundtrip mismatch")
+
+let test_optional_static_true_totality gate_seed payload_seed trail_seed =
+  let original =
+    {
+      os_gate = gate_seed land 0xFF;
+      os_payload = Some (payload_seed land 0xFF);
+      os_trail = trail_seed land 0xFF;
+    }
+  in
+  check_optional_encode_totality "optional static true" optional_static_codec
+    ~roundtrip:true original
+
+let test_optional_dynamic_totality gate_seed payload_seed trail_seed =
+  let payload =
+    if payload_seed land 1 = 0 then None
+    else Some ((payload_seed lsr 1) land 0xFF)
+  in
+  let original =
+    {
+      os_gate = gate_seed land 1;
+      os_payload = payload;
+      os_trail = trail_seed land 0xFF;
+    }
+  in
+  let roundtrip = original.os_gate <> 0 = option_is_some original.os_payload in
+  check_optional_encode_totality "optional dynamic" optional_dynamic_codec
+    ~roundtrip original
+
 let test_parse_anon_field buf =
   let buf = truncate buf in
   let c =
@@ -797,6 +884,10 @@ let record_tests =
     test_case "record bool roundtrip" [ int ] test_record_bool_roundtrip;
     test_case "bf encode overflow" [ int; int; int; int ]
       test_bf_encode_overflow;
+    test_case "optional static true totality" [ int; int; int ]
+      test_optional_static_true_totality;
+    test_case "optional dynamic totality" [ int; int; int ]
+      test_optional_dynamic_totality;
   ]
 
 let stream_tests =

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -1443,7 +1443,17 @@ and compile_optional : type a r.
         ~raw_reader:(fun buf base ->
           if present_fn buf base then Some (inner_reader buf base) else None)
         ~raw_writer:(fun v buf off ->
-          match get v with Some iv -> inner_writer buf off iv | None -> ())
+          match (present_fn buf off, get v) with
+          | true, Some iv -> inner_writer buf off iv
+          | false, None -> ()
+          | true, None ->
+              invalid_arg
+                "Codec.encode: optional field absent but presence predicate is \
+                 true"
+          | false, Some _ ->
+              invalid_arg
+                "Codec.encode: optional field present but presence predicate \
+                 is false")
         ~size_delta:0
         ~next_off:(dynamic_optional_next_off ctx present_fn fsize)
         ~populate:(fun arr buf base ->
@@ -1484,11 +1494,16 @@ and compile_optional_or : type a r.
         if present_fn buf base then inner_reader buf base else default
       in
       let populate = build_populate fld.typ ctx.lc_n_fields raw_reader in
-      optional_compiled ctx ~raw_reader
-        ~raw_writer:(fun v buf off ->
-          if present_fn buf off then inner_writer buf off (get v))
-        ~size_delta:0
-        ~next_off:(dynamic_optional_next_off ctx present_fn fsize)
+      (* Encode is value-driven: the user always has a value, so always
+         write [fsize] bytes. The gate is the decode-side oracle that
+         chooses between the decoded inner and [default]. Round-trips
+         exactly when the gate is set consistently with the user's
+         choice; if the user sets the gate to [absent] while the value
+         differs from [default], decoding loses the value and falls
+         back to [default]. *)
+      let raw_writer v buf off = inner_writer buf off (get v) in
+      optional_compiled ctx ~raw_reader ~raw_writer ~size_delta:fsize
+        ~next_off:(advance_next_off ctx.lc_next_off fsize)
         ~populate
   | _ ->
       invalid_arg

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -1425,10 +1425,20 @@ let rec size_of_typ_value : type a. a typ -> a -> int =
   | Optional { present = Bool true; inner } ->
       size_of_typ_value inner (Option.get v)
   | Optional { present = Bool false; _ } -> 0
-  | Optional _ -> 0
+  | Optional { inner; _ } -> (
+      (* Dynamic gate: value drives presence at encode time. The
+         buffer-driven [present_fn] is the decode-side oracle and would
+         disagree with [v] here, so consult [v] directly. *)
+      match v with
+      | Some inner_v -> size_of_typ_value inner inner_v
+      | None -> 0)
   | Optional_or { present = Bool true; inner; _ } -> size_of_typ_value inner v
   | Optional_or { present = Bool false; _ } -> 0
-  | Optional_or _ -> 0
+  | Optional_or { inner; _ } ->
+      (* Dynamic gate: encode always has a value (the default fills in
+         for [None]); the encoder writes the inner regardless of what
+         the runtime gate would have said at decode. *)
+      size_of_typ_value inner v
   | Codec { codec_size_of_value; _ } -> codec_size_of_value v
   | Single_elem { size = Int n; _ } -> n
   | Single_elem _ -> 0

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -781,6 +781,11 @@ module Codec : sig
   val wire_size_at : 'r t -> bytes -> int -> int
   (** Computes the actual wire size from a buffer at the given base offset. *)
 
+  val size_of_value : 'r t -> 'r -> int
+  (** [size_of_value c v] returns the number of bytes that [encode c v] will
+      write for value [v]. For fixed-size codecs, this is the same as
+      {!wire_size}; for dynamic-size codecs, the result depends on [v]. *)
+
   val is_fixed : 'r t -> bool
   (** [true] iff the codec has a statically known size. *)
 

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -2628,6 +2628,58 @@ let test_dyn_opt_get_trail () =
   Bytes.set_uint8 buf2 1 0xBB;
   Alcotest.(check int) "trail (absent)" 0xBB (get_trail buf2 0)
 
+let check_dyn_opt_roundtrip label expected_len expected_bytes original =
+  Alcotest.(check int)
+    (label ^ " size_of_value") expected_len
+    (Codec.size_of_value dyn_opt_codec original);
+  let buf = Bytes.create expected_len in
+  Codec.encode dyn_opt_codec original buf 0;
+  Alcotest.(check string)
+    (label ^ " bytes") expected_bytes (Bytes.to_string buf);
+  Alcotest.(check int)
+    (label ^ " wire_size_at") expected_len
+    (Codec.wire_size_at dyn_opt_codec buf 0);
+  let decoded = decode_ok (Codec.decode dyn_opt_codec buf 0) in
+  Alcotest.(check int) (label ^ " flags") original.do_flags decoded.do_flags;
+  Alcotest.(check (option int))
+    (label ^ " payload") original.do_payload decoded.do_payload;
+  Alcotest.(check int) (label ^ " trail") original.do_trail decoded.do_trail
+
+let test_field_optional_dynamic_roundtrip () =
+  check_dyn_opt_roundtrip "present" 4 "\x01\x12\x34\xFF"
+    { do_flags = 1; do_payload = Some 0x1234; do_trail = 0xFF };
+  check_dyn_opt_roundtrip "absent" 2 "\x00\xEE"
+    { do_flags = 0; do_payload = None; do_trail = 0xEE }
+
+let test_dyn_opt_reject_gate () =
+  let check_reject label v =
+    let len = Codec.size_of_value dyn_opt_codec v + 4 in
+    match Codec.encode dyn_opt_codec v (Bytes.create len) 0 with
+    | () -> Alcotest.failf "%s: encode unexpectedly succeeded" label
+    | exception Invalid_argument _ -> ()
+  in
+  check_reject "gate true / value None"
+    { do_flags = 1; do_payload = None; do_trail = 0xEE };
+  check_reject "gate false / value Some"
+    { do_flags = 0; do_payload = Some 0x1234; do_trail = 0xEE }
+
+let test_encode_totality () =
+  let check_exact label original =
+    let len = Codec.size_of_value dyn_opt_codec original in
+    let buf = Bytes.create len in
+    Codec.encode dyn_opt_codec original buf 0;
+    Alcotest.(check int)
+      (label ^ " wire_size_at") len
+      (Codec.wire_size_at dyn_opt_codec buf 0);
+    if len > 0 then
+      match Codec.encode dyn_opt_codec original (Bytes.create (len - 1)) 0 with
+      | () -> Alcotest.failf "%s: short buffer accepted" label
+      | exception Invalid_argument _ -> ()
+  in
+  check_exact "present"
+    { do_flags = 1; do_payload = Some 0x1234; do_trail = 0xFF };
+  check_exact "absent" { do_flags = 0; do_payload = None; do_trail = 0xEE }
+
 (* Dynamic optional via Field.ref on a bool field -- the TM frame pattern.
    Field.ref now accepts 'a t, so a bool field created with [bit] can be
    referenced directly in expressions. *)
@@ -3396,6 +3448,86 @@ let test_three_var_codecs_embedded () =
   Alcotest.(check string) "b" "be" (Slice.to_string b.ss_data);
   Alcotest.(check string) "c" "gamma!" (Slice.to_string c.ss_data)
 
+let test_four_var_codecs_embedded () =
+  let f_a = Field.v "a" (codec ssh_string_codec) in
+  let f_b = Field.v "b" (codec ssh_string_codec) in
+  let f_c = Field.v "c" (codec ssh_string_codec) in
+  let f_d = Field.v "d" (codec ssh_string_codec) in
+  let quad_codec =
+    let open Codec in
+    v "Quad"
+      (fun a b c d -> (a, b, c, d))
+      [
+        (f_a $ fun (a, _, _, _) -> a);
+        (f_b $ fun (_, b, _, _) -> b);
+        (f_c $ fun (_, _, c, _) -> c);
+        (f_d $ fun (_, _, _, d) -> d);
+      ]
+  in
+  let v =
+    ( mk_ssh_string "alpha",
+      mk_ssh_string "bravo",
+      mk_ssh_string "charlie",
+      mk_ssh_string "d" )
+  in
+  let len = Codec.size_of_value quad_codec v in
+  let buf = Bytes.create len in
+  Codec.encode quad_codec v buf 0;
+  Alcotest.(check int) "wire_size_at" len (Codec.wire_size_at quad_codec buf 0);
+  let a, b, c, d = decode_ok (Codec.decode quad_codec buf 0) in
+  Alcotest.(check string) "a" "alpha" (Slice.to_string a.ss_data);
+  Alcotest.(check string) "b" "bravo" (Slice.to_string b.ss_data);
+  Alcotest.(check string) "c" "charlie" (Slice.to_string c.ss_data);
+  Alcotest.(check string) "d" "d" (Slice.to_string d.ss_data)
+
+let test_slice_then_array () =
+  let f_slice_len = Field.v "slice_len" uint8 in
+  let f_slice = Field.v "slice" (byte_slice ~size:(Field.ref f_slice_len)) in
+  let f_array_len = Field.v "array_len" uint8 in
+  let f_array = Field.v "array" (byte_array ~size:(Field.ref f_array_len)) in
+  let mixed_codec =
+    let open Codec in
+    v "SliceThenArray"
+      (fun _ slice _ array -> (slice, array))
+      [
+        (f_slice_len $ fun (slice, _) -> Slice.length slice);
+        (f_slice $ fun (slice, _) -> slice);
+        (f_array_len $ fun (_, array) -> String.length array);
+        (f_array $ fun (_, array) -> array);
+      ]
+  in
+  let v = ((mk_ssh_string "slice").ss_data, "array-data") in
+  let len = Codec.size_of_value mixed_codec v in
+  let buf = Bytes.create len in
+  Codec.encode mixed_codec v buf 0;
+  Alcotest.(check int) "wire_size_at" len (Codec.wire_size_at mixed_codec buf 0);
+  let slice, array = decode_ok (Codec.decode mixed_codec buf 0) in
+  Alcotest.(check string) "slice" "slice" (Slice.to_string slice);
+  Alcotest.(check string) "array" "array-data" array
+
+let test_codec_then_array () =
+  let f_msg = Field.v "msg" (codec ssh_string_codec) in
+  let f_array_len = Field.v "array_len" uint8 in
+  let f_array = Field.v "array" (byte_array ~size:(Field.ref f_array_len)) in
+  let mixed_codec =
+    let open Codec in
+    v "CodecThenArray"
+      (fun msg _ array -> (msg, array))
+      [
+        (f_msg $ fun (msg, _) -> msg);
+        (f_array_len $ fun (_, array) -> String.length array);
+        (f_array $ fun (_, array) -> array);
+      ]
+  in
+  let v = (mk_ssh_string "message", "tail") in
+  let len = Codec.size_of_value mixed_codec v in
+  let buf = Bytes.create len in
+  Codec.encode mixed_codec v buf 0;
+  Alcotest.(check int) "wire_size_at" len (Codec.wire_size_at mixed_codec buf 0);
+  let msg, array = decode_ok (Codec.decode mixed_codec buf 0) in
+  Alcotest.(check string) "msg" "message" (Slice.to_string msg.ss_data);
+  Alcotest.(check string) "array" "tail" array
+
 let test_repeat_after_var_slice () =
   (* [Repeat] after a variable-size field used to trip [require_static_off]
      in [compile_repeat]. The fix mirrors [compile_codec]'s. *)
@@ -3861,6 +3993,12 @@ let suite =
       Alcotest.test_case "optional: dynamic absent" `Quick test_dyn_opt_absent;
       Alcotest.test_case "optional: dynamic get trail" `Quick
         test_dyn_opt_get_trail;
+      Alcotest.test_case "optional: dynamic roundtrip" `Quick
+        test_field_optional_dynamic_roundtrip;
+      Alcotest.test_case "optional: dynamic rejects inconsistent gate" `Quick
+        test_dyn_opt_reject_gate;
+      Alcotest.test_case "optional: encode size totality" `Quick
+        test_encode_totality;
       Alcotest.test_case "optional: bool ref present" `Quick
         test_dyn_opt_anyref_present;
       Alcotest.test_case "optional: bool ref absent" `Quick
@@ -3916,6 +4054,12 @@ let suite =
         test_two_var_codecs_embedded;
       Alcotest.test_case "multi-var: three embedded sub-codecs" `Quick
         test_three_var_codecs_embedded;
+      Alcotest.test_case "multi-var: four embedded sub-codecs" `Quick
+        test_four_var_codecs_embedded;
+      Alcotest.test_case "multi-var: byte_slice then byte_array" `Quick
+        test_slice_then_array;
+      Alcotest.test_case "multi-var: sub-codec then byte_array" `Quick
+        test_codec_then_array;
       Alcotest.test_case "multi-var: repeat after variable byte_slice" `Quick
         test_repeat_after_var_slice;
       (* uint: variable-width unsigned integer *)


### PR DESCRIPTION
Two related encoder fixes for dynamic [Field.optional](lib/types.ml#L1425) and [Field.optional_or](lib/codec.ml#L1465). In both, the value-driven `size_of_typ_value` and the buffer-driven encode-time writer used to disagree, producing a silent phantom byte / overrun. The fix makes size and write agree by construction: dynamic `Field.optional` raises `Invalid_argument` when the option and the gate disagree, and dynamic `Field.optional_or` now sizes and writes from the value with the gate kept as the decode-side selector between the decoded inner and the default. Same family as #53 and #54.