### PR TITLE
test: drop Wire__Module access via Wire.Private

### DIFF
--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -762,6 +762,8 @@ module Private = struct
   module UInt63 = UInt63
   module Types = Types
   module Eval = Eval
+  module Bitfield = Bitfield
+  module Uint_var = Uint_var
 
   let param_name = param_name
   let param_is_mutable = param_is_mutable

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -57,7 +57,7 @@ end
     lengths, byte-slice sizes, field constraints, and similar dependent
     structure. *)
 
-type 'a expr
+type 'a expr = 'a Types.expr
 type bitfield = U8 | U16 | U16be | U32 | U32be
 
 type bit_order = Types.bit_order =
@@ -84,7 +84,7 @@ type endian = Types.endian =
   | Little
   | Big  (** Byte order for multi-byte integers. *)
 
-type 'a typ
+type 'a typ = 'a Types.typ
 
 type param
 (** Untyped formal parameter declaration. Create via {!val:Param.input} or
@@ -406,6 +406,21 @@ module Field : sig
   (** [ref f] returns the expression referencing this field's underlying integer
       value. Works on any field whose wire type is or wraps an integer,
       including [bool] fields created with {!bit}. *)
+
+  val name : 'a t -> string
+  (** Field name. *)
+
+  val typ : 'a t -> 'a typ
+  (** Wire type. *)
+
+  val pp : Format.formatter -> 'a t -> unit
+  (** Pretty-print the field's name. *)
+
+  val constraint_ : 'a t -> bool expr option
+  (** Field constraint, if any. *)
+
+  val decl_of_packed : packed -> Types.field
+  (** The {!Types.field} declaration of a packed field. *)
 end
 
 (** {1 Type Descriptions}
@@ -1198,6 +1213,8 @@ module Private : sig
   module UInt63 = UInt63
   module Types = Types
   module Eval = Eval
+  module Bitfield = Bitfield
+  module Uint_var = Uint_var
 
   val param_name : param -> string
   (** Name of a formal parameter. *)

--- a/test/test_bitfield.ml
+++ b/test/test_bitfield.ml
@@ -1,5 +1,5 @@
-module Bitfield = Wire__Bitfield
-module Types = Wire__Types
+module Bitfield = Wire.Private.Bitfield
+module Types = Wire.Private.Types
 
 let bf_u8 = Types.BF_U8
 let bf_u16_le = Types.BF_U16 Little

--- a/test/test_field.ml
+++ b/test/test_field.ml
@@ -1,5 +1,5 @@
-module Field = Wire__Field
-module Types = Wire__Types
+module Field = Wire.Field
+module Types = Wire.Private.Types
 
 let test_v_creates_named_field () =
   let f = Field.v "Version" Types.uint8 in

--- a/test/test_uint_var.ml
+++ b/test/test_uint_var.ml
@@ -1,5 +1,5 @@
-module Uint_var = Wire__Uint_var
-module Types = Wire__Types
+module Uint_var = Wire.Private.Uint_var
+module Types = Wire.Private.Types
 
 let roundtrip ~endian ~size value () =
   let buf = Bytes.create size in


### PR DESCRIPTION
Three unit tests reached `Wire__Bitfield`, `Wire__Uint_var`, and `Wire__Types` directly via dune's wrapped-library prefix. They now go through `Wire.Private.Bitfield` / `Wire.Private.Uint_var` and a slightly fuller `Wire.Field` surface (`name`, `typ`, `pp`, `constraint_`, `decl_of_packed`).