### PR TITLE
everparse: hand embedded sub-codecs to WireSet* by offset

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -76,6 +76,10 @@
 
 ### Fixed
 
+- An embedded variable-size sub-codec (`Wire.codec`, e.g. a length-prefixed
+  string) used as a field no longer makes EverParse reject the schema with
+  `Parse_with_dep_action: tag not readable`; the field is handed to its
+  `WireSet*` callback by offset, like a byte slice or casetype (#87, @samoht)
 - A cross-field size/offset/`present` expression that reads an integer field
   whose value exceeds the native int range (a `uint64`/`int64` length beyond
   `max_int`), or that references a non-integer field, now raises

--- a/lib/everparse.ml
+++ b/lib/everparse.ml
@@ -37,6 +37,11 @@ let rec is_byte_field : type a. a Types.typ -> bool = function
   (* A repeat-into-list field has no single value 3D can read; expose its
      bytes via the [SetBytes] offset just like other variable-size fields. *)
   | Types.Repeat _ -> true
+  (* An embedded sub-codec projects to a struct value, which (like a casetype)
+     is not "readable" in a 3D action: passing it by value to a [WireSet*]
+     setter makes EverParse fail with "Parse_with_dep_action: tag not
+     readable". Expose its bytes via the [SetBytes] offset instead. *)
+  | Types.Codec _ -> true
   | _ -> false
 
 type setter_info = { setter_name : string; setter_val_typ : Types.packed_typ }

--- a/test/3d/test_wire_3d.ml
+++ b/test/3d/test_wire_3d.ml
@@ -335,8 +335,39 @@ let e2e_zeroterm_codec =
       Codec.( $ ) f_n (fun (_, _, n) -> n);
     ]
 
+(* Embedded variable-size sub-codec via the WireSet* setter path, with a
+   field after it (SSH Disconnect shape: a length-prefixed [SshString] is not
+   "readable", so it must be handed to the setter by offset rather than by
+   value; otherwise EverParse fails with "Parse_with_dep_action: tag not
+   readable"). *)
+let e2e_embedded_var_codec =
+  let open Wire in
+  let f_len = Field.v "Length" uint32be in
+  let ssh_string =
+    Codec.v "SshString"
+      (fun len data -> (len, data))
+      [
+        Codec.( $ ) f_len (fun (l, _) -> l);
+        Codec.( $ )
+          (Field.v "Bytes" (byte_slice ~size:(Field.ref f_len)))
+          (fun (_, d) -> d);
+      ]
+  in
+  let f_reason = Field.v "ReasonCode" uint32be in
+  let f_desc = Field.v "Description" (codec ssh_string) in
+  let f_lang = Field.v "Language" (codec ssh_string) in
+  let open Codec in
+  v "Disconnect"
+    (fun r d l -> (r, d, l))
+    [
+      (f_reason $ fun (r, _, _) -> r);
+      (f_desc $ fun (_, d, _) -> d);
+      (f_lang $ fun (_, _, l) -> l);
+    ]
+
 let test_e2e_compile_run () =
   compile_and_run ~name:"Demo" e2e_simple_codec;
+  compile_and_run ~name:"Disconnect" e2e_embedded_var_codec;
   compile_and_run ~name:"DhcpOpts" e2e_repeat_casetype_codec;
   compile_and_run ~name:"ZtRec" e2e_zeroterm_codec;
   compile_and_run ~name:"CLCW" e2e_allcaps_codec;


### PR DESCRIPTION
A codec that embeds a variable-size sub-codec as a field (an SSH message with a length-prefixed `SshString`, say) projected its `WireSet*` extern setter to take the sub-codec by value. EverParse rejects that with `Parse_with_dep_action: tag not readable`, since a variable-size struct cannot be read into a 3D action argument, so `gen.exe c` on the SSH codecs failed.

[`is_byte_field`](https://github.com/parsimoni-labs/ocaml-wire/blob/fix-embedded-codec-3d/lib/everparse.ml#L44) now treats an embedded `Codec` like a `Casetype`: a byte span handed to the setter by offset. The e2e suite gains a Disconnect case (a field after a length-prefixed sub-codec) that fails on the old projection and passes through 3d.exe on this one.
