### PR TITLE
test: add shared decode assertions in test_helpers

### DIFF
--- a/fuzz/gen/fuzz_gen.ml
+++ b/fuzz/gen/fuzz_gen.ml
@@ -424,8 +424,10 @@ let byte_array_where n ~per_byte =
     env = None;
   }
 
-let nested n inner =
-  let typ = Wire.nested ~size:(Wire.int n) inner.typ in
+(* [nested] and [nested_at_most] differ only in the typ constructor; the
+   payload-into-fixed-buffer generation is identical. *)
+let nested_sized make_typ n inner =
+  let typ = make_typ ~size:(Wire.int n) inner.typ in
   let codec = codec_of_typ typ in
   let positive =
     Alcobar.map
@@ -452,6 +454,8 @@ let nested n inner =
     equal = inner.equal;
     env = None;
   }
+
+let nested n inner = nested_sized Wire.nested n inner
 
 let map ~decode ~encode inner =
   let typ = Wire.map ~decode ~encode inner.typ in
@@ -547,6 +551,8 @@ let optional_or ?(present = true) ~default inner =
     env = None;
   }
 
+let list_equal eq a b = List.length a = List.length b && List.for_all2 eq a b
+
 let repeat ~bytes:total_bytes inner =
   let f_total = Wire.Field.v "_total" Wire.uint16be in
   let f_items =
@@ -578,16 +584,13 @@ let repeat ~bytes:total_bytes inner =
           Bytes.blit payload 0 buf 2 (count * n);
           (items, buf))
   in
-  let list_equal a b =
-    List.length a = List.length b && List.for_all2 inner.equal a b
-  in
   {
     codec;
     typ;
     positive;
     random = bytes_any;
     adversarial = bytes_any;
-    equal = list_equal;
+    equal = list_equal inner.equal;
     env = None;
   }
 
@@ -610,34 +613,7 @@ let codec_wrap (c : 'a Wire.Codec.t) ~value_gen ~equal =
     env = None;
   }
 
-let nested_at_most n inner =
-  let typ = Wire.nested_at_most ~size:(Wire.int n) inner.typ in
-  let codec = codec_of_typ typ in
-  let positive =
-    Alcobar.map
-      Alcobar.[ inner.positive ]
-      (fun (v, inner_bytes) ->
-        let buf = Bytes.create n in
-        Bytes.blit inner_bytes 0 buf 0 (min n (Bytes.length inner_bytes));
-        (v, buf))
-  in
-  let adversarial =
-    Alcobar.map
-      Alcobar.[ inner.adversarial ]
-      (fun b ->
-        let buf = Bytes.create n in
-        Bytes.blit b 0 buf 0 (min n (Bytes.length b));
-        buf)
-  in
-  {
-    codec;
-    typ;
-    positive;
-    random = bytes_fixed n;
-    adversarial;
-    equal = inner.equal;
-    env = None;
-  }
+let nested_at_most n inner = nested_sized Wire.nested_at_most n inner
 
 let variants name cases =
   let typ = Wire.variants name cases Wire.uint8 in
@@ -694,16 +670,13 @@ let array n inner =
       Alcobar.[ sample_array_of_positives inner.positive n ]
       (fun (vs, bss) -> (vs, concat_bytes_list bss))
   in
-  let list_equal a b =
-    List.length a = List.length b && List.for_all2 inner.equal a b
-  in
   {
     codec;
     typ;
     positive;
     random = bytes_any;
     adversarial = bytes_any;
-    equal = list_equal;
+    equal = list_equal inner.equal;
     env = None;
   }
 
@@ -903,16 +876,13 @@ let array_seq n inner =
       Alcobar.[ sample_array_of_positives inner.positive n ]
       (fun (vs, bss) -> (vs, concat_bytes_list bss))
   in
-  let list_equal a b =
-    List.length a = List.length b && List.for_all2 inner.equal a b
-  in
   {
     codec;
     typ;
     positive;
     random = bytes_any;
     adversarial = bytes_any;
-    equal = list_equal;
+    equal = list_equal inner.equal;
     env = None;
   }
 
@@ -946,16 +916,13 @@ let repeat_seq ~bytes:total_bytes inner =
           Bytes.blit payload 0 buf 2 (count * n);
           (items, buf))
   in
-  let list_equal a b =
-    List.length a = List.length b && List.for_all2 inner.equal a b
-  in
   {
     codec;
     typ;
     positive;
     random = bytes_any;
     adversarial = bytes_any;
-    equal = list_equal;
+    equal = list_equal inner.equal;
     env = None;
   }
 

--- a/test/cram/dune
+++ b/test/cram/dune
@@ -1,4 +1,4 @@
 (cram
  (deps
   (package wire)
-  ../fixtures/test_fixtures.ml))
+  ../helpers/test_helpers.ml))

--- a/test/dune
+++ b/test/dune
@@ -1,3 +1,3 @@
 (test
  (name test)
- (libraries wire wire.3d test_fixtures alcotest re))
+ (libraries wire wire.3d test_helpers alcotest re))

--- a/test/fixtures/dune
+++ b/test/fixtures/dune
@@ -1,3 +1,0 @@
-(library
- (name test_fixtures)
- (libraries wire))

--- a/test/helpers/dune
+++ b/test/helpers/dune
@@ -1,0 +1,3 @@
+(library
+ (name test_helpers)
+ (libraries wire alcotest))

--- a/test/helpers/test_helpers.ml
+++ b/test/helpers/test_helpers.ml
@@ -104,3 +104,15 @@ let multi_record_codec =
         (Field.v "x" uint16be $ fun (r : multi_record) -> r.x);
         (Field.v "y" uint16be $ fun (r : multi_record) -> r.y);
       ]
+
+(* -- Decode assertions -- *)
+
+let decode_ok = function
+  | Ok v -> v
+  | Error e -> Alcotest.failf "unexpected parse error: %a" pp_parse_error e
+
+let expect_constraint_fail = function
+  | Ok _ -> Alcotest.fail "expected a Constraint_failed parse error"
+  | Error (Constraint_failed _) -> ()
+  | Error e ->
+      Alcotest.failf "expected Constraint_failed, got %a" pp_parse_error e

--- a/test/helpers/test_helpers.ml
+++ b/test/helpers/test_helpers.ml
@@ -116,3 +116,6 @@ let expect_constraint_fail = function
   | Error (Constraint_failed _) -> ()
   | Error e ->
       Alcotest.failf "expected Constraint_failed, got %a" pp_parse_error e
+
+let roundtrip name typ testable v =
+  Alcotest.check testable name v (decode_ok (of_string typ (to_string typ v)))

--- a/test/helpers/test_helpers.mli
+++ b/test/helpers/test_helpers.mli
@@ -67,3 +67,12 @@ type multi_record = { x : int; y : int }
 val multi_record_codec : multi_record Codec.t
 (** [multi_record_codec] is a two-[uint16be]-field record reused by ASCII
     rendering and codec encode/decode tests. *)
+
+(** {1 Decode assertions} *)
+
+val decode_ok : ('a, parse_error) result -> 'a
+(** [decode_ok r] returns the decoded value, failing the test on [Error]. *)
+
+val expect_constraint_fail : ('a, parse_error) result -> unit
+(** [expect_constraint_fail r] asserts [r] is [Error (Constraint_failed _)],
+    failing the test otherwise. *)

--- a/test/helpers/test_helpers.mli
+++ b/test/helpers/test_helpers.mli
@@ -76,3 +76,7 @@ val decode_ok : ('a, parse_error) result -> 'a
 val expect_constraint_fail : ('a, parse_error) result -> unit
 (** [expect_constraint_fail r] asserts [r] is [Error (Constraint_failed _)],
     failing the test otherwise. *)
+
+val roundtrip : string -> 'a typ -> 'a Alcotest.testable -> 'a -> unit
+(** [roundtrip name typ testable v] checks that decoding the encoding of [v]
+    yields [v] again, failing the test on a parse error. *)

--- a/test/test_action.ml
+++ b/test/test_action.ml
@@ -10,6 +10,7 @@
    - If: conditional execution *)
 
 open Wire
+open Test_helpers
 
 (* Record type for two-field codecs *)
 type xy = { x : int; y : int }
@@ -36,11 +37,9 @@ let test_assign_propagates () =
   (* x=10, y=20 => out=10 *)
   let env = Codec.env codec in
   let buf = Bytes.of_string "\x0A\x14" in
-  match Codec.decode ~env codec buf 0 with
-  | Ok r ->
-      Alcotest.(check int) "x" 10 r.x;
-      Alcotest.(check int) "out" 10 (Param.get env out)
-  | Error e -> Alcotest.failf "%a" pp_parse_error e
+  let r = decode_ok (Codec.decode ~env codec buf 0) in
+  Alcotest.(check int) "x" 10 r.x;
+  Alcotest.(check int) "out" 10 (Param.get env out)
 
 let test_assign_propagates_fail () =
   (* Assign out = x, then constraint out + y <= 10 fails. *)
@@ -65,10 +64,7 @@ let test_assign_propagates_fail () =
   (* x=100, y=200 => out=100, 100+200=300 > 10: FAIL *)
   let env = Codec.env codec in
   let buf = Bytes.of_string "\x64\xC8" in
-  match Codec.decode ~env codec buf 0 with
-  | Ok _ -> Alcotest.fail "expected constraint failure"
-  | Error (Constraint_failed _) -> ()
-  | Error e -> Alcotest.failf "wrong error: %a" pp_parse_error e
+  expect_constraint_fail (Codec.decode ~env codec buf 0)
 
 let test_assign_expr () =
   (* Action assigns computed expression: out = x + 1 *)
@@ -92,9 +88,8 @@ let test_assign_expr () =
   (* x=42 => out=43 *)
   let env = Codec.env codec in
   let buf = Bytes.of_string "\x2A\x00" in
-  match Codec.decode ~env codec buf 0 with
-  | Ok _ -> Alcotest.(check int) "out" 43 (Param.get env out)
-  | Error e -> Alcotest.failf "%a" pp_parse_error e
+  ignore (decode_ok (Codec.decode ~env codec buf 0));
+  Alcotest.(check int) "out" 43 (Param.get env out)
 
 (* -- Return -- *)
 
@@ -110,9 +105,7 @@ let test_return_true () =
       ]
   in
   let buf = Bytes.of_string "\x42" in
-  match Codec.decode codec buf 0 with
-  | Ok _ -> ()
-  | Error e -> Alcotest.failf "%a" pp_parse_error e
+  ignore (decode_ok (Codec.decode codec buf 0))
 
 let test_return_false () =
   let codec =
@@ -126,10 +119,7 @@ let test_return_false () =
       ]
   in
   let buf = Bytes.of_string "\x42" in
-  match Codec.decode codec buf 0 with
-  | Ok _ -> Alcotest.fail "expected failure from return false"
-  | Error (Constraint_failed _) -> ()
-  | Error e -> Alcotest.failf "wrong error: %a" pp_parse_error e
+  expect_constraint_fail (Codec.decode codec buf 0)
 
 let test_return_bool_expr () =
   (* return (x > 10): succeeds when x=42 *)
@@ -147,9 +137,7 @@ let test_return_bool_expr () =
       ]
   in
   let buf = Bytes.of_string "\x2A" in
-  match Codec.decode codec buf 0 with
-  | Ok _ -> ()
-  | Error e -> Alcotest.failf "%a" pp_parse_error e
+  ignore (decode_ok (Codec.decode codec buf 0))
 
 let test_return_bool_expr_fail () =
   (* return (x > 10): fails when x=5 *)
@@ -167,10 +155,7 @@ let test_return_bool_expr_fail () =
       ]
   in
   let buf = Bytes.of_string "\x05" in
-  match Codec.decode codec buf 0 with
-  | Ok _ -> Alcotest.fail "expected failure from return false"
-  | Error (Constraint_failed _) -> ()
-  | Error e -> Alcotest.failf "wrong error: %a" pp_parse_error e
+  expect_constraint_fail (Codec.decode codec buf 0)
 
 (* -- Abort -- *)
 
@@ -183,10 +168,7 @@ let test_abort () =
       ]
   in
   let buf = Bytes.of_string "\x42" in
-  match Codec.decode codec buf 0 with
-  | Ok _ -> Alcotest.fail "expected abort"
-  | Error (Constraint_failed _) -> ()
-  | Error e -> Alcotest.failf "wrong error: %a" pp_parse_error e
+  expect_constraint_fail (Codec.decode codec buf 0)
 
 (* -- Var -- *)
 
@@ -216,9 +198,8 @@ let test_var_local () =
   (* x=42 => tmp=84, out=84 *)
   let env = Codec.env codec in
   let buf = Bytes.of_string "\x2A\x00" in
-  match Codec.decode ~env codec buf 0 with
-  | Ok _ -> Alcotest.(check int) "out" 84 (Param.get env out)
-  | Error e -> Alcotest.failf "%a" pp_parse_error e
+  ignore (decode_ok (Codec.decode ~env codec buf 0));
+  Alcotest.(check int) "out" 84 (Param.get env out)
 
 (* -- If -- *)
 
@@ -249,9 +230,8 @@ let test_if_true_branch () =
   in
   let env = Codec.env codec in
   let buf = Bytes.of_string "\x2A\x00" in
-  match Codec.decode ~env codec buf 0 with
-  | Ok _ -> Alcotest.(check int) "out" 1 (Param.get env out)
-  | Error e -> Alcotest.failf "%a" pp_parse_error e
+  ignore (decode_ok (Codec.decode ~env codec buf 0));
+  Alcotest.(check int) "out" 1 (Param.get env out)
 
 let test_if_false_branch () =
   (* if (x > 100) { out = 1 } => out stays 0 when x=5 *)
@@ -280,9 +260,8 @@ let test_if_false_branch () =
   in
   let env = Codec.env codec in
   let buf = Bytes.of_string "\x05\x00" in
-  match Codec.decode ~env codec buf 0 with
-  | Ok _ -> Alcotest.(check int) "out" 0 (Param.get env out)
-  | Error e -> Alcotest.failf "%a" pp_parse_error e
+  ignore (decode_ok (Codec.decode ~env codec buf 0));
+  Alcotest.(check int) "out" 0 (Param.get env out)
 
 let test_if_else () =
   (* if (x = 0) { out = 10 } else { out = 20 } *)
@@ -311,9 +290,8 @@ let test_if_else () =
   (* x=1 => else branch => out=20 *)
   let env = Codec.env codec in
   let buf = Bytes.of_string "\x01\x00" in
-  match Codec.decode ~env codec buf 0 with
-  | Ok _ -> Alcotest.(check int) "out" 20 (Param.get env out)
-  | Error e -> Alcotest.failf "%a" pp_parse_error e
+  ignore (decode_ok (Codec.decode ~env codec buf 0));
+  Alcotest.(check int) "out" 20 (Param.get env out)
 
 let test_if_abort_in_else () =
   (* if (x > 0) { out = x } else { abort } *)
@@ -339,10 +317,7 @@ let test_if_abort_in_else () =
   (* x=0 => else branch => abort *)
   let env = Codec.env codec in
   let buf = Bytes.of_string "\x00" in
-  match Codec.decode ~env codec buf 0 with
-  | Ok _ -> Alcotest.fail "expected abort from else branch"
-  | Error (Constraint_failed _) -> ()
-  | Error e -> Alcotest.failf "wrong error: %a" pp_parse_error e
+  expect_constraint_fail (Codec.decode ~env codec buf 0)
 
 let test_if_nested () =
   (* if (x > 0) { if (x < 100) { out = 1 } else { out = 2 } } *)
@@ -377,9 +352,8 @@ let test_if_nested () =
   (* x=50: 50>0 => true, 50<100 => true, out=1 *)
   let env = Codec.env codec in
   let buf = Bytes.of_string "\x32\x00" in
-  match Codec.decode ~env codec buf 0 with
-  | Ok _ -> Alcotest.(check int) "out" 1 (Param.get env out)
-  | Error e -> Alcotest.failf "%a" pp_parse_error e
+  ignore (decode_ok (Codec.decode ~env codec buf 0));
+  Alcotest.(check int) "out" 1 (Param.get env out)
 
 (* -- On_act vs On_success -- *)
 
@@ -398,14 +372,9 @@ let test_on_act () =
       ]
   in
   let buf = Bytes.of_string "\x2A" in
-  (match Codec.decode codec buf 0 with
-  | Ok _ -> ()
-  | Error e -> Alcotest.failf "on_act x=42: %a" pp_parse_error e);
+  ignore (decode_ok (Codec.decode codec buf 0));
   let buf_bad = Bytes.of_string "\x00" in
-  match Codec.decode codec buf_bad 0 with
-  | Ok _ -> Alcotest.fail "expected on_act failure"
-  | Error (Constraint_failed _) -> ()
-  | Error e -> Alcotest.failf "wrong error: %a" pp_parse_error e
+  expect_constraint_fail (Codec.decode codec buf_bad 0)
 
 (* -- Multiple statements sequencing -- *)
 
@@ -437,9 +406,8 @@ let test_stmt_sequencing () =
   (* x=42 => a=42, b=43, out=86 *)
   let env = Codec.env codec in
   let buf = Bytes.of_string "\x2A\x00" in
-  match Codec.decode ~env codec buf 0 with
-  | Ok _ -> Alcotest.(check int) "out" 86 (Param.get env out)
-  | Error e -> Alcotest.failf "%a" pp_parse_error e
+  ignore (decode_ok (Codec.decode ~env codec buf 0));
+  Alcotest.(check int) "out" 86 (Param.get env out)
 
 let test_return_short_circuits () =
   (* return true; abort => should succeed (abort never reached) *)
@@ -455,9 +423,7 @@ let test_return_short_circuits () =
       ]
   in
   let buf = Bytes.of_string "\x42" in
-  match Codec.decode codec buf 0 with
-  | Ok _ -> ()
-  | Error e -> Alcotest.failf "%a" pp_parse_error e
+  ignore (decode_ok (Codec.decode codec buf 0))
 
 let test_abort_short_circuits () =
   (* abort; assign out = 1 => should fail (assign never reached) *)
@@ -478,10 +444,7 @@ let test_abort_short_circuits () =
   in
   let env = Codec.env codec in
   let buf = Bytes.of_string "\x42\x00" in
-  match Codec.decode ~env codec buf 0 with
-  | Ok _ -> Alcotest.fail "expected abort"
-  | Error (Constraint_failed _) -> ()
-  | Error e -> Alcotest.failf "wrong error: %a" pp_parse_error e
+  expect_constraint_fail (Codec.decode ~env codec buf 0)
 
 (* -- Empty action -- *)
 
@@ -492,9 +455,7 @@ let test_empty_action () =
       [ Field.v "x" ~action:(Action.on_success []) uint8 $ Fun.id ]
   in
   let buf = Bytes.of_string "\x42" in
-  match Codec.decode codec buf 0 with
-  | Ok _ -> ()
-  | Error e -> Alcotest.failf "%a" pp_parse_error e
+  ignore (decode_ok (Codec.decode codec buf 0))
 
 (* -- Action on bitfield -- *)
 
@@ -515,11 +476,9 @@ let test_action_on_bitfield () =
   in
   let env = Codec.env codec in
   let buf = Bytes.of_string "\xAB" in
-  match Codec.decode ~env codec buf 0 with
-  | Ok _ ->
-      let out_val = Param.get env out in
-      Alcotest.(check bool) "out <= 15" true (out_val <= 15)
-  | Error e -> Alcotest.failf "%a" pp_parse_error e
+  ignore (decode_ok (Codec.decode ~env codec buf 0));
+  let out_val = Param.get env out in
+  Alcotest.(check bool) "out <= 15" true (out_val <= 15)
 
 (* -- Suite -- *)
 

--- a/test/test_ascii.ml
+++ b/test/test_ascii.ml
@@ -4,7 +4,7 @@
 
 open Wire
 open Wire.Everparse.Raw
-open Test_fixtures
+open Test_helpers
 
 let check name s expected =
   let output = Ascii.of_struct s in
@@ -112,7 +112,7 @@ let test_variable () =
     (Re.execp (Re.compile (Re.str "data")) output)
 
 (* -- Codec rendering --
-   [multi_record_codec] lives in {!Test_fixtures}. *)
+   [multi_record_codec] lives in {!Test_helpers}. *)
 
 let test_of_codec () =
   let output = Ascii.of_codec multi_record_codec in

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -2,13 +2,9 @@
 
 open Wire
 open Wire.Everparse.Raw
-open Test_fixtures
+open Test_helpers
 
 let contains ~sub s = Re.execp (Re.compile (Re.str sub)) s
-
-let decode_ok = function
-  | Ok v -> v
-  | Error e -> Alcotest.failf "%a" pp_parse_error e
 
 (* Helper: encode record to string using Codec API *)
 let encode_record codec v =
@@ -221,7 +217,7 @@ let test_struct_of_codec_metadata () =
     (contains ~sub:"mutable" output)
 
 (* Record with multiple uint16be fields --
-   [multi_record] / [multi_record_codec] live in {!Test_fixtures}. *)
+   [multi_record] / [multi_record_codec] live in {!Test_helpers}. *)
 
 let test_record_with_multi () =
   let original = { x = 0x1234; y = 0x5678 } in
@@ -2171,7 +2167,7 @@ let test_bitfield_load_shared () =
   Alcotest.(check int) "b" 0xB b
 
 (* -- Nested: Codec typ: embed a sub-codec as a field --
-   [inner] / [outer] / [inner_codec] / [outer_codec] live in {!Test_fixtures}. *)
+   [inner] / [outer] / [inner_codec] / [outer_codec] live in {!Test_helpers}. *)
 
 let test_codec_embed_decode () =
   (* header(1) + tag(1) + value(2) + trailer(1) = 5 bytes *)
@@ -2252,7 +2248,7 @@ let test_codec_embed_bitfield () =
   Alcotest.(check int) "checksum" 0xFF r.checksum
 
 (* Two levels of nesting --
-   [l0] / [l1] / [l2] and their codecs live in {!Test_fixtures}. *)
+   [l0] / [l1] / [l2] and their codecs live in {!Test_helpers}. *)
 
 let test_codec_embed_nested () =
   (* l2(1) + l1_y(2) + z(1) = 4 bytes *)
@@ -2514,7 +2510,7 @@ let test_codec_crossref_field_bitfield () =
 
 (* -- Nested: Optional typ: conditional field presence --
    [opt_record], [opt_codec], [opt_codec_present], [opt_codec_absent] live
-   in {!Test_fixtures}. *)
+   in {!Test_helpers}. *)
 
 let test_optional_present_decode () =
   (* hdr(1) + payload(2) + trail(1) = 4 bytes *)
@@ -2935,7 +2931,7 @@ let test_uint64_ref_in_size () =
   Alcotest.(check string) "data" "ABC" data
 
 (* -- Nested: Repeat typ: parse elements until byte budget exhausted --
-   [container], [f_cnt_length], [repeat_codec] live in {!Test_fixtures}. *)
+   [container], [f_cnt_length], [repeat_codec] live in {!Test_helpers}. *)
 
 let test_repeat_decode_empty () =
   (* length=0 -> no items *)
@@ -3253,7 +3249,7 @@ let test_length_prefixed_casetype () =
 
 (* -- Nested: Composition: optional + repeat + codec --
    TM-frame-like structure: header + data zone (repeat of packets) + optional
-   OCF + optional FECF. [packet] / [packet_codec] live in {!Test_fixtures}. *)
+   OCF + optional FECF. [packet] / [packet_codec] live in {!Test_helpers}. *)
 
 type tm_like = {
   tm_hdr : int;

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -2,7 +2,7 @@
 
 open Wire
 open Wire.Everparse.Raw
-open Test_fixtures
+open Test_helpers
 
 let contains ~sub s = Re.execp (Re.compile (Re.str sub)) s
 
@@ -86,7 +86,7 @@ let test_pretty_print () =
 (* -- Codec definitions for 3D extraction tests --
    The shared codecs ([inner], [outer], [l0]/[l1]/[l2], [opt_record],
    [container]/[repeat_codec], [packet]/[packet_codec]) live in
-   {!Test_fixtures}. *)
+   {!Test_helpers}. *)
 
 type tm_like = {
   hdr : int;

--- a/test/test_param.ml
+++ b/test/test_param.ml
@@ -3,6 +3,7 @@
 
 open Wire
 open Wire.Everparse.Raw
+open Test_helpers
 
 (* -- Param.input / Param.output / Param.decl -- *)
 
@@ -58,9 +59,8 @@ let test_output_binding () =
   Alcotest.(check int) "initial value" 0 (Param.get env out);
   (* after decode, output param is written by the action *)
   let buf = Bytes.of_string "\x07" in
-  match Codec.decode ~env c buf 0 with
-  | Ok _ -> Alcotest.(check int) "after decode" 7 (Param.get env out)
-  | Error e -> Alcotest.failf "%a" pp_parse_error e
+  ignore (decode_ok (Codec.decode ~env c buf 0));
+  Alcotest.(check int) "after decode" 7 (Param.get env out)
 
 (* -- Input param visible to constraints (via Codec) -- *)
 
@@ -76,15 +76,11 @@ let test_input_param_constraint () =
   (* limit=10, x=5: passes *)
   let buf = Bytes.of_string "\x05" in
   let env = Codec.env c |> Param.bind limit 10 in
-  (match Codec.decode ~env c buf 0 with
-  | Ok r -> Alcotest.(check int) "x" 5 r.x
-  | Error e -> Alcotest.failf "pass: %a" pp_parse_error e);
+  let r = decode_ok (Codec.decode ~env c buf 0) in
+  Alcotest.(check int) "x" 5 r.x;
   (* limit=3, x=5: fails *)
   let env = Codec.env c |> Param.bind limit 3 in
-  match Codec.decode ~env c buf 0 with
-  | Ok _ -> Alcotest.fail "expected constraint failure"
-  | Error (Constraint_failed _) -> ()
-  | Error e -> Alcotest.failf "wrong error: %a" pp_parse_error e
+  expect_constraint_fail (Codec.decode ~env c buf 0)
 
 (* -- Output param written by action (via Codec) -- *)
 
@@ -99,9 +95,8 @@ let test_output_param_action () =
   let c = Codec.v "Writer" (fun x -> { x }) Codec.[ (cf_x $ fun r -> r.x) ] in
   let buf = Bytes.of_string "\x2A" in
   let env = Codec.env c in
-  match Codec.decode ~env c buf 0 with
-  | Ok _ -> Alcotest.(check int) "out" 42 (Param.get env out)
-  | Error e -> Alcotest.failf "%a" pp_parse_error e
+  ignore (decode_ok (Codec.decode ~env c buf 0));
+  Alcotest.(check int) "out" 42 (Param.get env out)
 
 let test_output_param_computed () =
   let out = Param.output "out" uint16be in
@@ -115,9 +110,8 @@ let test_output_param_computed () =
   let c = Codec.v "Computed" (fun x -> { x }) Codec.[ (cf_x $ fun r -> r.x) ] in
   let buf = Bytes.of_string "\x15" in
   let env = Codec.env c in
-  match Codec.decode ~env c buf 0 with
-  | Ok _ -> Alcotest.(check int) "out" 42 (Param.get env out)
-  | Error e -> Alcotest.failf "%a" pp_parse_error e
+  ignore (decode_ok (Codec.decode ~env c buf 0));
+  Alcotest.(check int) "out" 42 (Param.get env out)
 
 (* -- Where clause with params (via Codec) -- *)
 
@@ -136,9 +130,8 @@ let test_where_clause_pass () =
   (* max_val=100, value=50: passes *)
   let buf = Bytes.of_string "\x00\x32" in
   let env = Codec.env c |> Param.bind max_val 100 in
-  match Codec.decode ~env c buf 0 with
-  | Ok r -> Alcotest.(check int) "value" 50 r.bv_value
-  | Error e -> Alcotest.failf "%a" pp_parse_error e
+  let r = decode_ok (Codec.decode ~env c buf 0) in
+  Alcotest.(check int) "value" 50 r.bv_value
 
 let test_where_clause_fail () =
   let max_val = Param.input "max_val" uint16be in
@@ -188,15 +181,11 @@ let test_mixed_params () =
   (* a=10, b=20 => out_sum=30, max_val=50 => 30 <= 50: OK *)
   let buf = Bytes.of_string "\x0A\x14" in
   let env = Codec.env c |> Param.bind max_val 50 in
-  (match Codec.decode ~env c buf 0 with
-  | Ok _ -> Alcotest.(check int) "out_sum" 30 (Param.get env out_sum)
-  | Error e -> Alcotest.failf "%a" pp_parse_error e);
+  ignore (decode_ok (Codec.decode ~env c buf 0));
+  Alcotest.(check int) "out_sum" 30 (Param.get env out_sum);
   (* a=10, b=20 => out_sum=30, max_val=20 => 30 > 20: FAIL *)
   let env = Codec.env c |> Param.bind max_val 20 in
-  match Codec.decode ~env c buf 0 with
-  | Ok _ -> Alcotest.fail "expected where failure"
-  | Error (Constraint_failed _) -> ()
-  | Error e -> Alcotest.failf "wrong error: %a" pp_parse_error e
+  expect_constraint_fail (Codec.decode ~env c buf 0)
 
 (* -- Codec.decode ~env:params with -- *)
 
@@ -219,11 +208,7 @@ let test_codec_param_decode () =
   in
   let buf = Bytes.of_string "\x05" in
   let env = Codec.env c |> Param.bind limit 10 in
-  let v =
-    match Codec.decode ~env c buf 0 with
-    | Ok v -> v
-    | Error e -> Alcotest.failf "%a" pp_parse_error e
-  in
+  let v = decode_ok (Codec.decode ~env c buf 0) in
   Alcotest.(check int) "x" 5 v.x
 
 let test_codec_param_where_fail () =
@@ -289,15 +274,9 @@ let test_3d_rendering () =
 
 let test_no_params () =
   let s = struct_ "Simple" [ field "x" uint8 ] in
-  match of_string (struct_typ s) "\x42" with
-  | Ok () -> ()
-  | Error e -> Alcotest.failf "%a" pp_parse_error e
+  ignore (decode_ok (of_string (struct_typ s) "\x42"))
 
 (* -- Param-driven size -- *)
-
-let decode_ok = function
-  | Ok v -> v
-  | Error e -> Alcotest.failf "%a" pp_parse_error e
 
 type param_size_record = { ps_data : string; ps_tag : int }
 

--- a/test/test_wire.ml
+++ b/test/test_wire.ml
@@ -2,6 +2,7 @@
 
 open Wire
 open Wire.Everparse.Raw
+open Test_helpers
 
 (* Helper: parse from a string delivered in slices of [chunk_size] bytes.
    Forces multi-byte values to straddle slice boundaries. *)
@@ -88,20 +89,14 @@ let test_int32be_negative () =
   Alcotest.(check int) "-2 BE" (-2) (of_bytes_exn int32be buf)
 
 let test_int64le_roundtrip () =
-  let v = -0x0102_0304_0506_0708L in
-  let s = to_string int64 v in
-  Alcotest.(check int64) "roundtrip" v (of_string_exn int64 s)
+  roundtrip "roundtrip" int64 Alcotest.int64 (-0x0102_0304_0506_0708L)
 
 let test_float32be_roundtrip () =
-  let v = 1.5 in
-  let s = to_string float32be v in
-  Alcotest.(check (float 0.0)) "1.5" v (of_string_exn float32be s)
+  roundtrip "1.5" float32be Alcotest.(float 0.0) 1.5
 
 let test_float64le_roundtrip () =
   List.iter
-    (fun v ->
-      let s = to_string float64 v in
-      Alcotest.(check (float 0.0)) "roundtrip" v (of_string_exn float64 s))
+    (roundtrip "roundtrip" float64 Alcotest.(float 0.0))
     [ 0.0; -0.0; 3.14159; -1e300; Float.infinity; Float.neg_infinity ]
 
 let test_float64_nan_roundtrip () =
@@ -715,42 +710,24 @@ let test_bits_roundtrip_all_combos () =
 (* -- Roundtrip tests -- *)
 
 let test_roundtrip_uint8 () =
-  let original = 0x42 in
-  let encoded = to_string uint8 original in
-  match of_string uint8 encoded with
-  | Ok decoded -> Alcotest.(check int) "roundtrip uint8" original decoded
-  | Error e -> Alcotest.failf "%a" pp_parse_error e
+  roundtrip "roundtrip uint8" uint8 Alcotest.int 0x42
 
 let test_roundtrip_uint16 () =
-  let original = 0x1234 in
-  let encoded = to_string uint16 original in
-  match of_string uint16 encoded with
-  | Ok decoded -> Alcotest.(check int) "roundtrip uint16" original decoded
-  | Error e -> Alcotest.failf "%a" pp_parse_error e
+  roundtrip "roundtrip uint16" uint16 Alcotest.int 0x1234
 
 let test_roundtrip_uint32 () =
-  let original = 0x12345678 in
-  let encoded = to_string uint32 original in
-  match of_string uint32 encoded with
-  | Ok decoded -> Alcotest.(check int) "roundtrip uint32" original decoded
-  | Error e -> Alcotest.failf "%a" pp_parse_error e
+  roundtrip "roundtrip uint32" uint32 Alcotest.int 0x12345678
 
 let test_roundtrip_array () =
-  let original = [ 1; 2; 3; 4; 5 ] in
-  let t = array ~len:(int 5) uint8 in
-  let encoded = to_string t original in
-  match of_string t encoded with
-  | Ok decoded -> Alcotest.(check (list int)) "roundtrip array" original decoded
-  | Error e -> Alcotest.failf "%a" pp_parse_error e
+  roundtrip "roundtrip array"
+    (array ~len:(int 5) uint8)
+    Alcotest.(list int)
+    [ 1; 2; 3; 4; 5 ]
 
 let test_roundtrip_byte_array () =
-  let original = "hello" in
-  let t = byte_array ~size:(int 5) in
-  let encoded = to_string t original in
-  match of_string t encoded with
-  | Ok decoded ->
-      Alcotest.(check string) "roundtrip byte_array" original decoded
-  | Error e -> Alcotest.failf "%a" pp_parse_error e
+  roundtrip "roundtrip byte_array"
+    (byte_array ~size:(int 5))
+    Alcotest.string "hello"
 
 (* -- Streaming: cross-slice boundary tests -- *)
 


### PR DESCRIPTION
Three test-only dedups against the shared helpers library.

`decode_ok` and `expect_constraint_fail`, added to the helpers (renamed from `test_fixtures` to `test_helpers`), replace the `match Codec.decode ... with Ok ... | Error e -> Alcotest.failf ...` epilogue repeated across the action, codec, and param suites. A `roundtrip` helper replaces the encode/decode/check-equal body of the per-type roundtrip tests in `test_wire`. In `fuzz_gen`, `nested_at_most` was a copy of `nested` apart from the typ constructor (now `nested_sized`), and `list_equal` is lifted out of `repeat` and `array`.

No behaviour change. The two specific-string `Constraint_failed "where clause"` assertions are kept as-is. `test_uint32`/`test_uint63` look similar but test different modules, so a functor would add boilerplate without a real gain and they are left explicit.
