### PR TITLE
ci: install ocamlformat 0.29.0 to match .ocamlformat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,6 @@ jobs:
           ocaml-compiler: '5.3'
           dune-version: '3.21'
 
-      - run: opam install ocamlformat.0.28.1
+      - run: opam install ocamlformat.0.29.0
       - run: opam exec -- dune fmt 2>/dev/null || true
       - run: git diff --exit-code


### PR DESCRIPTION
The `fmt` job installed `ocamlformat.0.28.1` while `.ocamlformat` pins `0.29.0`, so `dune fmt` aborted on the version mismatch. The error was hidden by `2>/dev/null || true`, so the following `git diff --exit-code` step never saw any reformatting and the check passed unconditionally -- a silent no-op rather than a real format gate.

Installing the pinned `0.29.0` makes `dune fmt` actually run, so the `git diff --exit-code` step enforces formatting again. The tree is already clean under `0.29.0`, so no files change here.