### PR TITLE
codec: size_of_value over repeat fields

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -70,11 +70,16 @@
 
 ### Fixed
 
+- `Codec.size_of_value` now counts a `Field.repeat`'s elements instead of
+  reporting zero for a dynamic byte budget. Like the casetype case in #78, a
+  buffer sized from `Codec.size_of_value` for a codec with a repeat field
+  under-allocated, so `Codec.encode` ran off the end with
+  `Invalid_argument "index out of bounds"` (#79, @samoht)
 - `Codec.size_of_value` now counts a `Wire.casetype` field's tag and
   matched-case body instead of reporting zero for it. Sizing a buffer with
   `Codec.size_of_value` for a codec containing a casetype field used to
   under-allocate, so `Codec.encode` then ran off the end with
-  `Invalid_argument "index out of bounds"` (#NN, @samoht)
+  `Invalid_argument "index out of bounds"` (#78, @samoht)
 - `Field.repeat` over a `Wire.casetype` element now encodes and decodes
   instead of raising `Failure "unsupported element type in repeat"`. The
   repeat element path had no case for a tag-dispatched union, which ruled

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -1474,8 +1474,13 @@ let rec size_of_typ_value : type a. a typ -> a -> int =
   | Codec { codec_size_of_value; _ } -> codec_size_of_value v
   | Single_elem { size = Int n; _ } -> n
   | Single_elem _ -> 0
-  | Repeat { size = Int n; _ } -> n
-  | Repeat _ -> 0
+  | Repeat { elem; seq = Seq_map s; _ } ->
+      (* Sum the actual element sizes from the value, like [Array]. The byte
+         budget ([size]) is only a literal when fixed; a dynamic budget left
+         this at 0, so [Codec.size_of_value] under-counted a repeat field. *)
+      let total = Stdlib.ref 0 in
+      s.iter (fun e -> total := !total + size_of_typ_value elem e) v;
+      !total
   | Array { elem; seq = Seq_map s; _ } ->
       let total = Stdlib.ref 0 in
       s.iter (fun e -> total := !total + size_of_typ_value elem e) v;

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -3001,6 +3001,22 @@ let test_repeat_primitive () =
   Alcotest.(check int) "n values" 3 (List.length r.ic_values);
   Alcotest.(check (list int)) "values" [ 0x1111; 0x2222; 0x3333 ] r.ic_values
 
+(* [Codec.size_of_value] must count a [Field.repeat]'s elements. With a
+   dynamic byte budget it used to report 0 for the repeat, so a buffer sized
+   from [size_of_value] under-allocated and [encode] ran off the end. *)
+let test_repeat_size_of_value () =
+  let v = { ic_count = 6; ic_values = [ 0x1111; 0x2222; 0x3333 ] } in
+  (* Count (1) + 3 * uint16be (6) = 7 *)
+  let n = Codec.size_of_value repeat_int_codec v in
+  Alcotest.(check int) "size_of_value" 7 n;
+  let buf = Bytes.create n in
+  Codec.encode repeat_int_codec v buf 0;
+  Alcotest.(check int)
+    "wire_size_at" 7
+    (Codec.wire_size_at repeat_int_codec buf 0);
+  let r = decode_ok (Codec.decode repeat_int_codec buf 0) in
+  Alcotest.(check (list int)) "roundtrip" v.ic_values r.ic_values
+
 (* Repeat with trailer after *)
 
 type repeat_trailer = { rt_len : int; rt_items : inner list; rt_check : int }
@@ -4232,6 +4248,8 @@ let suite =
       Alcotest.test_case "repeat: encode" `Quick test_repeat_encode;
       Alcotest.test_case "repeat: roundtrip" `Quick test_repeat_roundtrip;
       Alcotest.test_case "repeat: primitive" `Quick test_repeat_primitive;
+      Alcotest.test_case "repeat: size_of_value" `Quick
+        test_repeat_size_of_value;
       Alcotest.test_case "casetype field: login" `Quick
         test_casetype_field_login;
       Alcotest.test_case "casetype field: logout" `Quick


### PR DESCRIPTION
Sister fix to #78. [`size_of_typ_value`](https://github.com/parsimoni-labs/ocaml-wire/blob/fix-size-of-value-repeat/lib/types.ml#L1478) reported zero bytes for a `Field.repeat` with a dynamic byte budget (a literal budget happened to report the budget, a `Field.ref` one fell through to zero). `Codec.size_of_value` on a codec containing a repeat field then under-counted, the `let buf = Bytes.create (Codec.size_of_value c v) in Codec.encode c v buf 0` idiom allocated too small a buffer, and `encode` ran off the end with `Invalid_argument "index out of bounds"`.

The size is the sum of the elements' sizes taken from the value, exactly as the `Array` case already does; this fix mirrors it. Also backfills the `(#NN, ...)` placeholder #78 left in `CHANGES.md` to `(#78, ...)`.