### PR TITLE
codec: Field.repeat over a fixed byte_array/byte_slice element

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -88,6 +88,9 @@
   disagreed about the field's layout when the gate was false, so a value
   written by the OCaml encoder was rejected by the generated validator
   (#88, @samoht)
+- `Field.repeat` over a fixed `byte_array` / `byte_slice` element (a list of
+  n-byte chunks) now encodes, decodes, and generates a verified EverParse
+  validator. It previously raised `Failure` when decoding (#89, @samoht)
 - An embedded variable-size sub-codec (`Wire.codec`, e.g. a length-prefixed
   string) used as a field no longer makes EverParse reject the schema with
   `Parse_with_dep_action: tag not readable`; the field is handed to its

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -1044,6 +1044,10 @@ let rec read_elem : type a. a typ -> bytes -> int -> a =
   | Zeroterm ->
       let nul = zeroterm_nul_pos buf ~first:off ~limit:(Bytes.length buf) in
       Bytes.sub_string buf off (nul - off)
+  (* Fixed-size byte spans as repeat / array elements: a list of n-byte
+     chunks. The size is the element's own constant width. *)
+  | Byte_array { size = Int n } -> Bytes.sub_string buf off n
+  | Byte_slice { size = Int n } -> Slice.make buf ~first:off ~length:n
   | _ -> failwith "read_elem: unsupported element type in repeat"
 
 (* Write one element of a typ at a given buffer position. Used by Repeat. *)
@@ -1085,6 +1089,12 @@ let rec write_elem : type a. a typ -> bytes -> int -> a -> unit =
       let n = String.length v in
       Bytes.blit_string v 0 buf off n;
       Bytes.set_uint8 buf (off + n) 0
+  (* Fixed-size byte spans: the field encoder blits / pads the constant width
+     and returns the advanced offset, which the repeat loop recomputes. *)
+  | Byte_array { size = Int _ } ->
+      ignore (build_field_encoder typ buf off v : int)
+  | Byte_slice { size = Int _ } ->
+      ignore (build_field_encoder typ buf off v : int)
   | _ -> failwith "write_elem: unsupported element type in repeat"
 
 (* Compute the wire size of one element at a buffer position. Used by Repeat

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -1271,11 +1271,14 @@ and field_suffix : type a. a typ -> field_suffix * (Format.formatter -> unit) =
       field_suffix inner
   | Repeat { size; elem; _ } ->
       (* Variable-length list within a byte budget. A self-delimiting element
-         with no named type is referenced through its wrapper struct. *)
+         with no named type goes through its wrapper struct; otherwise the
+         element is emitted as its bare base (its own [:byte-size] suffix
+         dropped) so the only suffix is the budget: a list of fixed n-byte
+         chunks is just bytes on the wire, like a repeat of [UINT8]. *)
       let pp_elem ppf =
         match repeat_elem_struct elem with
         | Some name -> Fmt.string ppf name
-        | None -> pp_typ ppf elem
+        | None -> (snd (field_suffix elem)) ppf
       in
       (Byte_array size, pp_elem)
   | Zeroterm -> (Zeroterm, fun ppf -> Fmt.string ppf "UINT8")

--- a/test/3d/test_wire_3d.ml
+++ b/test/3d/test_wire_3d.ml
@@ -408,9 +408,21 @@ let e2e_optional_var_codec =
       (f_body $ fun (_, _, _, b) -> b);
     ]
 
+(* [Field.repeat] over a fixed byte_array element: a count-prefixed list of
+   n-byte chunks. Projects the element as bare [UINT8] under the byte budget. *)
+let e2e_repeat_byte_chunks_codec =
+  let open Wire in
+  let f_n = Field.v "N" uint16be in
+  let f_chunks =
+    Field.repeat "Chunks" ~size:(Field.ref f_n) (byte_array ~size:(int 4))
+  in
+  let open Codec in
+  v "RepChunks" (fun n chunks -> (n, chunks)) [ f_n $ fst; f_chunks $ snd ]
+
 let test_e2e_compile_run () =
   compile_and_run ~name:"Demo" e2e_simple_codec;
   compile_and_run ~name:"ZtRep" e2e_repeat_zeroterm_codec;
+  compile_and_run ~name:"RepChunks" e2e_repeat_byte_chunks_codec;
   compile_and_run ~name:"Disconnect" e2e_embedded_var_codec;
   compile_and_run ~name:"OptVarRec" e2e_optional_var_codec;
   compile_and_run ~name:"DhcpOpts" e2e_repeat_casetype_codec;

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -376,6 +376,40 @@ let test_optional_self_delimiting_codec () =
   Alcotest.(check int) "absent size" 1 n;
   Alcotest.(check (option string)) "absent desc" None d.desc
 
+(* Field.repeat over a fixed byte_array element: a list of n-byte chunks within
+   a byte budget. Decoding used to raise Failure "unsupported element type in
+   repeat" and the schema mis-projected as a double [:byte-size]. *)
+type rep_chunks = { rn : int; chunks : string list }
+
+let rep_chunks_codec =
+  let f_n = Field.v "n" uint16be in
+  let f_chunks =
+    Field.repeat "chunks" ~size:(Field.ref f_n) (byte_array ~size:(int 4))
+  in
+  Codec.v "RepChunks"
+    (fun rn chunks -> { rn; chunks })
+    Codec.[ (f_n $ fun r -> r.rn); (f_chunks $ fun r -> r.chunks) ]
+
+let test_repeat_byte_array_element () =
+  let v = { rn = 8; chunks = [ "aaaa"; "bbbb" ] } in
+  let sz = Codec.size_of_value rep_chunks_codec v in
+  Alcotest.(check int) "wire size" 10 sz;
+  let buf = Bytes.create sz in
+  Codec.encode rep_chunks_codec v buf 0;
+  match Codec.decode rep_chunks_codec buf 0 with
+  | Ok d ->
+      Alcotest.(check int) "count" 8 d.rn;
+      Alcotest.(check (list string)) "chunks" [ "aaaa"; "bbbb" ] d.chunks
+  | Error e -> Alcotest.failf "decode: %a" pp_parse_error e
+
+(* The schema projects the byte-span element as bare [UINT8] under the budget,
+   not a double [:byte-size]. *)
+let test_repeat_byte_array_projection () =
+  let out = render_3d rep_chunks_codec in
+  Alcotest.(check bool)
+    "single byte-size on the chunks field" true
+    (contains ~sub:"UINT8 chunks[:byte-size n]" out)
+
 (* -- Codec bitfield tests -- *)
 
 type bf32_record = { bf_a : int; bf_b : int; bf_c : int; bf_d : int }
@@ -4111,6 +4145,10 @@ let suite =
         test_optional_var_byte_array;
       Alcotest.test_case "optional: self-delimiting codec inner roundtrip"
         `Quick test_optional_self_delimiting_codec;
+      Alcotest.test_case "repeat: byte_array element roundtrip" `Quick
+        test_repeat_byte_array_element;
+      Alcotest.test_case "repeat: byte_array element projection" `Quick
+        test_repeat_byte_array_projection;
       (* codec bitfields *)
       Alcotest.test_case "codec bitfield: wire_size" `Quick
         test_codec_bitfield_wire_size;


### PR DESCRIPTION
`Field.repeat` over a fixed `byte_array` or `byte_slice` element (a count-prefixed list of n-byte chunks within a byte budget) raised `Failure "unsupported element type in repeat"` at decode, because [`read_elem`](https://github.com/parsimoni-labs/ocaml-wire/blob/fix-repeat-fixed-byte-elements/lib/codec.ml#L986) and `write_elem` had no case for a byte-span element. The schema also mis-projected the element as a double `[:byte-size]`.

A list of fixed n-byte chunks is just bytes on the wire, so the element now projects as its bare base under the budget (`UINT8 name[:byte-size budget]`, the same shape as a repeat of `UINT8` / `UINT16BE`) and decodes and encodes through the chunk readers. The new e2e case (`RepChunks`) compiles through `3d.exe` and the generated C; a codec round-trip and a projection assertion cover the OCaml side.