### PR TITLE
wire: add zeroterm string combinators

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ### Added
 
+- Add `Wire.zeroterm` and `Wire.zeroterm_at_most ~size` for
+  NUL-terminated strings: the bytes up to a terminator, or the same
+  within a fixed-size region. They project to the 3D `field[:zeroterm]`
+  and `field[:zeroterm-byte-size-at-most n]` forms (#77, @samoht)
 - `Wire.casetype` now accepts any tag typ (`'k typ`, not just `int`) and
   projects cleanly to 3D: int-tagged casetypes get an auto-emitted
   `casetype_decl` + wrapper typedef; byte-tagged casetypes (e.g.

--- a/fuzz/fuzz_wire.ml
+++ b/fuzz/fuzz_wire.ml
@@ -1317,6 +1317,56 @@ let repeat_tests =
       test_repeat_casetype_roundtrip;
   ]
 
+(* Zero-terminated strings: a NUL-terminated [name] followed by a
+   NUL-terminated [tag] bounded to 8 bytes, then a trailing scalar. *)
+type fuzz_zt = { z_name : string; z_tag : string; z_n : int }
+
+let fuzz_zt_codec =
+  let f_name = Wire.Field.v "name" Wire.zeroterm in
+  let f_tag = Wire.Field.v "tag" (Wire.zeroterm_at_most ~size:(Wire.int 8)) in
+  let f_n = Wire.Field.v "n" Wire.uint8 in
+  Wire.Codec.v "FuzzZt"
+    (fun name tag n -> { z_name = name; z_tag = tag; z_n = n })
+    Wire.Codec.
+      [
+        (f_name $ fun r -> r.z_name);
+        (f_tag $ fun r -> r.z_tag);
+        (f_n $ fun r -> r.z_n);
+      ]
+
+(* Strip NULs (a zeroterm value cannot contain its own terminator) and bound
+   the tag to 7 data bytes so it fits the 8-byte region with its terminator. *)
+let strip_nul s = String.concat "" (String.split_on_char '\000' s)
+
+let test_zeroterm_roundtrip seed =
+  let s = truncate seed in
+  let n = String.length s in
+  let cut = n / 2 in
+  let name = strip_nul (String.sub s 0 cut) in
+  let tag0 = strip_nul (String.sub s cut (n - cut)) in
+  let tag = if String.length tag0 > 7 then String.sub tag0 0 7 else tag0 in
+  let v =
+    { z_name = name; z_tag = tag; z_n = (if n > 0 then Char.code s.[0] else 0) }
+  in
+  let buf = Bytes.create (String.length name + 1 + 8 + 1) in
+  Wire.Codec.encode fuzz_zt_codec v buf 0;
+  match Wire.Codec.decode fuzz_zt_codec buf 0 with
+  | Ok r -> if r <> v then failf "zeroterm roundtrip mismatch"
+  | Error e -> failf "zeroterm decode: %a" Wire.pp_parse_error e
+
+(* Crash safety: decoding arbitrary bytes through a zeroterm field must never
+   raise -- an unterminated run is a clean parse error. *)
+let test_zeroterm_parse_crash buf =
+  let buf = truncate buf in
+  let _ = Wire.of_string Wire.zeroterm buf in
+  ()
+
+let zeroterm_tests =
+  [
+    test_case "zeroterm roundtrip" [ bytes ] test_zeroterm_roundtrip;
+    test_case "zeroterm parse crash-safety" [ bytes ] test_zeroterm_parse_crash;
+  ]
+
 (* {1 Gen DSL tests}
 
    Each leaf and the [Codec.v] composer drive three Alcobar generators
@@ -1450,4 +1500,5 @@ let alt_entry_tests =
 let suite =
   ( "wire",
     parse_tests @ roundtrip_tests @ record_tests @ stream_tests @ depsize_tests
-    @ float_tests @ repeat_tests @ gen_tests @ alt_entry_tests )
+    @ float_tests @ repeat_tests @ zeroterm_tests @ gen_tests @ alt_entry_tests
+  )

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -925,6 +925,7 @@ let rec iter_param_refs_typ : type a. (Param.packed -> unit) -> a typ -> unit =
       iter_param_refs f size;
       iter_param_refs f cond
   | Uint_var { size; _ } -> iter_param_refs f size
+  | Zeroterm_at_most { size } -> iter_param_refs f size
   | Single_elem { size; elem; _ } ->
       iter_param_refs f size;
       iter_param_refs_typ f elem
@@ -956,7 +957,7 @@ let rec iter_param_refs_typ : type a. (Param.packed -> unit) -> a typ -> unit =
         cases
   | Uint8 | Uint16 _ | Uint32 _ | Uint63 _ | Uint64 _ | Int8 | Int16 _ | Int32 _
   | Int64 _ | Float32 _ | Float64 _ | Bits _ | Unit | All_bytes | All_zeros
-  | Struct _ | Type_ref _ | Qualified_ref _ | Codec _ ->
+  | Zeroterm | Struct _ | Type_ref _ | Qualified_ref _ | Codec _ ->
       ()
 
 let iter_param_refs_fields f fields where =
@@ -1636,6 +1637,18 @@ let compile_repeat : type elt seq r.
     populate = no_populate;
   }
 
+(* Absolute index of the first NUL at or after [first], searching up to (but
+   not including) [limit]. Raises [Parse_error] when the region ends before a
+   terminator is found -- a truncated / unterminated zero-terminated string. *)
+let zeroterm_nul_pos buf ~first ~limit =
+  let rec go i =
+    if i >= limit then
+      raise (Parse_error (Constraint_failed "zeroterm: missing NUL terminator"))
+    else if Bytes.get_uint8 buf i = 0 then i
+    else go (i + 1)
+  in
+  go first
+
 let var_bytes_reader : type a.
     a typ -> (bytes -> int -> int) -> (bytes -> int -> int) -> bytes -> int -> a
     =
@@ -1647,6 +1660,12 @@ let var_bytes_reader : type a.
   | Byte_array _ -> Bytes.sub_string buf (base + fo) sz
   | Byte_array_where _ -> Bytes.sub_string buf (base + fo) sz
   | All_bytes -> Bytes.sub_string buf (base + fo) sz
+  (* [sz] already counts the terminator (see [compile_var_size_fn]). *)
+  | Zeroterm -> Bytes.sub_string buf (base + fo) (sz - 1)
+  | Zeroterm_at_most _ ->
+      let first = base + fo in
+      let nul = zeroterm_nul_pos buf ~first ~limit:(first + sz) in
+      Bytes.sub_string buf first (nul - first)
   | All_zeros ->
       let s = Bytes.sub_string buf (base + fo) sz in
       String.iter
@@ -1707,6 +1726,28 @@ let var_bytes_writer : type a r.
       let len = String.length s in
       Bytes.blit_string s 0 buf write_off len;
       write_off + len
+  | Zeroterm ->
+      let s = (value : string) in
+      if String.contains s '\000' then
+        invalid_arg "Codec.encode: zeroterm string contains a NUL byte";
+      let len = String.length s in
+      Bytes.blit_string s 0 buf write_off len;
+      Bytes.set_uint8 buf (write_off + len) 0;
+      write_off + len + 1
+  | Zeroterm_at_most _ ->
+      let s = (value : string) in
+      if String.contains s '\000' then
+        invalid_arg "Codec.encode: zeroterm string contains a NUL byte";
+      let region = size_fn buf base in
+      let len = String.length s in
+      if len + 1 > region then
+        Fmt.invalid_arg
+          "Codec.encode: zeroterm string needs %d bytes but region is %d"
+          (len + 1) region;
+      Bytes.blit_string s 0 buf write_off len;
+      (* Single fill covers the NUL terminator and any trailing padding. *)
+      Bytes.fill buf (write_off + len) (region - len) '\x00';
+      write_off + region
   | Casetype _ -> build_field_encoder typ buf write_off value
   | Single_elem { elem; _ } ->
       let n = size_fn buf base in
@@ -1730,6 +1771,11 @@ let compile_var_size_fn : type a.
       (* Tag is decoded first; the case body's size is whatever the
          selected case's inner typ reports. *)
       fun buf base -> elem_size_of typ buf (base + off_fn buf base)
+  | Zeroterm ->
+      (* Consumed bytes = string length plus the one-byte NUL terminator. *)
+      fun buf base ->
+        let first = base + off_fn buf base in
+        zeroterm_nul_pos buf ~first ~limit:(Bytes.length buf) - first + 1
   | _ ->
       let size_expr =
         match typ with
@@ -1738,6 +1784,7 @@ let compile_var_size_fn : type a.
         | Byte_array_where { size; _ } -> size
         | Uint_var { size; _ } -> size
         | Single_elem { size; _ } -> size
+        | Zeroterm_at_most { size } -> size
         | _ -> invalid_arg "add_field: unsupported variable-size field type"
       in
       let sizeof_this : bytes -> int -> int =

--- a/lib/eval.ml
+++ b/lib/eval.ml
@@ -38,9 +38,10 @@ let rec int_of : type a. a typ -> a -> int option =
   | Single_elem { elem; _ } -> int_of elem v
   | Apply { typ; _ } -> int_of typ v
   | Map { inner; encode; _ } -> int_of inner (encode v)
-  | Unit | All_bytes | All_zeros | Array _ | Byte_array _ | Byte_array_where _
-  | Byte_slice _ | Casetype _ | Struct _ | Type_ref _ | Qualified_ref _
-  | Codec _ | Optional _ | Optional_or _ | Repeat _ ->
+  | Unit | All_bytes | All_zeros | Zeroterm | Zeroterm_at_most _ | Array _
+  | Byte_array _ | Byte_array_where _ | Byte_slice _ | Casetype _ | Struct _
+  | Type_ref _ | Qualified_ref _ | Codec _ | Optional _ | Optional_or _
+  | Repeat _ ->
       None
 
 let rec expr : type a. ctx -> a expr -> a =

--- a/lib/everparse.ml
+++ b/lib/everparse.ml
@@ -24,6 +24,7 @@ let rec is_byte_field : type a. a Types.typ -> bool = function
   | Types.Uint_var _ ->
       true
   | Types.All_bytes | Types.All_zeros -> true
+  | Types.Zeroterm | Types.Zeroterm_at_most _ -> true
   | Types.Optional { present = Types.Bool _; _ } -> false
   | Types.Optional _ -> true
   | Types.Optional_or { present = Types.Bool _; _ } -> false

--- a/lib/param.ml
+++ b/lib/param.ml
@@ -38,9 +38,10 @@ let rec int_cvt : type a. a Types.typ -> a int_cvt =
       let c = int_cvt inner in
       { fwd = (fun v -> c.fwd (encode v)); bwd = (fun v -> decode (c.bwd v)) }
   | Apply { typ; _ } -> int_cvt typ
-  | Unit | All_bytes | All_zeros | Array _ | Byte_array _ | Byte_array_where _
-  | Byte_slice _ | Casetype _ | Struct _ | Type_ref _ | Qualified_ref _
-  | Codec _ | Optional _ | Optional_or _ | Repeat _ ->
+  | Unit | All_bytes | All_zeros | Zeroterm | Zeroterm_at_most _ | Array _
+  | Byte_array _ | Byte_array_where _ | Byte_slice _ | Casetype _ | Struct _
+  | Type_ref _ | Qualified_ref _ | Codec _ | Optional _ | Optional_or _
+  | Repeat _ ->
       invalid_arg "Param: unsupported parameter type"
 
 let to_int typ v = (int_cvt typ).fwd v

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -89,6 +89,8 @@ and _ typ =
   | Unit : unit typ
   | All_bytes : string typ
   | All_zeros : string typ
+  | Zeroterm : string typ
+  | Zeroterm_at_most : { size : int expr } -> string typ
   | Where : { cond : bool expr; inner : 'a typ } -> 'a typ
   | Array : {
       len : int expr;
@@ -348,6 +350,8 @@ let cases variants inner =
 let unit = Unit
 let all_bytes = All_bytes
 let all_zeros = All_zeros
+let zeroterm = Zeroterm
+let zeroterm_at_most ~size = Zeroterm_at_most { size }
 
 let where cond inner =
   reject_decoration ~combinator:"where" inner;
@@ -583,6 +587,7 @@ let rec ocaml_kind_of : type a. a typ -> ocaml_kind = function
   | Byte_array _ -> String
   | Byte_array_where _ -> String
   | Byte_slice _ -> String (* approximate: slice becomes string in output *)
+  | Zeroterm | Zeroterm_at_most _ -> String
   | Unit | All_bytes | All_zeros -> Unit
   | _ -> Int (* fallback *)
 
@@ -971,6 +976,9 @@ and pp_typ : type a. a typ Fmt.t =
   | Unit -> Fmt.string ppf "unit"
   | All_bytes -> Fmt.string ppf "all_bytes"
   | All_zeros -> Fmt.string ppf "all_zeros"
+  | Zeroterm -> Fmt.string ppf "UINT8[:zeroterm]"
+  | Zeroterm_at_most { size } ->
+      Fmt.pf ppf "UINT8[:zeroterm-byte-size-at-most %a]" pp_expr size
   | Where { cond; inner } -> Fmt.pf ppf "%a { %a }" pp_typ inner pp_expr cond
   | Array { len; elem; _ } -> Fmt.pf ppf "%a[%a]" pp_typ elem pp_expr len
   | Byte_array { size } | Byte_slice { size } ->
@@ -1084,6 +1092,8 @@ type field_suffix =
   | Byte_array of int expr
   | Single_elem of { size : int expr; at_most : bool }
   | Array of int expr
+  | Zeroterm
+  | Zeroterm_at_most of int expr
 
 let rec inner_wire_size : type a. a typ -> int option = function
   | Uint8 -> Some 1
@@ -1110,6 +1120,7 @@ let rec inner_wire_size_expr : type a. a typ -> int expr option = function
   | Byte_array { size } | Byte_slice { size } | Byte_array_where { size; _ } ->
       Some size
   | Single_elem { size; _ } -> Some size
+  | Zeroterm_at_most { size } -> Some size
   | Uint_var { size; _ } -> Some size
   | Array { len; elem; _ } -> (
       match inner_wire_size_expr elem with
@@ -1168,6 +1179,9 @@ let rec field_suffix : type a.
   | Repeat { size; elem; _ } ->
       (* Variable-length array with byte-size budget *)
       (Byte_array size, fun ppf -> pp_typ ppf elem)
+  | Zeroterm -> (Zeroterm, fun ppf -> Fmt.string ppf "UINT8")
+  | Zeroterm_at_most { size } ->
+      (Zeroterm_at_most size, fun ppf -> Fmt.string ppf "UINT8")
   | _ -> (No_suffix, fun ppf -> pp_typ ppf typ)
 
 let anon_counter = Stdlib.ref 0
@@ -1209,6 +1223,9 @@ let pp_field ppf (Field f) =
       Fmt.pf ppf "[:byte-size-single-element-array %a]" pp_expr size
   | Single_elem { size; at_most = true } ->
       Fmt.pf ppf "[:byte-size-single-element-array-at-most %a]" pp_expr size
+  | Zeroterm -> Fmt.pf ppf "[:zeroterm]"
+  | Zeroterm_at_most size ->
+      Fmt.pf ppf "[:zeroterm-byte-size-at-most %a]" pp_expr size
   | Array len -> Fmt.pf ppf "[%a]" pp_expr len);
   Option.iter (Fmt.pf ppf " { %a }" pp_expr) constraint_;
   Option.iter (Fmt.pf ppf " %a" pp_action) f.action;
@@ -1426,6 +1443,9 @@ let rec size_of_typ_value : type a. a typ -> a -> int =
   | Unit -> 0
   | All_bytes -> String.length v
   | All_zeros -> String.length v
+  | Zeroterm -> String.length v + 1
+  | Zeroterm_at_most { size = Int n } -> n
+  | Zeroterm_at_most _ -> 0
   | Byte_array _ -> String.length v
   | Byte_array_where _ -> String.length v
   | Byte_slice _ -> Bytesrw.Bytes.Slice.length v

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -121,6 +121,9 @@ and _ typ =
   | Unit : unit typ  (** Zero-width. *)
   | All_bytes : string typ  (** Remaining bytes as string. *)
   | All_zeros : string typ  (** Remaining bytes, must be zero. *)
+  | Zeroterm : string typ  (** NUL-terminated string. *)
+  | Zeroterm_at_most : { size : int expr } -> string typ
+      (** NUL-terminated string within an [size]-byte region. *)
   | Where : { cond : bool expr; inner : 'a typ } -> 'a typ  (** Guarded. *)
   | Array : {
       len : int expr;
@@ -455,6 +458,22 @@ val all_bytes : string typ
 
 val all_zeros : string typ
 (** Consume remaining bytes, asserting all zero. *)
+
+val zeroterm : string typ
+(** [zeroterm] is a NUL-terminated string: bytes up to (but excluding) the first
+    [0x00], which is consumed. Projects to the 3D [field[:zeroterm]] form, which
+    desugars to the EverParse prelude [cstring]/[parse_string] combinator. This
+    3D feature has no [3d-lang.html] section; see [EverParse3d.Prelude.fsti].
+    Encoding a string that itself contains a [0x00] raises [Invalid_argument].
+*)
+
+val zeroterm_at_most : size:int expr -> string typ
+(** [zeroterm_at_most ~size] is a NUL-terminated string occupying a fixed
+    [size]-byte region: the terminator must appear within [size] bytes, and the
+    field always consumes exactly [size] bytes (trailing bytes after the
+    terminator are zero padding). Projects to the 3D
+    [field[:zeroterm-byte-size-at-most size]] form ([t_at_most] of [cstring]).
+    Undocumented in the manual; see [EverParse3d.Prelude.fsti]. *)
 
 val where : bool expr -> 'a typ -> 'a typ
 (** Guard a type with a boolean constraint. *)

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -155,6 +155,16 @@ let parse_all_zeros buf off len =
   in
   (check 0, len)
 
+(* Index of the first NUL in [first, limit); raises on an unterminated run. *)
+let nul_pos buf ~first ~limit =
+  let rec go i =
+    if i >= limit then
+      raise (Parse_exn (Constraint_failed "zeroterm: missing NUL terminator"))
+    else if Bytes.get_uint8 buf i = 0 then i
+    else go (i + 1)
+  in
+  go first
+
 let parse_codec_typ codec_decode fixed_size size_of buf off len =
   let sz = match fixed_size with Some n -> n | None -> size_of buf off in
   check_eof len (off + sz);
@@ -245,6 +255,14 @@ let rec parse_direct : type a. a typ -> bytes -> int -> int -> a * int =
   | Unit -> ((), off)
   | All_bytes -> (Bytes.sub_string buf off (len - off), len)
   | All_zeros -> parse_all_zeros buf off len
+  | Zeroterm ->
+      let nul = nul_pos buf ~first:off ~limit:len in
+      (Bytes.sub_string buf off (nul - off), nul + 1)
+  | Zeroterm_at_most { size } ->
+      let n = Eval.expr Eval.empty size in
+      check_eof len (off + n);
+      let nul = nul_pos buf ~first:off ~limit:(off + n) in
+      (Bytes.sub_string buf off (nul - off), off + n)
   | Byte_array { size } ->
       let n = Eval.expr Eval.empty size in
       check_eof len (off + n);
@@ -560,6 +578,25 @@ let rec encode_into : type a. a typ -> a -> encoder -> unit =
   | Unit -> ()
   | All_bytes -> write_string enc v
   | All_zeros -> write_string enc v
+  | Zeroterm ->
+      if String.contains v '\000' then
+        invalid_arg "Wire.encode: zeroterm string contains a NUL byte";
+      write_string enc v;
+      write_byte enc 0
+  | Zeroterm_at_most { size } ->
+      if String.contains v '\000' then
+        invalid_arg "Wire.encode: zeroterm string contains a NUL byte";
+      let n = Eval.expr Eval.empty size in
+      let len = String.length v in
+      if len + 1 > n then
+        Fmt.invalid_arg
+          "Wire.encode: zeroterm string needs %d bytes but region is %d"
+          (len + 1) n;
+      write_string enc v;
+      (* Remaining bytes = NUL terminator plus any trailing padding. *)
+      for _ = len to n - 1 do
+        write_byte enc 0
+      done
   | Where { inner; _ } -> encode_into inner v enc
   | Array { elem; seq = Seq_map seq; _ } ->
       seq.iter (fun elem_v -> encode_into elem elem_v enc) v

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -559,6 +559,25 @@ val all_zeros : string typ
     This is mainly useful as the final field of a struct or record-shaped
     layout. *)
 
+val zeroterm : string typ
+(** [zeroterm] is a NUL-terminated string: the bytes up to (but excluding) the
+    first [0x00], which is consumed. Encoding a string that itself contains a
+    [0x00] raises [Invalid_argument].
+
+    Projects to the 3D [field[:zeroterm]] form, which desugars to the EverParse
+    prelude [cstring]/[parse_string] combinator. This 3D feature predates the
+    manual and has no [3d-lang.html] section; see [EverParse3d.Prelude.fsti]. *)
+
+val zeroterm_at_most : size:int expr -> string typ
+(** [zeroterm_at_most ~size] is a NUL-terminated string occupying a fixed
+    [size]-byte region: the terminator must appear within [size] bytes and the
+    field always consumes exactly [size] bytes (bytes after the terminator are
+    zero padding).
+
+    Projects to the 3D [field[:zeroterm-byte-size-at-most size]] form
+    ([t_at_most] of [cstring]). Like {!zeroterm}, undocumented in the manual;
+    see [EverParse3d.Prelude.fsti]. *)
+
 val where : bool expr -> 'a typ -> 'a typ
 (** Refine a description with a boolean constraint. *)
 

--- a/test/3d/test_wire_3d.ml
+++ b/test/3d/test_wire_3d.ml
@@ -319,9 +319,26 @@ let e2e_repeat_casetype_codec =
       Codec.( $ ) f_opts (fun xs -> xs);
     ]
 
+(* Zero-terminated strings: [name] runs to a NUL, [tag] is NUL-terminated
+   within a fixed region, then a trailing scalar. Projects to the 3D
+   [field[:zeroterm]] and [field[:zeroterm-byte-size-at-most n]] forms. *)
+let e2e_zeroterm_codec =
+  let open Wire in
+  let f_name = Field.v "name" zeroterm in
+  let f_tag = Field.v "tag" (zeroterm_at_most ~size:(int 8)) in
+  let f_n = Field.v "n" uint8 in
+  Codec.v "ZtRec"
+    (fun name tag n -> (name, tag, n))
+    [
+      Codec.( $ ) f_name (fun (s, _, _) -> s);
+      Codec.( $ ) f_tag (fun (_, t, _) -> t);
+      Codec.( $ ) f_n (fun (_, _, n) -> n);
+    ]
+
 let test_e2e_compile_run () =
   compile_and_run ~name:"Demo" e2e_simple_codec;
   compile_and_run ~name:"DhcpOpts" e2e_repeat_casetype_codec;
+  compile_and_run ~name:"ZtRec" e2e_zeroterm_codec;
   compile_and_run ~name:"CLCW" e2e_allcaps_codec;
   compile_and_run ~name:"TMFrame" e2e_tm_codec;
   compile_and_run ~name:"Ctt" e2e_casetype_codec;

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -3859,6 +3859,58 @@ let test_repeat_casetype_empty () =
   let opts = decode_ok (Codec.decode dhcp_codec buf 0) in
   Alcotest.(check int) "empty" 0 (List.length opts)
 
+(* -- Zero-terminated strings ([zeroterm] / [zeroterm_at_most]) -- *)
+
+type zt_rec = { zt_name : string; zt_tag : string; zt_n : int }
+
+let zt_f_name = Field.v "name" zeroterm
+let zt_f_tag = Field.v "tag" (zeroterm_at_most ~size:(int 8))
+let zt_f_n = Field.v "n" uint8
+
+let zt_codec =
+  Codec.v "ZtRec"
+    (fun name tag n -> { zt_name = name; zt_tag = tag; zt_n = n })
+    Codec.
+      [
+        (zt_f_name $ fun r -> r.zt_name);
+        (zt_f_tag $ fun r -> r.zt_tag);
+        (zt_f_n $ fun r -> r.zt_n);
+      ]
+
+let test_zeroterm_roundtrip () =
+  let v = { zt_name = "hello"; zt_tag = "ab"; zt_n = 7 } in
+  (* name(5+1) + tag(8) + n(1) = 15 *)
+  let buf = Bytes.create 15 in
+  Codec.encode zt_codec v buf 0;
+  Alcotest.(check int) "NUL after name" 0 (Bytes.get_uint8 buf 5);
+  Alcotest.(check int) "NUL after tag" 0 (Bytes.get_uint8 buf 8);
+  let r = decode_ok (Codec.decode zt_codec buf 0) in
+  Alcotest.(check string) "name" "hello" r.zt_name;
+  Alcotest.(check string) "tag" "ab" r.zt_tag;
+  Alcotest.(check int) "n" 7 r.zt_n
+
+let test_zeroterm_empty () =
+  let v = { zt_name = ""; zt_tag = ""; zt_n = 0 } in
+  let buf = Bytes.create 15 in
+  Codec.encode zt_codec v buf 0;
+  let r = decode_ok (Codec.decode zt_codec buf 0) in
+  Alcotest.(check string) "name" "" r.zt_name;
+  Alcotest.(check string) "tag" "" r.zt_tag
+
+let test_zeroterm_embedded_nul_rejected () =
+  let v = { zt_name = "a\000b"; zt_tag = ""; zt_n = 0 } in
+  let buf = Bytes.create 15 in
+  match Codec.encode zt_codec v buf 0 with
+  | () -> Alcotest.fail "expected Invalid_argument for embedded NUL"
+  | exception Invalid_argument _ -> ()
+
+let test_zeroterm_missing_terminator () =
+  (* No NUL anywhere: decode must fail rather than read past the buffer. *)
+  let buf = Bytes.make 6 'x' in
+  match Codec.decode zt_codec buf 0 with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "expected decode error on unterminated string"
+
 (* -- Suite -- *)
 
 let suite =
@@ -4182,6 +4234,13 @@ let suite =
         test_repeat_casetype_roundtrip;
       Alcotest.test_case "repeat: casetype TLV empty" `Quick
         test_repeat_casetype_empty;
+      (* zero-terminated strings *)
+      Alcotest.test_case "zeroterm: roundtrip" `Quick test_zeroterm_roundtrip;
+      Alcotest.test_case "zeroterm: empty" `Quick test_zeroterm_empty;
+      Alcotest.test_case "zeroterm: embedded NUL rejected" `Quick
+        test_zeroterm_embedded_nul_rejected;
+      Alcotest.test_case "zeroterm: missing terminator" `Quick
+        test_zeroterm_missing_terminator;
       Alcotest.test_case "repeat: with trailer" `Quick test_repeat_with_trailer;
       Alcotest.test_case "repeat: variable size elements" `Quick
         test_repeat_variable_size_elements;


### PR DESCRIPTION
[`zeroterm`](https://github.com/parsimoni-labs/ocaml-wire/blob/zeroterm-strings/lib/wire.mli#L562) and [`zeroterm_at_most`](https://github.com/parsimoni-labs/ocaml-wire/blob/zeroterm-strings/lib/wire.mli#L571) describe NUL-terminated strings: the bytes up to (and consuming) the first `0x00`, or the same within a fixed-size region that pads the remainder with zeros. They round-trip on the OCaml side, rejecting an embedded `0x00` on encode and a missing terminator on decode.

Both project to the EverParse 3D `field[:zeroterm]` and `field[:zeroterm-byte-size-at-most n]` forms (the prelude `cstring`/`parse_string`; this 3D feature predates the manual and has no `3d-lang.html` section). The end-to-end test compiles and runs the generated validator through `3d.exe`, which discharges all verification conditions.