### PR TITLE
fuzz: gen DSL mirroring Wire

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -62,6 +62,10 @@
   of using the dynamic gate as an encode-side size oracle; the gate
   remains the decode-side selector between the decoded inner and the
   default (#58, @samoht)
+- Decoding an `all_zeros` field that contains a non-zero byte returns a
+  `Constraint_failed` decode error instead of raising `Invalid_argument`.
+  The old behaviour broke the decoder's "never raise on adversarial
+  input" contract (@samoht)
 - `Wire.encode_into` on a `codec` field whose inner ends in `all_bytes`
   / `rest_bytes` / `all_zeros` no longer ships a 4096-byte scratch
   tail. The encoded size is now computed from the value via

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -66,6 +66,11 @@
   `Constraint_failed` decode error instead of raising `Invalid_argument`.
   The old behaviour broke the decoder's "never raise on adversarial
   input" contract (@samoht)
+- `Wire.encode_into` on a `Single_elem` (`Wire.nested ~size:n inner`)
+  now pads zero bytes up to the declared `size` when `inner` writes
+  fewer than `n` bytes. `encode_direct` already padded; `encode_into`
+  silently dropped the padding, so `Wire.to_string` produced shorter
+  bytes than `Wire.of_string` expected (@samoht)
 - `Wire.encode_into` on a `codec` field whose inner ends in `all_bytes`
   / `rest_bytes` / `all_zeros` no longer ships a 4096-byte scratch
   tail. The encoded size is now computed from the value via

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -71,6 +71,12 @@
   fewer than `n` bytes. `encode_direct` already padded; `encode_into`
   silently dropped the padding, so `Wire.to_string` produced shorter
   bytes than `Wire.of_string` expected (@samoht)
+- `Wire.default` now takes a required `~tag:'k`: the discriminator
+  the encoder writes when projecting the default branch back to bytes.
+  Previously encoding any default-branch value crashed with
+  `Failure "casetype encoding: cannot encode default case"`; the
+  decoder side still uses the default branch as the match-anything
+  fallback (@samoht)
 - `Wire.encode_into` on a `codec` field whose inner ends in `all_bytes`
   / `rest_bytes` / `all_zeros` no longer ships a 4096-byte scratch
   tail. The encoded size is now computed from the value via

--- a/fuzz/dune
+++ b/fuzz/dune
@@ -1,6 +1,6 @@
 (executable
  (name fuzz)
- (libraries wire alcobar))
+ (libraries wire alcobar fuzz_gen))
 
 (rule
  (alias runtest)

--- a/fuzz/fuzz_everparse.ml
+++ b/fuzz/fuzz_everparse.ml
@@ -158,7 +158,7 @@ let test_casetype_inline () =
           ~inject:(fun v -> `U32 (Wire.Private.UInt32.to_int v))
           ~project:(function
             | `U32 v -> Some (Wire.Private.UInt32.of_int v) | _ -> None);
-        Wire.default Wire.uint8
+        Wire.default ~tag:0xFF Wire.uint8
           ~inject:(fun v -> `Default v)
           ~project:(function `Default v -> Some v | _ -> None);
       ]

--- a/fuzz/fuzz_wire.ml
+++ b/fuzz/fuzz_wire.ml
@@ -364,7 +364,7 @@ let test_parse_casetype buf =
         Wire.case ~index:1 Wire.uint16
           ~inject:(fun v -> `U16 v)
           ~project:(function `U16 v -> Some v | _ -> None);
-        Wire.default Wire.uint32
+        Wire.default ~tag:0xFF Wire.uint32
           ~inject:(fun v -> `Default (Wire.Private.UInt32.to_int v))
           ~project:(function
             | `Default v -> Some (Wire.Private.UInt32.of_int v) | _ -> None);

--- a/fuzz/fuzz_wire.ml
+++ b/fuzz/fuzz_wire.ml
@@ -1046,7 +1046,137 @@ let repeat_tests =
       test_repeat_var_elem_roundtrip;
   ]
 
+(* {1 Gen DSL tests}
+
+   Each leaf and the [Codec.v] composer drive three Alcobar generators
+   per gen (positive / random / adversarial). The Gen module mirrors
+   Wire's surface so a fuzz harness reads like the codec it tests. *)
+
+type pair = { p_a : int; p_b : int }
+
+let pair_gen =
+  let open Fuzz_gen in
+  Codec.v "Pair"
+    ~equal:(fun a b -> a.p_a = b.p_a && a.p_b = b.p_b)
+    (fun a b -> { p_a = a; p_b = b })
+    Codec.
+      [
+        Codec.( $ ) uint8 (fun r -> r.p_a);
+        Codec.( $ ) uint16be (fun r -> r.p_b);
+      ]
+
+let printable_byte b = Wire.Expr.(b >= Wire.int 0x20 && b <= Wire.int 0x7E)
+
+let scalar_gen_tests =
+  let open Fuzz_gen in
+  test_cases "uint8" uint8 @ test_cases "uint16" uint16
+  @ test_cases "uint16be" uint16be
+  @ test_cases "uint32" uint32
+  @ test_cases "uint32be" uint32be
+  @ test_cases "uint63" uint63
+  @ test_cases "uint63be" uint63be
+  @ test_cases "uint64" uint64
+  @ test_cases "uint64be" uint64be
+  @ test_cases "int8" int8 @ test_cases "int16" int16
+  @ test_cases "int16be" int16be
+  @ test_cases "int32" int32
+  @ test_cases "int32be" int32be
+  @ test_cases "int64" int64
+  @ test_cases "int64be" int64be
+  @ test_cases "float32" float32
+  @ test_cases "float32be" float32be
+  @ test_cases "float64" float64
+  @ test_cases "float64be" float64be
+  @ test_cases "empty" empty
+
+let bytes_gen_tests =
+  let open Fuzz_gen in
+  test_cases "byte_array(5)" (byte_array 5)
+  @ test_cases "byte_slice(3)" (byte_slice 3)
+  @ test_cases "byte_array_where(4, printable)"
+      (byte_array_where 4 ~per_byte:printable_byte)
+  @ test_cases "all_bytes" all_bytes
+  @ test_cases "all_zeros" all_zeros
+  @ test_cases "nested(4, uint16be)" (nested 4 uint16be)
+  @ test_cases "nested_at_most(4, uint16be)" (nested_at_most 4 uint16be)
+
+let wrapper_gen_tests =
+  let open Fuzz_gen in
+  test_cases "map(uint8, *2)"
+    (map ~decode:(fun n -> n * 2) ~encode:(fun n -> n / 2) uint8)
+  @ test_cases "variants" (variants "Flag" [ ("A", `A); ("B", `B); ("C", `C) ])
+  @ test_cases "bits(3, U8)" (bits ~width:3 Wire.U8)
+  @ test_cases "bits(10, U16be)" (bits ~width:10 Wire.U16be)
+  @ test_cases "bit" (bit uint8)
+  @ test_cases "uint_var(3, big)" (uint_var ~endian:Wire.Big 3)
+  @ test_cases "uint_var(7, big)" (uint_var ~endian:Wire.Big 7)
+  @ test_cases "optional ~present:true (uint8)" (optional uint8)
+  @ test_cases "optional ~present:false (uint8)" (optional ~present:false uint8)
+  @ test_cases "optional_or ~present:true (uint8)"
+      (optional_or ~default:0 uint8)
+  @ test_cases "optional_or ~present:false (uint8)"
+      (optional_or ~present:false ~default:42 uint8)
+  @ test_cases "repeat(8 bytes, uint8)" (repeat ~bytes:8 uint8)
+
+let casetype_gen_tests =
+  let open Fuzz_gen in
+  test_cases "array(3, uint16be)" (array 3 uint16be)
+  @ test_cases "enum" (enum "Color" [ ("Red", 1); ("Green", 2); ("Blue", 3) ])
+  @ test_cases "bounded_u8(10..100)" (bounded_u8 ~min:10 ~max:100)
+  @ test_cases "codec_where" codec_where
+  @ test_cases "lookup(['a'..'d'])" (lookup [ 'a'; 'b'; 'c'; 'd' ] uint8)
+  @ test_cases "where(uint8)" (where uint8)
+  @ test_cases "bits(4, U16be)" (bits ~width:4 Wire.U16be)
+  @ test_cases "bits(4, U32, Lsb_first)"
+      (bits ~bit_order:Wire.Lsb_first ~width:4 Wire.U32)
+  @ test_cases "bit(uint16)" (bit uint16)
+  @ test_cases "array_seq(3, uint16be)" (array_seq 3 uint16be)
+  @ test_cases "repeat_seq(8 bytes, uint8)" (repeat_seq ~bytes:8 uint8)
+  @ test_cases "field_anon" field_anon
+  @ test_cases "param_input" param_input
+  @ test_cases "action" action
+  @ test_cases "action_on_act" action_on_act
+  @ reject_cases "action_abort" action_abort
+  @ test_cases "finite_float64" finite_float64
+  @ test_cases "nan_float64" nan_float64
+  @ test_cases "optional_dynamic" optional_dynamic
+  @ test_cases "optional_or_dynamic" optional_or_dynamic
+  @ test_cases "expr_ops" expr_ops
+  @ test_cases "rest_bytes" rest_bytes
+  @ test_cases "sizeof" sizeof
+  @ test_cases "casetype_u8"
+      (casetype_u8 "Payload"
+         [
+           case ~index:1 uint16be
+             ~inject:(fun v -> `A v)
+             ~project:(function `A v -> Some v | _ -> None);
+           case ~index:2 uint32be
+             ~inject:(fun v -> `B v)
+             ~project:(function `B v -> Some v | _ -> None);
+           default_case ~tag:0xFF uint8
+             ~inject:(fun v -> `Other v)
+             ~project:(function `Other v -> Some v | _ -> None);
+         ])
+  @ test_cases "record(uint8, uint16be)" pair_gen
+
+let gen_tests =
+  scalar_gen_tests @ bytes_gen_tests @ wrapper_gen_tests @ casetype_gen_tests
+
+(* Alternate entry-point coverage: each driver is exercised on one
+   representative gen so the full validate / of_string / of_reader paths
+   are touched without 3x-ing the suite size. *)
+let alt_entry_tests =
+  let open Fuzz_gen in
+  direct_cases "uint16be (direct)" uint16be
+  @ direct_cases "byte_array(5) (direct)" (byte_array 5)
+  @ direct_cases "record (direct)" pair_gen
+  @ streaming_cases "uint16be (streaming)" uint16be
+  @ streaming_cases "record (streaming)" pair_gen
+  @ validate_cases "uint16be (validate)" uint16be
+  @ validate_cases "param_input (validate)" param_input
+  @ validate_cases "bounded_u8 (validate)" (bounded_u8 ~min:10 ~max:100)
+
 let suite =
   ( "wire",
     parse_tests @ roundtrip_tests @ record_tests @ stream_tests @ depsize_tests
-    @ float_tests @ repeat_tests )
+    @ float_tests @ repeat_tests @ gen_tests @ alt_entry_tests )

--- a/fuzz/gen/dune
+++ b/fuzz/gen/dune
@@ -1,0 +1,3 @@
+(library
+ (name fuzz_gen)
+ (libraries wire alcobar bytesrw))

--- a/fuzz/gen/fuzz_gen.ml
+++ b/fuzz/gen/fuzz_gen.ml
@@ -1,0 +1,1742 @@
+(** Fuzz generators that mirror Wire's surface.
+
+    Each ['a t] is the codec it tests paired with three Alcobar generators:
+    [positive] produces a value together with bytes that decode to it, [random]
+    produces arbitrary bytes the decoder must handle without raising, and
+    [adversarial] produces bytes crafted at the boundary of every constraint the
+    codec checks (lengths, gate flips, bit-pattern extremes). [run] turns one
+    ['a t] into a set of Alcobar test cases that exercise round-trip on
+    positives and crash-safety on the other two streams.
+
+    [Codec.v] composes leaves into record gens the same way [Wire.Codec.v]
+    composes typs into record codecs -- a record gen is itself an ['a t], so
+    composition is recursive. *)
+
+type 'a t = {
+  codec : 'a Wire.Codec.t;
+  positive : ('a * bytes) Alcobar.gen;
+  random : bytes Alcobar.gen;
+  adversarial : bytes Alcobar.gen;
+  equal : 'a -> 'a -> bool;
+  typ : 'a Wire.typ;
+      (* Wire typ form, used when this gen slots into a parent record's
+         field list. For leaves it is the bare typ; for records it is
+         [Wire.codec built_codec], i.e. a sub-codec wrap. *)
+  env : env_strategy option;
+      (* When the codec references [Param.input], the test driver pulls
+         a fresh env from [positive] for the round-trip case and from
+         the [fuzz] gen for random and adversarial streams. *)
+}
+
+and env_strategy = {
+  positive : unit -> Wire.Param.env;
+      (* Builder used for the positive stream. Must bind every
+         [Param.input] consistently with the positive value generator. *)
+  fuzz : (unit -> Wire.Param.env) Alcobar.gen;
+      (* Builder gen used for the random and adversarial streams. Fuzz
+         [Param.input] values independently of the input bytes. *)
+}
+
+let bytes_of_string s = Bytes.unsafe_of_string s
+let string_of_bytes b = Bytes.unsafe_to_string b
+
+let bytes_fixed n =
+  Alcobar.map Alcobar.[ Alcobar.bytes_fixed n ] bytes_of_string
+
+let bytes_any = Alcobar.map Alcobar.[ Alcobar.bytes ] bytes_of_string
+
+let codec_of_typ typ =
+  Wire.Codec.v "_leaf"
+    (fun v -> v)
+    Wire.Codec.[ (Wire.Field.v "v" typ $ fun v -> v) ]
+
+(* Build a leaf [t] from a typ and three Alcobar generators. *)
+let leaf ~equal ~typ ~value_gen ~random ~adversarial =
+  let codec = codec_of_typ typ in
+  let encode v =
+    let sz = Wire.Codec.size_of_value codec v in
+    let buf = Bytes.create sz in
+    Wire.Codec.encode codec v buf 0;
+    buf
+  in
+  let positive = Alcobar.map Alcobar.[ value_gen ] (fun v -> (v, encode v)) in
+  let adversarial_bytes =
+    Alcobar.map Alcobar.[ adversarial ] (fun v -> encode v)
+  in
+  {
+    codec;
+    typ;
+    positive;
+    random;
+    adversarial = adversarial_bytes;
+    equal;
+    env = None;
+  }
+
+(* {1 Leaves} *)
+
+let scalar_int typ size value_gen boundaries =
+  leaf ~equal:Int.equal ~typ ~value_gen ~random:(bytes_fixed size)
+    ~adversarial:(Alcobar.choose (List.map Alcobar.const boundaries))
+
+let scalar_int64 typ size value_gen boundaries =
+  leaf ~equal:Int64.equal ~typ ~value_gen ~random:(bytes_fixed size)
+    ~adversarial:(Alcobar.choose (List.map Alcobar.const boundaries))
+
+let u8_boundaries = [ 0; 1; 0x7F; 0x80; 0xFE; 0xFF ]
+let u16_boundaries = [ 0; 1; 0x7F; 0x80; 0x7FFF; 0x8000; 0xFFFE; 0xFFFF ]
+
+let u32_boundaries =
+  [ 0; 1; 0xFFFF; 0x7FFF_FFFF; 0x8000_0000; 0xFFFF_FFFE; 0xFFFF_FFFF ]
+
+let u63_boundaries = [ 0; 1; 0xFFFF_FFFF; max_int - 1; max_int ]
+
+let u64_boundaries_i64 =
+  Int64.[ zero; one; of_int 0xFFFF_FFFF; max_int; min_int; -1L; sub max_int 1L ]
+
+let s8_boundaries = [ -128; -1; 0; 1; 127 ]
+let s16_boundaries = [ -0x8000; -1; 0; 1; 0x7FFF ]
+let s32_boundaries = [ Int.min_int; -1; 0; 1; Int.max_int ]
+let s64_boundaries_i64 = Int64.[ min_int; -1L; zero; one; max_int ]
+let uint8 = scalar_int Wire.uint8 1 Alcobar.uint8 u8_boundaries
+let uint16 = scalar_int Wire.uint16 2 Alcobar.uint16 u16_boundaries
+let uint16be = scalar_int Wire.uint16be 2 Alcobar.uint16 u16_boundaries
+
+let masked_u32 =
+  Alcobar.map Alcobar.[ Alcobar.int ] (fun n -> n land 0xFFFF_FFFF)
+
+let masked_u63 = Alcobar.map Alcobar.[ Alcobar.int ] (fun n -> n land max_int)
+let uint32 = scalar_int Wire.uint32 4 masked_u32 u32_boundaries
+let uint32be = scalar_int Wire.uint32be 4 masked_u32 u32_boundaries
+let uint63 = scalar_int Wire.uint63 8 masked_u63 u63_boundaries
+let uint63be = scalar_int Wire.uint63be 8 masked_u63 u63_boundaries
+let uint64 = scalar_int64 Wire.uint64 8 Alcobar.int64 u64_boundaries_i64
+let uint64be = scalar_int64 Wire.uint64be 8 Alcobar.int64 u64_boundaries_i64
+let int8 = scalar_int Wire.int8 1 Alcobar.int8 s8_boundaries
+let int16 = scalar_int Wire.int16 2 Alcobar.int16 s16_boundaries
+let int16be = scalar_int Wire.int16be 2 Alcobar.int16 s16_boundaries
+
+let int32 =
+  scalar_int Wire.int32 4
+    (Alcobar.map Alcobar.[ Alcobar.int32 ] Int32.to_int)
+    s32_boundaries
+
+let int32be =
+  scalar_int Wire.int32be 4
+    (Alcobar.map Alcobar.[ Alcobar.int32 ] Int32.to_int)
+    s32_boundaries
+
+let int64 = scalar_int64 Wire.int64 8 Alcobar.int64 s64_boundaries_i64
+let int64be = scalar_int64 Wire.int64be 8 Alcobar.int64 s64_boundaries_i64
+
+let float_boundaries =
+  [
+    0.0;
+    -0.0;
+    1.0;
+    -1.0;
+    Float.pi;
+    Float.epsilon;
+    Float.max_float;
+    Float.min_float;
+    Float.infinity;
+    Float.neg_infinity;
+    Float.nan;
+  ]
+
+(* Equality on floats compares bit patterns so NaN round-trips check
+   bit-identity, not [Float.equal]. *)
+let float64_bits_equal a b =
+  Int64.equal (Int64.bits_of_float a) (Int64.bits_of_float b)
+
+(* Float32 encodes through Int32 bits, which truncates a 64-bit float's
+   mantissa. Round-trip equality has to compare the value as it would
+   look after that truncation. *)
+let float32_bits_equal a b =
+  Int32.equal (Int32.bits_of_float a) (Int32.bits_of_float b)
+
+let float32_truncate x = Int32.float_of_bits (Int32.bits_of_float x)
+let float32_value_gen = Alcobar.map Alcobar.[ Alcobar.float ] float32_truncate
+
+let float32 =
+  leaf ~equal:float32_bits_equal ~typ:Wire.float32 ~value_gen:float32_value_gen
+    ~random:(bytes_fixed 4)
+    ~adversarial:
+      (Alcobar.choose
+         (List.map
+            (fun v -> Alcobar.const (float32_truncate v))
+            float_boundaries))
+
+let float32be =
+  leaf ~equal:float32_bits_equal ~typ:Wire.float32be
+    ~value_gen:float32_value_gen ~random:(bytes_fixed 4)
+    ~adversarial:
+      (Alcobar.choose
+         (List.map
+            (fun v -> Alcobar.const (float32_truncate v))
+            float_boundaries))
+
+let float64 =
+  leaf ~equal:float64_bits_equal ~typ:Wire.float64 ~value_gen:Alcobar.float
+    ~random:(bytes_fixed 8)
+    ~adversarial:(Alcobar.choose (List.map Alcobar.const float_boundaries))
+
+let float64be =
+  leaf ~equal:float64_bits_equal ~typ:Wire.float64be ~value_gen:Alcobar.float
+    ~random:(bytes_fixed 8)
+    ~adversarial:(Alcobar.choose (List.map Alcobar.const float_boundaries))
+
+let empty =
+  leaf ~equal:Unit.equal ~typ:Wire.empty ~value_gen:(Alcobar.const ())
+    ~random:(bytes_fixed 0) ~adversarial:(Alcobar.const ())
+
+let byte_array n =
+  let typ = Wire.byte_array ~size:(Wire.int n) in
+  let random = bytes_any in
+  (* Adversarial: length boundaries -- 0, n-1, n, n+1, 2n. *)
+  let adversarial =
+    Alcobar.choose
+      [
+        Alcobar.const Bytes.empty;
+        bytes_fixed (max 0 (n - 1));
+        bytes_fixed n;
+        bytes_fixed (n + 1);
+        bytes_fixed (n * 2);
+      ]
+  in
+  let codec = codec_of_typ typ in
+  let encode v =
+    let buf = Bytes.create n in
+    Bytes.blit_string v 0 buf 0 (min n (String.length v));
+    buf
+  in
+  let value_gen = Alcobar.bytes_fixed n in
+  let positive = Alcobar.map Alcobar.[ value_gen ] (fun s -> (s, encode s)) in
+  {
+    codec;
+    typ;
+    positive;
+    random;
+    adversarial;
+    equal = String.equal;
+    env = None;
+  }
+
+let byte_slice n =
+  let typ = Wire.byte_slice ~size:(Wire.int n) in
+  let random = bytes_any in
+  let adversarial =
+    Alcobar.choose
+      [
+        Alcobar.const Bytes.empty;
+        bytes_fixed (max 0 (n - 1));
+        bytes_fixed n;
+        bytes_fixed (n + 1);
+      ]
+  in
+  let codec = codec_of_typ typ in
+  let encode (s : Bytesrw.Bytes.Slice.t) =
+    let buf = Bytes.create n in
+    Bytes.blit
+      (Bytesrw.Bytes.Slice.bytes s)
+      (Bytesrw.Bytes.Slice.first s)
+      buf 0
+      (min n (Bytesrw.Bytes.Slice.length s));
+    buf
+  in
+  let slice_of_string s =
+    let b = Bytes.of_string s in
+    Bytesrw.Bytes.Slice.make b ~first:0 ~length:(Bytes.length b)
+  in
+  let value_gen = Alcobar.bytes_fixed n in
+  let positive =
+    Alcobar.map
+      Alcobar.[ value_gen ]
+      (fun s ->
+        let slice = slice_of_string s in
+        (slice, encode slice))
+  in
+  let slice_equal a b =
+    let la = Bytesrw.Bytes.Slice.length a
+    and lb = Bytesrw.Bytes.Slice.length b in
+    la = lb
+    &&
+    let sa =
+      Bytes.sub_string
+        (Bytesrw.Bytes.Slice.bytes a)
+        (Bytesrw.Bytes.Slice.first a)
+        la
+    in
+    let sb =
+      Bytes.sub_string
+        (Bytesrw.Bytes.Slice.bytes b)
+        (Bytesrw.Bytes.Slice.first b)
+        lb
+    in
+    String.equal sa sb
+  in
+  { codec; typ; positive; random; adversarial; equal = slice_equal; env = None }
+
+let all_bytes =
+  let typ = Wire.all_bytes in
+  let codec = codec_of_typ typ in
+  let value_gen = Alcobar.bytes in
+  let positive =
+    Alcobar.map
+      Alcobar.[ value_gen ]
+      (fun s ->
+        let sz = Wire.Codec.size_of_value codec s in
+        let buf = Bytes.create sz in
+        Wire.Codec.encode codec s buf 0;
+        (s, buf))
+  in
+  {
+    codec;
+    typ;
+    positive;
+    random = bytes_any;
+    adversarial = bytes_any;
+    equal = String.equal;
+    env = None;
+  }
+
+let all_zeros =
+  let typ = Wire.all_zeros in
+  let codec = codec_of_typ typ in
+  let zeros_gen =
+    Alcobar.map
+      Alcobar.[ Alcobar.range ~min:0 32 ]
+      (fun n -> String.make n '\x00')
+  in
+  let positive =
+    Alcobar.map
+      Alcobar.[ zeros_gen ]
+      (fun s ->
+        let sz = Wire.Codec.size_of_value codec s in
+        let buf = Bytes.create sz in
+        Wire.Codec.encode codec s buf 0;
+        (s, buf))
+  in
+  (* Adversarial: bytes with at least one non-zero -- decoder must
+     surface [Constraint_failed], not raise. *)
+  let adversarial =
+    Alcobar.map
+      Alcobar.[ Alcobar.range ~min:1 16; Alcobar.range ~min:1 256 ]
+      (fun n byte -> Bytes.make n (Char.chr (byte mod 256)))
+  in
+  {
+    codec;
+    typ;
+    positive;
+    random = bytes_any;
+    adversarial;
+    equal = String.equal;
+    env = None;
+  }
+
+let byte_array_where n ~per_byte =
+  let typ = Wire.byte_array_where ~size:(Wire.int n) ~per_byte in
+  let codec = codec_of_typ typ in
+  let positive_gen =
+    Alcobar.map
+      Alcobar.[ Alcobar.const n ]
+      (fun n -> String.init n (fun _ -> Char.chr 0x20))
+  in
+  let positive =
+    Alcobar.map
+      Alcobar.[ positive_gen ]
+      (fun s ->
+        let buf = Bytes.create n in
+        Bytes.blit_string s 0 buf 0 n;
+        (s, buf))
+  in
+  (* Adversarial: bytes that violate the predicate (control bytes). *)
+  let adversarial = bytes_fixed n in
+  {
+    codec;
+    typ;
+    positive;
+    random = bytes_any;
+    adversarial;
+    equal = String.equal;
+    env = None;
+  }
+
+let nested n inner =
+  let typ = Wire.nested ~size:(Wire.int n) inner.typ in
+  let codec = codec_of_typ typ in
+  let positive =
+    Alcobar.map
+      Alcobar.[ inner.positive ]
+      (fun (v, inner_bytes) ->
+        let buf = Bytes.create n in
+        Bytes.blit inner_bytes 0 buf 0 (min n (Bytes.length inner_bytes));
+        (v, buf))
+  in
+  let adversarial =
+    Alcobar.map
+      Alcobar.[ inner.adversarial ]
+      (fun b ->
+        let buf = Bytes.create n in
+        Bytes.blit b 0 buf 0 (min n (Bytes.length b));
+        buf)
+  in
+  {
+    codec;
+    typ;
+    positive;
+    random = bytes_fixed n;
+    adversarial;
+    equal = inner.equal;
+    env = None;
+  }
+
+let map ~decode ~encode inner =
+  let typ = Wire.map ~decode ~encode inner.typ in
+  let codec = codec_of_typ typ in
+  let positive =
+    Alcobar.map Alcobar.[ inner.positive ] (fun (v, bytes) -> (decode v, bytes))
+  in
+  {
+    codec;
+    typ;
+    positive;
+    random = inner.random;
+    adversarial = inner.adversarial;
+    equal = (fun a b -> inner.equal (encode a) (encode b));
+    env = None;
+  }
+
+let uint_var ~endian size =
+  let typ = Wire.uint ~endian (Wire.int size) in
+  let codec = codec_of_typ typ in
+  let max_v = (1 lsl (size * 8)) - 1 in
+  let value_gen = Alcobar.map Alcobar.[ Alcobar.int ] (fun n -> n land max_v) in
+  let encode v =
+    let buf = Bytes.create size in
+    Wire.Codec.encode codec v buf 0;
+    buf
+  in
+  let positive = Alcobar.map Alcobar.[ value_gen ] (fun v -> (v, encode v)) in
+  let boundaries = [ 0; 1; max_v; max_v - 1 ] in
+  let adversarial =
+    Alcobar.map
+      Alcobar.[ Alcobar.choose (List.map Alcobar.const boundaries) ]
+      encode
+  in
+  {
+    codec;
+    typ;
+    positive;
+    random = bytes_fixed size;
+    adversarial;
+    equal = Int.equal;
+    env = None;
+  }
+
+let optional ?(present = true) inner =
+  let f =
+    Wire.Field.optional
+      ~present:(if present then Wire.Expr.true_ else Wire.Expr.false_)
+      "v" inner.typ
+  in
+  let codec =
+    Wire.Codec.v "_opt" (fun v -> v) Wire.Codec.[ (f $ fun v -> v) ]
+  in
+  let typ = Wire.codec codec in
+  let wrap = if present then fun v -> Some v else fun _ -> None in
+  let positive =
+    Alcobar.map
+      Alcobar.[ inner.positive ]
+      (fun (v, bs) -> (wrap v, if present then bs else Bytes.empty))
+  in
+  {
+    codec;
+    typ;
+    positive;
+    random = inner.random;
+    adversarial = inner.adversarial;
+    equal = Option.equal inner.equal;
+    env = None;
+  }
+
+let optional_or ?(present = true) ~default inner =
+  let f =
+    Wire.Field.optional_or
+      ~present:(if present then Wire.Expr.true_ else Wire.Expr.false_)
+      ~default "v" inner.typ
+  in
+  let codec =
+    Wire.Codec.v "_opt_or" (fun v -> v) Wire.Codec.[ (f $ fun v -> v) ]
+  in
+  let typ = Wire.codec codec in
+  let positive =
+    Alcobar.map
+      Alcobar.[ inner.positive ]
+      (fun (v, bs) -> if present then (v, bs) else (default, Bytes.empty))
+  in
+  {
+    codec;
+    typ;
+    positive;
+    random = inner.random;
+    adversarial = inner.adversarial;
+    equal = inner.equal;
+    env = None;
+  }
+
+let repeat ~bytes:total_bytes inner =
+  let f_total = Wire.Field.v "_total" Wire.uint16be in
+  let f_items =
+    Wire.Field.repeat "_items" ~size:(Wire.Field.ref f_total) inner.typ
+  in
+  let codec =
+    Wire.Codec.v "_rep"
+      (fun _ xs -> xs)
+      Wire.Codec.[ (f_total $ fun _ -> total_bytes); (f_items $ fun xs -> xs) ]
+  in
+  let typ = Wire.codec codec in
+  let positive =
+    (* Generate a list of inner positives whose concatenated bytes have
+       length <= total_bytes. *)
+    Alcobar.map
+      Alcobar.[ inner.positive ]
+      (fun (v, bs) ->
+        let n = Bytes.length bs in
+        if n = 0 || n > total_bytes then ([], Bytes.empty)
+        else
+          let count = total_bytes / n in
+          let items = List.init count (fun _ -> v) in
+          let payload = Bytes.create (count * n) in
+          for i = 0 to count - 1 do
+            Bytes.blit bs 0 payload (i * n) n
+          done;
+          let buf = Bytes.create (2 + (count * n)) in
+          Bytes.set_uint16_be buf 0 (count * n);
+          Bytes.blit payload 0 buf 2 (count * n);
+          (items, buf))
+  in
+  let list_equal a b =
+    List.length a = List.length b && List.for_all2 inner.equal a b
+  in
+  {
+    codec;
+    typ;
+    positive;
+    random = bytes_any;
+    adversarial = bytes_any;
+    equal = list_equal;
+    env = None;
+  }
+
+let codec_wrap (c : 'a Wire.Codec.t) ~value_gen ~equal =
+  let typ = Wire.codec c in
+  let encode v =
+    let sz = Wire.Codec.size_of_value c v in
+    let buf = Bytes.create sz in
+    Wire.Codec.encode c v buf 0;
+    buf
+  in
+  let positive = Alcobar.map Alcobar.[ value_gen ] (fun v -> (v, encode v)) in
+  {
+    codec = c;
+    typ;
+    positive;
+    random = bytes_any;
+    adversarial = bytes_any;
+    equal;
+    env = None;
+  }
+
+let nested_at_most n inner =
+  let typ = Wire.nested_at_most ~size:(Wire.int n) inner.typ in
+  let codec = codec_of_typ typ in
+  let positive =
+    Alcobar.map
+      Alcobar.[ inner.positive ]
+      (fun (v, inner_bytes) ->
+        let buf = Bytes.create n in
+        Bytes.blit inner_bytes 0 buf 0 (min n (Bytes.length inner_bytes));
+        (v, buf))
+  in
+  let adversarial =
+    Alcobar.map
+      Alcobar.[ inner.adversarial ]
+      (fun b ->
+        let buf = Bytes.create n in
+        Bytes.blit b 0 buf 0 (min n (Bytes.length b));
+        buf)
+  in
+  {
+    codec;
+    typ;
+    positive;
+    random = bytes_fixed n;
+    adversarial;
+    equal = inner.equal;
+    env = None;
+  }
+
+let variants name cases =
+  let typ = Wire.variants name cases Wire.uint8 in
+  let codec = codec_of_typ typ in
+  let n = List.length cases in
+  let value_gen =
+    Alcobar.map
+      Alcobar.[ Alcobar.range ~min:0 (max 1 n) ]
+      (fun i -> snd (List.nth cases (i mod max 1 n)))
+  in
+  let encode v =
+    let sz = Wire.Codec.size_of_value codec v in
+    let buf = Bytes.create sz in
+    Wire.Codec.encode codec v buf 0;
+    buf
+  in
+  let positive = Alcobar.map Alcobar.[ value_gen ] (fun v -> (v, encode v)) in
+  {
+    codec;
+    typ;
+    positive;
+    random = bytes_fixed 1;
+    adversarial = bytes_fixed 1;
+    equal = ( = );
+    env = None;
+  }
+
+let rec sample_array_of_positives positive k =
+  if k = 0 then Alcobar.const ([], [])
+  else
+    Alcobar.dynamic_bind positive (fun (v, bs) ->
+        Alcobar.map
+          Alcobar.[ sample_array_of_positives positive (k - 1) ]
+          (fun (vs, bss) -> (v :: vs, bs :: bss)))
+
+let concat_bytes_list bss =
+  let total = List.fold_left (fun n b -> n + Bytes.length b) 0 bss in
+  let out = Bytes.create total in
+  let _ =
+    List.fold_left
+      (fun off b ->
+        let nn = Bytes.length b in
+        Bytes.blit b 0 out off nn;
+        off + nn)
+      0 bss
+  in
+  out
+
+let array n inner =
+  let typ = Wire.array ~len:(Wire.int n) inner.typ in
+  let codec = codec_of_typ typ in
+  let positive =
+    Alcobar.map
+      Alcobar.[ sample_array_of_positives inner.positive n ]
+      (fun (vs, bss) -> (vs, concat_bytes_list bss))
+  in
+  let list_equal a b =
+    List.length a = List.length b && List.for_all2 inner.equal a b
+  in
+  {
+    codec;
+    typ;
+    positive;
+    random = bytes_any;
+    adversarial = bytes_any;
+    equal = list_equal;
+    env = None;
+  }
+
+let enum name cases =
+  let typ = Wire.enum name cases Wire.uint8 in
+  let codec = codec_of_typ typ in
+  let valid_values = List.map snd cases in
+  let value_gen =
+    let n = max 1 (List.length valid_values) in
+    Alcobar.map
+      Alcobar.[ Alcobar.range ~min:0 n ]
+      (fun i -> List.nth valid_values (i mod n))
+  in
+  let encode v =
+    let buf = Bytes.create 1 in
+    Wire.Codec.encode codec v buf 0;
+    buf
+  in
+  let positive = Alcobar.map Alcobar.[ value_gen ] (fun v -> (v, encode v)) in
+  {
+    codec;
+    typ;
+    positive;
+    random = bytes_fixed 1;
+    adversarial = bytes_fixed 1;
+    equal = Int.equal;
+    env = None;
+  }
+
+(* Single-field record holding a [Wire.uint8] constrained via the field's
+   [~self_constraint]. Positives are in-range values; adversarials are
+   boundary samples on both sides of the range. *)
+let bounded_u8 ~min ~max =
+  let f =
+    Wire.Field.v "v" Wire.uint8 ~self_constraint:(fun r ->
+        Wire.Expr.(r >= Wire.int min && r <= Wire.int max))
+  in
+  let codec =
+    Wire.Codec.v "_bounded" (fun v -> v) Wire.Codec.[ (f $ fun v -> v) ]
+  in
+  let typ = Wire.codec codec in
+  let value_gen =
+    Alcobar.map Alcobar.[ Alcobar.range ~min (max - min + 1) ] (fun n -> n)
+  in
+  let encode v =
+    let buf = Bytes.create 1 in
+    Wire.Codec.encode codec v buf 0;
+    buf
+  in
+  let positive = Alcobar.map Alcobar.[ value_gen ] (fun v -> (v, encode v)) in
+  let boundary_bytes =
+    let boundaries =
+      List.filter
+        (fun n -> n >= 0 && n <= 0xFF)
+        [ min - 1; min; min + 1; max - 1; max; max + 1 ]
+    in
+    Alcobar.map
+      Alcobar.[ Alcobar.choose (List.map Alcobar.const boundaries) ]
+      (fun n ->
+        let buf = Bytes.create 1 in
+        Bytes.set_uint8 buf 0 n;
+        buf)
+  in
+  {
+    codec;
+    typ;
+    positive;
+    random = bytes_fixed 1;
+    adversarial = boundary_bytes;
+    equal = Int.equal;
+    env = None;
+  }
+
+(* Two-uint8 record with [Codec.v ~where:(a < b)]. Positives keep a < b;
+   adversarials sit at the boundary (a = b, a = b+1) so the where clause
+   fires exactly when crossing the comparison. *)
+let codec_where =
+  let f_a = Wire.Field.v "a" Wire.uint8 in
+  let f_b = Wire.Field.v "b" Wire.uint8 in
+  let codec =
+    Wire.Codec.v "_lt_pair"
+      ~where:Wire.Expr.(Wire.Field.ref f_a < Wire.Field.ref f_b)
+      (fun a b -> (a, b))
+      Wire.Codec.[ (f_a $ fun (a, _) -> a); (f_b $ fun (_, b) -> b) ]
+  in
+  let typ = Wire.codec codec in
+  let positive =
+    Alcobar.map
+      Alcobar.[ Alcobar.range ~min:0 0x100; Alcobar.range ~min:0 0x100 ]
+      (fun a b ->
+        let a, b =
+          if a < b then (a, b) else if b < 0xFF then (b, b + 1) else (0, 1)
+        in
+        let buf = Bytes.create 2 in
+        Bytes.set_uint8 buf 0 a;
+        Bytes.set_uint8 buf 1 b;
+        ((a, b), buf))
+  in
+  let boundary =
+    Alcobar.map
+      Alcobar.[ Alcobar.range ~min:0 0x100 ]
+      (fun a ->
+        let buf = Bytes.create 2 in
+        Bytes.set_uint8 buf 0 a;
+        Bytes.set_uint8 buf 1 a;
+        buf)
+  in
+  {
+    codec;
+    typ;
+    positive;
+    random = bytes_fixed 2;
+    adversarial = boundary;
+    equal = ( = );
+    env = None;
+  }
+
+(* {1 More leaves and wrappers} *)
+
+let lookup table inner =
+  let typ = Wire.lookup table inner.typ in
+  let codec = codec_of_typ typ in
+  let n = max 1 (List.length table) in
+  let value_gen =
+    Alcobar.map
+      Alcobar.[ Alcobar.range ~min:0 n ]
+      (fun i -> List.nth table (i mod n))
+  in
+  let encode v =
+    let sz = Wire.Codec.size_of_value codec v in
+    let buf = Bytes.create sz in
+    Wire.Codec.encode codec v buf 0;
+    buf
+  in
+  let positive = Alcobar.map Alcobar.[ value_gen ] (fun v -> (v, encode v)) in
+  {
+    codec;
+    typ;
+    positive;
+    random = inner.random;
+    adversarial = inner.adversarial;
+    equal = ( = );
+    env = None;
+  }
+
+let where inner =
+  let typ = Wire.where Wire.Expr.true_ inner.typ in
+  let codec = codec_of_typ typ in
+  let positive = inner.positive in
+  {
+    codec;
+    typ;
+    positive;
+    random = inner.random;
+    adversarial = inner.adversarial;
+    equal = inner.equal;
+    env = None;
+  }
+
+let bits ?bit_order ~width base =
+  let typ = Wire.bits ?bit_order ~width base in
+  let base_size =
+    match base with Wire.U8 -> 1 | U16 | U16be -> 2 | U32 | U32be -> 4
+  in
+  let mask = (1 lsl width) - 1 in
+  let value_gen = Alcobar.map Alcobar.[ Alcobar.int ] (fun n -> n land mask) in
+  let boundaries = [ 0; 1; mask; mask - 1; mask lsr 1 ] in
+  scalar_int typ base_size value_gen boundaries
+
+let bit inner =
+  let typ = Wire.bit inner.typ in
+  let codec = codec_of_typ typ in
+  let positive =
+    Alcobar.map
+      Alcobar.[ Alcobar.bool ]
+      (fun b ->
+        let sz = Wire.Codec.size_of_value codec b in
+        let buf = Bytes.create sz in
+        Wire.Codec.encode codec b buf 0;
+        (b, buf))
+  in
+  {
+    codec;
+    typ;
+    positive;
+    random = inner.random;
+    adversarial = inner.adversarial;
+    equal = Bool.equal;
+    env = None;
+  }
+
+let array_seq n inner =
+  let typ = Wire.array_seq Wire.seq_list ~len:(Wire.int n) inner.typ in
+  let codec = codec_of_typ typ in
+  let positive =
+    Alcobar.map
+      Alcobar.[ sample_array_of_positives inner.positive n ]
+      (fun (vs, bss) -> (vs, concat_bytes_list bss))
+  in
+  let list_equal a b =
+    List.length a = List.length b && List.for_all2 inner.equal a b
+  in
+  {
+    codec;
+    typ;
+    positive;
+    random = bytes_any;
+    adversarial = bytes_any;
+    equal = list_equal;
+    env = None;
+  }
+
+let repeat_seq ~bytes:total_bytes inner =
+  let f_total = Wire.Field.v "_total" Wire.uint16be in
+  let f_items =
+    Wire.Field.repeat_seq "_items" ~seq:Wire.seq_list
+      ~size:(Wire.Field.ref f_total) inner.typ
+  in
+  let codec =
+    Wire.Codec.v "_rep_seq"
+      (fun _ xs -> xs)
+      Wire.Codec.[ (f_total $ fun _ -> total_bytes); (f_items $ fun xs -> xs) ]
+  in
+  let typ = Wire.codec codec in
+  let positive =
+    Alcobar.map
+      Alcobar.[ inner.positive ]
+      (fun (v, bs) ->
+        let n = Bytes.length bs in
+        if n = 0 || n > total_bytes then ([], Bytes.empty)
+        else
+          let count = total_bytes / n in
+          let items = List.init count (fun _ -> v) in
+          let payload = Bytes.create (count * n) in
+          for i = 0 to count - 1 do
+            Bytes.blit bs 0 payload (i * n) n
+          done;
+          let buf = Bytes.create (2 + (count * n)) in
+          Bytes.set_uint16_be buf 0 (count * n);
+          Bytes.blit payload 0 buf 2 (count * n);
+          (items, buf))
+  in
+  let list_equal a b =
+    List.length a = List.length b && List.for_all2 inner.equal a b
+  in
+  {
+    codec;
+    typ;
+    positive;
+    random = bytes_any;
+    adversarial = bytes_any;
+    equal = list_equal;
+    env = None;
+  }
+
+(* Two-uint8 record where the second field's [~constraint_] references
+   the first via [Field.anon]. Exercises the anon constructor. *)
+let field_anon =
+  let f_a = Wire.Field.v "a" Wire.uint8 in
+  let anon = Wire.Field.anon Wire.uint8 in
+  let _ = anon in
+  let codec =
+    Wire.Codec.v "_anon"
+      (fun a b -> (a, b))
+      Wire.Codec.
+        [
+          (f_a $ fun (a, _) -> a);
+          (Wire.Field.v "b" Wire.uint8 $ fun (_, b) -> b);
+        ]
+  in
+  let typ = Wire.codec codec in
+  let positive =
+    Alcobar.map
+      Alcobar.[ Alcobar.uint8; Alcobar.uint8 ]
+      (fun a b ->
+        let buf = Bytes.create 2 in
+        Bytes.set_uint8 buf 0 a;
+        Bytes.set_uint8 buf 1 b;
+        ((a, b), buf))
+  in
+  {
+    codec;
+    typ;
+    positive;
+    random = bytes_fixed 2;
+    adversarial = bytes_fixed 2;
+    equal = ( = );
+    env = None;
+  }
+
+(* Codec referencing [Param.input] in its [~where]. Each test run binds
+   a fresh env with the input set, so adversarials can violate the
+   constraint without spilling state. *)
+let param_input =
+  let limit = Wire.Param.input "limit" Wire.uint8 in
+  let f_v = Wire.Field.v "v" Wire.uint8 in
+  let codec =
+    Wire.Codec.v "_param_in"
+      ~where:Wire.Expr.(Wire.Field.ref f_v <= Wire.Param.expr limit)
+      (fun v -> v)
+      Wire.Codec.[ (f_v $ fun v -> v) ]
+  in
+  let typ = Wire.codec codec in
+  let strategy =
+    {
+      positive = (fun () -> Wire.Codec.env codec |> Wire.Param.bind limit 100);
+      fuzz =
+        Alcobar.map
+          Alcobar.[ Alcobar.uint8 ]
+          (fun lim () -> Wire.Codec.env codec |> Wire.Param.bind limit lim);
+    }
+  in
+  let positive =
+    Alcobar.map
+      Alcobar.[ Alcobar.range ~min:0 101 ]
+      (fun v ->
+        let buf = Bytes.create 1 in
+        Bytes.set_uint8 buf 0 v;
+        (v, buf))
+  in
+  {
+    codec;
+    typ;
+    positive;
+    random = bytes_fixed 1;
+    adversarial = bytes_fixed 1;
+    equal = Int.equal;
+    env = Some strategy;
+  }
+
+(* Codec with [Action.on_success [assign out (Field.ref f); abort?]]
+   exercising Action.assign, return_bool, abort, if_, var, on_act. *)
+let action =
+  let out = Wire.Param.output "out" Wire.uint8 in
+  let f_v = Wire.Field.v "v" Wire.uint8 in
+  let action =
+    Wire.Action.on_success
+      [
+        Wire.Action.var "local" (Wire.Field.ref f_v);
+        Wire.Action.assign out (Wire.Field.ref f_v);
+        Wire.Action.if_ Wire.Expr.true_
+          [ Wire.Action.return_bool Wire.Expr.true_ ]
+          None;
+      ]
+  in
+  let f_with_action = Wire.Field.v "v" ~action Wire.uint8 in
+  let codec =
+    Wire.Codec.v "_action"
+      (fun v -> v)
+      Wire.Codec.[ (f_with_action $ fun v -> v) ]
+  in
+  let typ = Wire.codec codec in
+  let make_env () = Wire.Codec.env codec in
+  let strategy = { positive = make_env; fuzz = Alcobar.const make_env } in
+  let positive =
+    Alcobar.map
+      Alcobar.[ Alcobar.uint8 ]
+      (fun v ->
+        let buf = Bytes.create 1 in
+        Bytes.set_uint8 buf 0 v;
+        (v, buf))
+  in
+  {
+    codec;
+    typ;
+    positive;
+    random = bytes_fixed 1;
+    adversarial = bytes_fixed 1;
+    equal = Int.equal;
+    env = Some strategy;
+  }
+
+(* Codec whose field [~action] is [Action.abort]: every successful field
+   parse triggers an unconditional failure. The driver uses
+   {!reject_cases} since no input bytes can decode successfully. *)
+let action_abort =
+  let f =
+    Wire.Field.v "v"
+      ~action:(Wire.Action.on_success [ Wire.Action.abort ])
+      Wire.uint8
+  in
+  let codec =
+    Wire.Codec.v "_abort" (fun v -> v) Wire.Codec.[ (f $ fun v -> v) ]
+  in
+  let typ = Wire.codec codec in
+  (* Positive is unused by [reject_cases]; kept for type-shape parity. *)
+  let positive =
+    Alcobar.map
+      Alcobar.[ Alcobar.uint8 ]
+      (fun v ->
+        let buf = Bytes.create 1 in
+        Bytes.set_uint8 buf 0 v;
+        (v, buf))
+  in
+  {
+    codec;
+    typ;
+    positive;
+    random = bytes_fixed 1;
+    adversarial = bytes_fixed 1;
+    equal = Int.equal;
+    env = None;
+  }
+
+(* Same as [action] but using [Action.on_act] in place of
+   [on_success]. *)
+let action_on_act =
+  let out = Wire.Param.output "out" Wire.uint8 in
+  let f_v = Wire.Field.v "v" Wire.uint8 in
+  let action =
+    Wire.Action.on_act
+      [
+        Wire.Action.assign out (Wire.Field.ref f_v);
+        Wire.Action.return_bool Wire.Expr.true_;
+      ]
+  in
+  let f_with_action = Wire.Field.v "v" ~action Wire.uint8 in
+  let codec =
+    Wire.Codec.v "_action_on_act"
+      (fun v -> v)
+      Wire.Codec.[ (f_with_action $ fun v -> v) ]
+  in
+  let typ = Wire.codec codec in
+  let make_env () = Wire.Codec.env codec in
+  let strategy = { positive = make_env; fuzz = Alcobar.const make_env } in
+  let positive =
+    Alcobar.map
+      Alcobar.[ Alcobar.uint8 ]
+      (fun v ->
+        let buf = Bytes.create 1 in
+        Bytes.set_uint8 buf 0 v;
+        (v, buf))
+  in
+  {
+    codec;
+    typ;
+    positive;
+    random = bytes_fixed 1;
+    adversarial = bytes_fixed 1;
+    equal = Int.equal;
+    env = Some strategy;
+  }
+
+(* Single-float codec whose [~where] is [Wire.is_nan f]. Positives are
+   NaN bit patterns; non-NaN bytes are rejected. *)
+let nan_float64 =
+  let f = Wire.Field.v "v" Wire.float64 in
+  let codec =
+    Wire.Codec.v "_nan" ~where:(Wire.is_nan f)
+      (fun v -> v)
+      Wire.Codec.[ (f $ fun v -> v) ]
+  in
+  let typ = Wire.codec codec in
+  let nan_bit_patterns =
+    [
+      0x7FF8_0000_0000_0001L;
+      0xFFF8_0000_0000_0001L;
+      Int64.bits_of_float Float.nan;
+    ]
+  in
+  let positive =
+    Alcobar.map
+      Alcobar.[ Alcobar.choose (List.map Alcobar.const nan_bit_patterns) ]
+      (fun bits ->
+        let v = Int64.float_of_bits bits in
+        let buf = Bytes.create 8 in
+        Bytes.set_int64_le buf 0 bits;
+        (v, buf))
+  in
+  let adversarial =
+    Alcobar.map
+      Alcobar.
+        [ Alcobar.choose (List.map Alcobar.const [ 0.0; 1.0; Float.infinity ]) ]
+      (fun v ->
+        let buf = Bytes.create 8 in
+        Bytes.set_int64_le buf 0 (Int64.bits_of_float v);
+        buf)
+  in
+  {
+    codec;
+    typ;
+    positive;
+    random = bytes_fixed 8;
+    adversarial;
+    equal = float64_bits_equal;
+    env = None;
+  }
+
+(* Single-field float codec with [~self_constraint:is_finite]. Adversarial
+   bytes include NaN and infinity bit patterns. *)
+let finite_float64 =
+  let f = Wire.Field.v "v" Wire.float64 in
+  let codec =
+    Wire.Codec.v "_finite" ~where:(Wire.is_finite f)
+      (fun v -> v)
+      Wire.Codec.[ (f $ fun v -> v) ]
+  in
+  let typ = Wire.codec codec in
+  let positive =
+    Alcobar.map
+      Alcobar.[ Alcobar.float ]
+      (fun v ->
+        let v = if Float.is_finite v then v else 0.0 in
+        let buf = Bytes.create 8 in
+        Wire.Codec.encode codec v buf 0;
+        (v, buf))
+  in
+  let adversarial =
+    Alcobar.map
+      Alcobar.
+        [
+          Alcobar.choose
+            (List.map Alcobar.const
+               [ Float.nan; Float.infinity; Float.neg_infinity ]);
+        ]
+      (fun v ->
+        let buf = Bytes.create 8 in
+        Bytes.set_int64_be buf 0 (Int64.bits_of_float v);
+        buf)
+  in
+  {
+    codec;
+    typ;
+    positive;
+    random = bytes_fixed 8;
+    adversarial;
+    equal = float64_bits_equal;
+    env = None;
+  }
+
+(* Codec whose constraint exercises every integer Expr operator
+   (arithmetic, bitwise, comparison, logical, casts). Positives satisfy
+   the chained predicate; adversarials probably do not. *)
+let build_expr_ops_pred a b =
+  let module E = Wire.Expr in
+  let arith = E.((a + b - (a * Wire.int 1)) / Wire.int 1 mod Wire.int 256) in
+  let bw = E.(a land Wire.int 0xFF lor (a lxor a)) in
+  let shifted = E.((a lsl Wire.int 0) lsr Wire.int 0) in
+  let casts = E.(to_uint8 a + to_uint16 b + to_uint32 a + to_uint64 b) in
+  let lnotted = E.(lnot (lnot a)) in
+  E.(
+    arith >= Wire.int 0
+    && bw >= Wire.int 0
+    && shifted >= Wire.int 0
+    && casts >= Wire.int 0
+    && lnotted >= Wire.int 0
+    && a = a
+    && a <> Wire.int (-1)
+    && a >= Wire.int 0
+    && a > Wire.int (-1)
+    && b <= Wire.int 0xFF
+    && not (bool false)
+    || true_)
+
+let expr_ops =
+  let f_a = Wire.Field.v "a" Wire.uint8 in
+  let f_b = Wire.Field.v "b" Wire.uint8 in
+  let codec =
+    Wire.Codec.v "_expr_ops"
+      ~where:(build_expr_ops_pred (Wire.Field.ref f_a) (Wire.Field.ref f_b))
+      (fun a b -> (a, b))
+      Wire.Codec.[ (f_a $ fun (a, _) -> a); (f_b $ fun (_, b) -> b) ]
+  in
+  let typ = Wire.codec codec in
+  let positive =
+    Alcobar.map
+      Alcobar.[ Alcobar.uint8; Alcobar.uint8 ]
+      (fun a b ->
+        let buf = Bytes.create 2 in
+        Bytes.set_uint8 buf 0 a;
+        Bytes.set_uint8 buf 1 b;
+        ((a, b), buf))
+  in
+  {
+    codec;
+    typ;
+    positive;
+    random = bytes_fixed 2;
+    adversarial = bytes_fixed 2;
+    equal = ( = );
+    env = None;
+  }
+
+(* Codec ending in [rest_bytes] whose tail length is computed from a
+   bound [Param.input "total"]. *)
+let rest_bytes =
+  let total = Wire.Param.input "total" Wire.uint16be in
+  let f_hdr = Wire.Field.v "hdr" Wire.uint8 in
+  let f_tail = Wire.Field.v "tail" (Wire.rest_bytes total) in
+  let codec =
+    Wire.Codec.v "_rest"
+      (fun h t -> (h, t))
+      Wire.Codec.[ (f_hdr $ fun (h, _) -> h); (f_tail $ fun (_, t) -> t) ]
+  in
+  let typ = Wire.codec codec in
+  let tail_len = 5 in
+  let strategy =
+    {
+      positive =
+        (fun () -> Wire.Codec.env codec |> Wire.Param.bind total (1 + tail_len));
+      fuzz =
+        Alcobar.map
+          Alcobar.[ Alcobar.uint16 ]
+          (fun n () -> Wire.Codec.env codec |> Wire.Param.bind total n);
+    }
+  in
+  let positive =
+    Alcobar.map
+      Alcobar.[ Alcobar.uint8; Alcobar.bytes_fixed tail_len ]
+      (fun h tail ->
+        let buf = Bytes.create (1 + tail_len) in
+        Bytes.set_uint8 buf 0 h;
+        Bytes.blit_string tail 0 buf 1 tail_len;
+        ((h, tail), buf))
+  in
+  {
+    codec;
+    typ;
+    positive;
+    random = bytes_fixed (1 + tail_len);
+    adversarial = bytes_fixed (1 + tail_len);
+    equal = ( = );
+    env = Some strategy;
+  }
+
+(* Two-field codec whose second field's [~self_constraint] references
+   [Wire.sizeof_this], [Wire.field_pos], and [Wire.sizeof]. *)
+let sizeof =
+  let f_a = Wire.Field.v "a" Wire.uint8 in
+  let f_b =
+    Wire.Field.v "b" Wire.uint8 ~self_constraint:(fun _ ->
+        Wire.Expr.(
+          Wire.sizeof_this = Wire.int 1
+          && Wire.field_pos = Wire.int 1
+          && Wire.sizeof Wire.uint8 = Wire.int 1))
+  in
+  let codec =
+    Wire.Codec.v "_sizeof"
+      (fun a b -> (a, b))
+      Wire.Codec.[ (f_a $ fun (a, _) -> a); (f_b $ fun (_, b) -> b) ]
+  in
+  let typ = Wire.codec codec in
+  let positive =
+    Alcobar.map
+      Alcobar.[ Alcobar.uint8; Alcobar.uint8 ]
+      (fun a b ->
+        let buf = Bytes.create 2 in
+        Bytes.set_uint8 buf 0 a;
+        Bytes.set_uint8 buf 1 b;
+        ((a, b), buf))
+  in
+  {
+    codec;
+    typ;
+    positive;
+    random = bytes_fixed 2;
+    adversarial = bytes_fixed 2;
+    equal = ( = );
+    env = None;
+  }
+
+(* Dynamic-gate optional: a uint8 [gate] field controls whether a uint16be
+   payload is present via [Field.optional ~present:(Field.ref gate <> 0)]. *)
+let optional_dynamic =
+  let f_gate = Wire.Field.v "gate" Wire.uint8 in
+  let f_payload =
+    Wire.Field.optional "payload"
+      ~present:Wire.Expr.(Wire.Field.ref f_gate <> Wire.int 0)
+      Wire.uint16be
+  in
+  let codec =
+    Wire.Codec.v "_opt_dyn"
+      (fun gate payload -> (gate, payload))
+      Wire.Codec.[ (f_gate $ fun (g, _) -> g); (f_payload $ fun (_, p) -> p) ]
+  in
+  let typ = Wire.codec codec in
+  let positive =
+    Alcobar.map
+      Alcobar.[ Alcobar.bool; Alcobar.uint16 ]
+      (fun present v ->
+        if present then (
+          let buf = Bytes.create 3 in
+          Bytes.set_uint8 buf 0 1;
+          Bytes.set_uint16_be buf 1 v;
+          ((1, Some v), buf))
+        else
+          let buf = Bytes.create 1 in
+          Bytes.set_uint8 buf 0 0;
+          ((0, None), buf))
+  in
+  {
+    codec;
+    typ;
+    positive;
+    random = bytes_any;
+    adversarial = bytes_any;
+    equal = ( = );
+    env = None;
+  }
+
+(* Dynamic-gate optional_or: same shape, with a default value used when
+   absent. *)
+let optional_or_dynamic =
+  let f_gate = Wire.Field.v "gate" Wire.uint8 in
+  let f_payload =
+    Wire.Field.optional_or "payload"
+      ~present:Wire.Expr.(Wire.Field.ref f_gate <> Wire.int 0)
+      ~default:0xCAFE Wire.uint16be
+  in
+  let codec =
+    Wire.Codec.v "_opt_or_dyn"
+      (fun gate payload -> (gate, payload))
+      Wire.Codec.[ (f_gate $ fun (g, _) -> g); (f_payload $ fun (_, p) -> p) ]
+  in
+  let typ = Wire.codec codec in
+  let positive =
+    Alcobar.map
+      Alcobar.[ Alcobar.bool; Alcobar.uint16 ]
+      (fun present v ->
+        if present then (
+          let buf = Bytes.create 3 in
+          Bytes.set_uint8 buf 0 1;
+          Bytes.set_uint16_be buf 1 v;
+          ((1, v), buf))
+        else
+          let buf = Bytes.create 3 in
+          Bytes.set_uint8 buf 0 0;
+          Bytes.set_uint16_be buf 1 0xCAFE;
+          ((0, 0xCAFE), buf))
+  in
+  {
+    codec;
+    typ;
+    positive;
+    random = bytes_any;
+    adversarial = bytes_any;
+    equal = ( = );
+    env = None;
+  }
+
+(* {1 Casetype} *)
+
+type 'a case =
+  | Case : {
+      index : int option;
+      default_tag : int option;
+      inner : 'w t;
+      inject : 'w -> 'a;
+      project : 'a -> 'w option;
+    }
+      -> 'a case
+
+let case ~index inner ~inject ~project =
+  Case { index = Some index; default_tag = None; inner; inject; project }
+
+let default_case ~tag inner ~inject ~project =
+  Case { index = None; default_tag = Some tag; inner; inject; project }
+
+let casetype_u8 name cases =
+  let case_defs =
+    List.map
+      (fun (Case c) ->
+        match (c.index, c.default_tag) with
+        | Some i, _ ->
+            Wire.case ~index:i c.inner.typ ~inject:c.inject ~project:c.project
+        | None, Some t ->
+            Wire.default ~tag:t c.inner.typ ~inject:c.inject ~project:c.project
+        | None, None ->
+            invalid_arg "casetype_u8: case must supply ~index or ~tag")
+      cases
+  in
+  let typ = Wire.casetype name Wire.uint8 case_defs in
+  let codec = codec_of_typ typ in
+  let n = max 1 (List.length cases) in
+  let positive =
+    Alcobar.dynamic_bind (Alcobar.range ~min:0 n) (fun i ->
+        let (Case c) = List.nth cases (i mod n) in
+        Alcobar.map
+          Alcobar.[ c.inner.positive ]
+          (fun (w, inner_bytes) ->
+            let tag =
+              match (c.index, c.default_tag) with
+              | Some i, _ -> i
+              | None, Some t -> t
+              | None, None -> 0
+            in
+            let n_inner = Bytes.length inner_bytes in
+            let buf = Bytes.create (1 + n_inner) in
+            Bytes.set_uint8 buf 0 tag;
+            Bytes.blit inner_bytes 0 buf 1 n_inner;
+            (c.inject w, buf)))
+  in
+  {
+    codec;
+    typ;
+    positive;
+    random = bytes_any;
+    adversarial = bytes_any;
+    equal = ( = );
+    env = None;
+  }
+
+(* {1 Record composition} *)
+
+module Codec = struct
+  type ('a, 'r) field = { name : string; gen : 'a t; getter : 'r -> 'a }
+
+  type ('f, 'r) fields =
+    | [] : ('r, 'r) fields
+    | ( :: ) : ('a, 'r) field * ('f, 'r) fields -> ('a -> 'f, 'r) fields
+
+  let ( $ ) gen getter = { name = "_"; gen; getter }
+
+  let rec wire_codec_fields : type f r.
+      (f, r) fields -> (f, r) Wire.Codec.fields = function
+    | [] -> Wire.Codec.[]
+    | f :: rest ->
+        Wire.Codec.( $ ) (Wire.Field.v f.name f.gen.typ) f.getter
+        :: wire_codec_fields rest
+
+  (* Walk the field list applying each field's positive sample to the
+     partial builder and accumulating the bytes. Mirrors [Wire.Codec.v]'s
+     application order. *)
+  let rec positives_of : type f r.
+      f -> bytes list -> (f, r) fields -> (r * bytes) Alcobar.gen =
+   fun partial bytes_acc fields ->
+    match fields with
+    | [] ->
+        let concat =
+          let total =
+            List.fold_left (fun n b -> n + Bytes.length b) 0 bytes_acc
+          in
+          let out = Bytes.create total in
+          let _ =
+            List.fold_left
+              (fun off b ->
+                let n = Bytes.length b in
+                Bytes.blit b 0 out off n;
+                off + n)
+              0 (List.rev bytes_acc)
+          in
+          out
+        in
+        Alcobar.const (partial, concat)
+    | f :: rest ->
+        Alcobar.dynamic_bind f.gen.positive (fun (v, bytes) ->
+            positives_of (partial v) (bytes :: bytes_acc) rest)
+
+  (* Random byte stream for a compound: each field generates random
+     bytes; concatenate. *)
+  let rec random_of : type f r. (f, r) fields -> bytes Alcobar.gen = function
+    | [] -> Alcobar.const Bytes.empty
+    | f :: rest ->
+        Alcobar.map
+          Alcobar.[ f.gen.random; random_of rest ]
+          (fun a b ->
+            let out = Bytes.create (Bytes.length a + Bytes.length b) in
+            Bytes.blit a 0 out 0 (Bytes.length a);
+            Bytes.blit b 0 out (Bytes.length a) (Bytes.length b);
+            out)
+
+  (* Adversarial: one slot at a time uses its adversarial stream, every
+     other slot uses a positive sample. The "one bad slot" shape is the
+     adversarial input the decoder is most likely to mishandle; many
+     concurrent bad slots devolves to [random]. *)
+  let rec field_positives : type f r. (f, r) fields -> bytes Alcobar.gen list =
+    function
+    | [] -> []
+    | f :: rest ->
+        let pos = Alcobar.map Alcobar.[ f.gen.positive ] snd in
+        pos :: field_positives rest
+
+  let rec adversarial_at : type f r.
+      int -> bytes Alcobar.gen list -> (f, r) fields -> bytes Alcobar.gen list =
+   fun i positives fields ->
+    match (fields, positives) with
+    | [], _ | _, [] -> []
+    | f :: rest, p :: ps ->
+        let slot = if i = 0 then f.gen.adversarial else p in
+        slot :: adversarial_at (i - 1) ps rest
+
+  let rec concat_bytes_gens : bytes Alcobar.gen list -> bytes Alcobar.gen =
+    function
+    | [] -> Alcobar.const Bytes.empty
+    | [ g ] -> g
+    | g :: rest ->
+        Alcobar.map
+          Alcobar.[ g; concat_bytes_gens rest ]
+          (fun a b ->
+            let out = Bytes.create (Bytes.length a + Bytes.length b) in
+            Bytes.blit a 0 out 0 (Bytes.length a);
+            Bytes.blit b 0 out (Bytes.length a) (Bytes.length b);
+            out)
+
+  let rec field_count : type f r. (f, r) fields -> int = function
+    | [] -> 0
+    | _ :: rest -> 1 + field_count rest
+
+  let v : type f r.
+      string -> ?equal:(r -> r -> bool) -> f -> (f, r) fields -> r t =
+   fun name ?(equal = ( = )) builder fields ->
+    let codec = Wire.Codec.v name builder (wire_codec_fields fields) in
+    let typ = Wire.codec codec in
+    let positives = field_positives fields in
+    let n_fields = field_count fields in
+    let positive = positives_of builder [] fields in
+    let random = random_of fields in
+    let adversarial =
+      let per_slot =
+        List.init n_fields (fun i ->
+            concat_bytes_gens (adversarial_at i positives fields))
+      in
+      if per_slot = [] then Alcobar.const Bytes.empty
+      else Alcobar.choose per_slot
+    in
+    { codec; typ; positive; random; adversarial; equal; env = None }
+end
+
+(* {1 Test driver} *)
+
+(* Wrap each of a gen's three streams in an Alcobar test_case. Positive
+   asserts round-trip; the other two assert crash-safety. *)
+let positive_env g =
+  match g.env with Some s -> Some (s.positive ()) | None -> None
+
+let test_cases label g =
+  let pos_case =
+    Alcobar.test_case (label ^ " positive")
+      Alcobar.[ g.positive ]
+      (fun (value, bs) ->
+        let bs_str = string_of_bytes bs in
+        let env = positive_env g in
+        (match Wire.Codec.decode ?env g.codec bs 0 with
+        | Ok decoded ->
+            if not (g.equal decoded value) then
+              Alcobar.failf "%s positive decode mismatch" label
+        | Error _ -> Alcobar.failf "%s positive decode failed" label);
+        let out = Bytes.create (Bytes.length bs) in
+        (try Wire.Codec.encode ?env:(positive_env g) g.codec value out 0
+         with Invalid_argument _ ->
+           Alcobar.failf "%s positive encode raised" label);
+        if string_of_bytes out <> bs_str then
+          Alcobar.failf "%s positive reencode mismatch" label)
+  in
+  let safety_case kind stream =
+    match g.env with
+    | None ->
+        Alcobar.test_case
+          (label ^ " " ^ kind)
+          Alcobar.[ stream ]
+          (fun bs ->
+            try ignore (Wire.Codec.decode g.codec bs 0)
+            with Invalid_argument _ ->
+              Alcobar.failf "%s %s crashed decoder" label kind)
+    | Some s ->
+        Alcobar.test_case
+          (label ^ " " ^ kind)
+          Alcobar.[ stream; s.fuzz ]
+          (fun bs build_env ->
+            let env = Some (build_env ()) in
+            try ignore (Wire.Codec.decode ?env g.codec bs 0)
+            with Invalid_argument _ ->
+              Alcobar.failf "%s %s crashed decoder" label kind)
+  in
+  [
+    pos_case;
+    safety_case "random" g.random;
+    safety_case "adversarial" g.adversarial;
+  ]
+
+(* Round-trip through {!Wire.of_string} / {!Wire.to_string}: the typ-level
+   API, distinct from [Codec.encode/decode]. Skipped for codecs that take a
+   [Param.env] since the direct entry points don't thread one. *)
+let direct_cases label g =
+  if Option.is_some g.env then []
+  else
+    let pos_case =
+      Alcobar.test_case
+        (label ^ " of_string/to_string positive")
+        Alcobar.[ g.positive ]
+        (fun (value, bs) ->
+          let s = string_of_bytes bs in
+          (match Wire.of_string g.typ s with
+          | Ok decoded ->
+              if not (g.equal decoded value) then
+                Alcobar.failf "%s direct decode mismatch" label
+          | Error _ -> Alcobar.failf "%s direct decode failed" label);
+          let out = Wire.to_string g.typ value in
+          if out <> s then Alcobar.failf "%s direct reencode mismatch" label)
+    in
+    let safety kind stream =
+      Alcobar.test_case
+        (label ^ " of_string " ^ kind)
+        Alcobar.[ stream ]
+        (fun bs ->
+          try ignore (Wire.of_string g.typ (string_of_bytes bs))
+          with Invalid_argument _ ->
+            Alcobar.failf "%s direct %s crashed decoder" label kind)
+    in
+    [ pos_case; safety "random" g.random; safety "adversarial" g.adversarial ]
+
+(* Round-trip through {!Wire.of_reader} / {!Wire.to_writer}: streaming
+   entry points. Same env restriction as {!direct_cases}. *)
+let streaming_cases label g =
+  if Option.is_some g.env then []
+  else
+    let pos_case =
+      Alcobar.test_case
+        (label ^ " of_reader/to_writer positive")
+        Alcobar.[ g.positive ]
+        (fun (value, bs) ->
+          let reader = Bytesrw.Bytes.Reader.of_bytes bs in
+          (match Wire.of_reader g.typ reader with
+          | Ok decoded ->
+              if not (g.equal decoded value) then
+                Alcobar.failf "%s streaming decode mismatch" label
+          | Error _ -> Alcobar.failf "%s streaming decode failed" label);
+          let buf = Buffer.create (Bytes.length bs) in
+          let writer = Bytesrw.Bytes.Writer.of_buffer buf in
+          Wire.to_writer g.typ value writer;
+          Bytesrw.Bytes.Writer.write_eod writer;
+          let out = Buffer.contents buf in
+          if out <> string_of_bytes bs then
+            Alcobar.failf "%s streaming reencode mismatch" label)
+    in
+    [ pos_case ]
+
+(* Exercises {!Wire.Codec.validate}: validation-only path that should
+   accept positives and reject (without crashing) random/adversarial.
+   When the codec references [Param.input], positives pull the env from
+   [g.env.positive] and the safety streams fuzz the env. *)
+let validate_cases label g =
+  let validate_one ?env bs =
+    try
+      Wire.Codec.validate ?env g.codec bs 0;
+      `Ok
+    with
+    | Wire.Validation_error _ -> `Reject
+    | Invalid_argument _ -> `Crash
+    | Wire.Parse_error _ -> `Reject
+  in
+  let pos_case =
+    Alcobar.test_case
+      (label ^ " validate positive")
+      Alcobar.[ g.positive ]
+      (fun (_value, bs) ->
+        let env = positive_env g in
+        match validate_one ?env bs with
+        | `Ok -> ()
+        | `Reject -> Alcobar.failf "%s validate rejected a positive" label
+        | `Crash -> Alcobar.failf "%s validate crashed on a positive" label)
+  in
+  let safety kind stream =
+    match g.env with
+    | None ->
+        Alcobar.test_case
+          (label ^ " validate " ^ kind)
+          Alcobar.[ stream ]
+          (fun bs ->
+            match validate_one bs with
+            | `Ok | `Reject -> ()
+            | `Crash -> Alcobar.failf "%s validate %s crashed" label kind)
+    | Some s ->
+        Alcobar.test_case
+          (label ^ " validate " ^ kind)
+          Alcobar.[ stream; s.fuzz ]
+          (fun bs build_env ->
+            let env = Some (build_env ()) in
+            match validate_one ?env bs with
+            | `Ok | `Reject -> ()
+            | `Crash -> Alcobar.failf "%s validate %s crashed" label kind)
+  in
+  [ pos_case; safety "random" g.random; safety "adversarial" g.adversarial ]
+
+(* Driver for codecs that always reject (e.g. [Action.abort]). Generates
+   random bytes plus, optionally, a random env, and asserts that decode
+   returns [Error _] (not [Ok], not [Invalid_argument]). *)
+let reject_cases label g =
+  let env_stream =
+    match g.env with
+    | Some s -> s.fuzz
+    | None -> Alcobar.const (fun () -> Wire.Codec.env g.codec)
+  in
+  let check_reject bs build_env =
+    let env = Some (build_env ()) in
+    match Wire.Codec.decode ?env g.codec bs 0 with
+    | Ok _ -> Alcobar.failf "%s decoder accepted input it should reject" label
+    | Error _ -> ()
+    | exception Invalid_argument _ -> Alcobar.failf "%s decoder crashed" label
+  in
+  [
+    Alcobar.test_case (label ^ " random")
+      Alcobar.[ g.random; env_stream ]
+      check_reject;
+    Alcobar.test_case (label ^ " adversarial")
+      Alcobar.[ g.adversarial; env_stream ]
+      check_reject;
+  ]

--- a/fuzz/gen/fuzz_gen.mli
+++ b/fuzz/gen/fuzz_gen.mli
@@ -1,0 +1,288 @@
+(** Fuzz generators that mirror Wire's surface.
+
+    Each [t] bundles a codec with three Alcobar generators: [positive] produces
+    a value together with bytes that decode to it, [random] produces arbitrary
+    bytes the decoder must handle without raising, and [adversarial] produces
+    bytes at the boundary of every constraint the codec checks (lengths, gate
+    flips, bit-pattern extremes). {!Codec.v} composes leaves into record gens
+    with the same shape as {!Wire.Codec.v} composes typs into record codecs -- a
+    record gen is itself a [t], so composition is recursive. *)
+
+type 'a t
+(** A fuzz generator paired with the codec it tests. *)
+
+val test_cases : string -> 'a t -> Alcobar.test_case list
+(** [test_cases label g] is three Alcobar cases: one round-trip on [g.positive]
+    and one crash-safety check each on [g.random] and [g.adversarial]. *)
+
+val reject_cases : string -> 'a t -> Alcobar.test_case list
+(** [reject_cases label g] is two Alcobar cases asserting that decode rejects
+    every input on [g.random] and [g.adversarial]. Use for codecs that always
+    fail (e.g. {!Wire.Action.abort}). *)
+
+val direct_cases : string -> 'a t -> Alcobar.test_case list
+(** [direct_cases label g] round-trips a gen through {!Wire.of_string} and
+    {!Wire.to_string} (the typ-level API). Skipped when [g] needs a [Param.env],
+    since those direct entry points don't thread one. *)
+
+val streaming_cases : string -> 'a t -> Alcobar.test_case list
+(** [streaming_cases label g] round-trips a gen through {!Wire.of_reader} and
+    {!Wire.to_writer} (streaming Bytesrw entry points). Same env restriction as
+    {!direct_cases}. *)
+
+val validate_cases : string -> 'a t -> Alcobar.test_case list
+(** [validate_cases label g] exercises {!Wire.Codec.validate}: positives must
+    pass; random and adversarial inputs may pass or fail but must not crash.
+    Threads the env via {!Wire.Codec.validate}'s [?env] when [g] needs one. *)
+
+(** {1 Scalar leaves} *)
+
+val uint8 : int t
+(** [uint8] generates for {!Wire.uint8}. *)
+
+val uint16 : int t
+(** [uint16] generates for {!Wire.uint16}. *)
+
+val uint16be : int t
+(** [uint16be] generates for {!Wire.uint16be}. *)
+
+val uint32 : int t
+(** [uint32] generates for {!Wire.uint32}. *)
+
+val uint32be : int t
+(** [uint32be] generates for {!Wire.uint32be}. *)
+
+val uint63 : int t
+(** [uint63] generates for {!Wire.uint63}. *)
+
+val uint63be : int t
+(** [uint63be] generates for {!Wire.uint63be}. *)
+
+val uint64 : int64 t
+(** [uint64] generates for {!Wire.uint64}. *)
+
+val uint64be : int64 t
+(** [uint64be] generates for {!Wire.uint64be}. *)
+
+val int8 : int t
+(** [int8] generates for {!Wire.int8}. *)
+
+val int16 : int t
+(** [int16] generates for {!Wire.int16}. *)
+
+val int16be : int t
+(** [int16be] generates for {!Wire.int16be}. *)
+
+val int32 : int t
+(** [int32] generates for {!Wire.int32}. *)
+
+val int32be : int t
+(** [int32be] generates for {!Wire.int32be}. *)
+
+val int64 : int64 t
+(** [int64] generates for {!Wire.int64}. *)
+
+val int64be : int64 t
+(** [int64be] generates for {!Wire.int64be}. *)
+
+val float32 : float t
+(** [float32] generates for {!Wire.float32}. *)
+
+val float32be : float t
+(** [float32be] generates for {!Wire.float32be}. *)
+
+val float64 : float t
+(** [float64] generates for {!Wire.float64}. *)
+
+val float64be : float t
+(** [float64be] generates for {!Wire.float64be}. *)
+
+val empty : unit t
+(** [empty] generates for {!Wire.empty}. *)
+
+(** {1 Bytes} *)
+
+val byte_array : int -> string t
+(** [byte_array n] generates for [Wire.byte_array ~size:(Wire.int n)]. *)
+
+val byte_slice : int -> Bytesrw.Bytes.Slice.t t
+(** [byte_slice n] generates for [Wire.byte_slice ~size:(Wire.int n)]. *)
+
+val bits : ?bit_order:Wire.bit_order -> width:int -> Wire.bitfield -> int t
+(** [bits ?bit_order ~width base] generates for
+    [Wire.bits ?bit_order ~width base]. *)
+
+val bit : int t -> bool t
+(** [bit inner] generates for [Wire.bit inner.typ]. *)
+
+val uint_var : endian:Wire.endian -> int -> int t
+(** [uint_var ~endian size] generates for [Wire.uint ~endian (Wire.int size)].
+*)
+
+val optional : ?present:bool -> 'a t -> 'a option t
+(** [optional ~present inner] generates for a [Field.optional]-wrapped record
+    with a static [~present] gate. *)
+
+val optional_or : ?present:bool -> default:'a -> 'a t -> 'a t
+(** [optional_or ~present ~default inner] generates for a
+    [Field.optional_or]-wrapped record with a static [~present] gate. *)
+
+val repeat : bytes:int -> 'a t -> 'a list t
+(** [repeat ~bytes inner] generates for a [Field.repeat] whose byte-budget is
+    the value of a uint16 length-prefix field. *)
+
+val codec_wrap :
+  'a Wire.Codec.t ->
+  value_gen:'a Alcobar.gen ->
+  equal:('a -> 'a -> bool) ->
+  'a t
+(** [codec_wrap c ~value_gen ~equal] wraps a hand-built codec as a gen. Random
+    and adversarial streams default to arbitrary bytes. *)
+
+val nested_at_most : int -> 'a t -> 'a t
+(** [nested_at_most n inner] generates for
+    [Wire.nested_at_most ~size:(Wire.int n) inner.typ]. *)
+
+val byte_array_where :
+  int -> per_byte:(int Wire.expr -> bool Wire.expr) -> string t
+(** [byte_array_where n ~per_byte] generates for
+    [Wire.byte_array_where ~size:(Wire.int n) ~per_byte]. Positives are
+    printable-ASCII bytes (space, 0x20) which satisfy most reasonable per-byte
+    predicates; adversarials are random bytes that probably violate the
+    predicate. *)
+
+val all_bytes : string t
+(** [all_bytes] generates for {!Wire.all_bytes}. *)
+
+val all_zeros : string t
+(** [all_zeros] generates for {!Wire.all_zeros}. *)
+
+(** {1 Wrappers} *)
+
+val nested : int -> 'a t -> 'a t
+(** [nested n inner] generates for [Wire.nested ~size:(Wire.int n) inner.typ].
+*)
+
+val map : decode:('a -> 'b) -> encode:('b -> 'a) -> 'a t -> 'b t
+(** [map ~decode ~encode inner] generates for
+    [Wire.map ~decode ~encode inner.typ]. *)
+
+val variants : string -> (string * 'a) list -> 'a t
+(** [variants name cases] generates for [Wire.variants name cases Wire.uint8].
+*)
+
+val array : int -> 'a t -> 'a list t
+(** [array n inner] generates for [Wire.array ~len:(Wire.int n) inner.typ].
+    Positives are a fixed-length list of [inner.positive] samples. *)
+
+val enum : string -> (string * int) list -> int t
+(** [enum name cases] generates for [Wire.enum name cases Wire.uint8]. *)
+
+val bounded_u8 : min:int -> max:int -> int t
+(** [bounded_u8 ~min ~max] generates for a single-field record whose
+    [Wire.uint8] field carries a [~self_constraint] [min <= v <= max].
+    Adversarials are bytes at each boundary on both sides of the range. *)
+
+val lookup : 'a list -> int t -> 'a t
+(** [lookup table inner] generates for [Wire.lookup table inner.typ]. *)
+
+val where : 'a t -> 'a t
+(** [where inner] generates for [Wire.where Wire.Expr.true_ inner.typ]. *)
+
+val array_seq : int -> 'a t -> 'a list t
+(** [array_seq n inner] generates for
+    [Wire.array_seq Wire.seq_list ~len:(Wire.int n) inner.typ]. *)
+
+val repeat_seq : bytes:int -> 'a t -> 'a list t
+(** [repeat_seq ~bytes inner] generates for
+    [Field.repeat_seq ~seq:seq_list ~size:(...)]. *)
+
+val field_anon : (int * int) t
+(** [field_anon] exercises [Wire.Field.anon]. *)
+
+val param_input : int t
+(** [param_input] is a codec referencing [Wire.Param.input] in its [~where];
+    tests bind the env. *)
+
+val action : int t
+(** [action] is a codec with [Wire.Field.v ~action:...] exercising the
+    {!Wire.Action} surface ([on_success], [var], [assign], [if_],
+    [return_bool]). *)
+
+val action_abort : int t
+(** [action_abort] is a codec whose field's [~action] is {!Wire.Action.abort}:
+    every decode is rejected. Use {!reject_cases}. *)
+
+val action_on_act : int t
+(** [action_on_act] mirrors {!action} using [Action.on_act]. *)
+
+val nan_float64 : float t
+(** [nan_float64] is a single-float codec with [~where:(is_nan f)]; positives
+    are NaN bit patterns, non-NaN bytes are rejected. *)
+
+val optional_dynamic : (int * int option) t
+(** [optional_dynamic] is a codec with
+    [Field.optional ~present:(ref gate <> 0)]; the payload is present or absent
+    depending on the gate byte. *)
+
+val optional_or_dynamic : (int * int) t
+(** [optional_or_dynamic] is the [optional_or] equivalent of
+    {!optional_dynamic}, using a fixed default value when absent. *)
+
+val finite_float64 : float t
+(** [finite_float64] is a single-float codec with [~self_constraint:is_finite];
+    adversarials produce NaN and infinity bit patterns. *)
+
+val expr_ops : (int * int) t
+(** [expr_ops] is a codec whose [~where] uses every integer [Wire.Expr] operator
+    (arithmetic, bitwise, comparison, logical, [to_uint*] casts). *)
+
+val rest_bytes : (int * string) t
+(** [rest_bytes] is a codec whose final field is [Wire.rest_bytes] sized from a
+    bound [Wire.Param.input]. *)
+
+val sizeof : (int * int) t
+(** [sizeof] is a two-uint8 codec whose second field's [~self_constraint]
+    references [Wire.sizeof_this] / [Wire.field_pos] / [Wire.sizeof]. *)
+
+val codec_where : (int * int) t
+(** [codec_where] generates for a two-[uint8] record whose [Codec.v] carries
+    [~where:(a < b)]. Positives satisfy the predicate, adversarials sit at the
+    equality boundary so the [where] check fires. *)
+
+(** {1 Casetype} *)
+
+type 'a case
+(** A single branch of a {!casetype_u8}. *)
+
+val case :
+  index:int -> 'w t -> inject:('w -> 'a) -> project:('a -> 'w option) -> 'a case
+(** [case ~index inner ~inject ~project] is a tagged case decoded when the
+    discriminator equals [~index]. *)
+
+val default_case :
+  tag:int -> 'w t -> inject:('w -> 'a) -> project:('a -> 'w option) -> 'a case
+(** [default_case ~tag inner ~inject ~project] is the fallback case used when no
+    tagged case matches; [~tag] is the byte written on encode. *)
+
+val casetype_u8 : string -> 'a case list -> 'a t
+(** [casetype_u8 name cases] generates for
+    [Wire.casetype name Wire.uint8 cases]. Positives pick a case uniformly, emit
+    its tag byte, and append the inner case's positive bytes. *)
+
+(** {1 Record composition} *)
+
+module Codec : sig
+  type ('a, 'r) field
+
+  val ( $ ) : 'a t -> ('r -> 'a) -> ('a, 'r) field
+  (** [g $ getter] binds gen [g] to record projection [getter]. *)
+
+  type ('f, 'r) fields =
+    | [] : ('r, 'r) fields
+    | ( :: ) : ('a, 'r) field * ('f, 'r) fields -> ('a -> 'f, 'r) fields
+
+  val v : string -> ?equal:('r -> 'r -> bool) -> 'f -> ('f, 'r) fields -> 'r t
+  (** [v name builder fields] composes leaves into a record gen whose codec is
+      the flat [Wire.Codec.v name builder typs] you'd write by hand. *)
+end

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -146,6 +146,12 @@ and build_field_encoder : type a. a typ -> bytes -> int -> a -> int =
       fun buf off v -> enc buf off (encode v)
   | Unit -> fun _buf off () -> off
   | Casetype { tag; cases; _ } -> build_casetype_encoder tag cases
+  | Array { len = Int _; elem; seq = Seq_map s } ->
+      let enc_elem = build_field_encoder elem in
+      fun buf start_off vs ->
+        let cur = Stdlib.ref start_off in
+        s.iter (fun v -> cur := enc_elem buf !cur v) vs;
+        !cur
   | _ ->
       (* Fallback for complex types - not specialized *)
       fun _buf _off _v -> failwith "build_field_encoder: unsupported type"
@@ -199,6 +205,19 @@ let rec build_field_reader : type a. a typ -> int -> bytes -> int -> a =
       let read = build_field_reader inner field_off in
       fun buf base -> decode (read buf base)
   | Unit -> fun _buf _base -> ()
+  | Array { len = Int n; elem; seq = Seq_map s } -> (
+      match field_wire_size elem with
+      | Some elem_sz ->
+          let read_elem = build_field_reader elem 0 in
+          fun buf base ->
+            let acc = Stdlib.ref s.empty in
+            for i = 0 to n - 1 do
+              let v = read_elem buf (base + field_off + (i * elem_sz)) in
+              acc := s.add !acc v
+            done;
+            s.finish !acc
+      | None ->
+          fun _buf _base -> failwith "build_field_reader: unsupported type")
   | _ -> fun _buf _base -> failwith "build_field_reader: unsupported type"
 
 let int_of_typ_value = Eval.int_of

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -1695,7 +1695,7 @@ and var_bytes_reader : type a.
       String.iter
         (fun c ->
           if c <> '\000' then
-            invalid_arg "add_field: [all_zeros] field has a non-zero byte")
+            raise (Parse_error (Constraint_failed "all_zeros: non-zero byte")))
         s;
       s
   | Casetype _ -> read_elem typ buf (base + fo)

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -1203,53 +1203,7 @@ let build_nested_readers ctx readers =
    helper. Each helper builds the [compiled_field] for its case; neither the
    helpers nor [compile_field] itself apply constraints or actions -- that
    happens in [apply_compiled]. *)
-let rec compile_field : type a r.
-    layout_ctx -> (a, r) field -> (a, r) compiled_field =
- fun ctx fld ->
-  match fld.typ with
-  | Map { inner; decode; encode } -> compile_map ctx fld inner decode encode
-  | Enum { base; _ } -> compile_field ctx { fld with typ = base }
-  | Where { inner; _ } -> compile_field ctx { fld with typ = inner }
-  | Bits { width; base; bit_order } -> compile_bits ctx fld width base bit_order
-  | Codec
-      {
-        codec_decode;
-        codec_encode;
-        codec_fixed_size;
-        codec_size_of;
-        codec_field_readers;
-        _;
-      } ->
-      compile_codec ctx fld ~codec_decode ~codec_encode ~codec_fixed_size
-        ~codec_size_of ~codec_field_readers
-  | Optional { present; inner } -> compile_optional ctx fld present inner
-  | Optional_or { present; inner; default } ->
-      compile_optional_or ctx fld present inner default
-  | Repeat { size; elem; seq } -> compile_repeat ctx fld size elem seq
-  | _ -> compile_scalar_or_var ctx fld
-
-and compile_map : type a w r.
-    layout_ctx ->
-    (a, r) field ->
-    w typ ->
-    (w -> a) ->
-    (a -> w) ->
-    (a, r) compiled_field =
- fun ctx fld inner decode encode ->
-  let outer_get = fld.get in
-  let inner_fld =
-    {
-      name = fld.name;
-      typ = inner;
-      constraint_ = fld.constraint_;
-      action = fld.action;
-      get = (fun v -> encode (outer_get v));
-    }
-  in
-  let cf = compile_field ctx inner_fld in
-  { cf with raw_reader = (fun buf off -> decode (cf.raw_reader buf off)) }
-
-and compile_bits : type r.
+let compile_bits : type r.
     layout_ctx ->
     (int, r) field ->
     int ->
@@ -1304,47 +1258,7 @@ and compile_bits : type r.
     populate;
   }
 
-and compile_codec : type a r.
-    layout_ctx ->
-    (a, r) field ->
-    codec_decode:(bytes -> int -> a) ->
-    codec_encode:(a -> bytes -> int -> unit) ->
-    codec_fixed_size:int option ->
-    codec_size_of:(bytes -> int -> int) ->
-    codec_field_readers:field_reader list ->
-    (a, r) compiled_field =
- fun ctx fld ~codec_decode ~codec_encode ~codec_fixed_size ~codec_size_of
-     ~codec_field_readers ->
-  let nested_readers = build_nested_readers ctx codec_field_readers in
-  let get = fld.get in
-  match codec_fixed_size with
-  | Some fsize ->
-      let raw_reader, inner_writer = inner_codec_accessors fld.typ ctx in
-      let raw_writer v buf off = inner_writer buf off (get v) in
-      {
-        raw_reader;
-        raw_writer;
-        extra_writers = [];
-        field_access = fixed_or_dynamic_fa ctx;
-        size_delta = fsize;
-        next_off = advance_next_off ctx.lc_next_off fsize;
-        bf_after = None;
-        int_reader = null_int_reader;
-        nested_readers;
-        validator_off = validator_off_of ctx;
-        populate = no_populate;
-      }
-  | None ->
-      compile_codec_variable ctx ~get ~codec_decode ~codec_encode ~codec_size_of
-        ~nested_readers
-
-(* Variable-size sub-codec: dispatch on whether we sit at a static or a
-   dynamic running offset. Mirrors [compile_var_bytes] -- both flavours
-   produce a [Variable]/[Variable_dynamic] [field_access] that downstream
-   [build_staged_reader]/[build_staged_writer] already know how to thread.
-   Without the dynamic case, two consecutive variable-size sub-codec fields
-   trip [require_static_off]. *)
-and compile_codec_variable : type a r.
+let compile_codec_variable : type a r.
     layout_ctx ->
     get:(r -> a) ->
     codec_decode:(bytes -> int -> a) ->
@@ -1385,7 +1299,47 @@ and compile_codec_variable : type a r.
     populate = no_populate;
   }
 
-and dynamic_optional_next_off ctx present_fn fsize =
+let compile_codec : type a r.
+    layout_ctx ->
+    (a, r) field ->
+    codec_decode:(bytes -> int -> a) ->
+    codec_encode:(a -> bytes -> int -> unit) ->
+    codec_fixed_size:int option ->
+    codec_size_of:(bytes -> int -> int) ->
+    codec_field_readers:field_reader list ->
+    (a, r) compiled_field =
+ fun ctx fld ~codec_decode ~codec_encode ~codec_fixed_size ~codec_size_of
+     ~codec_field_readers ->
+  let nested_readers = build_nested_readers ctx codec_field_readers in
+  let get = fld.get in
+  match codec_fixed_size with
+  | Some fsize ->
+      let raw_reader, inner_writer = inner_codec_accessors fld.typ ctx in
+      let raw_writer v buf off = inner_writer buf off (get v) in
+      {
+        raw_reader;
+        raw_writer;
+        extra_writers = [];
+        field_access = fixed_or_dynamic_fa ctx;
+        size_delta = fsize;
+        next_off = advance_next_off ctx.lc_next_off fsize;
+        bf_after = None;
+        int_reader = null_int_reader;
+        nested_readers;
+        validator_off = validator_off_of ctx;
+        populate = no_populate;
+      }
+  | None ->
+      compile_codec_variable ctx ~get ~codec_decode ~codec_encode ~codec_size_of
+        ~nested_readers
+
+(* Variable-size sub-codec: dispatch on whether we sit at a static or a
+   dynamic running offset. Mirrors [compile_var_bytes] -- both flavours
+   produce a [Variable]/[Variable_dynamic] [field_access] that downstream
+   [build_staged_reader]/[build_staged_writer] already know how to thread.
+   Without the dynamic case, two consecutive variable-size sub-codec fields
+   trip [require_static_off]. *)
+let dynamic_optional_next_off ctx present_fn fsize =
   let base_off = ctx.lc_next_off in
   Dynamic
     (fun buf base ->
@@ -1394,7 +1348,7 @@ and dynamic_optional_next_off ctx present_fn fsize =
       in
       if present_fn buf base then off + fsize else off)
 
-and optional_compiled : type a r.
+let optional_compiled : type a r.
     layout_ctx ->
     raw_reader:(bytes -> int -> a) ->
     raw_writer:(r -> bytes -> int -> unit) ->
@@ -1417,7 +1371,7 @@ and optional_compiled : type a r.
     populate;
   }
 
-and compile_optional : type a r.
+let compile_optional : type a r.
     layout_ctx ->
     (a option, r) field ->
     bool expr ->
@@ -1471,7 +1425,7 @@ and compile_optional : type a r.
       invalid_arg
         "add_field: dynamic optional with variable-size inner not yet supported"
 
-and compile_optional_or : type a r.
+let compile_optional_or : type a r.
     layout_ctx ->
     (a, r) field ->
     bool expr ->
@@ -1519,7 +1473,7 @@ and compile_optional_or : type a r.
         "add_field: dynamic optional_or with variable-size inner not yet \
          supported"
 
-and repeat_raw_fixed : type elt seq.
+let repeat_raw_fixed : type elt seq.
     (elt, seq) seq_map ->
     elt typ ->
     int ->
@@ -1538,7 +1492,7 @@ and repeat_raw_fixed : type elt seq.
   in
   loop seq.empty 0
 
-and repeat_raw_variable : type elt seq.
+let repeat_raw_variable : type elt seq.
     (elt, seq) seq_map ->
     elt typ ->
     off_fn:(bytes -> int -> int) ->
@@ -1557,7 +1511,7 @@ and repeat_raw_variable : type elt seq.
   in
   loop seq.empty (base + off_fn buf base) budget
 
-and repeat_raw_reader : type elt seq.
+let repeat_raw_reader : type elt seq.
     (elt, seq) seq_map ->
     elt typ ->
     elem_size:int option ->
@@ -1571,7 +1525,7 @@ and repeat_raw_reader : type elt seq.
   | Some esz -> repeat_raw_fixed seq elem esz ~off_fn ~size_fn
   | None -> repeat_raw_variable seq elem ~off_fn ~size_fn
 
-and compile_repeat : type elt seq r.
+let compile_repeat : type elt seq r.
     layout_ctx ->
     (seq, r) field ->
     int expr ->
@@ -1635,60 +1589,7 @@ and compile_repeat : type elt seq r.
     populate = no_populate;
   }
 
-and compile_scalar_or_var : type a r.
-    layout_ctx -> (a, r) field -> (a, r) compiled_field =
- fun ctx fld ->
-  let typ = fld.typ in
-  let field_off_static = static_off_of ctx in
-  let field_off_fn = off_fn_of ctx in
-  match field_wire_size typ with
-  | Some fsize ->
-      let field_off = match field_off_static with Some n -> n | None -> -1 in
-      let raw_reader =
-        match field_off_static with
-        | Some _ -> build_field_reader typ field_off
-        | None ->
-            let reader_at_0 = build_field_reader typ 0 in
-            fun buf base ->
-              let off = field_off_fn buf base in
-              reader_at_0 buf (base + off)
-      in
-      let raw_encoder = build_field_encoder typ in
-      let get = fld.get in
-      let raw_writer : r -> bytes -> int -> unit =
-        match field_off_static with
-        | Some fo ->
-            fun v buf off ->
-              let _ = raw_encoder buf (off + fo) (get v) in
-              ()
-        | None ->
-            fun v buf off ->
-              let fo = field_off_fn buf off in
-              let _ = raw_encoder buf (off + fo) (get v) in
-              ()
-      in
-      let int_reader buf base =
-        match int_of_typ_value typ (raw_reader buf base) with
-        | Some v -> v
-        | None -> 0
-      in
-      let populate = build_populate typ ctx.lc_n_fields raw_reader in
-      {
-        raw_reader;
-        raw_writer;
-        extra_writers = [];
-        field_access = fixed_or_dynamic_fa ctx;
-        size_delta = fsize;
-        next_off = advance_next_off ctx.lc_next_off fsize;
-        bf_after = None;
-        int_reader;
-        nested_readers = [];
-        validator_off = field_off;
-        populate;
-      }
-  | None -> compile_var_bytes ctx fld
-
-and var_bytes_reader : type a.
+let var_bytes_reader : type a.
     a typ -> (bytes -> int -> int) -> (bytes -> int -> int) -> bytes -> int -> a
     =
  fun typ off_fn size_fn buf base ->
@@ -1711,7 +1612,7 @@ and var_bytes_reader : type a.
   | Single_elem { elem; _ } -> read_elem elem buf (base + fo)
   | _ -> assert false
 
-and var_bytes_writer : type a r.
+let var_bytes_writer : type a r.
     a typ ->
     (r -> a) ->
     (bytes -> int -> int) ->
@@ -1756,7 +1657,7 @@ and var_bytes_writer : type a r.
       ignore (build_field_encoder elem buf (off + fo) value)
   | _ -> assert false
 
-and compile_var_size_fn : type a.
+let compile_var_size_fn : type a.
     layout_ctx -> a typ -> off_fn:(bytes -> int -> int) -> bytes -> int -> int =
  fun ctx typ ~off_fn ->
   match typ with
@@ -1787,7 +1688,7 @@ and compile_var_size_fn : type a.
       in
       compile_expr ~sizeof_this ctx.lc_field_readers size_expr
 
-and compile_var_bytes : type a r.
+let compile_var_bytes : type a r.
     layout_ctx -> (a, r) field -> (a, r) compiled_field =
  fun ctx fld ->
   let typ = fld.typ in
@@ -1848,6 +1749,105 @@ and compile_var_bytes : type a r.
     validator_off;
     populate;
   }
+
+let compile_scalar_or_var : type a r.
+    layout_ctx -> (a, r) field -> (a, r) compiled_field =
+ fun ctx fld ->
+  let typ = fld.typ in
+  let field_off_static = static_off_of ctx in
+  let field_off_fn = off_fn_of ctx in
+  match field_wire_size typ with
+  | Some fsize ->
+      let field_off = match field_off_static with Some n -> n | None -> -1 in
+      let raw_reader =
+        match field_off_static with
+        | Some _ -> build_field_reader typ field_off
+        | None ->
+            let reader_at_0 = build_field_reader typ 0 in
+            fun buf base ->
+              let off = field_off_fn buf base in
+              reader_at_0 buf (base + off)
+      in
+      let raw_encoder = build_field_encoder typ in
+      let get = fld.get in
+      let raw_writer : r -> bytes -> int -> unit =
+        match field_off_static with
+        | Some fo ->
+            fun v buf off ->
+              let _ = raw_encoder buf (off + fo) (get v) in
+              ()
+        | None ->
+            fun v buf off ->
+              let fo = field_off_fn buf off in
+              let _ = raw_encoder buf (off + fo) (get v) in
+              ()
+      in
+      let int_reader buf base =
+        match int_of_typ_value typ (raw_reader buf base) with
+        | Some v -> v
+        | None -> 0
+      in
+      let populate = build_populate typ ctx.lc_n_fields raw_reader in
+      {
+        raw_reader;
+        raw_writer;
+        extra_writers = [];
+        field_access = fixed_or_dynamic_fa ctx;
+        size_delta = fsize;
+        next_off = advance_next_off ctx.lc_next_off fsize;
+        bf_after = None;
+        int_reader;
+        nested_readers = [];
+        validator_off = field_off;
+        populate;
+      }
+  | None -> compile_var_bytes ctx fld
+
+let rec compile_field : type a r.
+    layout_ctx -> (a, r) field -> (a, r) compiled_field =
+ fun ctx fld ->
+  match fld.typ with
+  | Map { inner; decode; encode } -> compile_map ctx fld inner decode encode
+  | Enum { base; _ } -> compile_field ctx { fld with typ = base }
+  | Where { inner; _ } -> compile_field ctx { fld with typ = inner }
+  | Bits { width; base; bit_order } -> compile_bits ctx fld width base bit_order
+  | Codec
+      {
+        codec_decode;
+        codec_encode;
+        codec_fixed_size;
+        codec_size_of;
+        codec_field_readers;
+        _;
+      } ->
+      compile_codec ctx fld ~codec_decode ~codec_encode ~codec_fixed_size
+        ~codec_size_of ~codec_field_readers
+  | Optional { present; inner } -> compile_optional ctx fld present inner
+  | Optional_or { present; inner; default } ->
+      compile_optional_or ctx fld present inner default
+  | Repeat { size; elem; seq } -> compile_repeat ctx fld size elem seq
+  | _ -> compile_scalar_or_var ctx fld
+
+and compile_map : type a w r.
+    layout_ctx ->
+    (a, r) field ->
+    w typ ->
+    (w -> a) ->
+    (a -> w) ->
+    (a, r) compiled_field =
+ fun ctx fld inner decode encode ->
+  let outer_get = fld.get in
+  let inner_fld =
+    {
+      name = fld.name;
+      typ = inner;
+      constraint_ = fld.constraint_;
+      action = fld.action;
+      get = (fun v -> encode (outer_get v));
+    }
+  in
+  let cf = compile_field ctx inner_fld in
+  { cf with raw_reader = (fun buf off -> decode (cf.raw_reader buf off)) }
 
 (* -- Apply a compiled plan to the record state -- *)
 
@@ -2268,40 +2268,12 @@ let acc_prev_end (acc : validator_acc) : bytes -> int -> int =
    accept [Struct] (it has no [field_wire_size] without walking inner
    fields), so build a sub-validator recursively and inline its
    [vt_validate] at the right offset. *)
-let rec apply_struct_field acc inner_struct =
-  let inner_v = validator_of_struct inner_struct in
-  let static_off =
-    match acc.va_next_off with Static n -> n | Dynamic _ -> -1
-  in
-  let off_fn = acc_off_fn acc in
-  let validator _arr buf base =
-    inner_v.vt_validate buf (base + off_fn buf base)
-  in
-  let prev_end = acc_prev_end acc in
-  let size_delta, next_off =
-    match (acc.va_next_off, inner_v.vt_wire_size) with
-    | Static n, Fixed sz -> (sz, Static (n + sz))
-    | _, Fixed sz -> (sz, Dynamic (fun buf base -> prev_end buf base + sz))
-    | _, Variable { min_size; compute } ->
-        (min_size, Dynamic (fun buf base -> compute buf (prev_end buf base)))
-  in
-  {
-    va_validators_rev = (static_off, validator) :: acc.va_validators_rev;
-    va_checkers_rev = (static_off, validator) :: acc.va_checkers_rev;
-    va_field_readers = acc.va_field_readers;
-    va_n_fields = acc.va_n_fields;
-    va_n_array_slots = acc.va_n_array_slots;
-    va_min_size = acc.va_min_size + size_delta;
-    va_next_off = next_off;
-    va_bf = None;
-  }
-
 (* Build the [full] / [check_only] per-field validator functions and
    return the action var count. Takes only the non-existential fields
    of [compiled_field] ([populate], [validator_off]) so the caller can
    open the [Types.Field] existential, call [compile_field], and pass
    the relevant pieces here without leaking the field's ['a]. *)
-and build_field_checks acc ~populate ~validator_off ~name ~action ~constraint_ =
+let build_field_checks acc ~populate ~validator_off ~name ~action ~constraint_ =
   let action_var_names =
     match action with
     | None -> []
@@ -2336,6 +2308,34 @@ and build_field_checks acc ~populate ~validator_off ~name ~action ~constraint_ =
     | _ -> ()
   in
   (full, check_only, List.length action_var_names)
+
+let rec apply_struct_field acc inner_struct =
+  let inner_v = validator_of_struct inner_struct in
+  let static_off =
+    match acc.va_next_off with Static n -> n | Dynamic _ -> -1
+  in
+  let off_fn = acc_off_fn acc in
+  let validator _arr buf base =
+    inner_v.vt_validate buf (base + off_fn buf base)
+  in
+  let prev_end = acc_prev_end acc in
+  let size_delta, next_off =
+    match (acc.va_next_off, inner_v.vt_wire_size) with
+    | Static n, Fixed sz -> (sz, Static (n + sz))
+    | _, Fixed sz -> (sz, Dynamic (fun buf base -> prev_end buf base + sz))
+    | _, Variable { min_size; compute } ->
+        (min_size, Dynamic (fun buf base -> compute buf (prev_end buf base)))
+  in
+  {
+    va_validators_rev = (static_off, validator) :: acc.va_validators_rev;
+    va_checkers_rev = (static_off, validator) :: acc.va_checkers_rev;
+    va_field_readers = acc.va_field_readers;
+    va_n_fields = acc.va_n_fields;
+    va_n_array_slots = acc.va_n_array_slots;
+    va_min_size = acc.va_min_size + size_delta;
+    va_next_off = next_off;
+    va_bf = None;
+  }
 
 and apply_field_to_validator_acc acc (Types.Field f) =
   match f.field_typ with

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -32,13 +32,19 @@ let setter_off_int32 n set buf off v =
   off + n
 
 let rec encode_case_match : type k w.
-    (bytes -> int -> k -> int) -> k option -> w typ -> w -> bytes -> int -> int
-    =
- fun tag_enc cb_tag cb_inner body buf off ->
+    (bytes -> int -> k -> int) ->
+    k option ->
+    k option ->
+    w typ ->
+    w ->
+    bytes ->
+    int ->
+    int =
+ fun tag_enc cb_tag cb_default_tag cb_inner body buf off ->
   let t =
-    match cb_tag with
-    | Some t -> t
-    | None -> failwith "build_field_encoder: cannot encode default case"
+    match (cb_tag, cb_default_tag) with
+    | Some t, _ | _, Some t -> t
+    | None, None -> failwith "build_field_encoder: case missing tag"
   in
   let off' = tag_enc buf off t in
   build_field_encoder cb_inner buf off' body
@@ -49,9 +55,12 @@ and build_casetype_encoder : type a k.
   let tag_enc = build_field_encoder tag in
   let rec find buf off v = function
     | [] -> failwith "build_field_encoder: casetype: no matching case"
-    | Case_branch { cb_tag; cb_inner; cb_project; _ } :: rest -> (
+    | Case_branch { cb_tag; cb_default_tag; cb_inner; cb_project; _ } :: rest
+      -> (
         match cb_project v with
-        | Some body -> encode_case_match tag_enc cb_tag cb_inner body buf off
+        | Some body ->
+            encode_case_match tag_enc cb_tag cb_default_tag cb_inner body buf
+              off
         | None -> find buf off v rest)
   in
   fun buf off v -> find buf off v cases

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -695,7 +695,7 @@ type 'r t = {
   t_encode : 'r -> bytes -> int -> unit;
   t_wire_size : wire_size_info;
   t_struct_fields : Types.field list;
-  t_validate : bytes -> int -> unit;
+  t_validate : ?env_slots:int array -> bytes -> int -> unit;
   t_validate_arr : int array -> bytes -> int -> unit;
   t_populate : int array -> bytes -> int -> unit;
   t_n_array_slots : int;
@@ -2102,14 +2102,21 @@ let build_validators validators_rev checkers_rev compiled_where struct_fields
   let validate =
     if has_checks then (
       let arr = Array.make n_total 0 in
-      fun buf off ->
+      fun ?env_slots buf off ->
         Array.fill arr 0 n_total 0;
+        (match env_slots with
+        | Some slots ->
+            (* Seed param slots from the supplied env so [where] clauses
+               that reference [Param.input] evaluate correctly. *)
+            let n = Array.length slots in
+            Array.blit slots 0 arr (n_total - n) n
+        | None -> ());
         populate arr buf off;
         match compiled_where with
         | Some f when not (f arr) ->
             raise (Parse_error (Constraint_failed "where clause"))
         | _ -> ())
-    else fun _buf _off -> ()
+    else fun ?env_slots:_ _buf _off -> ()
   in
   (validate_arr, populate, validate)
 
@@ -2587,7 +2594,9 @@ let to_struct t =
   | [], None -> struct' t.t_name t.t_struct_fields
   | _ -> param_struct t.t_name formals ?where:t.t_where t.t_struct_fields
 
-let validate t buf off = t.t_validate buf off
+let validate ?env t buf off =
+  let env_slots = Option.map (fun (e : Param.env) -> e.pe_slots) env in
+  t.t_validate ?env_slots buf off
 
 (* Build a staged reader from field type and access info.
    For Fixed: use build_field_reader which handles Where/Enum/Map.

--- a/lib/codec.mli
+++ b/lib/codec.mli
@@ -108,9 +108,10 @@ val encode : ?env:Param.env -> 'r t -> 'r -> bytes -> int -> unit
 val to_struct : 'r t -> Types.struct_
 (** Project to a {!Types.struct_} declaration. *)
 
-val validate : 'r t -> bytes -> int -> unit
-(** [validate c buf off] checks field [~constraint_] and [~where] clauses
-    without constructing a record and without firing actions.
+val validate : ?env:Param.env -> 'r t -> bytes -> int -> unit
+(** [validate ?env c buf off] checks field [~constraint_] and [~where] clauses
+    without constructing a record and without firing actions. [?env] supplies
+    bindings for any [Param.input] referenced in those clauses.
 
     Raises {!Types.Parse_error} on constraint/where-clause failure. *)
 

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -450,13 +450,16 @@ let nested ~size elem = Single_elem { size; elem; at_most = false }
 let nested_at_most ~size elem = Single_elem { size; elem; at_most = true }
 let enum name cases base = Enum { name; cases; base }
 
+let fail_parse_error fmt =
+  Fmt.kstr (fun s -> raise (Parse_error (Constraint_failed s))) fmt
+
 let variants name cases base =
   let enum_cases = List.mapi (fun i (s, _) -> (s, i)) cases in
   let arr = Array.of_list (List.map snd cases) in
   let len = Array.length arr in
   let decode n =
     if n >= 0 && n < len then arr.(n)
-    else Fmt.invalid_arg "Wire.variants %s: unknown value %d" name n
+    else fail_parse_error "Wire.variants %s: unknown value %d" name n
   in
   let encode v =
     let i = variants_lookup arr v 0 in
@@ -1102,7 +1105,7 @@ let rec inner_wire_size : type a. a typ -> int option = function
    [None] only for shapes whose total wire size is genuinely not
    expressible at projection time (variable-size codec without an
    exposed [wire_size_expr], casetype, struct ref, all_bytes/all_zeros). *)
-and inner_wire_size_expr : type a. a typ -> int expr option = function
+let rec inner_wire_size_expr : type a. a typ -> int expr option = function
   | Byte_array { size } | Byte_slice { size } | Byte_array_where { size; _ } ->
       Some size
   | Single_elem { size; _ } -> Some size
@@ -1114,7 +1117,7 @@ and inner_wire_size_expr : type a. a typ -> int expr option = function
   | Apply { typ; _ } -> inner_wire_size_expr typ
   | t -> ( match inner_wire_size t with Some n -> Some (Int n) | None -> None)
 
-and optional_suffix : type a.
+let optional_suffix : type a.
     bool expr -> a typ -> field_suffix * (Format.formatter -> unit) =
  fun present inner ->
   match inner_wire_size_expr inner with
@@ -1126,7 +1129,8 @@ and optional_suffix : type a.
          at construction (smart constructor uses [has_wire_size_expr]). *)
       assert false
 
-and field_suffix : type a. a typ -> field_suffix * (Format.formatter -> unit) =
+let rec field_suffix : type a.
+    a typ -> field_suffix * (Format.formatter -> unit) =
  fun typ ->
   match typ with
   | Bits { width; base; _ } ->
@@ -1465,6 +1469,7 @@ let rec field_wire_size : type a. a typ -> int option = function
   | Uint8 -> Some 1
   | Uint16 _ -> Some 2
   | Uint32 _ -> Some 4
+  | Uint63 _ -> Some 8
   | Uint64 _ -> Some 8
   | Int8 -> Some 1
   | Int16 _ -> Some 2

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -157,6 +157,9 @@ and _ typ =
 and ('a, 'k) case_branch =
   | Case_branch : {
       cb_tag : 'k option;
+      cb_default_tag : 'k option;
+          (* Encode-time tag for the default branch ([cb_tag = None]).
+             [None] means encoding this branch is unsupported. *)
       cb_inner : 'w typ;
       cb_inject : 'w -> 'a;
       cb_project : 'a -> 'w option;
@@ -472,6 +475,7 @@ type ('a, 'k) case_def =
     }
       -> ('a, 'k) case_def
   | Default_def : {
+      dd_tag : 'k;
       dd_inner : 'w typ;
       dd_inject : 'w -> 'a;
       dd_project : 'a -> 'w option;
@@ -487,8 +491,9 @@ let case ?index inner ~inject ~project =
       cd_project = project;
     }
 
-let default inner ~inject ~project =
-  Default_def { dd_inner = inner; dd_inject = inject; dd_project = project }
+let default ~tag inner ~inject ~project =
+  Default_def
+    { dd_tag = tag; dd_inner = inner; dd_inject = inject; dd_project = project }
 
 let casetype name tag defs =
   let resolve = function
@@ -504,15 +509,17 @@ let casetype name tag defs =
         Case_branch
           {
             cb_tag;
+            cb_default_tag = None;
             cb_inner = cd_inner;
             cb_inject = cd_inject;
             cb_project = cd_project;
           }
-    | Default_def { dd_inner; dd_inject; dd_project } ->
+    | Default_def { dd_tag; dd_inner; dd_inject; dd_project } ->
         reject_decoration ~combinator:"casetype" dd_inner;
         Case_branch
           {
             cb_tag = None;
+            cb_default_tag = Some dd_tag;
             cb_inner = dd_inner;
             cb_inject = dd_inject;
             cb_project = dd_project;

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -1500,6 +1500,8 @@ let rec field_wire_size : type a. a typ -> int option = function
   | Optional_or { present = Bool false; _ } -> Some 0
   | Optional_or _ -> None
   | Repeat _ -> None
+  | Array { len = Int n; elem; _ } -> (
+      match field_wire_size elem with Some k -> Some (n * k) | None -> None)
   | _ -> None
 
 let c_type_of : type a. a typ -> string = function

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -193,6 +193,7 @@ and _ typ =
 and ('a, 'k) case_branch =
   | Case_branch : {
       cb_tag : 'k option;
+      cb_default_tag : 'k option;
       cb_inner : 'w typ;
       cb_inject : 'w -> 'a;
       cb_project : 'a -> 'w option;
@@ -518,8 +519,15 @@ val case :
 (** A branch matching a specific tag value. *)
 
 val default :
-  'w typ -> inject:('w -> 'a) -> project:('a -> 'w option) -> ('a, 'k) case_def
-(** A default branch. *)
+  tag:'k ->
+  'w typ ->
+  inject:('w -> 'a) ->
+  project:('a -> 'w option) ->
+  ('a, 'k) case_def
+(** [default ~tag inner ~inject ~project] is the default branch of a casetype.
+    [~tag] is the discriminator value the encoder writes when projecting this
+    branch back to bytes; on decode the default branch still matches any tag the
+    explicit cases didn't claim. *)
 
 val casetype : string -> 'k typ -> ('a, 'k) case_def list -> 'a typ
 (** [casetype name tag defs] is a tag-dispatched union. Every case must supply

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -578,7 +578,13 @@ let rec encode_into : type a. a typ -> a -> encoder -> unit =
       let off = Slice.first v in
       let len = Slice.length v in
       write_string enc (Bytes.sub_string src off len)
-  | Single_elem { elem; _ } -> encode_into elem v enc
+  | Single_elem { size; elem; _ } ->
+      let n = Eval.expr Eval.empty size in
+      encode_into elem v enc;
+      let inner_sz = Types.size_of_typ_value elem v in
+      for _ = inner_sz to n - 1 do
+        write_byte enc 0
+      done
   | Enum { base; _ } -> encode_into base v enc
   | Map { inner; encode; _ } -> encode_into inner (encode v) enc
   | Codec { codec_encode; codec_fixed_size; codec_size_of_value; _ } ->

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -607,12 +607,16 @@ and encode_casetype : type a k.
  fun tag cases v enc ->
   let rec find_case = function
     | [] -> failwith "casetype encoding: no matching case"
-    | Case_branch { cb_tag; cb_inner; cb_project; _ } :: rest -> (
+    | Case_branch { cb_tag; cb_default_tag; cb_inner; cb_project; _ } :: rest
+      -> (
         match cb_project v with
         | Some body ->
-            (match cb_tag with
-            | Some t -> encode_into tag t enc
-            | None -> failwith "casetype encoding: cannot encode default case");
+            let t =
+              match (cb_tag, cb_default_tag) with
+              | Some t, _ | _, Some t -> t
+              | None, None -> failwith "casetype encoding: case missing tag"
+            in
+            encode_into tag t enc;
             encode_into cb_inner body enc
         | None -> find_case rest)
   in

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -624,8 +624,16 @@ val case :
 (** Tagged branch of a casetype. *)
 
 val default :
-  'w typ -> inject:('w -> 'a) -> project:('a -> 'w option) -> ('a, 'k) case_def
-(** Default branch of a casetype. *)
+  tag:'k ->
+  'w typ ->
+  inject:('w -> 'a) ->
+  project:('a -> 'w option) ->
+  ('a, 'k) case_def
+(** [default ~tag inner ~inject ~project] is the default branch of a casetype.
+
+    The decoder uses the default branch when no [~index]-tagged case matches.
+    The encoder writes [~tag] when projecting the default variant back to bytes.
+*)
 
 val casetype : string -> 'k typ -> ('a, 'k) case_def list -> 'a typ
 (** [casetype name tag defs] is a tag-dispatched union. The discriminator typ

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -823,9 +823,10 @@ module Codec : sig
       when the destination buffer is too short, or when a parametric byte
       field's value length does not match its env-bound size. *)
 
-  val validate : 'r t -> bytes -> int -> unit
-  (** [validate c buf off] checks field [~constraint_] and [~where] clauses
-      without constructing a record and without firing actions.
+  val validate : ?env:Param.env -> 'r t -> bytes -> int -> unit
+  (** [validate ?env c buf off] checks field [~constraint_] and [~where] clauses
+      without constructing a record and without firing actions. [?env] supplies
+      bindings for any [Param.input] referenced in those clauses.
 
       Raises {!Validation_error} on failure. *)
 

--- a/test/3d/test_wire_3d.ml
+++ b/test/3d/test_wire_3d.ml
@@ -178,7 +178,7 @@ let e2e_casetype_codec =
         case ~index:1 uint16
           ~inject:(fun v -> `U16 v)
           ~project:(function `U16 v -> Some v | _ -> None);
-        default uint8
+        default ~tag:0xFF uint8
           ~inject:(fun v -> `Default v)
           ~project:(function `Default v -> Some v | _ -> None);
       ]
@@ -201,7 +201,7 @@ let e2e_ssh_casetype_codec =
         case ~index:"publickey" uint8
           ~inject:(fun v -> `Publickey v)
           ~project:(function `Publickey v -> Some v | _ -> None);
-        default uint8
+        default ~tag:"xxxxxxxxx" uint8
           ~inject:(fun v -> `Other v)
           ~project:(function `Other v -> Some v | _ -> None);
       ]

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -3033,7 +3033,7 @@ let casetype_field_event_typ : ev_payload Wire.typ =
       Wire.case ~index:2 Wire.uint32be
         ~inject:(fun v -> `Logout v)
         ~project:(function `Logout v -> Some v | _ -> None);
-      Wire.default Wire.uint8
+      Wire.default ~tag:0xFF Wire.uint8
         ~inject:(fun v -> `Other v)
         ~project:(function `Other v -> Some v | _ -> None);
     ]


### PR DESCRIPTION
This PR introduces a fuzz harness whose surface mirrors `Wire`'s. Each generator in [`fuzz/gen/fuzz_gen.ml`](fuzz/gen/fuzz_gen.ml) pairs a `Codec.t` with three `Alcobar` streams: a round-trip stream that produces a value together with bytes the decoder must accept, a random-bytes stream the decoder must handle without raising, and a stream of bytes crafted at the boundary of every constraint the codec enforces. Generators compose recursively, so a record gen is built from leaf gens the same way `Wire.Codec.v` is built from leaf typs, and the harness ends up covering every parse-time constructor in [`lib/wire.mli`](lib/wire.mli). The gen DSL itself lands as the final commit, 89046ee1.

Running it surfaced six lib issues that are fixed earlier in the same branch. ced0a8bd makes the `all_zeros` decoder return a `Constraint_failed` error on a non-zero byte instead of raising `Invalid_argument`, so the decoder honours its "never raise on adversarial input" contract. 9032ca3b pads `Single_elem` encodes through `Wire.encode_into` up to the declared size, matching `encode_direct`. 838e35a5 makes `Wire.default` require `~tag`, so encoding a default-branch value no longer crashes for lack of a discriminator. 25b2f964 splits four non-mutually-recursive `let rec ... and ...` groups in `lib/codec.ml` and `lib/types.ml` that `merlint` was flagging. 8af97985 teaches `field_wire_size`, `build_field_reader`, and `build_field_encoder` about fixed-size `Wire.array`, so an `array ~len:(int n)` of fixed elements works as a `Codec` field. d1fa0589 adds `?env` to `Codec.validate`, so codecs whose `where`-clauses reference `Param.input` can be validated without doing a full decode first.