### PR TITLE
codec: variable-size inner for Field.optional/optional_or

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ### Added
 
+- `Field.optional` and `Field.optional_or` now accept a variable-size inner,
+  so an optional field can be a length-prefixed string or a whole sub-message,
+  not just a fixed-width value. Building such a codec previously raised
+  `Invalid_argument` (#88, @samoht)
 - Add `Wire.zeroterm` and `Wire.zeroterm_at_most ~size` for
   NUL-terminated strings: the bytes up to a terminator, or the same
   within a fixed-size region. They project to the 3D `field[:zeroterm]`
@@ -79,6 +83,11 @@
 - `Field.repeat` over a `zeroterm` element (a list of NUL-terminated strings
   within a byte budget) now encodes, decodes, and generates a verified
   EverParse validator. It previously raised `Failure` when decoding (#93, @samoht)
+- A `Field.optional_or` with a dynamic gate now generates an EverParse C
+  validator that accepts the bytes `Codec.encode` produces. The two previously
+  disagreed about the field's layout when the gate was false, so a value
+  written by the OCaml encoder was rejected by the generated validator
+  (#88, @samoht)
 - An embedded variable-size sub-codec (`Wire.codec`, e.g. a length-prefixed
   string) used as a field no longer makes EverParse reject the schema with
   `Parse_with_dep_action: tag not readable`; the field is handed to its

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -1425,6 +1425,11 @@ let dynamic_optional_next_off ctx present_fn fsize =
       in
       if present_fn buf base then off + fsize else off)
 
+(* Absolute byte position a [next_off] points at, given the record [base]. *)
+let next_off_pos : next_off -> bytes -> int -> int = function
+  | Static n -> fun _buf base -> base + n
+  | Dynamic f -> f
+
 let optional_compiled : type a r.
     layout_ctx ->
     raw_reader:(bytes -> int -> a) ->
@@ -1447,113 +1452,6 @@ let optional_compiled : type a r.
     validator_off = validator_off_of ctx;
     populate;
   }
-
-let compile_optional : type a r.
-    layout_ctx ->
-    (a option, r) field ->
-    bool expr ->
-    a typ ->
-    (a option, r) compiled_field =
- fun ctx fld present inner ->
-  let inner_size = field_wire_size inner in
-  let nfields = ctx.n_fields in
-  match (present, inner_size) with
-  | Bool true, Some fsize ->
-      let inner_reader, inner_writer = inner_codec_accessors inner ctx in
-      let inner_populate = build_populate inner nfields inner_reader in
-      let get = fld.get in
-      optional_compiled ctx
-        ~raw_reader:(fun buf base -> Some (inner_reader buf base))
-        ~raw_writer:(fun v buf _base write_off ->
-          match get v with
-          | Some iv -> inner_writer buf write_off iv
-          | None -> write_off + fsize)
-        ~size_delta:fsize
-        ~next_off:(advance_next_off ctx.next_off fsize)
-        ~populate:inner_populate
-  | Bool false, _ ->
-      optional_compiled ctx
-        ~raw_reader:(fun _buf _base -> None)
-        ~raw_writer:(fun _v _buf _base write_off -> write_off)
-        ~size_delta:0 ~next_off:ctx.next_off ~populate:no_populate
-  | _, Some fsize ->
-      let present_fn = compile_bool_expr ctx.field_readers present in
-      let inner_reader, inner_writer = inner_codec_accessors inner ctx in
-      let inner_populate = build_populate inner nfields inner_reader in
-      let get = fld.get in
-      optional_compiled ctx
-        ~raw_reader:(fun buf base ->
-          if present_fn buf base then Some (inner_reader buf base) else None)
-        ~raw_writer:(fun v buf base write_off ->
-          match (present_fn buf base, get v) with
-          | true, Some iv -> inner_writer buf write_off iv
-          | false, None -> write_off
-          | true, None ->
-              invalid_arg
-                "Codec.encode: optional field absent but presence predicate is \
-                 true"
-          | false, Some _ ->
-              invalid_arg
-                "Codec.encode: optional field present but presence predicate \
-                 is false")
-        ~size_delta:0
-        ~next_off:(dynamic_optional_next_off ctx present_fn fsize)
-        ~populate:(fun arr buf base ->
-          if present_fn buf base then inner_populate arr buf base)
-  | _ ->
-      invalid_arg
-        "add_field: dynamic optional with variable-size inner not yet supported"
-
-let compile_optional_or : type a r.
-    layout_ctx ->
-    (a, r) field ->
-    bool expr ->
-    a typ ->
-    a ->
-    (a, r) compiled_field =
- fun ctx fld present inner default ->
-  let inner_size = field_wire_size inner in
-  match (present, inner_size) with
-  | Bool true, Some fsize ->
-      let inner_reader, inner_writer = inner_codec_accessors inner ctx in
-      let get = fld.get in
-      let populate = build_populate fld.typ ctx.n_fields inner_reader in
-      optional_compiled ctx ~raw_reader:inner_reader
-        ~raw_writer:(fun v buf _base write_off ->
-          inner_writer buf write_off (get v))
-        ~size_delta:fsize
-        ~next_off:(advance_next_off ctx.next_off fsize)
-        ~populate
-  | Bool false, _ ->
-      optional_compiled ctx
-        ~raw_reader:(fun _buf _base -> default)
-        ~raw_writer:(fun _v _buf _base write_off -> write_off)
-        ~size_delta:0 ~next_off:ctx.next_off ~populate:no_populate
-  | _, Some fsize ->
-      let present_fn = compile_bool_expr ctx.field_readers present in
-      let inner_reader, inner_writer = inner_codec_accessors inner ctx in
-      let get = fld.get in
-      let raw_reader buf base =
-        if present_fn buf base then inner_reader buf base else default
-      in
-      let populate = build_populate fld.typ ctx.n_fields raw_reader in
-      (* Encode is value-driven: the user always has a value, so always
-         write [fsize] bytes. The gate is the decode-side oracle that
-         chooses between the decoded inner and [default]. Round-trips
-         exactly when the gate is set consistently with the user's
-         choice; if the user sets the gate to [absent] while the value
-         differs from [default], decoding loses the value and falls
-         back to [default]. *)
-      let raw_writer v buf _base write_off =
-        inner_writer buf write_off (get v)
-      in
-      optional_compiled ctx ~raw_reader ~raw_writer ~size_delta:fsize
-        ~next_off:(advance_next_off ctx.next_off fsize)
-        ~populate
-  | _ ->
-      invalid_arg
-        "add_field: dynamic optional_or with variable-size inner not yet \
-         supported"
 
 let repeat_raw_fixed : type elt seq.
     (elt, seq) seq_map ->
@@ -1955,6 +1853,191 @@ and compile_map : type a w r.
   in
   let cf = compile_field ctx inner_fld in
   { cf with raw_reader = (fun buf off -> decode (cf.raw_reader buf off)) }
+
+and compile_optional : type a r.
+    layout_ctx ->
+    (a option, r) field ->
+    bool expr ->
+    a typ ->
+    (a option, r) compiled_field =
+ fun ctx fld present inner ->
+  let inner_size = field_wire_size inner in
+  let nfields = ctx.n_fields in
+  match (present, inner_size) with
+  | Bool true, Some fsize ->
+      let inner_reader, inner_writer = inner_codec_accessors inner ctx in
+      let inner_populate = build_populate inner nfields inner_reader in
+      let get = fld.get in
+      optional_compiled ctx
+        ~raw_reader:(fun buf base -> Some (inner_reader buf base))
+        ~raw_writer:(fun v buf _base write_off ->
+          match get v with
+          | Some iv -> inner_writer buf write_off iv
+          | None -> write_off + fsize)
+        ~size_delta:fsize
+        ~next_off:(advance_next_off ctx.next_off fsize)
+        ~populate:inner_populate
+  | Bool false, _ ->
+      optional_compiled ctx
+        ~raw_reader:(fun _buf _base -> None)
+        ~raw_writer:(fun _v _buf _base write_off -> write_off)
+        ~size_delta:0 ~next_off:ctx.next_off ~populate:no_populate
+  | _, Some fsize ->
+      let present_fn = compile_bool_expr ctx.field_readers present in
+      let inner_reader, inner_writer = inner_codec_accessors inner ctx in
+      let inner_populate = build_populate inner nfields inner_reader in
+      let get = fld.get in
+      optional_compiled ctx
+        ~raw_reader:(fun buf base ->
+          if present_fn buf base then Some (inner_reader buf base) else None)
+        ~raw_writer:(fun v buf base write_off ->
+          match (present_fn buf base, get v) with
+          | true, Some iv -> inner_writer buf write_off iv
+          | false, None -> write_off
+          | true, None ->
+              invalid_arg
+                "Codec.encode: optional field absent but presence predicate is \
+                 true"
+          | false, Some _ ->
+              invalid_arg
+                "Codec.encode: optional field present but presence predicate \
+                 is false")
+        ~size_delta:0
+        ~next_off:(dynamic_optional_next_off ctx present_fn fsize)
+        ~populate:(fun arr buf base ->
+          if present_fn buf base then inner_populate arr buf base)
+  | _ -> compile_optional_variable ctx fld present inner
+
+(* Variable-size inner: compile it as its own field and gate that compiled plan
+   on [present]. This reuses every per-type path (outer-sized byte slices,
+   self-delimiting sub-codecs, casetypes), so the inner decodes and encodes
+   exactly as it would unwrapped; an absent gate advances no bytes. *)
+and compile_optional_variable : type a r.
+    layout_ctx ->
+    (a option, r) field ->
+    bool expr ->
+    a typ ->
+    (a option, r) compiled_field =
+ fun ctx fld present inner ->
+  let present_fn = compile_bool_expr ctx.field_readers present in
+  let get = fld.get in
+  let inner_fld =
+    {
+      name = fld.name;
+      typ = inner;
+      constraint_ = None;
+      action = None;
+      get =
+        (fun v ->
+          match get v with
+          | Some iv -> iv
+          | None ->
+              invalid_arg
+                "Codec.encode: optional field absent but presence predicate is \
+                 true");
+    }
+  in
+  let cf = compile_field ctx inner_fld in
+  let present_end = next_off_pos cf.next_off in
+  let absent_end = next_off_pos ctx.next_off in
+  optional_compiled ctx
+    ~raw_reader:(fun buf base ->
+      if present_fn buf base then Some (cf.raw_reader buf base) else None)
+    ~raw_writer:(fun v buf base write_off ->
+      match (present_fn buf base, get v) with
+      | true, Some _ -> cf.raw_writer v buf base write_off
+      | false, None -> write_off
+      | true, None ->
+          invalid_arg
+            "Codec.encode: optional field absent but presence predicate is true"
+      | false, Some _ ->
+          invalid_arg
+            "Codec.encode: optional field present but presence predicate is \
+             false")
+    ~size_delta:0
+    ~next_off:
+      (Dynamic
+         (fun buf base ->
+           if present_fn buf base then present_end buf base
+           else absent_end buf base))
+    ~populate:(fun arr buf base ->
+      if present_fn buf base then cf.populate arr buf base)
+
+and compile_optional_or : type a r.
+    layout_ctx ->
+    (a, r) field ->
+    bool expr ->
+    a typ ->
+    a ->
+    (a, r) compiled_field =
+ fun ctx fld present inner default ->
+  let inner_size = field_wire_size inner in
+  match (present, inner_size) with
+  | Bool true, Some fsize ->
+      let inner_reader, inner_writer = inner_codec_accessors inner ctx in
+      let get = fld.get in
+      let populate = build_populate fld.typ ctx.n_fields inner_reader in
+      optional_compiled ctx ~raw_reader:inner_reader
+        ~raw_writer:(fun v buf _base write_off ->
+          inner_writer buf write_off (get v))
+        ~size_delta:fsize
+        ~next_off:(advance_next_off ctx.next_off fsize)
+        ~populate
+  | Bool false, _ ->
+      optional_compiled ctx
+        ~raw_reader:(fun _buf _base -> default)
+        ~raw_writer:(fun _v _buf _base write_off -> write_off)
+        ~size_delta:0 ~next_off:ctx.next_off ~populate:no_populate
+  | _, Some fsize ->
+      let present_fn = compile_bool_expr ctx.field_readers present in
+      let inner_reader, inner_writer = inner_codec_accessors inner ctx in
+      let get = fld.get in
+      let raw_reader buf base =
+        if present_fn buf base then inner_reader buf base else default
+      in
+      let populate = build_populate fld.typ ctx.n_fields raw_reader in
+      (* Encode is value-driven: the user always has a value, so always
+         write [fsize] bytes. The gate is the decode-side oracle that
+         chooses between the decoded inner and [default]. Round-trips
+         exactly when the gate is set consistently with the user's
+         choice; if the user sets the gate to [absent] while the value
+         differs from [default], decoding loses the value and falls
+         back to [default]. *)
+      let raw_writer v buf _base write_off =
+        inner_writer buf write_off (get v)
+      in
+      optional_compiled ctx ~raw_reader ~raw_writer ~size_delta:fsize
+        ~next_off:(advance_next_off ctx.next_off fsize)
+        ~populate
+  | _ -> compile_optional_or_variable ctx fld present inner default
+
+(* Variable-size inner. As in the fixed case [optional_or] is value-driven and
+   always occupies the inner's bytes; the gate only chooses the decoded inner
+   vs [default] on the read side, so the layout always advances past it. *)
+and compile_optional_or_variable : type a r.
+    layout_ctx ->
+    (a, r) field ->
+    bool expr ->
+    a typ ->
+    a ->
+    (a, r) compiled_field =
+ fun ctx fld present inner default ->
+  let present_fn = compile_bool_expr ctx.field_readers present in
+  let inner_fld =
+    {
+      name = fld.name;
+      typ = inner;
+      constraint_ = None;
+      action = None;
+      get = fld.get;
+    }
+  in
+  let cf = compile_field ctx inner_fld in
+  optional_compiled ctx
+    ~raw_reader:(fun buf base ->
+      if present_fn buf base then cf.raw_reader buf base else default)
+    ~raw_writer:(fun v buf base write_off -> cf.raw_writer v buf base write_off)
+    ~size_delta:0 ~next_off:cf.next_off ~populate:cf.populate
 
 (* -- Apply a compiled plan to the record state -- *)
 

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -397,6 +397,28 @@ let reject_variable_size ~combinator t =
        [byte-size] suffix that needs the element width."
       combinator combinator
 
+(* A self-delimiting inner carries its own length / structure, so it decodes a
+   known span without an external size. These project as a gate-dispatched
+   casetype (present case = the inner, absent case = a 0-byte field), unlike the
+   byte-size suffix used for [has_wire_size_expr] inners. *)
+let rec is_self_delimiting : type a. a typ -> bool = function
+  | Codec _ -> true
+  | Casetype _ -> true
+  | Map { inner; _ } -> is_self_delimiting inner
+  | Where { inner; _ } -> is_self_delimiting inner
+  | Apply { typ; _ } -> is_self_delimiting typ
+  | _ -> false
+
+(* [optional]/[optional_or] accept any inner that projects to 3D: either a
+   byte-sized inner (conditional [byte-size] region) or a self-delimiting one
+   (gate-dispatched casetype). Everything else has no clean projection. *)
+let reject_unprojectable_optional ~combinator t =
+  if not (has_wire_size_expr t || is_self_delimiting t) then
+    Fmt.invalid_arg
+      "Wire.%s: inner type does not project to 3D -- it is neither byte-sized \
+       nor self-delimiting."
+      combinator combinator
+
 let array ~len elem =
   reject_decoration ~combinator:"array" elem;
   reject_variable_size ~combinator:"array" elem;
@@ -431,11 +453,11 @@ let synth_name_of_elt_var ev =
 let byte_slice ~size = Byte_slice { size }
 
 let optional present inner =
-  reject_variable_size ~combinator:"optional" inner;
+  reject_unprojectable_optional ~combinator:"optional" inner;
   Optional { present; inner }
 
 let optional_or present ~default inner =
-  reject_variable_size ~combinator:"optional_or" inner;
+  reject_unprojectable_optional ~combinator:"optional_or" inner;
   Optional_or { present; inner; default }
 
 (* [repeat ~size elem] is more permissive than [array]: 3D's
@@ -777,6 +799,39 @@ let repeat_elem_struct : type a. a typ -> string option = function
   | Zeroterm -> Some "ZtElem"
   | _ -> None
 
+(* The synthesised gate-dispatch casetype name for an [optional] whose inner is
+   self-delimiting (no wire-size expression). Derived from the inner so two
+   optionals over the same inner share one declaration. *)
+let optional_casetype_name : type a. a typ -> string =
+ fun inner ->
+  let rec base : type a. a typ -> string = function
+    | Codec { codec_name; _ } -> codec_name
+    | Casetype { name; _ } -> name
+    | Map { inner; _ } -> base inner
+    | Where { inner; _ } -> base inner
+    | Apply { typ; _ } -> base typ
+    | _ -> "Inner"
+  in
+  "Opt_" ^ base inner
+
+(* Project a self-delimiting [optional] inner as a casetype dispatched on the
+   gate: [case 0] parses a 0-byte field (the gate arg is [present ? 1 : 0], so 0
+   means absent), the default case parses the inner. An empty case body is a 3D
+   syntax error, hence the 0-byte field. *)
+let optional_casetype_decl : type a. string -> a typ -> decl =
+ fun name inner ->
+  Casetype_decl
+    {
+      name;
+      params = [ param "present" Uint8 ];
+      tag = Pack_typ Uint8;
+      cases =
+        [
+          (Some (Pack_expr (Int 0)), Pack_typ (Byte_array { size = Int 0 }));
+          (None, Pack_typ inner);
+        ];
+    }
+
 let casetype_decls_of_struct (s : struct_) : decl list =
   let seen = Hashtbl.create 4 in
   let acc = Stdlib.ref [] in
@@ -804,6 +859,15 @@ let casetype_decls_of_struct (s : struct_) : decl list =
     | Codec _ -> ()
     | Map { inner; _ } -> extract inner
     | Where { inner; _ } -> extract inner
+    | Optional { inner; _ } when not (has_wire_size_expr inner) ->
+        (* Self-delimiting inner: declare its dependencies, then the
+           gate-dispatch casetype that references them. *)
+        extract inner;
+        let opt_name = optional_casetype_name inner in
+        if not (Hashtbl.mem seen opt_name) then begin
+          Hashtbl.add seen opt_name ();
+          acc := optional_casetype_decl opt_name inner :: !acc
+        end
     | Optional { inner; _ } -> extract inner
     | Optional_or { inner; _ } -> extract inner
     | Apply { typ; _ } -> extract typ
@@ -1144,20 +1208,29 @@ let rec inner_wire_size_expr : type a. a typ -> int expr option = function
   | Apply { typ; _ } -> inner_wire_size_expr typ
   | t -> ( match inner_wire_size t with Some n -> Some (Int n) | None -> None)
 
-let optional_suffix : type a.
+let rec optional_suffix : type a.
     bool expr -> a typ -> field_suffix * (Format.formatter -> unit) =
  fun present inner ->
   match inner_wire_size_expr inner with
   | Some s ->
-      ( Byte_array (If_then_else (present, s, Int 0)),
-        fun ppf -> pp_typ ppf inner )
+      (* Project the optional as a conditional byte region: [present ? s : 0]
+         bytes. The base printer comes from [field_suffix] so the inner's
+         element type (e.g. [UINT8] for a byte array) is emitted once, without
+         its own [byte-size] suffix duplicating the conditional one. *)
+      let _, pp_base = field_suffix inner in
+      (Byte_array (If_then_else (present, s, Int 0)), pp_base)
   | None ->
-      (* Unreachable: [optional]/[optional_or] reject variable-size inner
-         at construction (smart constructor uses [has_wire_size_expr]). *)
-      assert false
+      (* Self-delimiting inner with no wire-size expression (a variable-size
+         sub-codec, casetype, ...). Dispatch on the gate via the synthesised
+         casetype: [present ? 1 : 0] selects its absent (0-byte) or inner case. *)
+      let opt_name = optional_casetype_name inner in
+      let arg = If_then_else (present, Int 1, Int 0) in
+      ( No_suffix,
+        fun ppf ->
+          pp_typ ppf
+            (Apply { typ = Type_ref opt_name; args = [ Pack_expr arg ] }) )
 
-let rec field_suffix : type a.
-    a typ -> field_suffix * (Format.formatter -> unit) =
+and field_suffix : type a. a typ -> field_suffix * (Format.formatter -> unit) =
  fun typ ->
   match typ with
   | Bits { width; base; _ } ->
@@ -1190,7 +1263,12 @@ let rec field_suffix : type a.
   | Optional_or { present = Bool true; inner; _ } -> field_suffix inner
   | Optional_or { present = Bool false; _ } ->
       (Byte_array (Int 0), fun ppf -> Fmt.string ppf "UINT8")
-  | Optional_or { present; inner; _ } -> optional_suffix present inner
+  | Optional_or { inner; _ } ->
+      (* A dynamic [optional_or] is value-driven: the inner always occupies its
+         bytes in the wire (the gate only selects decoded vs default on read),
+         so it projects unconditionally, never as a [present ? size : 0]
+         region. *)
+      field_suffix inner
   | Repeat { size; elem; _ } ->
       (* Variable-length list within a byte budget. A self-delimiting element
          with no named type is referenced through its wrapper struct. *)
@@ -1221,6 +1299,23 @@ let combine_constraints a b =
   | None, x | x, None -> x
   | Some a, Some b -> Some (And (a, b))
 
+(* Render the [:byte-size ...] / bitwidth / array suffix that follows a field
+   name. Shared by [pp_field] and [pp_casetype_cases] so a casetype case body
+   gets the suffix after its name (a valid field declaration) rather than
+   inline on the type. *)
+let pp_field_suffix ppf = function
+  | No_suffix -> ()
+  | Bitwidth w -> Fmt.pf ppf " : %d" w
+  | Byte_array size -> Fmt.pf ppf "[:byte-size %a]" pp_expr size
+  | Single_elem { size; at_most = false } ->
+      Fmt.pf ppf "[:byte-size-single-element-array %a]" pp_expr size
+  | Single_elem { size; at_most = true } ->
+      Fmt.pf ppf "[:byte-size-single-element-array-at-most %a]" pp_expr size
+  | Zeroterm -> Fmt.pf ppf "[:zeroterm]"
+  | Zeroterm_at_most size ->
+      Fmt.pf ppf "[:zeroterm-byte-size-at-most %a]" pp_expr size
+  | Array len -> Fmt.pf ppf "[%a]" pp_expr len
+
 let pp_field ppf (Field f) =
   let name =
     match f.field_name with
@@ -1235,19 +1330,7 @@ let pp_field ppf (Field f) =
   let where_cond, typ = extract_where_constraint f.field_typ in
   let constraint_ = combine_constraints f.constraint_ where_cond in
   let suffix, pp_base = field_suffix typ in
-  Fmt.pf ppf "@,%t %s" pp_base name;
-  (match suffix with
-  | No_suffix -> ()
-  | Bitwidth w -> Fmt.pf ppf " : %d" w
-  | Byte_array size -> Fmt.pf ppf "[:byte-size %a]" pp_expr size
-  | Single_elem { size; at_most = false } ->
-      Fmt.pf ppf "[:byte-size-single-element-array %a]" pp_expr size
-  | Single_elem { size; at_most = true } ->
-      Fmt.pf ppf "[:byte-size-single-element-array-at-most %a]" pp_expr size
-  | Zeroterm -> Fmt.pf ppf "[:zeroterm]"
-  | Zeroterm_at_most size ->
-      Fmt.pf ppf "[:zeroterm-byte-size-at-most %a]" pp_expr size
-  | Array len -> Fmt.pf ppf "[%a]" pp_expr len);
+  Fmt.pf ppf "@,%t %s%a" pp_base name pp_field_suffix suffix;
   Option.iter (Fmt.pf ppf " { %a }" pp_expr) constraint_;
   Option.iter (Fmt.pf ppf " %a" pp_action) f.action;
   Fmt.string ppf ";"
@@ -1356,10 +1439,13 @@ let pp_casetype_cases ppf cases =
   List.iteri
     (fun i (tag_opt, Pack_typ typ) ->
       let field_name = Fmt.str "v%d" i in
+      let suffix, pp_base = field_suffix typ in
+      let pp_body ppf () =
+        Fmt.pf ppf "%t %s%a" pp_base field_name pp_field_suffix suffix
+      in
       match tag_opt with
-      | Some e ->
-          Fmt.pf ppf "@,case %a: %a %s;" pp_packed_expr e pp_typ typ field_name
-      | None -> Fmt.pf ppf "@,default: %a %s;" pp_typ typ field_name)
+      | Some e -> Fmt.pf ppf "@,case %a: %a;" pp_packed_expr e pp_body ()
+      | None -> Fmt.pf ppf "@,default: %a;" pp_body ())
     cases
 
 let pp_decl ppf = function

--- a/test/3d/test_wire_3d.ml
+++ b/test/3d/test_wire_3d.ml
@@ -374,10 +374,45 @@ let e2e_repeat_zeroterm_codec =
   let open Codec in
   v "ZtRep" (fun n names -> (n, names)) [ f_n $ fst; f_names $ snd ]
 
+(* A dynamic [Field.optional] over a variable-size inner: a self-delimiting
+   sub-codec (projects as a gate-dispatched casetype) and a byte array sized by
+   a prior field (projects as a conditional byte region). Both gated on the same
+   flag. *)
+let e2e_optional_var_codec =
+  let open Wire in
+  let f_len = Field.v "Length" uint32be in
+  let opt_str =
+    Codec.v "OptStr"
+      (fun len data -> (len, data))
+      [
+        Codec.( $ ) f_len (fun (l, _) -> l);
+        Codec.( $ )
+          (Field.v "Bytes" (byte_slice ~size:(Field.ref f_len)))
+          (fun (_, d) -> d);
+      ]
+  in
+  let f_gate = Field.v "Gate" uint8 in
+  let cond = Expr.(Field.ref f_gate <> int 0) in
+  let f_desc = Field.optional "Desc" ~present:cond (codec opt_str) in
+  let f_blen = Field.v "BodyLen" uint8 in
+  let f_body =
+    Field.optional "Body" ~present:cond (byte_array ~size:(Field.ref f_blen))
+  in
+  let open Codec in
+  v "OptVarRec"
+    (fun g d bl b -> (g, d, bl, b))
+    [
+      (f_gate $ fun (g, _, _, _) -> g);
+      (f_desc $ fun (_, d, _, _) -> d);
+      (f_blen $ fun (_, _, bl, _) -> bl);
+      (f_body $ fun (_, _, _, b) -> b);
+    ]
+
 let test_e2e_compile_run () =
   compile_and_run ~name:"Demo" e2e_simple_codec;
   compile_and_run ~name:"ZtRep" e2e_repeat_zeroterm_codec;
   compile_and_run ~name:"Disconnect" e2e_embedded_var_codec;
+  compile_and_run ~name:"OptVarRec" e2e_optional_var_codec;
   compile_and_run ~name:"DhcpOpts" e2e_repeat_casetype_codec;
   compile_and_run ~name:"ZtRec" e2e_zeroterm_codec;
   compile_and_run ~name:"CLCW" e2e_allcaps_codec;

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -308,6 +308,74 @@ let test_repeat_zeroterm_projection () =
     "zeroterm element wrapped in a struct" true
     (contains ~sub:"ZtElem names[:byte-size n]" out)
 
+(* Dynamic [Field.optional] over a variable-size inner. Group A: a byte array
+   sized by a prior field. The gate drives present/absent, and both round-trip
+   (absent consumes no bytes, present consumes the inner). *)
+type opt_var = { gate : int; len : int; body : string option }
+
+let opt_var_codec =
+  let f_gate = Field.v "gate" uint8 in
+  let f_len = Field.v "len" uint8 in
+  let f_body =
+    Field.optional "body"
+      ~present:Expr.(Field.ref f_gate <> int 0)
+      (byte_array ~size:(Field.ref f_len))
+  in
+  Codec.v "OptVar"
+    (fun gate len body -> { gate; len; body })
+    Codec.
+      [
+        (f_gate $ fun r -> r.gate);
+        (f_len $ fun r -> r.len);
+        (f_body $ fun r -> r.body);
+      ]
+
+let roundtrip codec v =
+  let n = Codec.size_of_value codec v in
+  let buf = Bytes.create n in
+  Codec.encode codec v buf 0;
+  (n, Codec.decode_exn codec buf 0)
+
+let test_optional_var_byte_array () =
+  let n, d = roundtrip opt_var_codec { gate = 1; len = 3; body = Some "abc" } in
+  Alcotest.(check int) "present size" 5 n;
+  Alcotest.(check (option string)) "present body" (Some "abc") d.body;
+  let n, d = roundtrip opt_var_codec { gate = 0; len = 0; body = None } in
+  Alcotest.(check int) "absent size" 2 n;
+  Alcotest.(check (option string)) "absent body" None d.body
+
+(* Group B: a self-delimiting sub-codec (its own length prefix) as the optional
+   inner. *)
+let sub_string_codec =
+  let f_slen = Field.v "slen" uint8 in
+  Codec.v "OptSub"
+    (fun _slen s -> s)
+    Codec.
+      [
+        f_slen $ String.length;
+        Field.v "sdata" (byte_array ~size:(Field.ref f_slen)) $ Fun.id;
+      ]
+
+type opt_sub = { g : int; desc : string option }
+
+let opt_sub_codec =
+  let f_g = Field.v "g" uint8 in
+  let f_desc =
+    Field.optional "desc"
+      ~present:Expr.(Field.ref f_g <> int 0)
+      (codec sub_string_codec)
+  in
+  Codec.v "OptSubRec"
+    (fun g desc -> { g; desc })
+    Codec.[ (f_g $ fun r -> r.g); (f_desc $ fun r -> r.desc) ]
+
+let test_optional_self_delimiting_codec () =
+  let _, d = roundtrip opt_sub_codec { g = 1; desc = Some "hi" } in
+  Alcotest.(check (option string)) "present desc" (Some "hi") d.desc;
+  let n, d = roundtrip opt_sub_codec { g = 0; desc = None } in
+  Alcotest.(check int) "absent size" 1 n;
+  Alcotest.(check (option string)) "absent desc" None d.desc
+
 (* -- Codec bitfield tests -- *)
 
 type bf32_record = { bf_a : int; bf_b : int; bf_c : int; bf_d : int }
@@ -4039,6 +4107,10 @@ let suite =
         test_repeat_zeroterm_element;
       Alcotest.test_case "repeat: zeroterm element projection" `Quick
         test_repeat_zeroterm_projection;
+      Alcotest.test_case "optional: variable byte_array inner roundtrip" `Quick
+        test_optional_var_byte_array;
+      Alcotest.test_case "optional: self-delimiting codec inner roundtrip"
+        `Quick test_optional_self_delimiting_codec;
       (* codec bitfields *)
       Alcotest.test_case "codec bitfield: wire_size" `Quick
         test_codec_bitfield_wire_size;


### PR DESCRIPTION
`Field.optional` and `Field.optional_or` rejected any variable-size inner at codec build time, so an optional length-prefixed string (an SSH message's optional description, for instance) was not expressible even though it projects cleanly to 3D. They now accept a variable-size inner: a byte-sized inner (a `byte_slice` or `byte_array` sized by a prior field) projects to a conditional `[:byte-size (present ? size : 0)]` region, and a self-delimiting sub-codec or `casetype` projects to a gate-dispatched casetype whose absent case is a 0-byte field. The OCaml side [compiles the inner as its own field](https://github.com/parsimoni-labs/ocaml-wire/blob/optional-variable-inner/lib/codec.ml#L1902) and gates its reader, writer, and offset on the presence predicate.

`optional_or` additionally now projects its inner unconditionally. Its encoder is value-driven and always writes the inner's bytes, but the projection gated the region as `present ? size : 0`, so EverParse and the OCaml codec disagreed on the wire size when the gate was false. A new e2e case (`OptVarRec`) compiles through `3d.exe` and the generated C, and round-trip tests cover the present and absent paths for both a byte-array and a sub-codec inner.