### PR TITLE
bench: use a real compiler barrier instead of volatile sinks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY: build test 3d bench bench-demo bench-routing bench-gateway bench-clcw \
-       prof memtrace memtrace-demo memtrace-routing memtrace-gateway memtrace-clcw clean
+       prof memtrace memtrace-demo memtrace-routing memtrace-gateway memtrace-clcw \
+       cppcheck clean
 
 build:
 	dune build
@@ -49,6 +50,19 @@ memtrace-gateway:
 memtrace-clcw:
 	BUILD_EVERPARSE=1 MEMTRACE=clcw.ctf dune exec --profile=release bench/clcw/bench.exe
 	memtrace_hotspots clcw.ctf
+
+cppcheck:
+	@command -v cppcheck >/dev/null 2>&1 || { \
+	  echo "cppcheck not installed; skipping. Install with: brew install cppcheck"; \
+	  exit 0; }
+	cppcheck --enable=all --check-level=exhaustive --inconclusive \
+	  --std=c11 --language=c \
+	  --suppress=missingIncludeSystem --suppress=missingInclude \
+	  --suppress=unusedFunction --suppress=checkersReport \
+	  --suppress=normalCheckLevelMaxBranches --suppress=unmatchedSuppression \
+	  --inline-suppr --quiet --error-exitcode=1 \
+	  c_stubs.c bench/bench_common.h bench/clcw/clcw_c.c \
+	  bench/gateway/gateway_c.c bench/routing/routing_c.c
 
 clean:
 	dune clean

--- a/bench/bench_common.h
+++ b/bench/bench_common.h
@@ -3,6 +3,7 @@
 #ifndef BENCH_COMMON_H
 #define BENCH_COMMON_H
 
+#include <stdatomic.h>
 #include <stdint.h>
 #include <time.h>
 
@@ -10,6 +11,14 @@ static inline int64_t now_ns(void) {
   struct timespec ts;
   clock_gettime(CLOCK_MONOTONIC, &ts);
   return ts.tv_sec * 1000000000LL + ts.tv_nsec;
+}
+
+/* Compiler barrier: keeps [v] alive across the call and forbids the
+   compiler from reordering memory ops past it. Single-threaded
+   benches don't need a CPU fence -- this compiles to no instructions. */
+static inline void wire_compiler_barrier(uint64_t v) {
+  *(volatile uint64_t *)&v = v;
+  atomic_signal_fence(memory_order_seq_cst);
 }
 
 static void bench_err(const char *t, const char *f, const char *r,

--- a/bench/clcw/clcw_c.c
+++ b/bench/clcw/clcw_c.c
@@ -43,8 +43,8 @@ CAMLprim value c_clcw_poll(value v_buf, value v_off, value v_n) {
 
   int n_words = buf_len / WORD_SIZE;
   int64_t t0 = now_ns();
-  volatile int anomalies = count_anomalies(buf, n_words, n);
-  (void)anomalies;
+  int anomalies = count_anomalies(buf, n_words, n);
+  wire_compiler_barrier((uint64_t)anomalies);
   int64_t t1 = now_ns();
   return Val_int(t1 - t0);
 }

--- a/bench/gateway/gateway_c.c
+++ b/bench/gateway/gateway_c.c
@@ -41,8 +41,7 @@ static void walk_frame(uint8_t *frame, int tm_hdr, int pkt_size,
   if (checksum != NULL) {
     *checksum = hash_int(hash_int(*checksum, vcid), fhp);
   } else {
-    volatile int keep = vcid + fhp;
-    (void)keep;
+    wire_compiler_barrier((uint64_t)(vcid + fhp));
   }
 
   SpacePacketFields sp = {0};
@@ -56,8 +55,7 @@ static void walk_frame(uint8_t *frame, int tm_hdr, int pkt_size,
     if (checksum != NULL) {
       *checksum = hash_int(hash_int(*checksum, apid), seq);
     } else {
-      volatile int keep = apid + seq;
-      (void)keep;
+      wire_compiler_barrier((uint64_t)(apid + seq));
     }
     off += pkt_size;
   }

--- a/bench/gen_stubs.ml
+++ b/bench/gen_stubs.ml
@@ -142,18 +142,17 @@ let generate_c oc =
       pr "  const uint32_t item_size = %d;\n" item_size;
       pr "  const uint32_t n_items = len / item_size;\n";
       pr "  int count = Int_val(v_n);\n";
-      pr "  volatile uint64_t result = 0;\n";
       pr "  if (n_items == 0) CAMLreturn(Val_int(0));\n";
       pr "  %sFields ctx = {0};\n" ep;
       pr "  int64_t t0 = now_ns();\n";
       pr "  for (int i = 0; i < count; i++) {\n";
       pr "    uint8_t *item = buf + ((uint32_t)i %% n_items) * item_size;\n";
       pr
-        "    result = %sValidate%s((WIRECTX *) &ctx, NULL, bench_err, item, \
-         item_size, 0);\n"
+        "    uint64_t r = %sValidate%s((WIRECTX *) &ctx, NULL, bench_err, \
+         item, item_size, 0);\n"
         ep ep;
+      pr "    wire_compiler_barrier(r);\n";
       pr "  }\n";
-      pr "  (void)result;\n";
       pr "  int64_t t1 = now_ns();\n";
       pr "  CAMLreturn(Val_int(t1 - t0));\n";
       pr "}\n\n")


### PR DESCRIPTION
The bench loops in [`bench/gen_stubs.ml`](bench/gen_stubs.ml#L145), [`bench/clcw/clcw_c.c`](bench/clcw/clcw_c.c#L46) and [`bench/gateway/gateway_c.c`](bench/gateway/gateway_c.c#L44) used a `volatile uint64_t result = ...; (void)result;` sink to keep the validator return live. `volatile` is not a compiler optimisation barrier -- compilers reorder non-volatile loads, stores and arithmetic across volatile accesses, fold loop-invariant work out, and can move the timing reads relative to the loop body. The three sites now route the sink through `wire_compiler_barrier` in [`bench/bench_common.h`](bench/bench_common.h), which keeps the value live with a `volatile` store and then issues an `atomic_signal_fence(memory_order_seq_cst)` from `<stdatomic.h>`.

```
                        before     after
CLCW polling            202.5      201.5   Mword/s
TM frame reassembly     10.3       10.3    Mfrm/s
```

Within timing noise; OCaml/C checksums on TM reassembly still match byte for byte.

Adds `make cppcheck`: runs `cppcheck --enable=all --check-level=exhaustive --inconclusive --std=c11 --language=c` over the generated `c_stubs.c` and the three bench `.c` files. Currently clean. Skips with a hint when cppcheck isn't installed (`brew install cppcheck`). Active checker count is 119/186 on this codebase; the remaining 67 are C++-only (`CheckClass::*`, `CheckExceptionSafety::*`, etc.) and don't apply to pure C.