### PR TITLE
codec: reject a bitfield element in array/repeat at construction

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -94,6 +94,10 @@
 - `Wire.array` whose element is a fixed `byte_array` / `byte_slice` (e.g. an
   array of fixed-size addresses) now generates a valid EverParse validator;
   the generated 3D schema was previously malformed for such arrays (#92, @samoht)
+- `Field.repeat` / `Wire.array` over a bitfield element (`Wire.bits` or
+  `Wire.bit`) now raises `Invalid_argument` when the codec is built, instead of
+  crashing at decode. A bitfield only exists packed inside a record, so it
+  cannot be a repeat or array element (#90, @samoht)
 - An embedded variable-size sub-codec (`Wire.codec`, e.g. a length-prefixed
   string) used as a field no longer makes EverParse reject the schema with
   `Parse_with_dep_action: tag not readable`; the field is handed to its

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -419,13 +419,33 @@ let reject_unprojectable_optional ~combinator t =
        nor self-delimiting."
       combinator combinator
 
+(* A bitfield is packed within an enclosing base word in a record; it has no
+   standalone wire form, so it cannot be an [array] / [repeat] element (there is
+   no byte boundary per element, and no 3D element type to project to). Reject
+   it at construction rather than crash at decode. *)
+let rec is_bitfield_element : type a. a typ -> bool = function
+  | Bits _ -> true
+  | Map { inner; _ } -> is_bitfield_element inner
+  | Where { inner; _ } -> is_bitfield_element inner
+  | Enum { base; _ } -> is_bitfield_element base
+  | _ -> false
+
+let reject_bitfield_element ~combinator t =
+  if is_bitfield_element t then
+    Fmt.invalid_arg
+      "Wire.%s: a bitfield has no standalone element form (bits are packed \
+       within an enclosing word); it cannot be an element of %s."
+      combinator combinator
+
 let array ~len elem =
   reject_decoration ~combinator:"array" elem;
+  reject_bitfield_element ~combinator:"array" elem;
   reject_variable_size ~combinator:"array" elem;
   Array { len; elem; seq = seq_list }
 
 let array_seq seq ~len elem =
   reject_decoration ~combinator:"array_seq" elem;
+  reject_bitfield_element ~combinator:"array_seq" elem;
   reject_variable_size ~combinator:"array_seq" elem;
   Array { len; elem; seq }
 
@@ -467,10 +487,12 @@ let optional_or present ~default inner =
    refuse is a field decoration nested inside [elem]. *)
 let repeat ~size elem =
   reject_decoration ~combinator:"repeat" elem;
+  reject_bitfield_element ~combinator:"repeat" elem;
   Repeat { size; elem; seq = seq_list }
 
 let repeat_seq seq ~size elem =
   reject_decoration ~combinator:"repeat_seq" elem;
+  reject_bitfield_element ~combinator:"repeat_seq" elem;
   Repeat { size; elem; seq }
 
 let nested ~size elem = Single_elem { size; elem; at_most = false }

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -406,6 +406,27 @@ let test_array_byte_array_projection () =
     "single byte-size on the array field" true
     (contains ~sub:"UINT8 addrs[:byte-size (3 * 4)]" out)
 
+(* A bitfield has no standalone element form, so [array] / [Field.repeat] over
+   one is rejected at construction rather than crashing at decode. *)
+let raises_invalid f =
+  try
+    ignore (f ());
+    false
+  with Invalid_argument _ -> true
+
+let test_repeat_array_reject_bitfield () =
+  Alcotest.(check bool)
+    "array over bits rejected" true
+    (raises_invalid (fun () -> array ~len:(int 4) (bits ~width:3 U8)));
+  Alcotest.(check bool)
+    "repeat over bits rejected" true
+    (raises_invalid (fun () ->
+         Field.repeat "x" ~size:(int 4) (bits ~width:3 U8)));
+  Alcotest.(check bool)
+    "repeat over bit (bool over bits) rejected" true
+    (raises_invalid (fun () ->
+         Field.repeat "x" ~size:(int 4) (bit (bits ~width:1 U8))))
+
 (* Field.repeat over a fixed byte_array element: a list of n-byte chunks within
    a byte budget. Decoding used to raise Failure "unsupported element type in
    repeat" and the schema mis-projected as a double [:byte-size]. *)
@@ -4183,6 +4204,8 @@ let suite =
         test_array_byte_array_element;
       Alcotest.test_case "array: byte_array element projection" `Quick
         test_array_byte_array_projection;
+      Alcotest.test_case "repeat/array reject bitfield element" `Quick
+        test_repeat_array_reject_bitfield;
       (* codec bitfields *)
       Alcotest.test_case "codec bitfield: wire_size" `Quick
         test_codec_bitfield_wire_size;


### PR DESCRIPTION
`Wire.array` and `Field.repeat` accepted a bitfield element (`Wire.bits` / `Wire.bit`) at construction, then crashed at decode with `Failure "unsupported element type in repeat"`. A bitfield is packed within an enclosing word: it has no per-element byte boundary and no standalone 3D element type, so it cannot be an array or repeat element.

[`array`](https://github.com/parsimoni-labs/ocaml-wire/blob/fix-reject-bitfield-repeat-element/lib/types.ml#L417) and `repeat` now reject a bitfield element at construction with `Invalid_argument`, turning a decode-time crash into a clear build-time error. Surfaced by the nested-composition fuzzer.