### PR TITLE
fuzz: drive size_of_value across the gen DSL and cover zeroterm

### DIFF
--- a/fuzz/fuzz_wire.ml
+++ b/fuzz/fuzz_wire.ml
@@ -1418,6 +1418,8 @@ let bytes_gen_tests =
       (byte_array_where 4 ~per_byte:printable_byte)
   @ test_cases "all_bytes" all_bytes
   @ test_cases "all_zeros" all_zeros
+  @ test_cases "zeroterm" zeroterm
+  @ test_cases "zeroterm_at_most(8)" (zeroterm_at_most 8)
   @ test_cases "nested(4, uint16be)" (nested 4 uint16be)
   @ test_cases "nested_at_most(4, uint16be)" (nested_at_most 4 uint16be)
 

--- a/fuzz/gen/fuzz_gen.ml
+++ b/fuzz/gen/fuzz_gen.ml
@@ -334,6 +334,68 @@ let all_zeros =
     env = None;
   }
 
+(* NUL-free string: a [zeroterm] value cannot contain its own terminator. *)
+let nul_free_gen =
+  Alcobar.map
+    Alcobar.[ Alcobar.bytes ]
+    (fun s -> String.concat "" (String.split_on_char '\x00' s))
+
+let zeroterm =
+  let typ = Wire.zeroterm in
+  let codec = codec_of_typ typ in
+  let positive =
+    Alcobar.map
+      Alcobar.[ nul_free_gen ]
+      (fun s ->
+        let sz = Wire.Codec.size_of_value codec s in
+        let buf = Bytes.create sz in
+        Wire.Codec.encode codec s buf 0;
+        (s, buf))
+  in
+  (* Adversarial: a run with no terminator -- decode must surface a clean
+     error, not raise. *)
+  let adversarial =
+    Alcobar.map Alcobar.[ Alcobar.range ~min:0 32 ] (fun n -> Bytes.make n 'x')
+  in
+  {
+    codec;
+    typ;
+    positive;
+    random = bytes_any;
+    adversarial;
+    equal = String.equal;
+    env = None;
+  }
+
+let zeroterm_at_most n =
+  let typ = Wire.zeroterm_at_most ~size:(Wire.int n) in
+  let codec = codec_of_typ typ in
+  (* The terminator must fit in the region, so cap the data at [n - 1]. *)
+  let value_gen =
+    Alcobar.map
+      Alcobar.[ nul_free_gen ]
+      (fun s ->
+        if String.length s > n - 1 then String.sub s 0 (max 0 (n - 1)) else s)
+  in
+  let positive =
+    Alcobar.map
+      Alcobar.[ value_gen ]
+      (fun s ->
+        let sz = Wire.Codec.size_of_value codec s in
+        let buf = Bytes.create sz in
+        Wire.Codec.encode codec s buf 0;
+        (s, buf))
+  in
+  {
+    codec;
+    typ;
+    positive;
+    random = bytes_fixed n;
+    adversarial = bytes_fixed n;
+    equal = String.equal;
+    env = None;
+  }
+
 let byte_array_where n ~per_byte =
   let typ = Wire.byte_array_where ~size:(Wire.int n) ~per_byte in
   let codec = codec_of_typ typ in
@@ -1567,24 +1629,37 @@ end
 let positive_env g =
   match g.env with Some s -> Some (s.positive ()) | None -> None
 
+(* Round-trip one positive sample: decode the canonical bytes back to the
+   value, then re-encode into a buffer sized from [size_of_value] and require
+   the two to agree. Sizing from [size_of_value] (rather than from the
+   canonical bytes) drives the value-driven size for every combinator,
+   including ones whose [positive] bytes are hand-assembled (casetype,
+   nested_at_most) and so never otherwise exercise [encode] / [size_of_value].
+   A wrong [size_of_value] then shows up here as a mismatch -- or, if it
+   under-counts, as an [encode] overrun -- rather than silently. *)
+let check_positive label g (value, bs) =
+  let bs_str = string_of_bytes bs in
+  let env = positive_env g in
+  (match Wire.Codec.decode ?env g.codec bs 0 with
+  | Ok decoded ->
+      if not (g.equal decoded value) then
+        Alcobar.failf "%s positive decode mismatch" label
+  | Error _ -> Alcobar.failf "%s positive decode failed" label);
+  let sz = Wire.Codec.size_of_value g.codec value in
+  if sz <> Bytes.length bs then
+    Alcobar.failf "%s size_of_value = %d but canonical encoding is %d" label sz
+      (Bytes.length bs);
+  let out = Bytes.create sz in
+  (try Wire.Codec.encode ?env:(positive_env g) g.codec value out 0
+   with Invalid_argument _ -> Alcobar.failf "%s positive encode raised" label);
+  if string_of_bytes out <> bs_str then
+    Alcobar.failf "%s positive reencode mismatch" label
+
 let test_cases label g =
   let pos_case =
     Alcobar.test_case (label ^ " positive")
       Alcobar.[ g.positive ]
-      (fun (value, bs) ->
-        let bs_str = string_of_bytes bs in
-        let env = positive_env g in
-        (match Wire.Codec.decode ?env g.codec bs 0 with
-        | Ok decoded ->
-            if not (g.equal decoded value) then
-              Alcobar.failf "%s positive decode mismatch" label
-        | Error _ -> Alcobar.failf "%s positive decode failed" label);
-        let out = Bytes.create (Bytes.length bs) in
-        (try Wire.Codec.encode ?env:(positive_env g) g.codec value out 0
-         with Invalid_argument _ ->
-           Alcobar.failf "%s positive encode raised" label);
-        if string_of_bytes out <> bs_str then
-          Alcobar.failf "%s positive reencode mismatch" label)
+      (check_positive label g)
   in
   let safety_case kind stream =
     match g.env with

--- a/fuzz/gen/fuzz_gen.mli
+++ b/fuzz/gen/fuzz_gen.mli
@@ -157,6 +157,15 @@ val all_bytes : string t
 val all_zeros : string t
 (** [all_zeros] generates for {!Wire.all_zeros}. *)
 
+val zeroterm : string t
+(** [zeroterm] generates for {!Wire.zeroterm}. Positives are NUL-free strings;
+    the adversarial stream includes unterminated runs. *)
+
+val zeroterm_at_most : int -> string t
+(** [zeroterm_at_most n] generates for
+    [Wire.zeroterm_at_most ~size:(Wire.int n)]. Positives are NUL-free strings
+    capped at [n - 1] bytes so the terminator fits the region. *)
+
 (** {1 Wrappers} *)
 
 val nested : int -> 'a t -> 'a t


### PR DESCRIPTION
Builds on #79 (and #78). The generative round-trip runner's positive case sized its re-encode buffer from the canonical bytes, so [`check_positive`](https://github.com/parsimoni-labs/ocaml-wire/blob/fuzz-feature-coverage/fuzz/gen/fuzz_gen.ml#L1640) never had to consult `Codec.size_of_value` for combinators whose `positive` bytes are hand-assembled (`casetype`, `nested_at_most`). That blind spot is how the casetype and repeat `size_of_value` undercounts reached `main`: every `size_of_value`-sized encode happened to be sized correctly elsewhere, so a zero never bit.

The positive case now sizes the buffer from `size_of_value` and asserts it equals the canonical length, so the value-driven size is checked for every combinator uniformly. Re-run against `main` before #78/#79 it flags both bugs immediately. This PR also adds `zeroterm` and `zeroterm_at_most` gen leaves, which had no generators, so the full feature set now runs through the generative fuzzer (positive round-trip, crash-safety, and the new size check).