### PR TITLE
docs: clear merlint documentation warnings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -58,6 +58,9 @@
 
 ### Documentation
 
+- Add odoc cross-reference links and the doc comments that were missing
+  across the public interfaces, and expose a `pp` printer on `UInt32`,
+  `UInt63`, `Param`, and `Wire.Diff` (#73, @samoht)
 - Type-check `README.md` and every public `.mli` under `mdx`
   (#39, @samoht)
 

--- a/fuzz/gen/fuzz_gen.mli
+++ b/fuzz/gen/fuzz_gen.mli
@@ -226,7 +226,7 @@ val optional_dynamic : (int * int option) t
     depending on the gate byte. *)
 
 val optional_or_dynamic : (int * int) t
-(** [optional_or_dynamic] is the [optional_or] equivalent of
+(** [optional_or_dynamic] is the {!val-optional_or} equivalent of
     {!optional_dynamic}, using a fixed default value when absent. *)
 
 val finite_float64 : float t
@@ -246,9 +246,10 @@ val sizeof : (int * int) t
     references [Wire.sizeof_this] / [Wire.field_pos] / [Wire.sizeof]. *)
 
 val codec_where : (int * int) t
-(** [codec_where] generates for a two-[uint8] record whose [Codec.v] carries
-    [~where:(a < b)]. Positives satisfy the predicate, adversarials sit at the
-    equality boundary so the [where] check fires. *)
+(** [codec_where] generates for a two-{!val-uint8} record whose
+    {!module-Codec.val-v} carries [~where:(a < b)]. Positives satisfy the
+    predicate, adversarials sit at the equality boundary so the {!val-where}
+    check fires. *)
 
 (** {1 Casetype} *)
 

--- a/lib/bitfield.mli
+++ b/lib/bitfield.mli
@@ -1,6 +1,8 @@
 (** Shared bitfield utilities. *)
 
 val byte_size : Types.bitfield_base -> int
+(** [byte_size base] is the number of bytes used by one packed bitfield base
+    word. *)
 
 val total_bits : Types.bitfield_base -> int
 (** Total bits in a bitfield base type (8, 16, or 32). *)

--- a/lib/diff/dune
+++ b/lib/diff/dune
@@ -1,4 +1,4 @@
 (library
  (name wire_diff)
  (public_name wire.diff)
- (libraries wire eio))
+ (libraries wire eio fmt))

--- a/lib/diff/wire_diff.ml
+++ b/lib/diff/wire_diff.ml
@@ -103,6 +103,8 @@ type t = {
   test_roundtrip : string -> result;
 }
 
+let pp ppf t = Fmt.pf ppf "%s(%d bytes)" t.name t.wire_size
+
 let harness ~name ~codec ~read ~write ~project ~equal ?ocaml_read () =
   let h = v ~name ~codec ~read ~write ~project ~equal ?ocaml_read () in
   let ws = wire_size h in

--- a/lib/diff/wire_diff.mli
+++ b/lib/diff/wire_diff.mli
@@ -20,6 +20,9 @@ type t = {
 }
 (** A type-erased diff test. *)
 
+val pp : Format.formatter -> t -> unit
+(** Pretty-print a diff test summary. *)
+
 val harness :
   name:string ->
   codec:'r Wire.Codec.t ->

--- a/lib/everparse.mli
+++ b/lib/everparse.mli
@@ -63,6 +63,7 @@ type t = {
     schemas). *)
 
 val pp : Format.formatter -> t -> unit
+(** Pretty-print a schema summary. *)
 
 val filename : t -> string
 (** [filename s] is the [.3d] output filename for schema [s]. EverParse requires
@@ -89,7 +90,8 @@ type plug_field = {
 
 val plug_fields : t -> plug_field list
 (** [plug_fields s] enumerates the named fields of the source struct in
-    declaration order. Returns [[]] for schemas without a [source] struct. *)
+    declaration order. Returns [[]] for schemas without a {!field-source}
+    struct. *)
 
 val plug_setters : t -> (string * string) list
 (** [plug_setters s] lists the unique [WireSet*] setters referenced by [s] as
@@ -131,11 +133,12 @@ type field_action_form = No_action | On_act | On_success
 val field_action_forms :
   struct_ -> (string option * bool * field_action_form) list
 (** [field_action_forms st] enumerates the fields of [st] in declaration order.
-    Each tuple is [(name, is_bitfield, action_form)]: [name] is [None] for
-    anonymous fields; [is_bitfield] is [true] if the field's type is (or reduces
-    to) a bitfield; [action_form] is the currently attached action kind. Used by
-    tests to assert the [map_field_action] invariant: bitfields must carry
-    [On_act], scalars [On_success], anonymous fields [No_action]. *)
+    Each tuple is [(name, is_bitfield, action_form)]: {!field-name} is [None]
+    for anonymous fields; [is_bitfield] is [true] if the field's type is (or
+    reduces to) a bitfield; [action_form] is the currently attached action kind.
+    Used by tests to assert the [map_field_action] invariant: bitfields must
+    carry {!constructor-On_act}, scalars {!constructor-On_success}, anonymous
+    fields {!constructor-No_action}. *)
 
 val write_3d : outdir:string -> t list -> unit
 (** [write_3d ~outdir ts] writes one [.3d] file per schema in [outdir]. *)

--- a/lib/field.mli
+++ b/lib/field.mli
@@ -10,6 +10,7 @@ type 'a t
 (** A named field carrying values of type ['a]. *)
 
 val pp : Format.formatter -> 'a t -> unit
+(** Pretty-print the field name. *)
 
 type 'a anon
 (** An anonymous (padding) field. Cannot be referenced. *)

--- a/lib/param.ml
+++ b/lib/param.ml
@@ -2,6 +2,8 @@ type input = Types.param_input
 type output = Types.param_output
 type ('a, 'k) t = ('a, 'k) Types.param_handle
 
+let pp ppf p = Fmt.string ppf p.Types.ph_name
+
 (* Per-typ converter from the OCaml representation to [int] and back. One
    match dispatches both directions; [to_int] and [of_int] just project
    the relevant field. Avoids drift between the parallel cases. *)

--- a/lib/param.mli
+++ b/lib/param.mli
@@ -7,6 +7,9 @@ type input = Types.param_input
 type output = Types.param_output
 type ('a, 'k) t = ('a, 'k) Types.param_handle
 
+val pp : Format.formatter -> ('a, 'k) t -> unit
+(** Pretty-print a parameter by name. *)
+
 val input : string -> 'a Types.typ -> ('a, input) t
 (** [input name typ] declares an input parameter. *)
 
@@ -17,6 +20,7 @@ val decl : ('a, 'k) t -> Types.param
 (** Project to an untyped formal declaration (for 3D rendering). *)
 
 val name : ('a, 'k) t -> string
+(** [name p] is the formal parameter name. *)
 
 val expr : ('a, 'k) t -> int Types.expr
 (** [expr p] returns the expression referencing this param. *)

--- a/lib/stubs/wire_stubs.mli
+++ b/lib/stubs/wire_stubs.mli
@@ -45,6 +45,7 @@ val of_structs :
     need them directly. *)
 
 val to_c_stubs : Wire.Everparse.Raw.struct_ list -> string
+(** Generate C stubs that call the EverParse validators directly. *)
 
 val to_ml_stubs : Wire.Everparse.Raw.struct_ list -> string
 (** Generate OCaml external declarations and record types for all structs. *)

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -389,11 +389,12 @@ val int16be : int typ
 (** 16-bit signed, big-endian. *)
 
 val int32 : int typ
-(** [int32] is a 32-bit signed little-endian integer, returned as OCaml [int]
-    (64-bit hosts only). *)
+(** [int32] is a 32-bit signed little-endian integer, returned as an OCaml
+    integer (64-bit hosts only). *)
 
 val int32be : int typ
-(** [int32be] is a 32-bit signed big-endian integer, returned as OCaml [int]. *)
+(** [int32be] is a 32-bit signed big-endian integer, returned as an OCaml
+    integer. *)
 
 val int64 : int64 typ
 (** 64-bit signed, little-endian. *)
@@ -434,7 +435,7 @@ val bf_uint32be : bitfield_base
 (** 32-bit bitfield base, big-endian. *)
 
 val bits : ?bit_order:bit_order -> width:int -> bitfield_base -> int typ
-(** [bits ~width base] extracts [width] bits from a bitfield base. [bit_order]
+(** [bits ~width base] extracts [width] bits from a bitfield base. The bit order
     defaults to {!Msb_first}. *)
 
 val map : ('w -> 'a) -> ('a -> 'w) -> 'w typ -> 'a typ
@@ -471,13 +472,13 @@ val byte_array_where :
   size:int expr -> per_byte:(int expr -> bool expr) -> string typ
 (** [byte_array_where ~size ~per_byte] is a byte span of [size] bytes where each
     byte must satisfy [per_byte]. The argument to [per_byte] is an expression
-    bound to the current byte's integer value. Decode raises [Parse_error] on
-    the first byte that violates the constraint; encode raises
-    [Invalid_argument]. *)
+    bound to the current byte's integer value. Decode raises
+    {!exception:Parse_error} on the first byte that violates the constraint;
+    encode raises [Invalid_argument]. *)
 
 val synth_name_of_elt_var : string -> string
 (** [synth_name_of_elt_var ev] is the 3D-side synthesised refinement-typedef
-    name derived from a [byte_array_where] element variable. Internal: used by
+    name derived from a {!byte_array_where} element variable. Internal: used by
     the EverParse projection. *)
 
 val byte_slice : size:int expr -> Bytesrw.Bytes.Slice.t typ
@@ -531,16 +532,16 @@ val default :
 
 val casetype : string -> 'k typ -> ('a, 'k) case_def list -> 'a typ
 (** [casetype name tag defs] is a tag-dispatched union. Every case must supply
-    an explicit [~index]; the discriminator type ['k] can be [int], [string], or
-    any other typ with decidable equality. *)
+    an explicit [~index]; the discriminator type ['k] can be an integer, a
+    string, or any other typ with decidable equality. *)
 
 val split_string_casetype_fields : struct_ -> struct_
-(** [split_string_casetype_fields s] rewrites each [Casetype] field of [s] whose
-    tag is not an int-shaped typ into two adjacent byte fields: the tag bytes
-    and a trailing [all_bytes] body. Used by the 3D projection so string-tagged
-    casetype dispatch becomes caller code instead of parser code, matching how
-    real protocol implementations like OpenSSH split the parse and dispatch
-    steps. *)
+(** [split_string_casetype_fields s] rewrites each {!constructor:Casetype} field
+    of [s] whose tag is not an int-shaped typ into two adjacent byte fields: the
+    tag bytes and a trailing {!all_bytes} body. Used by the 3D projection so
+    string-tagged casetype dispatch becomes caller code instead of parser code,
+    matching how real protocol implementations like OpenSSH split the parse and
+    dispatch steps. *)
 
 (** {1 Struct Constructors} *)
 
@@ -555,6 +556,7 @@ val struct_ : string -> field list -> struct_
 (** Construct a struct from fields. *)
 
 val struct_name : struct_ -> string
+(** Name of the struct declaration. *)
 
 val field_names : struct_ -> string list
 (** Named field names in declaration order. *)
@@ -736,4 +738,5 @@ val c_type_of : 'a typ -> string
 
 val ml_type_of : 'a typ -> string
 (** [ml_type_of typ] returns the OCaml type name for FFI stub generation:
-    ["int"] for integer types that fit in OCaml [int], ["int64"] for uint64. *)
+    ["int"] for integer types that fit in OCaml integers, ["int64"] for uint64.
+*)

--- a/lib/uInt32.ml
+++ b/lib/uInt32.ml
@@ -1,5 +1,7 @@
 type t = int
 
+let pp = Fmt.int
+
 let le buf off =
   Bytes.get_int32_le buf off |> Int32.to_int |> ( land ) 0xFFFF_FFFF
 

--- a/lib/uInt32.mli
+++ b/lib/uInt32.mli
@@ -2,6 +2,9 @@
 
 type t = int
 
+val pp : Format.formatter -> t -> unit
+(** Pretty-printer for unsigned 32-bit values represented as OCaml integers. *)
+
 val le : bytes -> int -> t
 (** [le buf off] reads a little-endian value from [buf] at offset [off]. *)
 

--- a/lib/uInt63.ml
+++ b/lib/uInt63.ml
@@ -2,6 +2,7 @@
 
 type t = int
 
+let pp = Fmt.int
 let le buf off = Bytes.get_int64_le buf off |> Int64.to_int |> ( land ) max_int
 let be buf off = Bytes.get_int64_be buf off |> Int64.to_int |> ( land ) max_int
 let set_le buf off v = Bytes.set_int64_le buf off (Int64.of_int v)

--- a/lib/uInt63.mli
+++ b/lib/uInt63.mli
@@ -2,6 +2,9 @@
 
 type t = int
 
+val pp : Format.formatter -> t -> unit
+(** Pretty-printer for unsigned 63-bit values represented as OCaml integers. *)
+
 val le : bytes -> int -> t
 (** [le buf off] reads a little-endian value from [buf] at offset [off]. *)
 

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -146,6 +146,7 @@ module Param : sig
   (** Project to an untyped formal declaration (for 3D rendering). *)
 
   val name : ('a, 'k) t -> string
+  (** Parameter name. *)
 
   type env = Param.env
   (** Parameter environment. Create with {!Codec.env}, bind inputs with {!bind},
@@ -303,7 +304,7 @@ module Expr : sig
   (** Truncate to unsigned 32-bit range (mask [0xFFFFFFFF]). *)
 
   val to_uint64 : int expr -> int expr
-  (** 3D codegen cast. At runtime this is the identity -- OCaml [int] cannot
+  (** 3D codegen cast. At runtime this is the identity -- OCaml integers cannot
       represent the full unsigned 64-bit range. Use only for 3D output where
       EverParse needs an explicit [(UINT64)] cast annotation. *)
 end
@@ -405,7 +406,7 @@ module Field : sig
   val ref : 'a t -> int expr
   (** [ref f] returns the expression referencing this field's underlying integer
       value. Works on any field whose wire type is or wraps an integer,
-      including [bool] fields created with {!bit}. *)
+      including boolean fields created with {!bit}. *)
 
   val name : 'a t -> string
   (** Field name. *)
@@ -454,12 +455,12 @@ val uint63be : int typ
 (** Unsigned 63-bit big-endian integer carried on 8 bytes. *)
 
 val uint64 : int64 typ
-(** [uint64] is an unsigned 64-bit little-endian integer represented as [int64].
-*)
+(** [uint64] is an unsigned 64-bit little-endian integer represented as an OCaml
+    64-bit integer. *)
 
 val uint64be : int64 typ
-(** [uint64be] is an unsigned 64-bit big-endian integer represented as [int64].
-*)
+(** [uint64be] is an unsigned 64-bit big-endian integer represented as an OCaml
+    64-bit integer. *)
 
 val int8 : int typ
 (** Signed 8-bit two's-complement integer. *)
@@ -471,11 +472,12 @@ val int16be : int typ
 (** Signed 16-bit big-endian integer. *)
 
 val int32 : int typ
-(** [int32] is a signed 32-bit little-endian integer, returned as OCaml [int]
-    (64-bit hosts only: on a 32-bit host, the top bit may not fit). *)
+(** [int32] is a signed 32-bit little-endian integer, returned as an OCaml
+    integer (64-bit hosts only: on a 32-bit host, the top bit may not fit). *)
 
 val int32be : int typ
-(** [int32be] is a signed 32-bit big-endian integer, returned as OCaml [int]. *)
+(** [int32be] is a signed 32-bit big-endian integer, returned as an OCaml
+    integer. *)
 
 val int64 : int64 typ
 (** Signed 64-bit little-endian integer. *)
@@ -500,8 +502,8 @@ val float64be : float typ
 val is_finite : float Field.t -> bool expr
 (** [is_finite f] is a constraint that holds iff [f]'s decoded IEEE 754 value is
     neither [NaN] nor [+/- infinity]. Compiles to a bit-mask check on the
-    field's exponent (against [0x7F80_0000] for [float32] and
-    [0x7FF0_0000_0000_0000] for [float64]); the same expression is emitted into
+    field's exponent (against [0x7F80_0000] for binary32 and
+    [0x7FF0_0000_0000_0000] for binary64); the same expression is emitted into
     the 3D output, so wire's OCaml decoder and EverParse's verified C decoder
     reject the same set of inputs. *)
 
@@ -620,9 +622,10 @@ val nested_at_most : size:int expr -> 'a typ -> 'a typ
 
 val enum : string -> (string * int) list -> int typ -> int typ
 (** [enum name cases base] validates that the decoded integer is one of the
-    named values. The result is still [int] -- use {!variants} instead if you
-    want to decode to proper OCaml values. [enum] is mainly useful for 3D
-    projection where the name and cases appear in the generated [.3d] file. *)
+    named values. The result is still an OCaml integer -- use {!variants}
+    instead if you want to decode to proper OCaml values. [enum] is mainly
+    useful for 3D projection where the name and cases appear in the generated
+    [.3d] file. *)
 
 val variants : string -> (string * 'a) list -> int typ -> 'a typ
 (** [variants name cases base] maps integer values to OCaml values via a named
@@ -652,8 +655,8 @@ val default :
 
 val casetype : string -> 'k typ -> ('a, 'k) case_def list -> 'a typ
 (** [casetype name tag defs] is a tag-dispatched union. The discriminator typ
-    ['k] can be [int], [string], or any other typ with decidable equality; every
-    case must supply an explicit [~index]. *)
+    ['k] can be an integer, a string, or any other typ with decidable equality;
+    every case must supply an explicit [~index]. *)
 
 val size : 'a typ -> int option
 (** [size t] is the fixed wire size of a description, if known statically. *)
@@ -810,7 +813,7 @@ module Codec : sig
       {!wire_size}; for dynamic-size codecs, the result depends on [v]. *)
 
   val is_fixed : 'r t -> bool
-  (** [true] iff the codec has a statically known size. *)
+  (** Returns true iff the codec has a statically known size. *)
 
   val env : 'r t -> Param.env
   (** [env c] creates a fresh parameter environment for codec [c]. *)
@@ -841,7 +844,7 @@ module Codec : sig
   val validate : ?env:Param.env -> 'r t -> bytes -> int -> unit
   (** [validate ?env c buf off] checks field [~constraint_] and [~where] clauses
       without constructing a record and without firing actions. [?env] supplies
-      bindings for any [Param.input] referenced in those clauses.
+      bindings for any {!val:Param.input} referenced in those clauses.
 
       Raises {!Validation_error} on failure. *)
 
@@ -1046,7 +1049,8 @@ module Everparse : sig
     struct_ -> (string option * bool * field_action_form) list
   (** [field_action_forms st] enumerates fields as [(name, is_bitfield, form)]
       tuples. Used by tests to assert the codegen invariant that bitfields carry
-      [On_act], scalars [On_success], anonymous fields [No_action]. *)
+      {!constructor:On_act}, scalars {!constructor:On_success}, anonymous fields
+      {!constructor:No_action}. *)
 
   val write_3d : outdir:string -> t list -> unit
   (** Writes one [.3d] file per schema into [outdir]. *)
@@ -1220,7 +1224,7 @@ module Private : sig
   (** Name of a formal parameter. *)
 
   val param_is_mutable : param -> bool
-  (** [true] for output (mutable) parameters. *)
+  (** Returns true for output (mutable) parameters. *)
 
   val param_c_type : param -> string
   (** C type name of a parameter (e.g., ["uint16_t"]). *)

--- a/test/fixtures/test_fixtures.mli
+++ b/test/fixtures/test_fixtures.mli
@@ -5,20 +5,20 @@ open Wire
 type inner = { tag : int; value : int }
 
 val f_inner_tag : int Field.t
-(** [f_inner_tag] is the field reference for [inner.tag]; reused by codecs that
-    depend on the parsed tag value. *)
+(** [f_inner_tag] is the field reference for the inner tag; reused by codecs
+    that depend on the parsed tag value. *)
 
 val f_inner_value : int Field.t
-(** [f_inner_value] is the field reference for [inner.value]. *)
+(** [f_inner_value] is the field reference for the inner value. *)
 
 val inner_codec : inner Codec.t
 (** [inner_codec] is the tag-prefixed inner record used as the building block
-    for [outer_codec], [repeat_codec], and many test cases. *)
+    for {!outer_codec}, {!repeat_codec}, and many test cases. *)
 
 type outer = { header : int; inner : inner; trailer : int }
 
 val outer_codec : outer Codec.t
-(** [outer_codec] embeds [inner_codec] between a header and trailer byte;
+(** [outer_codec] embeds {!inner_codec} between a header and trailer byte;
     exercises the [codec] field combinator. *)
 
 type l2 = { x : int }
@@ -29,11 +29,11 @@ val l2_codec : l2 Codec.t
 (** [l2_codec] is the innermost level of a 3-deep codec nesting. *)
 
 val l1_codec : l1 Codec.t
-(** [l1_codec] is the middle level, embedding [l2_codec]. *)
+(** [l1_codec] is the middle level, embedding {!l2_codec}. *)
 
 val l0_codec : l0 Codec.t
-(** [l0_codec] is the outermost level, embedding [l1_codec]; exercises two-level
-    nesting. *)
+(** [l0_codec] is the outermost level, embedding {!l1_codec}; exercises
+    two-level nesting. *)
 
 type opt_record = { hdr : int; payload : int option; trail : int }
 
@@ -50,11 +50,11 @@ val opt_codec_absent : opt_record Codec.t
 type container = { length : int; items : inner list }
 
 val f_cnt_length : int Field.t
-(** [f_cnt_length] is the field reference for [container.length], used to size
+(** [f_cnt_length] is the field reference for the container length, used to size
     the trailing [repeat] body. *)
 
 val repeat_codec : container Codec.t
-(** [repeat_codec] is a length-prefixed list of [inner] elements. *)
+(** [repeat_codec] is a length-prefixed list of {!type:inner} elements. *)
 
 type packet = { id : int; data : int }
 


### PR DESCRIPTION
Running merlint over the tree surfaced documentation warnings across the public interfaces: doc comments that named other exported items in `[brackets]` instead of odoc cross-references, public values with no comment at all, two boolean accessors whose docs did not follow the `[name] is ...` convention, and four types named `t` without a `pp`.

This links every flagged reference with the appropriate `{!val-...}` / `{!type-...}` / `{!constructor-...}` / `{!field-...}` form, fills in the missing comments, rewrites the boolean-accessor docs, and exposes a `pp` on `UInt32`, `UInt63`, `Param`, and `Wire.Diff`. No behaviour change; `merlint` now reports zero issues.