### PR TITLE
chore: clear pre-existing merlint project-structure warnings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,9 @@
 
 ### Changed
 
+- `memtrace` is now a regular dependency rather than test-only: the
+  benchmark libraries link it outside the test scope, so `opam install`
+  pulls it in (#76, @samoht)
 - Remove `Wire.optional` / `Wire.optional_or` / `Wire.repeat` /
   `Wire.repeat_seq` from the typ-level surface; use the matching
   `Field.*` combinators instead (#46, @samoht)

--- a/dune-project
+++ b/dune-project
@@ -26,7 +26,7 @@
   (bytesrw (>= 0.1))
   (eio (>= 1.0))
   (fmt (>= 0.9))
-  (memtrace :with-test)
+  memtrace
   (alcotest :with-test)
   (alcobar :with-test)
   (re :with-test)

--- a/test/diff/dune
+++ b/test/diff/dune
@@ -40,11 +40,12 @@
 ;
 ; Run with: BUILD_EVERPARSE=1 dune build @ocaml-wire/test/diff/gen_c
 
+; The executable builds unconditionally (its deps are always available) so
+; gen_c.ml is covered by a live stanza; only the generation rule below, which
+; needs 3d.exe, stays gated on BUILD_EVERPARSE.
 (executable
  (name gen_c)
  (modules gen_c)
- (enabled_if
-  (= %{env:BUILD_EVERPARSE=} "1"))
  (libraries wire wire.3d wire.stubs unix))
 
 (rule

--- a/wire.opam
+++ b/wire.opam
@@ -15,7 +15,7 @@ depends: [
   "bytesrw" {>= "0.1"}
   "eio" {>= "1.0"}
   "fmt" {>= "0.9"}
-  "memtrace" {with-test}
+  "memtrace"
   "alcotest" {with-test}
   "alcobar" {with-test}
   "re" {with-test}


### PR DESCRIPTION
Two pre-existing `merlint` project-structure warnings on `main`, split out of the feature work that surfaced them.

`memtrace` was declared `with-test` in [`dune-project`](https://github.com/parsimoni-labs/ocaml-wire/blob/chore-merlint-debt/dune-project), but the routing, gateway and clcw benchmark libraries link it outside any test scope (E941), so it becomes a regular dependency. The `gen_c` executable in [`test/diff/dune`](https://github.com/parsimoni-labs/ocaml-wire/blob/chore-merlint-debt/test/diff/dune) was gated on `BUILD_EVERPARSE`, leaving its module in no live stanza and silently excluded from the build (E523); it now builds unconditionally with only its generation rule gated, since its dependencies are always available.