### PR TITLE
codec: Field.repeat over a zeroterm element

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -76,6 +76,9 @@
 
 ### Fixed
 
+- `Field.repeat` over a `zeroterm` element (a list of NUL-terminated strings
+  within a byte budget) now encodes, decodes, and generates a verified
+  EverParse validator. It previously raised `Failure` when decoding (#93, @samoht)
 - An embedded variable-size sub-codec (`Wire.codec`, e.g. a length-prefixed
   string) used as a field no longer makes EverParse reject the schema with
   `Parse_with_dep_action: tag not readable`; the field is handed to its

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -982,6 +982,15 @@ let iter_param_refs_fields f fields where =
     fields;
   Option.iter (iter_param_refs f) where
 
+let zeroterm_nul_pos buf ~first ~limit =
+  let rec go i =
+    if i >= limit then
+      raise (Parse_error (Constraint_failed "zeroterm: missing NUL terminator"))
+    else if Bytes.get_uint8 buf i = 0 then i
+    else go (i + 1)
+  in
+  go first
+
 (* Read one element of a typ at a given buffer position. Used by Repeat. *)
 let rec read_elem : type a. a typ -> bytes -> int -> a =
  fun typ buf off ->
@@ -1031,6 +1040,10 @@ let rec read_elem : type a. a typ -> bytes -> int -> a =
       in
       find cases
   | Unit -> ()
+  (* NUL-terminated string element: the bytes up to (not including) the NUL. *)
+  | Zeroterm ->
+      let nul = zeroterm_nul_pos buf ~first:off ~limit:(Bytes.length buf) in
+      Bytes.sub_string buf off (nul - off)
   | _ -> failwith "read_elem: unsupported element type in repeat"
 
 (* Write one element of a typ at a given buffer position. Used by Repeat. *)
@@ -1067,6 +1080,11 @@ let rec write_elem : type a. a typ -> bytes -> int -> a -> unit =
      repeat loop advances by [elem_size_of], so the returned offset is
      discarded here. *)
   | Casetype _ -> ignore (build_field_encoder typ buf off v : int)
+  (* NUL-terminated string element: the bytes followed by a NUL terminator. *)
+  | Zeroterm ->
+      let n = String.length v in
+      Bytes.blit_string v 0 buf off n;
+      Bytes.set_uint8 buf (off + n) 0
   | _ -> failwith "write_elem: unsupported element type in repeat"
 
 (* Compute the wire size of one element at a buffer position. Used by Repeat
@@ -1093,6 +1111,10 @@ let rec elem_size_of : type a. a typ -> bytes -> int -> int =
       find cases
   | Map { inner; _ } -> elem_size_of inner buf off
   | Where { inner; _ } -> elem_size_of inner buf off
+  (* Bytes up to the NUL plus the one-byte terminator. *)
+  | Zeroterm ->
+      let nul = zeroterm_nul_pos buf ~first:off ~limit:(Bytes.length buf) in
+      nul - off + 1
   | _ -> (
       match field_wire_size typ with
       | Some n -> n
@@ -1653,15 +1675,6 @@ let compile_repeat : type elt seq r.
 (* Absolute index of the first NUL at or after [first], searching up to (but
    not including) [limit]. Raises [Parse_error] when the region ends before a
    terminator is found -- a truncated / unterminated zero-terminated string. *)
-let zeroterm_nul_pos buf ~first ~limit =
-  let rec go i =
-    if i >= limit then
-      raise (Parse_error (Constraint_failed "zeroterm: missing NUL terminator"))
-    else if Bytes.get_uint8 buf i = 0 then i
-    else go (i + 1)
-  in
-  go first
-
 let var_bytes_reader : type a.
     a typ -> (bytes -> int -> int) -> (bytes -> int -> int) -> bytes -> int -> a
     =

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -768,6 +768,15 @@ let casetype_pair : type a k.
   let wrapper = typedef (struct_ name [ tag_field; body_field ]) in
   (dispatch, wrapper)
 
+(* A variable-size, self-delimiting [repeat] element with no named 3D type
+   (e.g. a NUL-terminated string) is wrapped in a one-field element struct so
+   the byte-budget list references a bare name. Fixed-size byte elements use the
+   flat-base form instead; named elements (sub-codecs, casetypes) already render
+   as a name. Returns the wrapper struct name, or [None]. *)
+let repeat_elem_struct : type a. a typ -> string option = function
+  | Zeroterm -> Some "ZtElem"
+  | _ -> None
+
 let casetype_decls_of_struct (s : struct_) : decl list =
   let seen = Hashtbl.create 4 in
   let acc = Stdlib.ref [] in
@@ -798,7 +807,13 @@ let casetype_decls_of_struct (s : struct_) : decl list =
     | Optional { inner; _ } -> extract inner
     | Optional_or { inner; _ } -> extract inner
     | Apply { typ; _ } -> extract typ
-    | Repeat { elem; _ } -> extract elem
+    | Repeat { elem; _ } -> (
+        extract elem;
+        match repeat_elem_struct elem with
+        | Some name when not (Hashtbl.mem seen name) ->
+            Hashtbl.add seen name ();
+            acc := typedef (struct_ name [ field "v" elem ]) :: !acc
+        | _ -> ())
     | Array { elem; _ } -> extract elem
     | Single_elem { elem; _ } -> extract elem
     | _ -> ()
@@ -1177,8 +1192,14 @@ let rec field_suffix : type a.
       (Byte_array (Int 0), fun ppf -> Fmt.string ppf "UINT8")
   | Optional_or { present; inner; _ } -> optional_suffix present inner
   | Repeat { size; elem; _ } ->
-      (* Variable-length array with byte-size budget *)
-      (Byte_array size, fun ppf -> pp_typ ppf elem)
+      (* Variable-length list within a byte budget. A self-delimiting element
+         with no named type is referenced through its wrapper struct. *)
+      let pp_elem ppf =
+        match repeat_elem_struct elem with
+        | Some name -> Fmt.string ppf name
+        | None -> pp_typ ppf elem
+      in
+      (Byte_array size, pp_elem)
   | Zeroterm -> (Zeroterm, fun ppf -> Fmt.string ppf "UINT8")
   | Zeroterm_at_most { size } ->
       (Zeroterm_at_most size, fun ppf -> Fmt.string ppf "UINT8")

--- a/test/3d/test_wire_3d.ml
+++ b/test/3d/test_wire_3d.ml
@@ -365,8 +365,18 @@ let e2e_embedded_var_codec =
       (f_lang $ fun (_, _, l) -> l);
     ]
 
+(* [Field.repeat] over a zeroterm element: a count-prefixed list of
+   NUL-terminated strings. Projects through a synthesised element struct. *)
+let e2e_repeat_zeroterm_codec =
+  let open Wire in
+  let f_n = Field.v "N" uint16be in
+  let f_names = Field.repeat "Names" ~size:(Field.ref f_n) zeroterm in
+  let open Codec in
+  v "ZtRep" (fun n names -> (n, names)) [ f_n $ fst; f_names $ snd ]
+
 let test_e2e_compile_run () =
   compile_and_run ~name:"Demo" e2e_simple_codec;
+  compile_and_run ~name:"ZtRep" e2e_repeat_zeroterm_codec;
   compile_and_run ~name:"Disconnect" e2e_embedded_var_codec;
   compile_and_run ~name:"DhcpOpts" e2e_repeat_casetype_codec;
   compile_and_run ~name:"ZtRec" e2e_zeroterm_codec;

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -280,6 +280,34 @@ let test_record_byte_array_padding () =
             (String.sub decoded.uuid 0 5)
       | Error e -> Alcotest.failf "%a" pp_parse_error e)
 
+(* Field.repeat over a zeroterm element: a list of NUL-terminated strings
+   within a byte budget. Used to raise Failure at decode; now decodes and
+   projects through a synthesised element struct. *)
+type zt_rep = { zn : int; names : string list }
+
+let zt_rep_codec =
+  let f_n = Field.v "n" uint16be in
+  let f_names = Field.repeat "names" ~size:(Field.ref f_n) zeroterm in
+  Codec.v "ZtRep"
+    (fun zn names -> { zn; names })
+    Codec.[ (f_n $ fun r -> r.zn); (f_names $ fun r -> r.names) ]
+
+let test_repeat_zeroterm_element () =
+  let v = { zn = 12; names = [ "abc"; "de"; "fghi" ] } in
+  let sz = Codec.size_of_value zt_rep_codec v in
+  Alcotest.(check int) "wire size" 14 sz;
+  let buf = Bytes.create sz in
+  Codec.encode zt_rep_codec v buf 0;
+  match Codec.decode zt_rep_codec buf 0 with
+  | Ok d -> Alcotest.(check (list string)) "names" v.names d.names
+  | Error e -> Alcotest.failf "decode: %a" pp_parse_error e
+
+let test_repeat_zeroterm_projection () =
+  let out = render_3d zt_rep_codec in
+  Alcotest.(check bool)
+    "zeroterm element wrapped in a struct" true
+    (contains ~sub:"ZtElem names[:byte-size n]" out)
+
 (* -- Codec bitfield tests -- *)
 
 type bf32_record = { bf_a : int; bf_b : int; bf_c : int; bf_d : int }
@@ -4007,6 +4035,10 @@ let suite =
         test_record_byte_array_roundtrip;
       Alcotest.test_case "record: byte_array padding" `Quick
         test_record_byte_array_padding;
+      Alcotest.test_case "repeat: zeroterm element roundtrip" `Quick
+        test_repeat_zeroterm_element;
+      Alcotest.test_case "repeat: zeroterm element projection" `Quick
+        test_repeat_zeroterm_projection;
       (* codec bitfields *)
       Alcotest.test_case "codec bitfield: wire_size" `Quick
         test_codec_bitfield_wire_size;


### PR DESCRIPTION
`Field.repeat` over a `zeroterm` element (a list of NUL-terminated strings within a byte budget) raised `Failure` at decode and had no 3D projection. [`read_elem`](https://github.com/parsimoni-labs/ocaml-wire/blob/fix-repeat-zeroterm-element/lib/codec.ml#L996), `write_elem`, and `elem_size_of` now handle a NUL-terminated element, and the element is projected through a synthesised one-field element struct (`ZtElem { UINT8 v[:zeroterm]; }`) so the byte-budget list references a bare name.

A variable, self-delimiting element verifies in a byte-budget nlist (unlike a fixed-size one, which is why fixed byte chunks stay flat in #89/#92). A round-trip plus projection test and a `ZtRep` e2e through `3d.exe` cover it. Surfaced by the nested-composition fuzzer.