### PR TITLE
codec: reject out-of-range size fields instead of reading 0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -76,6 +76,11 @@
 
 ### Fixed
 
+- A cross-field size/offset/`present` expression that reads an integer field
+  whose value exceeds the native int range (a `uint64`/`int64` length beyond
+  `max_int`), or that references a non-integer field, now raises
+  `Parse_error` instead of silently evaluating to 0. An out-of-range length
+  was being read as an empty field, masking malformed input (#82, @samoht)
 - `Codec.size_of_value` now counts a `Field.repeat`'s elements instead of
   reporting zero for a dynamic byte budget. Like the casetype case in #78, a
   buffer sized from `Codec.size_of_value` for a codec with a repeat field

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -221,7 +221,7 @@ let rec build_field_reader : type a. a typ -> int -> bytes -> int -> a =
           fun _buf _base -> failwith "build_field_reader: unsupported type")
   | _ -> fun _buf _base -> failwith "build_field_reader: unsupported type"
 
-let int_of_typ_value = Eval.int_of_default
+let int_of_typ_value = Eval.int_of_exn
 
 (* Build a populate function that writes a field value into the validator
    array without allocating. Resolves the type at seal time so the hot

--- a/lib/eval.ml
+++ b/lib/eval.ml
@@ -44,11 +44,23 @@ let rec int_of : type a. a typ -> a -> int option =
   | Repeat _ ->
       None
 
-(* Hot-path variant of [int_of]: returns [int] directly, mapping the types
-   [int_of] reports as [None] (non-numeric, or uint64/int64 over 2^62) to 0.
-   This is exactly what the cross-field size/offset readers do with [int_of]'s
-   result, so collapsing it here avoids boxing a [Some] per field read. *)
-let rec int_of_default : type a. a typ -> a -> int =
+(* Hot-path variant of [int_of] for the cross-field size/offset/present
+   readers, which need a plain [int]. Returns it directly (no [Some] box on the
+   numeric path) and raises [Parse_error] when the value is not a usable int: a
+   [uint64]/[int64] beyond the native int range (adversarial input), or a
+   non-integer field referenced where an integer is required (a schema error). *)
+let int_overflow () =
+  raise
+    (Parse_error
+       (Constraint_failed "integer field value exceeds the native int range"))
+
+let not_an_integer () =
+  raise
+    (Parse_error
+       (Constraint_failed
+          "non-integer field referenced where an integer is required"))
+
+let rec int_of_exn : type a. a typ -> a -> int =
  fun typ v ->
   match typ with
   | Uint8 -> v
@@ -56,24 +68,26 @@ let rec int_of_default : type a. a typ -> a -> int =
   | Uint_var _ -> v
   | Uint32 _ -> UInt32.to_int v
   | Uint63 _ -> UInt63.to_int v
-  | Uint64 _ -> ( match Int64.unsigned_to_int v with Some n -> n | None -> 0)
+  | Uint64 _ -> (
+      match Int64.unsigned_to_int v with Some n -> n | None -> int_overflow ())
   | Int8 -> v
   | Int16 _ -> v
   | Int32 _ -> v
-  | Int64 _ -> ( match Int64.unsigned_to_int v with Some n -> n | None -> 0)
-  | Float32 _ -> 0
-  | Float64 _ -> 0
+  | Int64 _ -> (
+      match Int64.unsigned_to_int v with Some n -> n | None -> int_overflow ())
+  | Float32 _ -> not_an_integer ()
+  | Float64 _ -> not_an_integer ()
   | Bits _ -> v
-  | Enum { base; _ } -> int_of_default base v
-  | Where { inner; _ } -> int_of_default inner v
-  | Single_elem { elem; _ } -> int_of_default elem v
-  | Apply { typ; _ } -> int_of_default typ v
-  | Map { inner; encode; _ } -> int_of_default inner (encode v)
+  | Enum { base; _ } -> int_of_exn base v
+  | Where { inner; _ } -> int_of_exn inner v
+  | Single_elem { elem; _ } -> int_of_exn elem v
+  | Apply { typ; _ } -> int_of_exn typ v
+  | Map { inner; encode; _ } -> int_of_exn inner (encode v)
   | Unit | All_bytes | All_zeros | Zeroterm | Zeroterm_at_most _ | Array _
   | Byte_array _ | Byte_array_where _ | Byte_slice _ | Casetype _ | Struct _
   | Type_ref _ | Qualified_ref _ | Codec _ | Optional _ | Optional_or _
   | Repeat _ ->
-      0
+      not_an_integer ()
 
 let rec expr : type a. ctx -> a expr -> a =
  fun ctx e ->

--- a/lib/eval.mli
+++ b/lib/eval.mli
@@ -24,10 +24,13 @@ val int_of : 'a Types.typ -> 'a -> int option
 (** [int_of typ v] converts a typed value to [int]. Returns [None] for types
     that don't fit in OCaml int (uint64 > 2^62, non-numeric). *)
 
-val int_of_default : 'a Types.typ -> 'a -> int
-(** [int_of_default typ v] is [int_of typ v] with the [None] cases (non-numeric,
-    or uint64/int64 over 2^62) mapped to 0. Allocation-free on the numeric path;
-    used by the cross-field size/offset readers, which want an [int] anyway. *)
+val int_of_exn : 'a Types.typ -> 'a -> int
+(** [int_of_exn typ v] is {!val-int_of} without the [option]: it returns the
+    [int] directly (no boxing on the numeric path) and raises
+    {!Types.Parse_error} for the cases {!val-int_of} reports as [None] (a
+    [uint64]/[int64] value beyond the native int range, or a non-integer type).
+    Used by the cross-field size/offset/present readers, where an
+    unrepresentable value must fail the parse. *)
 
 val expr : ctx -> 'a Types.expr -> 'a
 (** [expr ctx e] evaluates a top-level expression. Raises on [Ref] (cross-field

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -1967,6 +1967,48 @@ let test_dep_codec_ref () =
     "ref data[4]" 0x14
     (Bytes.get_uint8 (Bs.bytes data) (Bs.first data + 4))
 
+(* A [byte_slice] sized by a 64-bit length field: an adversarial length that
+   does not fit a native int must fail the parse, not be silently read as a
+   0-length field. *)
+let u64_sized_codec =
+  let f_len = Field.v "Len" uint64be in
+  let f_data = Field.v "Data" (byte_slice ~size:(Field.ref f_len)) in
+  let cf_len = Codec.(f_len $ fun (l, _) -> l) in
+  let cf_data = Codec.(f_data $ fun (_, d) -> d) in
+  Codec.v "U64Size" (fun len data -> (len, data)) [ cf_len; cf_data ]
+
+let u64_len_buf v =
+  (* 8-byte BE length followed by a few payload bytes. *)
+  let b = Bytes.create 16 in
+  Bytes.set_int64_be b 0 v;
+  b
+
+let test_dep_size_in_range () =
+  let _len, data =
+    decode_ok (Codec.decode u64_sized_codec (u64_len_buf 4L) 0)
+  in
+  Alcotest.(check int)
+    "in-range length reads that many bytes" 4 (Bs.length data)
+
+let test_dep_size_out_of_range () =
+  let cases =
+    [
+      ("all-ones", 0xFFFF_FFFF_FFFF_FFFFL);
+      ("2^63", 0x8000_0000_0000_0000L);
+      ("max_int + 1", Int64.add (Int64.of_int max_int) 1L);
+      ("int64 -1 as length", -1L);
+    ]
+  in
+  List.iter
+    (fun (name, v) ->
+      match Codec.decode u64_sized_codec (u64_len_buf v) 0 with
+      | Ok _ -> Alcotest.failf "%s: expected Parse_error, decoded ok" name
+      | Error (Constraint_failed _) -> ()
+      | Error e ->
+          Alcotest.failf "%s: expected Constraint_failed, got %a" name
+            pp_parse_error e)
+    cases
+
 let test_dep_ref_size_eval () =
   (* Test that the size expression is evaluated correctly for wire_size_at *)
   let f_sz = Field.v "Size" uint8 in
@@ -4145,6 +4187,9 @@ let suite =
       Alcotest.test_case "dep: wire_size_at" `Quick test_dep_compute_wire_size;
       (* Field.ref expressions *)
       Alcotest.test_case "dep: codec ref" `Quick test_dep_codec_ref;
+      Alcotest.test_case "dep: u64 size in range" `Quick test_dep_size_in_range;
+      Alcotest.test_case "dep: u64 size out of range raises" `Quick
+        test_dep_size_out_of_range;
       Alcotest.test_case "dep: codec ref size eval" `Quick
         test_dep_ref_size_eval;
       (* struct_of_codec for variable-size codecs *)

--- a/test/test_eval.ml
+++ b/test/test_eval.ml
@@ -19,6 +19,51 @@ let test_int_of () =
     (Eval.int_of Types.uint64be 0xFFFF_FFFF_FFFF_FFFFL);
   Alcotest.(check (option int)) "unit" None (Eval.int_of Types.Unit ())
 
+(* [int_of_exn] returns the same value as [int_of] on the representable cases,
+   but where [int_of] returns [None] -- an out-of-range 64-bit value or a
+   non-integer type -- it raises [Parse_error (Constraint_failed _)] instead of
+   silently coercing to 0. *)
+let raises_constraint name f =
+  match f () with
+  | _ -> Alcotest.failf "%s: expected Parse_error, got a value" name
+  | exception Types.Parse_error (Types.Constraint_failed _) -> ()
+  | exception e ->
+      Alcotest.failf "%s: expected Parse_error, got %s" name
+        (Printexc.to_string e)
+
+let test_int_of_exn_ok () =
+  Alcotest.(check int) "uint8" 7 (Eval.int_of_exn Types.uint8 7);
+  Alcotest.(check int) "uint16be" 300 (Eval.int_of_exn Types.uint16be 300);
+  Alcotest.(check int) "uint64 small" 42 (Eval.int_of_exn Types.uint64be 42L);
+  Alcotest.(check int)
+    "int64 small" 100
+    (Eval.int_of_exn Types.(Int64 Big) 100L);
+  (* [max_int] is the largest value [Int64.unsigned_to_int] accepts. *)
+  Alcotest.(check int)
+    "uint64 = max_int" max_int
+    (Eval.int_of_exn Types.uint64be (Int64.of_int max_int))
+
+let test_int_of_exn_overflow () =
+  (* Adversarial 64-bit lengths that do not fit a native int must fail the
+     parse rather than be read as 0. *)
+  raises_constraint "uint64 all-ones" (fun () ->
+      Eval.int_of_exn Types.uint64be 0xFFFF_FFFF_FFFF_FFFFL);
+  raises_constraint "uint64 = 2^63" (fun () ->
+      Eval.int_of_exn Types.uint64be 0x8000_0000_0000_0000L);
+  raises_constraint "uint64 = max_int + 1" (fun () ->
+      Eval.int_of_exn Types.uint64be (Int64.add (Int64.of_int max_int) 1L));
+  (* A signed int64 with the top bit set is a huge unsigned value. *)
+  raises_constraint "int64 = -1" (fun () ->
+      Eval.int_of_exn Types.(Int64 Big) (-1L));
+  raises_constraint "int64 = min_int" (fun () ->
+      Eval.int_of_exn Types.(Int64 Big) Int64.min_int)
+
+let test_int_of_exn_non_integer () =
+  raises_constraint "unit" (fun () -> Eval.int_of_exn Types.Unit ());
+  raises_constraint "float64" (fun () -> Eval.int_of_exn Types.float64be 1.5);
+  raises_constraint "byte_array" (fun () ->
+      Eval.int_of_exn (Types.byte_array ~size:(Types.Int 4)) "abcd")
+
 let test_expr_const () =
   let ctx = Eval.empty in
   Alcotest.(check int) "int" 42 (Eval.expr ctx (Types.Int 42));
@@ -60,6 +105,11 @@ let suite =
   ( "eval",
     [
       Alcotest.test_case "int_of" `Quick test_int_of;
+      Alcotest.test_case "int_of_exn representable" `Quick test_int_of_exn_ok;
+      Alcotest.test_case "int_of_exn overflow raises" `Quick
+        test_int_of_exn_overflow;
+      Alcotest.test_case "int_of_exn non-integer raises" `Quick
+        test_int_of_exn_non_integer;
       Alcotest.test_case "expr constants" `Quick test_expr_const;
       Alcotest.test_case "expr Ref fails" `Quick test_expr_ref_fails;
       Alcotest.test_case "cast U8" `Quick test_cast_u8;


### PR DESCRIPTION
[`int_of_exn`](https://github.com/parsimoni-labs/ocaml-wire/blob/size-field-out-of-range/lib/eval.ml#L63) and the cross-field size/offset readers that use it mapped an unrepresentable field value to 0: a `uint64`/`int64` length beyond `max_int`, or a non-integer field used as a size. A malformed length then parsed as an empty field. It now raises `Parse_error`.

Follow-up to #81, which made that reader allocation free. Adversarial coverage lives in `test_eval` (boundary values) and [`test_codec`](https://github.com/parsimoni-labs/ocaml-wire/blob/size-field-out-of-range/test/test_codec.ml#L1993) (a `uint64`-sized `byte_slice` decoded with out-of-range lengths).
