### PR TITLE
codec: catch silent encoder underruns in Codec.encode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -54,6 +54,11 @@
 
 ### Fixed
 
+- `Codec.encode` now raises `Invalid_argument` when the writer emits fewer
+  bytes than `Codec.size_of_value v` promised, so a buggy writer that
+  leaves trailing bytes uninitialised fails loudly at the encode site
+  instead of shipping silently-corrupted bytes that a decoder reads as
+  part of the value (#62, @samoht)
 - `Codec.encode` checks the buffer against `Codec.size_of_value v` instead
   of the static `min_size` lower bound, so a variable-size codec encoded
   into a too-small buffer fails loudly with a precise byte count instead

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -2584,7 +2584,21 @@ let decode ?env t buf off =
 let encode ?env:e t v buf off =
   require_env t e;
   (match e with Some env -> load_env_into_cells t env | None -> ());
-  t.t_encode v buf off
+  let expected = t.t_size_of_value v in
+  t.t_encode v buf off;
+  let actual =
+    match t.t_wire_size with
+    | Fixed n -> n
+    | Variable { compute; _ } -> compute buf off - off
+  in
+  (* Underrun = silent data corruption: the trailing bytes the caller
+     allocated stay uninitialised and the decoder reads them as part
+     of the value. Overrun is loud already. *)
+  if actual < expected then
+    Fmt.invalid_arg
+      "Codec.encode %s: size_of_value reported %d bytes but the encoded form \
+       spans %d -- writer wrote fewer bytes than promised"
+      t.t_name expected actual
 
 let collect_params (fields : Types.field list) where =
   collect_param_handles fields where

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -448,6 +448,24 @@ let test_codec_bitfield_overflow_1bit () =
   Codec.encode codec 0 buf 0;
   Codec.encode codec 1 buf 0
 
+let test_encode_underrun_raises () =
+  (* byte_array ~size:n truncates a value longer than n at write time,
+     while size_of_value reports String.length v. Passing a 5-byte value
+     to a 3-byte field is the simplest underrun: the assertion must fire. *)
+  let codec =
+    Codec.v "Mismatch" Fun.id
+      Codec.[ Field.v "data" (byte_array ~size:(Wire.int 3)) $ Fun.id ]
+  in
+  let buf = Bytes.create 5 in
+  match Codec.encode codec "AAAAA" buf 0 with
+  | exception Invalid_argument m
+    when String.length m > 0
+         && contains ~sub:"writer wrote fewer bytes than promised" m ->
+      ()
+  | exception Invalid_argument m ->
+      Alcotest.failf "wrong Invalid_argument message: %s" m
+  | () -> Alcotest.fail "expected underrun assertion to fire"
+
 let test_packed_bf_size () =
   let f_a = Field.v "a" (bits ~width:1 U8) in
   let f_b = Field.v "b" (bits ~width:7 U8) in
@@ -3789,6 +3807,8 @@ let suite =
         test_codec_bitfield_overflow_1bit;
       Alcotest.test_case "codec bitfield: size_of_value packed" `Quick
         test_packed_bf_size;
+      Alcotest.test_case "encode: underrun raises" `Quick
+        test_encode_underrun_raises;
       (* action semantics *)
       Alcotest.test_case "action: fires on decode_env" `Quick
         test_action_fires_decode_env;


### PR DESCRIPTION
[`Codec.encode`](lib/codec.ml#L2584) used to walk the per-field writers and return. If a writer emitted fewer bytes than `Codec.size_of_value` promised, the trailing bytes in the caller's buffer stayed uninitialised and a decoder read them as part of the value -- silent data corruption with no diagnostic. It now compares the value-driven size against the buffer-driven `wire_size_at` of the just-written bytes and raises `Invalid_argument` when the encoded form is shorter than promised.

Would have caught the unpadded `Single_elem` fixed in #54 (encode wrote fewer bytes than the declared size) and the bitfield overcount fixed in #61 (`size_of_value` claimed N bytes for a 1-byte packed group). One-sided on purpose: the overrun direction is loud already (`Bytes.set_*` raises on out-of-range), and a symmetric check would false-positive on codecs whose tail is `all_bytes` / `all_zeros` / `rest_bytes` when the caller passes an oversized buffer, where `wire_size_at` returns the buffer remainder rather than the value's natural length.

Cost is one extra match-and-compare per `Codec.encode`. The CLCW polling bench (1M-frame encode setup + read loop) measured 0.43s vs 0.44s user time with and without the check -- within timing noise.