### PR TITLE
codec: support casetype elements inside Field.repeat

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -66,6 +66,12 @@
 
 ### Fixed
 
+- `Field.repeat` over a `Wire.casetype` element now encodes and decodes
+  instead of raising `Failure "unsupported element type in repeat"`. The
+  repeat element path had no case for a tag-dispatched union, which ruled
+  out a DHCP-style options TLV whose cases mix bare single-byte tags (PAD,
+  END) with length-prefixed bodies (#75, @samoht)
+
 - `Codec.size_of_value` no longer over-counts a packed bitfield reached
   through a value wrapper such as `Wire.bit` or an enum/map over `bits`.
   The per-field size was keyed off the field's logical type, so a wrapped

--- a/fuzz/fuzz_wire.ml
+++ b/fuzz/fuzz_wire.ml
@@ -1234,10 +1234,87 @@ let test_repeat_var_elem_roundtrip seed =
         failf "repeat-var name mismatch: %S vs %S" a.ext_name b.ext_name)
     v.exts decoded.exts
 
+(* [Field.repeat] over a [casetype] with mixed-shape cases: bare [unit] tags
+   (PAD/END) beside a length-prefixed sub-codec body. Exercises the codec's
+   repeat element path for casetypes, which must dispatch per element and mix
+   zero-length cases with variable-length ones. *)
+type fuzz_opt = OPad | OEnd | OGen of string
+
+let fuzz_opt_body_codec =
+  let f_len = Wire.Field.v "len" Wire.uint8 in
+  let f_data =
+    Wire.Field.v "data" (Wire.byte_array ~size:(Wire.Field.ref f_len))
+  in
+  Wire.Codec.v "FuzzOptBody"
+    (fun _l d -> d)
+    Wire.Codec.[ (f_len $ fun d -> String.length d); (f_data $ fun d -> d) ]
+
+let fuzz_opt_typ : fuzz_opt Wire.typ =
+  Wire.casetype "FuzzOpt" Wire.uint8
+    [
+      Wire.case ~index:0 Wire.empty
+        ~inject:(fun () -> OPad)
+        ~project:(function OPad -> Some () | _ -> None);
+      Wire.case ~index:255 Wire.empty
+        ~inject:(fun () -> OEnd)
+        ~project:(function OEnd -> Some () | _ -> None);
+      Wire.case ~index:53
+        (Wire.codec fuzz_opt_body_codec)
+        ~inject:(fun d -> OGen d)
+        ~project:(function OGen d -> Some d | _ -> None);
+    ]
+
+let fuzz_opt_size = function OPad | OEnd -> 1 | OGen d -> 2 + String.length d
+
+let fuzz_opts_codec =
+  let f_total = Wire.Field.v "total" Wire.uint16be in
+  let f_opts =
+    Wire.Field.repeat "opts" ~size:(Wire.Field.ref f_total) fuzz_opt_typ
+  in
+  Wire.Codec.v "FuzzOpts"
+    (fun _t xs -> xs)
+    Wire.Codec.
+      [
+        f_total $ List.fold_left (fun n o -> n + fuzz_opt_size o) 0;
+        (f_opts $ fun xs -> xs);
+      ]
+
+(* Cut [seed] into a list of options spanning all three case shapes: byte 0
+   yields PAD, 255 yields END, anything else yields a length-prefixed Generic
+   whose body is drawn from the following bytes. *)
+let extract_opts seed =
+  let len = String.length seed in
+  let rec loop i acc =
+    if i >= len then List.rev acc
+    else
+      let code = Char.code seed.[i] in
+      if code = 0 then loop (i + 1) (OPad :: acc)
+      else if code = 255 then loop (i + 1) (OEnd :: acc)
+      else
+        let take = min code (len - i - 1) in
+        let body = if take > 0 then String.sub seed (i + 1) take else "" in
+        loop (i + 1 + take) (OGen body :: acc)
+  in
+  loop 0 []
+
+let test_repeat_casetype_roundtrip seed =
+  let opts = extract_opts (truncate seed) in
+  let total = List.fold_left (fun n o -> n + fuzz_opt_size o) 0 opts in
+  let buf = Bytes.create (2 + total) in
+  Wire.Codec.encode fuzz_opts_codec opts buf 0;
+  let decoded =
+    match Wire.Codec.decode fuzz_opts_codec buf 0 with
+    | Ok x -> x
+    | Error e -> failf "repeat-casetype decode: %a" Wire.pp_parse_error e
+  in
+  if decoded <> opts then failf "repeat-casetype roundtrip mismatch"
+
 let repeat_tests =
   [
     test_case "repeat var-elem roundtrip" [ bytes ]
       test_repeat_var_elem_roundtrip;
+    test_case "repeat casetype-elem roundtrip" [ bytes ]
+      test_repeat_casetype_roundtrip;
   ]
 
 (* {1 Gen DSL tests}

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -145,6 +145,7 @@ and build_field_encoder : type a. a typ -> bytes -> int -> a -> int =
       let enc = build_field_encoder inner in
       fun buf off v -> enc buf off (encode v)
   | Unit -> fun _buf off () -> off
+  | Codec { codec_encode; _ } -> fun buf off v -> codec_encode v buf off
   | Casetype { tag; cases; _ } -> build_casetype_encoder tag cases
   | Array { len = Int _; elem; seq = Seq_map s } ->
       let enc_elem = build_field_encoder elem in
@@ -1015,6 +1016,7 @@ let rec read_elem : type a. a typ -> bytes -> int -> a =
         | _ :: rest -> find rest
       in
       find cases
+  | Unit -> ()
   | _ -> failwith "read_elem: unsupported element type in repeat"
 
 (* Write one element of a typ at a given buffer position. Used by Repeat. *)
@@ -1046,6 +1048,11 @@ let rec write_elem : type a. a typ -> bytes -> int -> a -> unit =
   | Map { inner; encode; _ } -> write_elem inner buf off (encode v)
   | Where { inner; _ } -> write_elem inner buf off v
   | Enum { base; _ } -> write_elem base buf off v
+  | Unit -> ()
+  (* Casetype reuses the full field encoder (tag + dispatched body); the
+     repeat loop advances by [elem_size_of], so the returned offset is
+     discarded here. *)
+  | Casetype _ -> ignore (build_field_encoder typ buf off v : int)
   | _ -> failwith "write_elem: unsupported element type in repeat"
 
 (* Compute the wire size of one element at a buffer position. Used by Repeat

--- a/test/3d/test_wire_3d.ml
+++ b/test/3d/test_wire_3d.ml
@@ -274,8 +274,54 @@ let e2e_repeat_var_elem =
       Codec.( $ ) f_exts (fun xs -> xs);
     ]
 
+(* [Field.repeat] over a [casetype] with mixed-shape cases: bare [unit] tags
+   (PAD/END) beside a length-prefixed sub-codec body (DHCP-options TLV). The
+   3D projection emits the casetype dispatch decl plus [DhcpOpt opts[:byte-size
+   total]]; this is the one shape that earlier tripped the codec's repeat
+   element path. *)
+type dhcp_opt = Pad | End | Generic of string
+
+let dhcp_opt_body_codec =
+  let open Wire in
+  let f_len = Field.v "len" uint8 in
+  let f_data = Field.v "data" (byte_array ~size:(Field.ref f_len)) in
+  Codec.v "DhcpOptBody"
+    (fun _l d -> d)
+    [
+      Codec.( $ ) f_len (fun d -> String.length d);
+      Codec.( $ ) f_data (fun d -> d);
+    ]
+
+let e2e_repeat_casetype_codec =
+  let open Wire in
+  let opt : dhcp_opt typ =
+    casetype "DhcpOpt" uint8
+      [
+        case ~index:0 empty
+          ~inject:(fun () -> Pad)
+          ~project:(function Pad -> Some () | _ -> None);
+        case ~index:255 empty
+          ~inject:(fun () -> End)
+          ~project:(function End -> Some () | _ -> None);
+        case ~index:53
+          (codec dhcp_opt_body_codec)
+          ~inject:(fun d -> Generic d)
+          ~project:(function Generic d -> Some d | _ -> None);
+      ]
+  in
+  let size = function Pad | End -> 1 | Generic d -> 2 + String.length d in
+  let f_total = Field.v "total" uint8 in
+  let f_opts = Field.repeat "opts" ~size:(Field.ref f_total) opt in
+  Codec.v "DhcpOpts"
+    (fun _t xs -> xs)
+    [
+      Codec.( $ ) f_total (List.fold_left (fun a o -> a + size o) 0);
+      Codec.( $ ) f_opts (fun xs -> xs);
+    ]
+
 let test_e2e_compile_run () =
   compile_and_run ~name:"Demo" e2e_simple_codec;
+  compile_and_run ~name:"DhcpOpts" e2e_repeat_casetype_codec;
   compile_and_run ~name:"CLCW" e2e_allcaps_codec;
   compile_and_run ~name:"TMFrame" e2e_tm_codec;
   compile_and_run ~name:"Ctt" e2e_casetype_codec;

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -3786,6 +3786,79 @@ let test_bitorder_diff_start_newword () =
   Alcotest.(check int)
     "byte 1 = 0x05 (Lsb_first y)" 0x05 (Bytes.get_uint8 buf 1)
 
+(* -- [repeat] of a [casetype] with mixed-shape cases (DHCP-options TLV) --
+
+   Each option dispatches on a [u8] code. PAD (0) and END (255) are a bare tag
+   with no body ([unit]); every other code is a length-prefixed body
+   ([len:u8] + [data:byte_array(len)]). This exercises a casetype as a repeat
+   element with structurally different per-case lengths -- zero-length cases
+   beside variable-length ones. *)
+type dhcp_opt = Pad | End | Generic of string
+type opt_body = { data : string }
+
+let ob_len = Field.v "len" uint8
+let ob_data = Field.v "data" (byte_array ~size:(Field.ref ob_len))
+
+let opt_body_codec =
+  Codec.v "OptBody"
+    (fun _l d -> { data = d })
+    Codec.
+      [ (ob_len $ fun b -> String.length b.data); (ob_data $ fun b -> b.data) ]
+
+let dhcp_opt_typ : dhcp_opt typ =
+  casetype "DhcpOpt" uint8
+    [
+      case ~index:0 empty
+        ~inject:(fun () -> Pad)
+        ~project:(function Pad -> Some () | _ -> None);
+      case ~index:255 empty
+        ~inject:(fun () -> End)
+        ~project:(function End -> Some () | _ -> None);
+      case ~index:53 (codec opt_body_codec)
+        ~inject:(fun b -> Generic b.data)
+        ~project:(function Generic d -> Some { data = d } | _ -> None);
+    ]
+
+let dhcp_opt_size = function Pad | End -> 1 | Generic d -> 2 + String.length d
+
+(* Trailing options region sized by a leading byte budget. *)
+let dhcp_f_total = Field.v "total" uint8
+
+let dhcp_f_opts =
+  Field.repeat "opts" ~size:(Field.ref dhcp_f_total) dhcp_opt_typ
+
+let dhcp_codec =
+  Codec.v "DhcpOpts"
+    (fun _t xs -> xs)
+    Codec.
+      [
+        ( dhcp_f_total $ fun xs ->
+          List.fold_left (fun a o -> a + dhcp_opt_size o) 0 xs );
+        (dhcp_f_opts $ fun xs -> xs);
+      ]
+
+let test_repeat_casetype_decode () =
+  (* total=10: 35 03 'abc' | 00 | 35 01 'z' | ff *)
+  let buf = Bytes.of_string "\x0a\x35\x03abc\x00\x35\x01z\xff" in
+  let opts = decode_ok (Codec.decode dhcp_codec buf 0) in
+  Alcotest.(check int) "count" 4 (List.length opts);
+  match opts with
+  | [ Generic "abc"; Pad; Generic "z"; End ] -> ()
+  | _ -> Alcotest.fail "unexpected options"
+
+let test_repeat_casetype_roundtrip () =
+  let v = [ Generic "abc"; Pad; Generic "z"; End ] in
+  let total = List.fold_left (fun a o -> a + dhcp_opt_size o) 0 v in
+  let buf = Bytes.create (1 + total) in
+  Codec.encode dhcp_codec v buf 0;
+  let decoded = decode_ok (Codec.decode dhcp_codec buf 0) in
+  Alcotest.(check bool) "roundtrip" true (decoded = v)
+
+let test_repeat_casetype_empty () =
+  let buf = Bytes.of_string "\x00" in
+  let opts = decode_ok (Codec.decode dhcp_codec buf 0) in
+  Alcotest.(check int) "empty" 0 (List.length opts)
+
 (* -- Suite -- *)
 
 let suite =
@@ -4103,6 +4176,12 @@ let suite =
         test_casetype_field_roundtrip;
       Alcotest.test_case "casetype field: length-prefixed" `Quick
         test_length_prefixed_casetype;
+      Alcotest.test_case "repeat: casetype TLV decode" `Quick
+        test_repeat_casetype_decode;
+      Alcotest.test_case "repeat: casetype TLV roundtrip" `Quick
+        test_repeat_casetype_roundtrip;
+      Alcotest.test_case "repeat: casetype TLV empty" `Quick
+        test_repeat_casetype_empty;
       Alcotest.test_case "repeat: with trailer" `Quick test_repeat_with_trailer;
       Alcotest.test_case "repeat: variable size elements" `Quick
         test_repeat_variable_size_elements;


### PR DESCRIPTION
[`read_elem`](https://github.com/parsimoni-labs/ocaml-wire/blob/repeat-casetype-in-repeat/lib/codec.ml#L972) and [`write_elem`](https://github.com/parsimoni-labs/ocaml-wire/blob/repeat-casetype-in-repeat/lib/codec.ml#L1023), the element path used only by `Field.repeat`, had no case for `casetype`, nor for a `unit` body, so a `Field.repeat` over a tag-dispatched union raised `Failure "unsupported element type in repeat"` on both decode and encode.

The fix routes that path through the field encoder and decoder used everywhere else. A repeated `casetype` whose cases mix bare single-byte tags (PAD and END) with length-prefixed bodies, the shape of a DHCP options TLV, now round-trips and the projection verifies end-to-end through `3d.exe`.