### PR TITLE
test: factor more repeated test and fuzz scaffolding

### DIFF
--- a/fuzz/gen/fuzz_gen.ml
+++ b/fuzz/gen/fuzz_gen.ml
@@ -553,13 +553,14 @@ let optional_or ?(present = true) ~default inner =
 
 let list_equal eq a b = List.length a = List.length b && List.for_all2 eq a b
 
-let repeat ~bytes:total_bytes inner =
+(* [repeat] and [repeat_seq] differ only in the codec name and the items
+   field constructor (list vs seq); the length-prefixed payload generation is
+   identical. *)
+let repeat_sized name make_items ~bytes:total_bytes inner =
   let f_total = Wire.Field.v "_total" Wire.uint16be in
-  let f_items =
-    Wire.Field.repeat "_items" ~size:(Wire.Field.ref f_total) inner.typ
-  in
+  let f_items = make_items ~size:(Wire.Field.ref f_total) inner.typ in
   let codec =
-    Wire.Codec.v "_rep"
+    Wire.Codec.v name
       (fun _ xs -> xs)
       Wire.Codec.[ (f_total $ fun _ -> total_bytes); (f_items $ fun xs -> xs) ]
   in
@@ -593,6 +594,11 @@ let repeat ~bytes:total_bytes inner =
     equal = list_equal inner.equal;
     env = None;
   }
+
+let repeat ~bytes inner =
+  repeat_sized "_rep"
+    (fun ~size typ -> Wire.Field.repeat "_items" ~size typ)
+    ~bytes inner
 
 let codec_wrap (c : 'a Wire.Codec.t) ~value_gen ~equal =
   let typ = Wire.codec c in
@@ -662,8 +668,9 @@ let concat_bytes_list bss =
   in
   out
 
-let array n inner =
-  let typ = Wire.array ~len:(Wire.int n) inner.typ in
+(* [array] and [array_seq] differ only in the typ constructor. *)
+let array_sized make_typ n inner =
+  let typ = make_typ ~len:(Wire.int n) inner.typ in
   let codec = codec_of_typ typ in
   let positive =
     Alcobar.map
@@ -679,6 +686,8 @@ let array n inner =
     equal = list_equal inner.equal;
     env = None;
   }
+
+let array n inner = array_sized Wire.array n inner
 
 let enum name cases =
   let typ = Wire.enum name cases Wire.uint8 in
@@ -868,63 +877,13 @@ let bit inner =
     env = None;
   }
 
-let array_seq n inner =
-  let typ = Wire.array_seq Wire.seq_list ~len:(Wire.int n) inner.typ in
-  let codec = codec_of_typ typ in
-  let positive =
-    Alcobar.map
-      Alcobar.[ sample_array_of_positives inner.positive n ]
-      (fun (vs, bss) -> (vs, concat_bytes_list bss))
-  in
-  {
-    codec;
-    typ;
-    positive;
-    random = bytes_any;
-    adversarial = bytes_any;
-    equal = list_equal inner.equal;
-    env = None;
-  }
+let array_seq n inner = array_sized (Wire.array_seq Wire.seq_list) n inner
 
-let repeat_seq ~bytes:total_bytes inner =
-  let f_total = Wire.Field.v "_total" Wire.uint16be in
-  let f_items =
-    Wire.Field.repeat_seq "_items" ~seq:Wire.seq_list
-      ~size:(Wire.Field.ref f_total) inner.typ
-  in
-  let codec =
-    Wire.Codec.v "_rep_seq"
-      (fun _ xs -> xs)
-      Wire.Codec.[ (f_total $ fun _ -> total_bytes); (f_items $ fun xs -> xs) ]
-  in
-  let typ = Wire.codec codec in
-  let positive =
-    Alcobar.map
-      Alcobar.[ inner.positive ]
-      (fun (v, bs) ->
-        let n = Bytes.length bs in
-        if n = 0 || n > total_bytes then ([], Bytes.empty)
-        else
-          let count = total_bytes / n in
-          let items = List.init count (fun _ -> v) in
-          let payload = Bytes.create (count * n) in
-          for i = 0 to count - 1 do
-            Bytes.blit bs 0 payload (i * n) n
-          done;
-          let buf = Bytes.create (2 + (count * n)) in
-          Bytes.set_uint16_be buf 0 (count * n);
-          Bytes.blit payload 0 buf 2 (count * n);
-          (items, buf))
-  in
-  {
-    codec;
-    typ;
-    positive;
-    random = bytes_any;
-    adversarial = bytes_any;
-    equal = list_equal inner.equal;
-    env = None;
-  }
+let repeat_seq ~bytes inner =
+  repeat_sized "_rep_seq"
+    (fun ~size typ ->
+      Wire.Field.repeat_seq "_items" ~seq:Wire.seq_list ~size typ)
+    ~bytes inner
 
 (* Two-uint8 record where the second field's [~constraint_] references
    the first via [Field.anon]. Exercises the anon constructor. *)

--- a/test/test_action.ml
+++ b/test/test_action.ml
@@ -203,14 +203,15 @@ let test_var_local () =
 
 (* -- If -- *)
 
-let test_if_true_branch () =
-  (* if (x > 0) { out = 1 } => out should be 1 when x=42 *)
+(* [if (x > threshold) { out = 1 }], out starting at 0: same codec, the
+   branch is taken or not depending on the input byte. *)
+let check_if_gate name ~threshold ~input ~expected =
   let out = Param.output "out" uint8 in
   let f_x = Field.v "x" uint8 in
   let f_y = Field.v "y" uint8 in
   let codec =
     let open Codec in
-    v "IfTrue"
+    v name
       (fun x y -> { x; y })
       [
         ( Field.v "x"
@@ -219,7 +220,7 @@ let test_if_true_branch () =
                  [
                    Action.assign out (int 0);
                    Action.if_
-                     Expr.(Field.ref f_x > int 0)
+                     Expr.(Field.ref f_x > int threshold)
                      [ Action.assign out (int 1) ]
                      None;
                  ])
@@ -229,39 +230,14 @@ let test_if_true_branch () =
       ]
   in
   let env = Codec.env codec in
-  let buf = Bytes.of_string "\x2A\x00" in
-  ignore (decode_ok (Codec.decode ~env codec buf 0));
-  Alcotest.(check int) "out" 1 (Param.get env out)
+  ignore (decode_ok (Codec.decode ~env codec (Bytes.of_string input) 0));
+  Alcotest.(check int) "out" expected (Param.get env out)
+
+let test_if_true_branch () =
+  check_if_gate "IfTrue" ~threshold:0 ~input:"\x2A\x00" ~expected:1
 
 let test_if_false_branch () =
-  (* if (x > 100) { out = 1 } => out stays 0 when x=5 *)
-  let out = Param.output "out" uint8 in
-  let f_x = Field.v "x" uint8 in
-  let f_y = Field.v "y" uint8 in
-  let codec =
-    let open Codec in
-    v "IfFalse"
-      (fun x y -> { x; y })
-      [
-        ( Field.v "x"
-            ~action:
-              (Action.on_success
-                 [
-                   Action.assign out (int 0);
-                   Action.if_
-                     Expr.(Field.ref f_x > int 100)
-                     [ Action.assign out (int 1) ]
-                     None;
-                 ])
-            uint8
-        $ fun r -> r.x );
-        (f_y $ fun r -> r.y);
-      ]
-  in
-  let env = Codec.env codec in
-  let buf = Bytes.of_string "\x05\x00" in
-  ignore (decode_ok (Codec.decode ~env codec buf 0));
-  Alcotest.(check int) "out" 0 (Param.get env out)
+  check_if_gate "IfFalse" ~threshold:100 ~input:"\x05\x00" ~expected:0
 
 let test_if_else () =
   (* if (x = 0) { out = 10 } else { out = 20 } *)

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -6,6 +6,10 @@ open Test_helpers
 
 let contains ~sub s = Re.execp (Re.compile (Re.str sub)) s
 
+(* Project a codec to its 3D rendering for substring assertions. *)
+let render_3d codec =
+  to_3d (module_ [ typedef (Everparse.struct_of_codec codec) ])
+
 (* Helper: encode record to string using Codec API *)
 let encode_record codec v =
   let ws = Codec.wire_size codec in
@@ -68,9 +72,7 @@ let test_record_roundtrip () =
       | Error e -> Alcotest.failf "%a" pp_parse_error e)
 
 let test_struct_of_record () =
-  let s = Everparse.struct_of_codec simple_record_codec in
-  let m = module_ [ typedef s ] in
-  let output = to_3d m in
+  let output = render_3d simple_record_codec in
   Alcotest.(check bool) "contains UINT8" true (contains ~sub:"UINT8" output);
   Alcotest.(check bool) "contains UINT16" true (contains ~sub:"UINT16" output);
   Alcotest.(check bool) "contains UINT32" true (contains ~sub:"UINT32" output);
@@ -197,9 +199,7 @@ let test_validate_then_get () =
   Alcotest.(check int) "validate then get" 8 (get_x buf 0)
 
 let test_struct_of_codec_metadata () =
-  let s = Everparse.struct_of_codec projection_codec in
-  let m = module_ [ typedef s ] in
-  let output = to_3d m in
+  let output = render_3d projection_codec in
   (* The struct-level [where] referencing the field [x] is lowered onto the
      field as a [{ ... }] constraint -- 3D's [where] only sees params. *)
   Alcotest.(check bool)
@@ -513,9 +513,7 @@ let test_packed_mapped_bf_size () =
     (Bytes.unsafe_to_string buf)
 
 let test_struct_of_codec_bitfield () =
-  let s = Everparse.struct_of_codec bf32_codec in
-  let m = module_ [ typedef s ] in
-  let output = to_3d m in
+  let output = render_3d bf32_codec in
   Alcotest.(check bool)
     "contains UINT32BE" true
     (contains ~sub:"UINT32BE" output);
@@ -2024,9 +2022,7 @@ let test_dep_ref_size_eval () =
 
 let test_struct_of_dep () =
   (* struct_of_codec should produce a valid struct for variable-size codecs *)
-  let s = Everparse.struct_of_codec dep_slice_codec in
-  let m = module_ [ typedef s ] in
-  let output = to_3d m in
+  let output = render_3d dep_slice_codec in
   Alcotest.(check bool)
     "contains UINT16BE" true
     (contains ~sub:"UINT16BE" output);
@@ -2034,9 +2030,7 @@ let test_struct_of_dep () =
   Alcotest.(check bool) "contains Payload" true (contains ~sub:"Payload" output)
 
 let test_struct_of_dep_trailer () =
-  let s = Everparse.struct_of_codec trailer_codec in
-  let m = module_ [ typedef s ] in
-  let output = to_3d m in
+  let output = render_3d trailer_codec in
   Alcotest.(check bool) "contains Length" true (contains ~sub:"Length" output);
   Alcotest.(check bool) "contains Payload" true (contains ~sub:"Payload" output);
   Alcotest.(check bool)
@@ -2854,37 +2848,39 @@ let bg_codec ~present =
         (Field.optional "Body" ~present uint8 $ fun r -> r.bg_body);
       ]
 
+(* Decode a present-payload buffer (expect [Some 0x2A]) and an absent buffer
+   (expect [None]) through a [bg_codec] gated on [present]. *)
+let check_bit_gated ~present ~present_buf ~present_label ~absent_buf
+    ~absent_label =
+  let c = bg_codec ~present in
+  let r = decode_ok (Codec.decode c (Bytes.of_string present_buf) 0) in
+  Alcotest.(check (option int)) present_label (Some 0x2A) r.bg_body;
+  let r = decode_ok (Codec.decode c (Bytes.of_string absent_buf) 0) in
+  Alcotest.(check (option int)) absent_label None r.bg_body
+
 let test_optional_land_predicate () =
-  let c =
-    bg_codec ~present:Expr.(Field.ref f_bg_flags land int 0x80 <> int 0)
-  in
-  let r = decode_ok (Codec.decode c (Bytes.of_string "\x80\x2A") 0) in
-  Alcotest.(check (option int)) "high bit set" (Some 0x2A) r.bg_body;
-  let r = decode_ok (Codec.decode c (Bytes.of_string "\x00") 0) in
-  Alcotest.(check (option int)) "high bit clear" None r.bg_body
+  check_bit_gated
+    ~present:Expr.(Field.ref f_bg_flags land int 0x80 <> int 0)
+    ~present_buf:"\x80\x2A" ~present_label:"high bit set" ~absent_buf:"\x00"
+    ~absent_label:"high bit clear"
 
 let test_optional_lsr_predicate () =
-  let c = bg_codec ~present:Expr.(Field.ref f_bg_flags lsr int 4 <> int 0) in
-  let r = decode_ok (Codec.decode c (Bytes.of_string "\x10\x2A") 0) in
-  Alcotest.(check (option int)) "top nibble set" (Some 0x2A) r.bg_body;
-  let r = decode_ok (Codec.decode c (Bytes.of_string "\x0F") 0) in
-  Alcotest.(check (option int)) "top nibble clear" None r.bg_body
+  check_bit_gated
+    ~present:Expr.(Field.ref f_bg_flags lsr int 4 <> int 0)
+    ~present_buf:"\x10\x2A" ~present_label:"top nibble set" ~absent_buf:"\x0F"
+    ~absent_label:"top nibble clear"
 
 let test_optional_mod_predicate () =
-  let c = bg_codec ~present:Expr.(Field.ref f_bg_flags mod int 2 <> int 0) in
-  let r = decode_ok (Codec.decode c (Bytes.of_string "\x03\x2A") 0) in
-  Alcotest.(check (option int)) "odd" (Some 0x2A) r.bg_body;
-  let r = decode_ok (Codec.decode c (Bytes.of_string "\x02") 0) in
-  Alcotest.(check (option int)) "even" None r.bg_body
+  check_bit_gated
+    ~present:Expr.(Field.ref f_bg_flags mod int 2 <> int 0)
+    ~present_buf:"\x03\x2A" ~present_label:"odd" ~absent_buf:"\x02"
+    ~absent_label:"even"
 
 let test_optional_lor_predicate () =
-  let c =
-    bg_codec ~present:Expr.(Field.ref f_bg_flags lor int 0x01 = int 0x01)
-  in
-  let r = decode_ok (Codec.decode c (Bytes.of_string "\x01\x2A") 0) in
-  Alcotest.(check (option int)) "lor matches" (Some 0x2A) r.bg_body;
-  let r = decode_ok (Codec.decode c (Bytes.of_string "\xFF") 0) in
-  Alcotest.(check (option int)) "lor no match" None r.bg_body
+  check_bit_gated
+    ~present:Expr.(Field.ref f_bg_flags lor int 0x01 = int 0x01)
+    ~present_buf:"\x01\x2A" ~present_label:"lor matches" ~absent_buf:"\xFF"
+    ~absent_label:"lor no match"
 
 (* [Field.ref] on an [optional] field must read the inner value, not 0.
    The codec engine used to skip populating the int_array slot for

--- a/test/test_param.ml
+++ b/test/test_param.ml
@@ -7,31 +7,25 @@ open Test_helpers
 
 (* -- Param.input / Param.output / Param.decl -- *)
 
+let contains ~sub s = Re.execp (Re.compile (Re.str sub)) s
+
+(* Render a one-field struct carrying [p] to 3D for substring assertions. *)
+let render_param_3d p =
+  to_3d
+    (module_
+       [ typedef (param_struct "T" [ Param.decl p ] [ field "x" uint8 ]) ])
+
 let test_input_spec () =
-  let p = Param.input "limit" uint8 in
-  let spec = Param.decl p in
-  let s = param_struct "T" [ spec ] [ field "x" uint8 ] in
-  let m = module_ [ typedef s ] in
-  let output = to_3d m in
+  let output = render_param_3d (Param.input "limit" uint8) in
   Alcotest.(check bool)
     "contains UINT8 limit" true
-    (Re.execp (Re.compile (Re.str "UINT8 limit")) output);
-  Alcotest.(check bool)
-    "not mutable" false
-    (Re.execp (Re.compile (Re.str "mutable")) output)
+    (contains ~sub:"UINT8 limit" output);
+  Alcotest.(check bool) "not mutable" false (contains ~sub:"mutable" output)
 
 let test_output_spec () =
-  let p = Param.output "out" uint16be in
-  let spec = Param.decl p in
-  let s = param_struct "T" [ spec ] [ field "x" uint8 ] in
-  let m = module_ [ typedef s ] in
-  let output = to_3d m in
-  Alcotest.(check bool)
-    "contains mutable" true
-    (Re.execp (Re.compile (Re.str "mutable")) output);
-  Alcotest.(check bool)
-    "contains out" true
-    (Re.execp (Re.compile (Re.str "out")) output)
+  let output = render_param_3d (Param.output "out" uint16be) in
+  Alcotest.(check bool) "contains mutable" true (contains ~sub:"mutable" output);
+  Alcotest.(check bool) "contains out" true (contains ~sub:"out" output)
 
 (* -- Param.bind / Param.get / Param.env -- *)
 

--- a/test/test_uint32.ml
+++ b/test/test_uint32.ml
@@ -2,17 +2,16 @@
 
 open Wire.Private
 
-let test_roundtrip_le () =
+let check_roundtrip name ~set ~get v =
   let buf = Bytes.create 4 in
-  let v = 0xDEAD_BEEF in
-  UInt32.set_le buf 0 v;
-  Alcotest.(check int) "le roundtrip" (v land 0xFFFF_FFFF) (UInt32.le buf 0)
+  set buf 0 v;
+  Alcotest.(check int) name (v land 0xFFFF_FFFF) (get buf 0)
+
+let test_roundtrip_le () =
+  check_roundtrip "le roundtrip" ~set:UInt32.set_le ~get:UInt32.le 0xDEAD_BEEF
 
 let test_roundtrip_be () =
-  let buf = Bytes.create 4 in
-  let v = 0xCAFE_BABE in
-  UInt32.set_be buf 0 v;
-  Alcotest.(check int) "be roundtrip" (v land 0xFFFF_FFFF) (UInt32.be buf 0)
+  check_roundtrip "be roundtrip" ~set:UInt32.set_be ~get:UInt32.be 0xCAFE_BABE
 
 let test_of_int_masks () =
   Alcotest.(check int) "mask" 0xFF (UInt32.of_int 0xFF);

--- a/test/test_uint63.ml
+++ b/test/test_uint63.ml
@@ -2,17 +2,18 @@
 
 open Wire.Private
 
-let test_roundtrip_le () =
+let check_roundtrip name ~set ~get v =
   let buf = Bytes.create 8 in
-  let v = 0x1234_5678_9ABC in
-  UInt63.set_le buf 0 v;
-  Alcotest.(check int) "le roundtrip" v (UInt63.le buf 0)
+  set buf 0 v;
+  Alcotest.(check int) name v (get buf 0)
+
+let test_roundtrip_le () =
+  check_roundtrip "le roundtrip" ~set:UInt63.set_le ~get:UInt63.le
+    0x1234_5678_9ABC
 
 let test_roundtrip_be () =
-  let buf = Bytes.create 8 in
-  let v = 0x1234_5678_9ABC in
-  UInt63.set_be buf 0 v;
-  Alcotest.(check int) "be roundtrip" v (UInt63.be buf 0)
+  check_roundtrip "be roundtrip" ~set:UInt63.set_be ~get:UInt63.be
+    0x1234_5678_9ABC
 
 let test_of_int_identity () =
   Alcotest.(check int) "identity" 42 (UInt63.to_int (UInt63.of_int 42))


### PR DESCRIPTION
More test and fuzz dedup, in the spirit of #83. No behaviour change.

In `fuzz_gen`, `repeat_seq` and `array_seq` were copies of `repeat` and `array` apart from the field or typ constructor, so they now share `repeat_sized` and `array_sized` (the same shape as the `nested_sized` merge in #83). In the test suites, near-identical bodies move behind small per-pattern helpers: `check_if_gate` (action if-branch), `check_bit_gated` and `render_3d` (codec), `render_param_3d` (param), and a set/get roundtrip in the uint32/uint63 suites.

Helpers were only introduced where the distinguishing inputs stay visible at the call site. Clusters where a helper would hide the thing under test, or where two tests target different modules, are left explicit on purpose.
