### PR TITLE
codec: size_of_value over casetype fields

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -70,6 +70,11 @@
 
 ### Fixed
 
+- `Codec.size_of_value` now counts a `Wire.casetype` field's tag and
+  matched-case body instead of reporting zero for it. Sizing a buffer with
+  `Codec.size_of_value` for a codec containing a casetype field used to
+  under-allocate, so `Codec.encode` then ran off the end with
+  `Invalid_argument "index out of bounds"` (#NN, @samoht)
 - `Field.repeat` over a `Wire.casetype` element now encodes and decodes
   instead of raising `Failure "unsupported element type in repeat"`. The
   repeat element path had no case for a tag-dispatched union, which ruled

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -1481,7 +1481,21 @@ let rec size_of_typ_value : type a. a typ -> a -> int =
       s.iter (fun e -> total := !total + size_of_typ_value elem e) v;
       !total
   | Apply { typ; _ } -> size_of_typ_value typ v
-  | Casetype _ -> 0
+  | Casetype { tag; cases; _ } ->
+      (* Tag bytes plus the matched case's body: find the branch whose
+         [project] accepts [v], then size its inner from the projected body.
+         Without this the value-driven size dropped the whole casetype to 0,
+         so [Codec.size_of_value] under-allocated and [encode] ran off the
+         buffer. *)
+      let tag_size = Option.value ~default:0 (inner_wire_size tag) in
+      let rec find = function
+        | [] -> tag_size
+        | Case_branch { cb_inner; cb_project; _ } :: rest -> (
+            match cb_project v with
+            | Some body -> tag_size + size_of_typ_value cb_inner body
+            | None -> find rest)
+      in
+      find cases
   | Struct _ -> 0
   | Type_ref _ -> 0
   | Qualified_ref _ -> 0

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -3148,6 +3148,20 @@ let test_casetype_field_roundtrip () =
     "data roundtrip" true
     (original.ev_data = decoded.ev_data)
 
+(* [Codec.size_of_value] must count a casetype field's tag + matched-case
+   body. It used to drop the whole casetype to 0, so a buffer sized from it
+   was too short and [Codec.encode] ran off the end. *)
+let test_casetype_size_of_value () =
+  let original = { ev_ts = 123L; ev_data = `Login 0xabcd } in
+  (* ev_ts (8) + tag (1) + Login body uint16be (2) = 11 *)
+  let n = Codec.size_of_value casetype_field_codec original in
+  Alcotest.(check int) "size_of_value" 11 n;
+  let buf = Bytes.create n in
+  Codec.encode casetype_field_codec original buf 0;
+  let decoded = decode_ok (Codec.decode casetype_field_codec buf 0) in
+  Alcotest.(check int64) "ts" original.ev_ts decoded.ev_ts;
+  Alcotest.(check bool) "data" true (original.ev_data = decoded.ev_data)
+
 (* Length-prefixed casetype dispatch: [tag][length][body] where length
    bounds the inner casetype's tag + body. *)
 
@@ -4226,6 +4240,8 @@ let suite =
         test_casetype_field_default;
       Alcotest.test_case "casetype field: roundtrip" `Quick
         test_casetype_field_roundtrip;
+      Alcotest.test_case "casetype field: size_of_value" `Quick
+        test_casetype_size_of_value;
       Alcotest.test_case "casetype field: length-prefixed" `Quick
         test_length_prefixed_casetype;
       Alcotest.test_case "repeat: casetype TLV decode" `Quick


### PR DESCRIPTION
[`size_of_typ_value`](https://github.com/parsimoni-labs/ocaml-wire/blob/fix-size-of-value-casetype/lib/types.ml#L1484) reported zero bytes for a `Wire.casetype`, so `Codec.size_of_value` on any codec containing a casetype field under-counted. The usual `let buf = Bytes.create (Codec.size_of_value c v) in Codec.encode c v buf 0` idiom then allocated a buffer too small for the encoded tag and body, and `Codec.encode` ran off the end with `Invalid_argument "index out of bounds"` instead of producing bytes.

The size is computable from the value: the tag width plus the size of the matched case's body, found by walking the branches' `project` functions. The fix does that, so a casetype's value-driven size now matches the bytes `encode` writes (and `wire_size_at` reads). Pure codec-side fix; the 3D projection doesn't use `size_of_value`.