### PR TITLE
codec: project Wire.array over a fixed byte element correctly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -91,6 +91,9 @@
 - `Field.repeat` over a fixed `byte_array` / `byte_slice` element (a list of
   n-byte chunks) now encodes, decodes, and generates a verified EverParse
   validator. It previously raised `Failure` when decoding (#89, @samoht)
+- `Wire.array` whose element is a fixed `byte_array` / `byte_slice` (e.g. an
+  array of fixed-size addresses) now generates a valid EverParse validator;
+  the generated 3D schema was previously malformed for such arrays (#92, @samoht)
 - An embedded variable-size sub-codec (`Wire.codec`, e.g. a length-prefixed
   string) used as a field no longer makes EverParse reject the schema with
   `Parse_with_dep_action: tag not readable`; the field is handed to its

--- a/lib/everparse.ml
+++ b/lib/everparse.ml
@@ -37,6 +37,10 @@ let rec is_byte_field : type a. a Types.typ -> bool = function
   (* A repeat-into-list field has no single value 3D can read; expose its
      bytes via the [SetBytes] offset just like other variable-size fields. *)
   | Types.Repeat _ -> true
+  (* An array projects to a byte region (its elements laid out contiguously);
+     like a repeat, expose it through the [SetBytes] offset rather than passing
+     a C array by value. *)
+  | Types.Array _ -> true
   (* An embedded sub-codec projects to a struct value, which (like a casetype)
      is not "readable" in a 3D action: passing it by value to a [WireSet*]
      setter makes EverParse fail with "Parse_with_dep_action: tag not

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -1250,7 +1250,11 @@ and field_suffix : type a. a typ -> field_suffix * (Format.formatter -> unit) =
          sized payloads, codec-with-fixed-size, and nested arrays. *)
       match (inner_wire_size elem, inner_wire_size_expr elem) with
       | Some 1, _ -> (Array len, fun ppf -> pp_typ ppf elem)
-      | _, Some s -> (Byte_array (Mul (len, s)), fun ppf -> pp_typ ppf elem)
+      | _, Some s ->
+          (* A wider element is emitted as its bare base under a byte budget of
+             [len * width]; its own [:byte-size] suffix (e.g. for a [byte_array]
+             chunk) is dropped so it is not duplicated. *)
+          (Byte_array (Mul (len, s)), snd (field_suffix elem))
       | _ ->
           (* Unreachable: [array] rejects variable-size elem at construction. *)
           assert false)

--- a/test/3d/test_wire_3d.ml
+++ b/test/3d/test_wire_3d.ml
@@ -408,6 +408,18 @@ let e2e_optional_var_codec =
       (f_body $ fun (_, _, _, b) -> b);
     ]
 
+(* [Wire.array] over a fixed byte_array element: a fixed-count list of n-byte
+   chunks (e.g. an array of IPv4 addresses). Projects the element as bare
+   [UINT8] under a [len * width] byte budget. *)
+let e2e_array_byte_chunks_codec =
+  let open Wire in
+  let f_tag = Field.v "Tag" uint8 in
+  let f_addrs =
+    Field.v "Addrs" (array ~len:(int 3) (byte_array ~size:(int 4)))
+  in
+  let open Codec in
+  v "ArrChunks" (fun tag addrs -> (tag, addrs)) [ f_tag $ fst; f_addrs $ snd ]
+
 (* [Field.repeat] over a fixed byte_array element: a count-prefixed list of
    n-byte chunks. Projects the element as bare [UINT8] under the byte budget. *)
 let e2e_repeat_byte_chunks_codec =
@@ -423,6 +435,7 @@ let test_e2e_compile_run () =
   compile_and_run ~name:"Demo" e2e_simple_codec;
   compile_and_run ~name:"ZtRep" e2e_repeat_zeroterm_codec;
   compile_and_run ~name:"RepChunks" e2e_repeat_byte_chunks_codec;
+  compile_and_run ~name:"ArrChunks" e2e_array_byte_chunks_codec;
   compile_and_run ~name:"Disconnect" e2e_embedded_var_codec;
   compile_and_run ~name:"OptVarRec" e2e_optional_var_codec;
   compile_and_run ~name:"DhcpOpts" e2e_repeat_casetype_codec;

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -376,6 +376,36 @@ let test_optional_self_delimiting_codec () =
   Alcotest.(check int) "absent size" 1 n;
   Alcotest.(check (option string)) "absent desc" None d.desc
 
+(* Wire.array over a fixed byte_array element: a fixed-count list of n-byte
+   chunks (e.g. an array of IPv4 addresses). Used to project a double
+   [:byte-size]; the element is now emitted as bare bytes under the budget. *)
+type arr_chunks = { atag : int; addrs : string list }
+
+let arr_chunks_codec =
+  let f_tag = Field.v "tag" uint8 in
+  let f_addrs =
+    Field.v "addrs" (array ~len:(int 3) (byte_array ~size:(int 4)))
+  in
+  Codec.v "ArrChunks"
+    (fun atag addrs -> { atag; addrs })
+    Codec.[ (f_tag $ fun r -> r.atag); (f_addrs $ fun r -> r.addrs) ]
+
+let test_array_byte_array_element () =
+  let v = { atag = 7; addrs = [ "aaaa"; "bbbb"; "cccc" ] } in
+  let sz = Codec.size_of_value arr_chunks_codec v in
+  Alcotest.(check int) "wire size" 13 sz;
+  let buf = Bytes.create sz in
+  Codec.encode arr_chunks_codec v buf 0;
+  match Codec.decode arr_chunks_codec buf 0 with
+  | Ok d -> Alcotest.(check (list string)) "addrs" v.addrs d.addrs
+  | Error e -> Alcotest.failf "decode: %a" pp_parse_error e
+
+let test_array_byte_array_projection () =
+  let out = render_3d arr_chunks_codec in
+  Alcotest.(check bool)
+    "single byte-size on the array field" true
+    (contains ~sub:"UINT8 addrs[:byte-size (3 * 4)]" out)
+
 (* Field.repeat over a fixed byte_array element: a list of n-byte chunks within
    a byte budget. Decoding used to raise Failure "unsupported element type in
    repeat" and the schema mis-projected as a double [:byte-size]. *)
@@ -4149,6 +4179,10 @@ let suite =
         test_repeat_byte_array_element;
       Alcotest.test_case "repeat: byte_array element projection" `Quick
         test_repeat_byte_array_projection;
+      Alcotest.test_case "array: byte_array element roundtrip" `Quick
+        test_array_byte_array_element;
+      Alcotest.test_case "array: byte_array element projection" `Quick
+        test_array_byte_array_projection;
       (* codec bitfields *)
       Alcotest.test_case "codec bitfield: wire_size" `Quick
         test_codec_bitfield_wire_size;


### PR DESCRIPTION
An array whose element is a fixed `byte_array` / `byte_slice` (e.g. an array of fixed-size addresses) generated a malformed EverParse schema: the element was emitted with its own `[:byte-size]` suffix on top of the array budget (a double suffix), and the field's extern setter took the array by value with an invalid C type.

The element now projects as its bare base under a `len * width` byte budget, and the array field is exposed to its setter by offset like other byte spans. A round-trip plus projection test and an `ArrChunks` e2e through `3d.exe` cover it. Same projection family as #89 (repeat over byte elements); surfaced by the nested-composition fuzzer.