### PR TITLE
chore: extract helpers from oversized functions

### DIFF
--- a/bench/gen_stubs.ml
+++ b/bench/gen_stubs.ml
@@ -24,8 +24,27 @@ let struct_size s =
 
 let projection_structs = Demo_bench_cases.projection_structs
 
+(* Projection pair for a struct: a string per kind of field, naming the
+   extractor when the kind matches and a no-op constant otherwise. *)
+let projection_strings ~lower ~is_proj ~field_kinds =
+  if not is_proj then ("(fun _ _ -> 0)", "(fun _ _ -> 0L)")
+  else
+    match field_kinds with
+    | [ (_, Wire.Everparse.Raw.Int64) ] ->
+        ("(fun _ _ -> 0)", Fmt.str "%s_projected_int64" lower)
+    | [ _ ] -> (Fmt.str "%s_projected_int" lower, "(fun _ _ -> 0L)")
+    | _ -> ("(fun _ _ -> 0)", "(fun _ _ -> 0L)")
+
+(* [ffi_parse] uses [_parse_k] directly (the single C entry point) with a
+   no-op continuation. The OCaml-side record-returning [_parse] wrapper
+   adds an extra C-to-OCaml callback hop just to build a record we'd then
+   discard; the bench measures pure validation cost, so skip the wrapper. *)
+let noop_continuation ~n_args =
+  "(fun " ^ String.concat " " (List.init n_args (fun _ -> "_")) ^ " -> ())"
+
 let generate_stub_registry ppf structs projection_structs =
   let pr fmt = Fmt.pf ppf fmt in
+  let all_structs = structs @ projection_structs in
   pr "type stubs = {\n";
   pr "  check : bytes -> bool;\n";
   pr "  ffi_parse : bytes -> int -> unit;\n";
@@ -38,37 +57,21 @@ let generate_stub_registry ppf structs projection_structs =
     (fun s ->
       let name = Wire.Everparse.Raw.struct_name s in
       let lower = String.lowercase_ascii name in
-      let proj_int, proj_int64 =
-        let is_proj =
-          List.exists
-            (fun p -> Wire.Everparse.Raw.struct_name p = name)
-            projection_structs
-        in
-        if is_proj then
-          match Wire.Everparse.Raw.field_kinds s with
-          | [ (_, Wire.Everparse.Raw.Int64) ] ->
-              ("(fun _ _ -> 0)", Fmt.str "%s_projected_int64" lower)
-          | [ _ ] -> (Fmt.str "%s_projected_int" lower, "(fun _ _ -> 0L)")
-          | _ -> ("(fun _ _ -> 0)", "(fun _ _ -> 0L)")
-        else ("(fun _ _ -> 0)", "(fun _ _ -> 0L)")
+      let is_proj =
+        List.exists
+          (fun p -> Wire.Everparse.Raw.struct_name p = name)
+          projection_structs
       in
-      (* [ffi_parse] uses [_parse_k] directly (the single C entry point)
-         with a no-op continuation. The OCaml-side record-returning
-         [_parse] wrapper adds an extra C-to-OCaml callback hop just to
-         build a record we'd then discard; the bench measures pure
-         validation cost, so skip the wrapper. *)
+      let field_kinds = Wire.Everparse.Raw.field_kinds s in
+      let proj_int, proj_int64 = projection_strings ~lower ~is_proj ~field_kinds in
       let n_args =
         List.length
           (Wire.Everparse.Raw.field_kinds
              (List.find
                 (fun p -> Wire.Everparse.Raw.struct_name p = name)
-                (structs @ projection_structs)))
+                all_structs))
       in
-      let cont =
-        "(fun "
-        ^ String.concat " " (List.init n_args (fun _ -> "_"))
-        ^ " -> ())"
-      in
+      let cont = noop_continuation ~n_args in
       pr
         "  | %S -> { check = %s_check; ffi_parse = (fun b off -> %s_parse_k %s \
          b off); loop = %s_loop; projected_int = %s; projected_int64 = %s }\n"

--- a/fuzz/fuzz_wire.ml
+++ b/fuzz/fuzz_wire.ml
@@ -226,28 +226,29 @@ let test_parse_struct_bitfields buf =
   let _ = Wire.Codec.decode bf_codec (Bytes.of_string buf) 0 in
   ()
 
+let fits_in width n = n >= 0 && n lsr width = 0
+
+let check_bf_roundtrip v encoded =
+  match record_of_string bf_codec encoded with
+  | Ok decoded ->
+      if v.bf_a <> decoded.bf_a then fail "bf_a mismatch";
+      if v.bf_b <> decoded.bf_b then fail "bf_b mismatch";
+      if v.bf_c <> decoded.bf_c then fail "bf_c mismatch";
+      if v.bf_d <> decoded.bf_d then fail "bf_d mismatch"
+  | Error _ -> fail "bf roundtrip decode failed"
+
 (* Bitfield encode overflow: arbitrary ints must either fit and roundtrip,
    or raise Invalid_argument when they exceed the field width. *)
 let test_bf_encode_overflow a b c d =
   let v = { bf_a = a; bf_b = b; bf_c = c; bf_d = d } in
-  let fits_a = a lsr 3 = 0 && a >= 0 in
-  let fits_b = b lsr 5 = 0 && b >= 0 in
-  let fits_c = c lsr 10 = 0 && c >= 0 in
-  let fits_d = d lsr 6 = 0 && d >= 0 in
-  let all_fit = fits_a && fits_b && fits_c && fits_d in
+  let all_fit = fits_in 3 a && fits_in 5 b && fits_in 10 c && fits_in 6 d in
   match string_of_record bf_codec v with
   | exception Invalid_argument _ ->
       if all_fit then fail "unexpected overflow for in-range values"
   | Error _ -> fail "unexpected encode error"
-  | Ok encoded -> (
+  | Ok encoded ->
       if not all_fit then fail "expected overflow but encode succeeded";
-      match record_of_string bf_codec encoded with
-      | Ok decoded ->
-          if v.bf_a <> decoded.bf_a then fail "bf_a mismatch";
-          if v.bf_b <> decoded.bf_b then fail "bf_b mismatch";
-          if v.bf_c <> decoded.bf_c then fail "bf_c mismatch";
-          if v.bf_d <> decoded.bf_d then fail "bf_d mismatch"
-      | Error _ -> fail "bf roundtrip decode failed")
+      check_bf_roundtrip v encoded
 
 type optional_struct = {
   os_gate : int;


### PR DESCRIPTION
Splits the two functions merlint flagged for complexity: `bench/gen_stubs.ml`'s `generate_stub_registry` (was 51 lines, now under the 50-line cap) and `fuzz/fuzz_wire.ml`'s `test_bf_encode_overflow` (was cyclomatic 15, now under 10).