### PR TITLE
codec: tighten Codec.encode buffer-bound check to size_of_value

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -54,6 +54,13 @@
 
 ### Fixed
 
+- `Codec.encode` checks the buffer against `Codec.size_of_value v` instead
+  of the static `min_size` lower bound, so a variable-size codec encoded
+  into a too-small buffer fails loudly with a precise byte count instead
+  of writing past the end. Also fixes a latent overcount in
+  `Codec.size_of_value` where each bitfield in a packed group reported the
+  full base size, returning `base_count * base_size` for codecs that
+  actually fit in one base word (#61, @samoht)
 - `Field.optional` with a dynamic gate no longer ships a silent phantom
   byte or overruns the buffer on inconsistent input; the encoder raises
   `Invalid_argument` when the gate and the option value disagree

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -1926,7 +1926,13 @@ let apply_compiled : type a f r.
   in
   let field_typ = fld.typ in
   let field_get = fld.get in
-  let field_size_of_value v = size_of_typ_value field_typ (field_get v) in
+  (* Bitfields share a base byte; [cf.size_delta] is the correct
+     non-overlapping contribution. *)
+  let field_size_of_value =
+    match field_typ with
+    | Bits _ -> fun _ -> cf.size_delta
+    | _ -> fun v -> size_of_typ_value field_typ (field_get v)
+  in
   Record
     {
       r_name = r.r_name;
@@ -2202,9 +2208,10 @@ let seal : type r. (r, r) record -> r t =
     t_decode = build_checked_decode raw_decode wire_size_info min_size;
     t_encode =
       (fun v buf off ->
-        if off + min_size > Bytes.length buf then
+        let need = size_of_value v in
+        if off + need > Bytes.length buf then
           Fmt.invalid_arg "Codec.encode %s: buffer too short (need %d, got %d)"
-            r.r_name min_size
+            r.r_name need
             (Bytes.length buf - off);
         for i = 0 to n_writers - 1 do
           writers.(i) v buf off

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -448,6 +448,16 @@ let test_codec_bitfield_overflow_1bit () =
   Codec.encode codec 0 buf 0;
   Codec.encode codec 1 buf 0
 
+let test_packed_bf_size () =
+  let f_a = Field.v "a" (bits ~width:1 U8) in
+  let f_b = Field.v "b" (bits ~width:7 U8) in
+  let codec =
+    Codec.v "Packed" (fun a b -> (a, b)) Codec.[ f_a $ fst; f_b $ snd ]
+  in
+  Alcotest.(check int)
+    "size_of_value matches wire_size" (Codec.wire_size codec)
+    (Codec.size_of_value codec (0, 0))
+
 let test_struct_of_codec_bitfield () =
   let s = Everparse.struct_of_codec bf32_codec in
   let m = module_ [ typedef s ] in
@@ -3777,6 +3787,8 @@ let suite =
         test_codec_bitfield_max_valid;
       Alcotest.test_case "codec bitfield: overflow 1-bit" `Quick
         test_codec_bitfield_overflow_1bit;
+      Alcotest.test_case "codec bitfield: size_of_value packed" `Quick
+        test_packed_bf_size;
       (* action semantics *)
       Alcotest.test_case "action: fires on decode_env" `Quick
         test_action_fires_decode_env;


### PR DESCRIPTION
This PR replaces the static-`min_size` buffer-bound check in `t_encode` with the value-driven `Codec.size_of_value v`, the oracle introduced in #58. The old check let a variable-size codec encoded against a too-small buffer write past the end before anyone noticed; the new one fails loudly with a precise byte count.

It also fixes a latent overcount in `r_size_of_value_rev` for bitfields. The per-field size accumulator summed `size_of_typ_value` over every field, but bitfields share a base byte and each contributed its full base size, so `size_of_value` for a packed bit codec returned `base_count * base_size` instead of `base_size`. Bitfields now contribute `cf.size_delta` to the sum, matching how `r_min_wire_size` already handles them. Surfaced as a bench failure when the new check went in -- `CasesDemo` is the smallest repro: two 1-byte-shared bitfields, encoded into a 1-byte buffer, claimed it needed 2.