### PR TITLE
codec: avoid per-field allocation when decoding variable-size structs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,6 +41,12 @@
 
 ### Changed
 
+- Decoding a struct with variable-size fields (`byte_slice`, `byte_array`
+  or `repeat` whose size is a cross-field expression) no longer allocates
+  on each field access: the size/offset evaluator now takes `buf` and
+  `base` as separate arguments instead of a per-call pair, and reads
+  integer fields without boxing an `int option`. Pure speedup, no API
+  change (#81, @samoht)
 - Remove `Wire.optional` / `Wire.optional_or` / `Wire.repeat` /
   `Wire.repeat_seq` from the typ-level surface; use the matching
   `Field.*` combinators instead (#46, @samoht)

--- a/bench/memtrace/bench.ml
+++ b/bench/memtrace/bench.ml
@@ -136,6 +136,124 @@ let repeat_data n =
       done;
       b)
 
+(* SSH_MSG_KEXINIT (RFC 4253 7.1): a 16-byte cookie followed by ten
+   length-prefixed name-lists, then a flag and a reserved word. Every
+   name-list is a [byte_slice] whose size is [ref length], so each one
+   compiles through [compile_expr] (codec.ml:550) and reads its length
+   field via [int_of_typ_value] (eval.ml). Because the offsets are
+   dynamic, decoding field k re-chains every prior [size_fn], making the
+   per-decode tuple/option allocation quadratic in the ten name-lists --
+   the exact shape that surfaces both hotspots in a trace. *)
+module Slice = Bytesrw.Bytes.Slice
+
+type kexinit = {
+  k_cookie : Slice.t;
+  k_kex : Slice.t;
+  k_host_key : Slice.t;
+  k_enc_c2s : Slice.t;
+  k_enc_s2c : Slice.t;
+  k_mac_c2s : Slice.t;
+  k_mac_s2c : Slice.t;
+  k_comp_c2s : Slice.t;
+  k_comp_s2c : Slice.t;
+  k_lang_c2s : Slice.t;
+  k_lang_s2c : Slice.t;
+  k_first_follows : int;
+  k_reserved : int;
+}
+
+let kex_len name = Wire.Field.v name Wire.uint32be
+let f_kex_len = kex_len "KexLen"
+let f_hk_len = kex_len "HostKeyLen"
+let f_ec_len = kex_len "EncC2SLen"
+let f_es_len = kex_len "EncS2CLen"
+let f_mc_len = kex_len "MacC2SLen"
+let f_ms_len = kex_len "MacS2CLen"
+let f_cc_len = kex_len "CompC2SLen"
+let f_cs_len = kex_len "CompS2CLen"
+let f_lc_len = kex_len "LangC2SLen"
+let f_ls_len = kex_len "LangS2CLen"
+
+let name_list name len_field =
+  Wire.Field.v name (Wire.byte_slice ~size:(Wire.Field.ref len_field))
+
+let kexinit_codec =
+  Wire.Codec.v "Kexinit"
+    (fun cookie _kl kex _hl hk _ecl ec _esl es _mcl mc _msl ms _ccl cc _csl cs
+         _lcl lc _lsl ls first reserved ->
+      {
+        k_cookie = cookie;
+        k_kex = kex;
+        k_host_key = hk;
+        k_enc_c2s = ec;
+        k_enc_s2c = es;
+        k_mac_c2s = mc;
+        k_mac_s2c = ms;
+        k_comp_c2s = cc;
+        k_comp_s2c = cs;
+        k_lang_c2s = lc;
+        k_lang_s2c = ls;
+        k_first_follows = first;
+        k_reserved = reserved;
+      })
+    Wire.Codec.
+      [
+        ( Wire.Field.v "Cookie" (Wire.byte_slice ~size:(Wire.int 16)) $ fun r ->
+          r.k_cookie );
+        (f_kex_len $ fun r -> Slice.length r.k_kex);
+        (name_list "Kex" f_kex_len $ fun r -> r.k_kex);
+        (f_hk_len $ fun r -> Slice.length r.k_host_key);
+        (name_list "HostKey" f_hk_len $ fun r -> r.k_host_key);
+        (f_ec_len $ fun r -> Slice.length r.k_enc_c2s);
+        (name_list "EncC2S" f_ec_len $ fun r -> r.k_enc_c2s);
+        (f_es_len $ fun r -> Slice.length r.k_enc_s2c);
+        (name_list "EncS2C" f_es_len $ fun r -> r.k_enc_s2c);
+        (f_mc_len $ fun r -> Slice.length r.k_mac_c2s);
+        (name_list "MacC2S" f_mc_len $ fun r -> r.k_mac_c2s);
+        (f_ms_len $ fun r -> Slice.length r.k_mac_s2c);
+        (name_list "MacS2C" f_ms_len $ fun r -> r.k_mac_s2c);
+        (f_cc_len $ fun r -> Slice.length r.k_comp_c2s);
+        (name_list "CompC2S" f_cc_len $ fun r -> r.k_comp_c2s);
+        (f_cs_len $ fun r -> Slice.length r.k_comp_s2c);
+        (name_list "CompS2C" f_cs_len $ fun r -> r.k_comp_s2c);
+        (f_lc_len $ fun r -> Slice.length r.k_lang_c2s);
+        (name_list "LangC2S" f_lc_len $ fun r -> r.k_lang_c2s);
+        (f_ls_len $ fun r -> Slice.length r.k_lang_s2c);
+        (name_list "LangS2C" f_ls_len $ fun r -> r.k_lang_s2c);
+        (Wire.Field.v "FirstFollows" Wire.uint8 $ fun r -> r.k_first_follows);
+        (Wire.Field.v "Reserved" Wire.uint32be $ fun r -> r.k_reserved);
+      ]
+
+let kexinit_lists =
+  [
+    "curve25519-sha256,ecdh-sha2-nistp256,diffie-hellman-group14-sha256";
+    "ssh-ed25519,rsa-sha2-512,rsa-sha2-256";
+    "chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-ctr";
+    "chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-ctr";
+    "hmac-sha2-256-etm@openssh.com,hmac-sha2-256";
+    "hmac-sha2-256-etm@openssh.com,hmac-sha2-256";
+    "none,zlib@openssh.com";
+    "none,zlib@openssh.com";
+    "";
+    "";
+  ]
+
+let kexinit_wire () =
+  let b = Buffer.create 512 in
+  Buffer.add_string b (String.make 16 '\x42');
+  List.iter
+    (fun s ->
+      let n = String.length s in
+      Buffer.add_char b (Char.chr ((n lsr 24) land 0xFF));
+      Buffer.add_char b (Char.chr ((n lsr 16) land 0xFF));
+      Buffer.add_char b (Char.chr ((n lsr 8) land 0xFF));
+      Buffer.add_char b (Char.chr (n land 0xFF));
+      Buffer.add_string b s)
+    kexinit_lists;
+  Buffer.add_char b '\x00';
+  Buffer.add_string b "\x00\x00\x00\x00";
+  Bytes.unsafe_of_string (Buffer.contents b)
+
 let all_schemas =
   [
     Any
@@ -248,6 +366,16 @@ let run_clcw_polling () =
     done
   done
 
+let run_kexinit () =
+  let buf = kexinit_wire () in
+  let decode = Wire.Codec.decode_exn kexinit_codec in
+  Fmt.pr "  KEXINIT decode (10 length-prefixed name-lists)...\n%!";
+  for _ = 1 to iterations do
+    for _ = 1 to n_values do
+      ignore (Sys.opaque_identity (decode buf 0))
+    done
+  done
+
 let () =
   Memtrace.trace_if_requested ~context:"wire-codecs" ();
   let filter = if Array.length Sys.argv > 1 then Some Sys.argv.(1) else None in
@@ -264,4 +392,5 @@ let () =
   Fmt.pr "\n";
   if filter_matches "clcw" then run_zero_copy ();
   if filter_matches "polling" || filter_matches "clcw" then run_clcw_polling ();
+  if filter_matches "kexinit" then run_kexinit ();
   Fmt.pr "\nDone.\n"

--- a/bench/memtrace/dune
+++ b/bench/memtrace/dune
@@ -1,3 +1,3 @@
 (executable
  (name bench)
- (libraries demo space wire memtrace))
+ (libraries demo space wire bytesrw memtrace))

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -1697,6 +1697,11 @@ let var_bytes_writer : type a r.
          (parametric size, bind via ?env)"
         actual expected
   in
+  let write_str s =
+    let len = String.length s in
+    Bytes.blit_string s 0 buf write_off len;
+    write_off + len
+  in
   match typ with
   | Byte_slice _ ->
       let src = (value : Slice.t) in
@@ -1706,34 +1711,21 @@ let var_bytes_writer : type a r.
       write_off + len
   | Byte_array _ ->
       let s = (value : string) in
-      let len = String.length s in
-      check_len ~actual:len;
-      Bytes.blit_string s 0 buf write_off len;
-      write_off + len
+      check_len ~actual:(String.length s);
+      write_str s
   | Byte_array_where _ ->
       let s = (value : string) in
-      let len = String.length s in
-      check_len ~actual:len;
-      Bytes.blit_string s 0 buf write_off len;
-      write_off + len
-  | All_bytes ->
-      let s = (value : string) in
-      let len = String.length s in
-      Bytes.blit_string s 0 buf write_off len;
-      write_off + len
-  | All_zeros ->
-      let s = (value : string) in
-      let len = String.length s in
-      Bytes.blit_string s 0 buf write_off len;
-      write_off + len
+      check_len ~actual:(String.length s);
+      write_str s
+  | All_bytes -> write_str (value : string)
+  | All_zeros -> write_str (value : string)
   | Zeroterm ->
       let s = (value : string) in
       if String.contains s '\000' then
         invalid_arg "Codec.encode: zeroterm string contains a NUL byte";
-      let len = String.length s in
-      Bytes.blit_string s 0 buf write_off len;
-      Bytes.set_uint8 buf (write_off + len) 0;
-      write_off + len + 1
+      let e = write_str s in
+      Bytes.set_uint8 buf e 0;
+      e + 1
   | Zeroterm_at_most _ ->
       let s = (value : string) in
       if String.contains s '\000' then

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -221,7 +221,7 @@ let rec build_field_reader : type a. a typ -> int -> bytes -> int -> a =
           fun _buf _base -> failwith "build_field_reader: unsupported type")
   | _ -> fun _buf _base -> failwith "build_field_reader: unsupported type"
 
-let int_of_typ_value = Eval.int_of
+let int_of_typ_value = Eval.int_of_default
 
 (* Build a populate function that writes a field value into the validator
    array without allocating. Resolves the type at seal time so the hot
@@ -376,20 +376,24 @@ type field_reader = string * (bytes -> int -> int)
 
 type packed_param = Pack_param : ('a, 'k) param_handle -> packed_param
 
-(* Leaves resolution strategy for a given access layer. *)
-type 'ctx leaves = {
-  ref_ : string -> 'ctx -> int;
-  param_ref : packed_param -> 'ctx -> int;
-  sizeof_typ : packed_typ -> 'ctx -> int;
-  sizeof_this : 'ctx -> int;
-  field_pos : 'ctx -> int;
+(* Leaves resolution strategy for a given access layer. The context is
+   threaded as two curried arguments rather than a single packed value: the
+   closure access layer passes [buf base] with no per-call tuple, and the
+   int-array layer passes [arr ()] with an immediate unit. *)
+type ('c1, 'c2) leaves = {
+  ref_ : string -> 'c1 -> 'c2 -> int;
+  param_ref : packed_param -> 'c1 -> 'c2 -> int;
+  sizeof_typ : packed_typ -> 'c1 -> 'c2 -> int;
+  sizeof_this : 'c1 -> 'c2 -> int;
+  field_pos : 'c1 -> 'c2 -> int;
 }
 
-let rec compile_int : type ctx. ctx leaves -> int expr -> ctx -> int =
+let rec compile_int : type c1 c2. (c1, c2) leaves -> int expr -> c1 -> c2 -> int
+    =
  fun l e ->
   let rec_ = compile_int l in
   match e with
-  | Int n -> fun _ -> n
+  | Int n -> fun _ _ -> n
   | Ref name -> l.ref_ name
   | Param_ref p -> l.param_ref (Pack_param p)
   | Sizeof t -> l.sizeof_typ (Pack_typ t)
@@ -397,52 +401,53 @@ let rec compile_int : type ctx. ctx leaves -> int expr -> ctx -> int =
   | Field_pos -> l.field_pos
   | Add (a, b) ->
       let fa = rec_ a and fb = rec_ b in
-      fun c -> fa c + fb c
+      fun c d -> fa c d + fb c d
   | Sub (a, b) ->
       let fa = rec_ a and fb = rec_ b in
-      fun c -> fa c - fb c
+      fun c d -> fa c d - fb c d
   | Mul (a, b) ->
       let fa = rec_ a and fb = rec_ b in
-      fun c -> fa c * fb c
+      fun c d -> fa c d * fb c d
   | Div (a, b) ->
       let fa = rec_ a and fb = rec_ b in
-      fun c -> fa c / fb c
+      fun c d -> fa c d / fb c d
   | Mod (a, b) ->
       let fa = rec_ a and fb = rec_ b in
-      fun c -> fa c mod fb c
+      fun c d -> fa c d mod fb c d
   | Land (a, b) ->
       let fa = rec_ a and fb = rec_ b in
-      fun c -> fa c land fb c
+      fun c d -> fa c d land fb c d
   | Lor (a, b) ->
       let fa = rec_ a and fb = rec_ b in
-      fun c -> fa c lor fb c
+      fun c d -> fa c d lor fb c d
   | Lxor (a, b) ->
       let fa = rec_ a and fb = rec_ b in
-      fun c -> fa c lxor fb c
+      fun c d -> fa c d lxor fb c d
   | Lnot a ->
       let fa = rec_ a in
-      fun c -> lnot (fa c)
+      fun c d -> lnot (fa c d)
   | Lsl (a, b) ->
       let fa = rec_ a and fb = rec_ b in
-      fun c -> fa c lsl fb c
+      fun c d -> fa c d lsl fb c d
   | Lsr (a, b) ->
       let fa = rec_ a and fb = rec_ b in
-      fun c -> fa c lsr fb c
+      fun c d -> fa c d lsr fb c d
   | Cast (w, a) -> (
       let fa = rec_ a in
       match w with
-      | `U8 -> fun c -> fa c land 0xFF
-      | `U16 -> fun c -> fa c land 0xFFFF
-      | `U32 -> fun c -> fa c land 0xFFFF_FFFF
+      | `U8 -> fun c d -> fa c d land 0xFF
+      | `U16 -> fun c d -> fa c d land 0xFFFF
+      | `U32 -> fun c d -> fa c d land 0xFFFF_FFFF
       | `U64 -> fa)
   | If_then_else (c, t, e) ->
       let fc = compile_bool l c in
       let ft = rec_ t and fe = rec_ e in
-      fun c' -> if fc c' then ft c' else fe c'
+      fun c' d' -> if fc c' d' then ft c' d' else fe c' d'
 
 (* Typed-GADT projector: refines [a expr] to [int expr] / [bool expr]
    so [Eq] / [Ne] can dispatch to the right compiler at the right type. *)
-and try_int : type a ctx. ctx leaves -> a expr -> (ctx -> int) option =
+and try_int : type a c1 c2.
+    (c1, c2) leaves -> a expr -> (c1 -> c2 -> int) option =
  fun l e ->
   let go e = Some (compile_int l e) in
   match e with
@@ -467,7 +472,8 @@ and try_int : type a ctx. ctx leaves -> a expr -> (ctx -> int) option =
   | If_then_else _ as e -> go e
   | _ -> None
 
-and try_bool : type a ctx. ctx leaves -> a expr -> (ctx -> bool) option =
+and try_bool : type a c1 c2.
+    (c1, c2) leaves -> a expr -> (c1 -> c2 -> bool) option =
  fun l e ->
   let go e = Some (compile_bool l e) in
   match e with
@@ -483,76 +489,74 @@ and try_bool : type a ctx. ctx leaves -> a expr -> (ctx -> bool) option =
   | Not _ as e -> go e
   | _ -> None
 
-and compile_bool : type ctx. ctx leaves -> bool expr -> ctx -> bool =
+and compile_bool : type c1 c2. (c1, c2) leaves -> bool expr -> c1 -> c2 -> bool
+    =
  fun l e ->
   let int_rec = compile_int l in
   let bool_rec = compile_bool l in
   match e with
-  | Bool b -> fun _ -> b
+  | Bool b -> fun _ _ -> b
   | Eq (a, b) -> (
       match (try_int l a, try_int l b, try_bool l a, try_bool l b) with
-      | Some fa, Some fb, _, _ -> fun c -> fa c = fb c
-      | _, _, Some fa, Some fb -> fun c -> fa c = fb c
+      | Some fa, Some fb, _, _ -> fun c d -> fa c d = fb c d
+      | _, _, Some fa, Some fb -> fun c d -> fa c d = fb c d
       | _ -> assert false)
   | Ne (a, b) -> (
       match (try_int l a, try_int l b, try_bool l a, try_bool l b) with
-      | Some fa, Some fb, _, _ -> fun c -> fa c <> fb c
-      | _, _, Some fa, Some fb -> fun c -> fa c <> fb c
+      | Some fa, Some fb, _, _ -> fun c d -> fa c d <> fb c d
+      | _, _, Some fa, Some fb -> fun c d -> fa c d <> fb c d
       | _ -> assert false)
   | Lt (a, b) ->
       let fa = int_rec a and fb = int_rec b in
-      fun c -> fa c < fb c
+      fun c d -> fa c d < fb c d
   | Le (a, b) ->
       let fa = int_rec a and fb = int_rec b in
-      fun c -> fa c <= fb c
+      fun c d -> fa c d <= fb c d
   | Gt (a, b) ->
       let fa = int_rec a and fb = int_rec b in
-      fun c -> fa c > fb c
+      fun c d -> fa c d > fb c d
   | Ge (a, b) ->
       let fa = int_rec a and fb = int_rec b in
-      fun c -> fa c >= fb c
+      fun c d -> fa c d >= fb c d
   | And (a, b) ->
       let fa = bool_rec a and fb = bool_rec b in
-      fun c -> fa c && fb c
+      fun c d -> fa c d && fb c d
   | Or (a, b) ->
       let fa = bool_rec a and fb = bool_rec b in
-      fun c -> fa c || fb c
+      fun c d -> fa c d || fb c d
   | Not e ->
       let fe = bool_rec e in
-      fun c -> not (fe c)
+      fun c d -> not (fe c d)
 
-(* Closure-based access layer: [ctx = bytes * int]. The pair is
-   re-allocated per call site; profile if this becomes hot. *)
+(* Closure-based access layer: the context is [buf] and [base], passed as two
+   curried arguments. The compiled offset/size functions are [bytes -> int ->
+   int] directly, so evaluating a size expression allocates nothing per call. *)
 let bytes_leaves ?(sizeof_this : bytes -> int -> int = fun _ _ -> 0)
-    (env : field_reader list) : (bytes * int) leaves =
+    (env : field_reader list) : (bytes, int) leaves =
   {
     ref_ =
       (fun name ->
         match List.assoc_opt name env with
-        | Some reader -> fun (buf, base) -> reader buf base
+        | Some reader -> reader
         | None ->
             Fmt.invalid_arg "Codec: unbound field ref %S in size expression"
               name);
-    param_ref = (fun (Pack_param p) _ -> !(p.ph_cell));
+    param_ref = (fun (Pack_param p) _ _ -> !(p.ph_cell));
     sizeof_typ =
       (fun (Pack_typ t) ->
         match field_wire_size t with
-        | Some n -> fun _ -> n
+        | Some n -> fun _ _ -> n
         | None -> invalid_arg "Codec: sizeof on variable-size type");
-    sizeof_this = (fun (buf, base) -> sizeof_this buf base);
+    sizeof_this;
     field_pos =
-      (fun _ -> invalid_arg "Codec: [field_pos] only valid inside an action");
+      (fun _ _ -> invalid_arg "Codec: [field_pos] only valid inside an action");
   }
 
 let compile_expr ?sizeof_this env e =
-  let l = bytes_leaves ?sizeof_this env in
-  let f = compile_int l e in
-  fun buf base -> f (buf, base)
+  compile_int (bytes_leaves ?sizeof_this env) e
 
 let compile_bool_expr ?sizeof_this env e =
-  let l = bytes_leaves ?sizeof_this env in
-  let f = compile_bool l e in
-  fun buf base -> f (buf, base)
+  compile_bool (bytes_leaves ?sizeof_this env) e
 
 (* Int-array access layer: zero-alloc per decode. Used by field
    constraints / where clauses where the validator has already populated
@@ -560,26 +564,35 @@ let compile_bool_expr ?sizeof_this env e =
 type idx = string -> int
 type compile_ctx = { idx : idx; sizeof_this : int; field_pos : int }
 
-let array_leaves (cc : compile_ctx) : int array leaves =
+let array_leaves (cc : compile_ctx) : (int array, unit) leaves =
   {
     ref_ =
       (fun name ->
         let i = cc.idx name in
-        fun a -> a.(i));
+        fun a () -> a.(i));
     param_ref =
-      (fun (Pack_param p) a ->
+      (fun (Pack_param p) a () ->
+        (* [ph_slot] is assigned during sealing, after the leaves are built,
+           so it must be read per call rather than captured here. *)
         let i = p.ph_slot in
         if i >= 0 then a.(i) else !(p.ph_cell));
     sizeof_typ =
       (fun (Pack_typ t) ->
         let n = field_wire_size t |> Option.value ~default:0 in
-        fun _ -> n);
-    sizeof_this = (fun _ -> cc.sizeof_this);
-    field_pos = (fun _ -> cc.field_pos);
+        fun _ () -> n);
+    sizeof_this = (fun _ () -> cc.sizeof_this);
+    field_pos = (fun _ () -> cc.field_pos);
   }
 
-let compile_int_arr cc e = compile_int (array_leaves cc) e
-let compile_bool_arr cc e = compile_bool (array_leaves cc) e
+(* The int-array layer needs only the array, so the second context argument is
+   an immediate unit -- threaded here so callers keep the [arr -> _] shape. *)
+let compile_int_arr cc e =
+  let f = compile_int (array_leaves cc) e in
+  fun arr -> f arr ()
+
+let compile_bool_arr cc e =
+  let f = compile_bool (array_leaves cc) e in
+  fun arr -> f arr ()
 
 (* Compile action statements to operate on an int array instead of Eval.ctx.
    Assign writes to ph_cell (mutable param) and updates the array.
@@ -1822,11 +1835,7 @@ let compile_var_bytes : type a r.
     | _ ->
         let raw_reader = var_bytes_reader typ off_fn size_fn in
         let raw_writer = var_bytes_writer typ fld.get size_fn in
-        let int_reader buf base =
-          match int_of_typ_value typ (raw_reader buf base) with
-          | Some v -> v
-          | None -> 0
-        in
+        let int_reader buf base = int_of_typ_value typ (raw_reader buf base) in
         (raw_reader, raw_writer, int_reader)
   in
   let populate = build_populate typ ctx.n_fields raw_reader in
@@ -1871,11 +1880,7 @@ let compile_scalar_or_var : type a r.
       let raw_writer : r -> bytes -> int -> int -> int =
        fun v buf _base write_off -> raw_encoder buf write_off (get v)
       in
-      let int_reader buf base =
-        match int_of_typ_value typ (raw_reader buf base) with
-        | Some v -> v
-        | None -> 0
-      in
+      let int_reader buf base = int_of_typ_value typ (raw_reader buf base) in
       let populate = build_populate typ ctx.n_fields raw_reader in
       {
         raw_reader;

--- a/lib/eval.ml
+++ b/lib/eval.ml
@@ -44,6 +44,37 @@ let rec int_of : type a. a typ -> a -> int option =
   | Repeat _ ->
       None
 
+(* Hot-path variant of [int_of]: returns [int] directly, mapping the types
+   [int_of] reports as [None] (non-numeric, or uint64/int64 over 2^62) to 0.
+   This is exactly what the cross-field size/offset readers do with [int_of]'s
+   result, so collapsing it here avoids boxing a [Some] per field read. *)
+let rec int_of_default : type a. a typ -> a -> int =
+ fun typ v ->
+  match typ with
+  | Uint8 -> v
+  | Uint16 _ -> v
+  | Uint_var _ -> v
+  | Uint32 _ -> UInt32.to_int v
+  | Uint63 _ -> UInt63.to_int v
+  | Uint64 _ -> ( match Int64.unsigned_to_int v with Some n -> n | None -> 0)
+  | Int8 -> v
+  | Int16 _ -> v
+  | Int32 _ -> v
+  | Int64 _ -> ( match Int64.unsigned_to_int v with Some n -> n | None -> 0)
+  | Float32 _ -> 0
+  | Float64 _ -> 0
+  | Bits _ -> v
+  | Enum { base; _ } -> int_of_default base v
+  | Where { inner; _ } -> int_of_default inner v
+  | Single_elem { elem; _ } -> int_of_default elem v
+  | Apply { typ; _ } -> int_of_default typ v
+  | Map { inner; encode; _ } -> int_of_default inner (encode v)
+  | Unit | All_bytes | All_zeros | Zeroterm | Zeroterm_at_most _ | Array _
+  | Byte_array _ | Byte_array_where _ | Byte_slice _ | Casetype _ | Struct _
+  | Type_ref _ | Qualified_ref _ | Codec _ | Optional _ | Optional_or _
+  | Repeat _ ->
+      0
+
 let rec expr : type a. ctx -> a expr -> a =
  fun ctx e ->
   match e with

--- a/lib/eval.mli
+++ b/lib/eval.mli
@@ -24,6 +24,11 @@ val int_of : 'a Types.typ -> 'a -> int option
 (** [int_of typ v] converts a typed value to [int]. Returns [None] for types
     that don't fit in OCaml int (uint64 > 2^62, non-numeric). *)
 
+val int_of_default : 'a Types.typ -> 'a -> int
+(** [int_of_default typ v] is [int_of typ v] with the [None] cases (non-numeric,
+    or uint64/int64 over 2^62) mapped to 0. Allocation-free on the numeric path;
+    used by the cross-field size/offset readers, which want an [int] anyway. *)
+
 val expr : ctx -> 'a Types.expr -> 'a
 (** [expr ctx e] evaluates a top-level expression. Raises on [Ref] (cross-field
     references are only valid inside a struct). [Sizeof_this] and [Field_pos]

--- a/test/diff/dune
+++ b/test/diff/dune
@@ -40,11 +40,12 @@
 ;
 ; Run with: BUILD_EVERPARSE=1 dune build @ocaml-wire/test/diff/gen_c
 
+; The executable is pure OCaml and always builds; only running it (the
+; [gen_c] rule below) needs EverParse, so the build gate lives on the rule.
+
 (executable
  (name gen_c)
  (modules gen_c)
- (enabled_if
-  (= %{env:BUILD_EVERPARSE=} "1"))
  (libraries wire wire.3d wire.stubs unix))
 
 (rule


### PR DESCRIPTION
[`compile_expr`](https://github.com/parsimoni-labs/ocaml-wire/blob/perf-unbox-size-eval/lib/codec.ml#L555) compiled each variable-size field's size/offset function to a closure that allocated a fresh `(buf, base)` pair per call and read integer field references through `Eval.int_of`, which boxes an `int option` the caller immediately discards. Field offsets chain, so decoding field _k_ re-evaluates every earlier size function: the per-decode allocation grew quadratically in the number of variable-size fields, and an SSH KEXINIT message with its ten length-prefixed name-lists spent essentially all of its decode allocation there.

The evaluator now threads `buf` and `base` unboxed through the [walker](https://github.com/parsimoni-labs/ocaml-wire/blob/perf-unbox-size-eval/lib/codec.ml#L391) and reads fields via [`int_of_default`](https://github.com/parsimoni-labs/ocaml-wire/blob/perf-unbox-size-eval/lib/eval.ml#L51), with the closures still built once at codec construction.

On the new KEXINIT decode bench (`bench/memtrace`, run with `-- kexinit`) minor allocation drops from 4.6 GB/s to 25 MB/s and the two hot sites leave the profile:

```
before   0.6 TB (59.8%)  compile_expr.(fun)   lib/codec.ml
         0.4 TB (39.8%)  Eval.int_of          lib/eval.ml
after    gone -- only the result record and the byte slices remain
```

Two unrelated lint cleanups land first: d9190a21 merges the identical `var_bytes_writer` arms behind a helper and 2090e752 keeps the `gen_c` generator building when `BUILD_EVERPARSE` is unset; d763a513 then adds the bench, and the final commit is the fix.
