### PR TITLE
codec: reject bitfield array/repeat element + changelog tidy

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,25 +6,18 @@
   so an optional field can be a length-prefixed string or a whole sub-message,
   not just a fixed-width value. Building such a codec previously raised
   `Invalid_argument` (#88, @samoht)
-- Add `Wire.zeroterm` and `Wire.zeroterm_at_most ~size` for
-  NUL-terminated strings: the bytes up to a terminator, or the same
-  within a fixed-size region. They project to the 3D `field[:zeroterm]`
-  and `field[:zeroterm-byte-size-at-most n]` forms (#77, @samoht)
-- `Wire.casetype` now accepts any tag typ (`'k typ`, not just `int`) and
-  projects cleanly to 3D: int-tagged casetypes get an auto-emitted
-  `casetype_decl` + wrapper typedef; byte-tagged casetypes (e.g.
-  `byte_array ~size`) project as two adjacent byte spans so dispatch
-  happens in caller code, matching how OpenSSH and similar protocol
-  parsers handle string-discriminated messages (#49, @samoht)
-- Project a casetype case whose body is an embedded sub-codec to a
-  separate 3D struct. Sub-codecs may end in `all_bytes`; the
-  declaration order places the sub-codec before the dispatch decl
-  that names it (#50, @samoht)
-- `Field.repeat` now projects to 3D for variable-size elements (e.g.
-  a sub-codec with its own length-prefixed bytes), emitting
-  `<Elem> name[:byte-size budget]` (#51, @samoht)
-- `Wire.Codec.size_of_value` (#58, @samoht)
-- Support `Wire.casetype` and `Wire.nested ~size` as `Codec` fields
+- `Wire.zeroterm` and `Wire.zeroterm_at_most ~size` for NUL-terminated
+  strings: the bytes up to a terminator, optionally bounded to a
+  fixed-size region (#77, @samoht)
+- `Wire.casetype` now accepts any tag type (`'k typ`, not just `int`), so a
+  string-discriminated union (a `byte_array`-tagged casetype, as in many
+  SSH messages) is expressible (#49, @samoht)
+- A `Wire.casetype` case body can be an embedded sub-codec, including one
+  that ends in `all_bytes` (#50, @samoht)
+- `Field.repeat` now supports variable-size elements, e.g. a list of
+  length-prefixed sub-messages (#51, @samoht)
+- `Wire.Codec.size_of_value`: the encoded byte length of a value (#58, @samoht)
+- `Wire.casetype` and `Wire.nested ~size` can be used as `Codec` fields
   (#47, @samoht)
 - Add `Field.optional` / `Field.optional_or` / `Field.repeat` /
   `Field.repeat_seq` (#46, @samoht)
@@ -45,12 +38,9 @@
 
 ### Changed
 
-- Decoding a struct with variable-size fields (`byte_slice`, `byte_array`
-  or `repeat` whose size is a cross-field expression) no longer allocates
-  on each field access: the size/offset evaluator now takes `buf` and
-  `base` as separate arguments instead of a per-call pair, and reads
-  integer fields without boxing an `int option`. Pure speedup, no API
-  change (#81, @samoht)
+- Decoding a struct with variable-size fields (`byte_slice`, `byte_array`,
+  or a `repeat` sized by a cross-field expression) no longer allocates on
+  each field access. Pure speedup, no API change (#81, @samoht)
 - Remove `Wire.optional` / `Wire.optional_or` / `Wire.repeat` /
   `Wire.repeat_seq` from the typ-level surface; use the matching
   `Field.*` combinators instead (#46, @samoht)
@@ -64,11 +54,8 @@
   `codec_id`, `slots`, `bound`. Callers using `Param.bind` / `Param.get`
   are unaffected; code that pattern-matches the record or reads fields
   directly needs to update (#63, @samoht)
-- `Codec.raw_encode` and the `Codec` typ constructor's `codec_encode` now
-  return the offset after the written bytes (`int`) instead of `unit`.
-  `Codec.encode` is unaffected. Callers that bound `raw_encode` and
-  threaded its result need to discard the returned offset or use it as
-  the new running position (#65, @samoht)
+- `Codec.raw_encode` now returns the offset after the written bytes instead
+  of `unit`. `Codec.encode` is unaffected (#65, @samoht)
 
 ### Documentation
 
@@ -98,91 +85,57 @@
   `Wire.bit`) now raises `Invalid_argument` when the codec is built, instead of
   crashing at decode. A bitfield only exists packed inside a record, so it
   cannot be a repeat or array element (#90, @samoht)
-- An embedded variable-size sub-codec (`Wire.codec`, e.g. a length-prefixed
-  string) used as a field no longer makes EverParse reject the schema with
-  `Parse_with_dep_action: tag not readable`; the field is handed to its
-  `WireSet*` callback by offset, like a byte slice or casetype (#87, @samoht)
-- A cross-field size/offset/`present` expression that reads an integer field
-  whose value exceeds the native int range (a `uint64`/`int64` length beyond
-  `max_int`), or that references a non-integer field, now raises
-  `Parse_error` instead of silently evaluating to 0. An out-of-range length
-  was being read as an empty field, masking malformed input (#82, @samoht)
-- `Codec.size_of_value` now counts a `Field.repeat`'s elements instead of
-  reporting zero for a dynamic byte budget. Like the casetype case in #78, a
-  buffer sized from `Codec.size_of_value` for a codec with a repeat field
-  under-allocated, so `Codec.encode` ran off the end with
-  `Invalid_argument "index out of bounds"` (#79, @samoht)
-- `Codec.size_of_value` now counts a `Wire.casetype` field's tag and
-  matched-case body instead of reporting zero for it. Sizing a buffer with
-  `Codec.size_of_value` for a codec containing a casetype field used to
-  under-allocate, so `Codec.encode` then ran off the end with
-  `Invalid_argument "index out of bounds"` (#78, @samoht)
+- A codec that embeds a variable-size sub-codec (`Wire.codec`, e.g. a
+  length-prefixed string) as a field is now accepted by EverParse; it
+  previously failed schema generation (#87, @samoht)
+- A cross-field length / offset / `present` expression that reads an integer
+  beyond the native int range (a `uint64`/`int64` length over `max_int`), or
+  reads a non-integer field, now fails the parse instead of silently reading
+  0. The old behaviour masked malformed input (#82, @samoht)
+- `Codec.size_of_value` under-counted a `Field.repeat` with a dynamic byte
+  budget, so `Codec.encode` overran the buffer. It now counts the elements
+  (#79, @samoht)
+- `Codec.size_of_value` under-counted a `Wire.casetype` field, so
+  `Codec.encode` overran the buffer. It now counts the tag and matched case
+  (#78, @samoht)
 - `Field.repeat` over a `Wire.casetype` element now encodes and decodes
-  instead of raising `Failure "unsupported element type in repeat"`. The
-  repeat element path had no case for a tag-dispatched union, which ruled
-  out a DHCP-style options TLV whose cases mix bare single-byte tags (PAD,
-  END) with length-prefixed bodies (#75, @samoht)
-
-- `Codec.size_of_value` no longer over-counts a packed bitfield reached
-  through a value wrapper such as `Wire.bit` or an enum/map over `bits`.
-  The per-field size was keyed off the field's logical type, so a wrapped
-  bit sharing a base byte (e.g. a 7-bit reserved field followed by a 1-bit
-  `bool` flag packed into one byte) reported an extra byte; `Codec.encode`
-  then raised a spurious `Invalid_argument` even though the writer emitted
-  the correct bytes (#72, @samoht)
+  instead of raising. This covers DHCP-style options whose cases mix bare
+  single-byte tags with length-prefixed bodies (#75, @samoht)
+- `Codec.size_of_value` no longer over-counts a packed bitfield wrapped by
+  `Wire.bit` or an enum/map, which made `Codec.encode` raise a spurious
+  `Invalid_argument` (#72, @samoht)
 - `Codec.encode` now raises `Invalid_argument` when the writer emits fewer
-  bytes than `Codec.size_of_value v` promised, so a buggy writer that
-  leaves trailing bytes uninitialised fails loudly at the encode site
-  instead of shipping silently-corrupted bytes that a decoder reads as
-  part of the value (#62, @samoht)
-- `Codec.encode` checks the buffer against `Codec.size_of_value v` instead
-  of the static `min_size` lower bound, so a variable-size codec encoded
-  into a too-small buffer fails loudly with a precise byte count instead
-  of writing past the end. Also fixes a latent overcount in
-  `Codec.size_of_value` where each bitfield in a packed group reported the
-  full base size, returning `base_count * base_size` for codecs that
-  actually fit in one base word (#61, @samoht)
-- `Field.optional` with a dynamic gate no longer ships a silent phantom
-  byte or overruns the buffer on inconsistent input; the encoder raises
-  `Invalid_argument` when the gate and the option value disagree
-  (#58, @samoht)
-- Dynamic `Field.optional_or` now sizes and writes from the value instead
-  of using the dynamic gate as an encode-side size oracle; the gate
-  remains the decode-side selector between the decoded inner and the
-  default (#58, @samoht)
-- Decoding an `all_zeros` field that contains a non-zero byte returns a
-  `Constraint_failed` decode error instead of raising `Invalid_argument`.
-  The old behaviour broke the decoder's "never raise on adversarial
-  input" contract (@samoht)
-- `Wire.encode_into` on a `Single_elem` (`Wire.nested ~size:n inner`)
-  now pads zero bytes up to the declared `size` when `inner` writes
-  fewer than `n` bytes. `encode_direct` already padded; `encode_into`
-  silently dropped the padding, so `Wire.to_string` produced shorter
-  bytes than `Wire.of_string` expected (@samoht)
-- `Wire.default` now takes a required `~tag:'k`: the discriminator
-  the encoder writes when projecting the default branch back to bytes.
-  Previously encoding any default-branch value crashed with
-  `Failure "casetype encoding: cannot encode default case"`; the
-  decoder side still uses the default branch as the match-anything
-  fallback (@samoht)
-- `Wire.encode_into` on a `codec` field whose inner ends in `all_bytes`
-  / `rest_bytes` / `all_zeros` no longer ships a 4096-byte scratch
-  tail. The encoded size is now computed from the value via
-  `Codec.size_of_value`; the buffer-driven `size_of` mismeasured
-  variable tails as "remaining buffer space" (#54, @samoht)
-- `Codec.encode` / `Codec.raw_encode` accept `?env:Param.env`, mirroring
-  `Codec.decode`. Encoding a parametric codec without an env (or with an
-  env that left an input param unbound) now raises `Invalid_argument`
-  naming the offending param instead of silently writing zero-sized
-  regions. A parametric byte field whose value length disagrees with its
-  env-bound size also raises rather than truncating (#53, @samoht)
-- Fix silent always-true compilation of `Field.optional` /
-  `Field.optional_or` predicates that use bitwise / shift / mod
-  operators, and fix `Field.ref` on an `optional` field reading 0
-  instead of the decoded inner value (#48, @samoht)
-- Allow variable-size sub-codecs and `Field.repeat` after a
-  variable-size field (#38, @samoht)
-- Fix C stub generator for schema names with 2+ leading capitals
+  bytes than `size_of_value` promised, instead of shipping a value with
+  uninitialised trailing bytes (#62, @samoht)
+- `Codec.encode` into a too-small buffer now fails with a precise byte count
+  instead of writing past the end (#61, @samoht)
+- `Field.optional` with a dynamic gate no longer writes a phantom byte or
+  overruns the buffer when the gate and the value disagree; it raises
+  `Invalid_argument` (#58, @samoht)
+- `Field.optional_or` with a dynamic gate now encodes from the value; the
+  gate selects the decoded value or the default on decode (#58, @samoht)
+- Decoding an `all_zeros` field that contains a non-zero byte now returns a
+  `Constraint_failed` error instead of raising (@samoht)
+- `Wire.to_string` on a `Wire.nested ~size:n` field now zero-pads to `n`
+  bytes when the inner writes fewer, so it agrees with `Wire.of_string`
+  (@samoht)
+- `Wire.default` now takes a required `~tag`: the discriminator written when
+  encoding the default branch. Encoding a default-branch value previously
+  crashed (@samoht)
+- `Wire.to_string` on a `codec` field whose inner ends in `all_bytes` /
+  `rest_bytes` / `all_zeros` no longer appends a 4 KB scratch tail; the size
+  is computed from the value (#54, @samoht)
+- `Codec.encode` / `Codec.raw_encode` accept `?env:Param.env`, like
+  `Codec.decode`. Encoding a parametric codec with a missing param binding
+  now raises `Invalid_argument` naming the param instead of writing
+  zero-sized regions (#53, @samoht)
+- `Field.optional` / `Field.optional_or` predicates that use bitwise / shift
+  / mod operators are no longer silently treated as always-true, and
+  `Field.ref` on an `optional` field now reads the decoded value instead of 0
+  (#48, @samoht)
+- A variable-size sub-codec or `Field.repeat` may now follow a variable-size
+  field (#38, @samoht)
+- Fix C stub generation for schema names with two or more leading capitals
   (e.g. `IPv4`, `EP_Header`) (#36, @samoht)
 
 ## 0.9.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -94,6 +94,10 @@
 - `Wire.array` whose element is a fixed `byte_array` / `byte_slice` (e.g. an
   array of fixed-size addresses) now generates a valid EverParse validator;
   the generated 3D schema was previously malformed for such arrays (#92, @samoht)
+- `Field.repeat` / `Wire.array` over a bitfield element (`Wire.bits` or
+  `Wire.bit`) now raises `Invalid_argument` when the codec is built, instead of
+  crashing at decode. A bitfield only exists packed inside a record, so it
+  cannot be a repeat or array element (#90, @samoht)
 - An embedded variable-size sub-codec (`Wire.codec`, e.g. a length-prefixed
   string) used as a field no longer makes EverParse reject the schema with
   `Parse_with_dep_action: tag not readable`; the field is handed to its

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -419,13 +419,33 @@ let reject_unprojectable_optional ~combinator t =
        nor self-delimiting."
       combinator combinator
 
+(* A bitfield is packed within an enclosing base word in a record; it has no
+   standalone wire form, so it cannot be an [array] / [repeat] element (there is
+   no byte boundary per element, and no 3D element type to project to). Reject
+   it at construction rather than crash at decode. *)
+let rec is_bitfield_element : type a. a typ -> bool = function
+  | Bits _ -> true
+  | Map { inner; _ } -> is_bitfield_element inner
+  | Where { inner; _ } -> is_bitfield_element inner
+  | Enum { base; _ } -> is_bitfield_element base
+  | _ -> false
+
+let reject_bitfield_element ~combinator t =
+  if is_bitfield_element t then
+    Fmt.invalid_arg
+      "Wire.%s: a bitfield has no standalone element form (bits are packed \
+       within an enclosing word); it cannot be an element of %s."
+      combinator combinator
+
 let array ~len elem =
   reject_decoration ~combinator:"array" elem;
+  reject_bitfield_element ~combinator:"array" elem;
   reject_variable_size ~combinator:"array" elem;
   Array { len; elem; seq = seq_list }
 
 let array_seq seq ~len elem =
   reject_decoration ~combinator:"array_seq" elem;
+  reject_bitfield_element ~combinator:"array_seq" elem;
   reject_variable_size ~combinator:"array_seq" elem;
   Array { len; elem; seq }
 
@@ -467,10 +487,12 @@ let optional_or present ~default inner =
    refuse is a field decoration nested inside [elem]. *)
 let repeat ~size elem =
   reject_decoration ~combinator:"repeat" elem;
+  reject_bitfield_element ~combinator:"repeat" elem;
   Repeat { size; elem; seq = seq_list }
 
 let repeat_seq seq ~size elem =
   reject_decoration ~combinator:"repeat_seq" elem;
+  reject_bitfield_element ~combinator:"repeat_seq" elem;
   Repeat { size; elem; seq }
 
 let nested ~size elem = Single_elem { size; elem; at_most = false }

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -406,6 +406,27 @@ let test_array_byte_array_projection () =
     "single byte-size on the array field" true
     (contains ~sub:"UINT8 addrs[:byte-size (3 * 4)]" out)
 
+(* A bitfield has no standalone element form, so [array] / [Field.repeat] over
+   one is rejected at construction rather than crashing at decode. *)
+let raises_invalid f =
+  try
+    ignore (f ());
+    false
+  with Invalid_argument _ -> true
+
+let test_repeat_array_reject_bitfield () =
+  Alcotest.(check bool)
+    "array over bits rejected" true
+    (raises_invalid (fun () -> array ~len:(int 4) (bits ~width:3 U8)));
+  Alcotest.(check bool)
+    "repeat over bits rejected" true
+    (raises_invalid (fun () ->
+         Field.repeat "x" ~size:(int 4) (bits ~width:3 U8)));
+  Alcotest.(check bool)
+    "repeat over bit (bool over bits) rejected" true
+    (raises_invalid (fun () ->
+         Field.repeat "x" ~size:(int 4) (bit (bits ~width:1 U8))))
+
 (* Field.repeat over a fixed byte_array element: a list of n-byte chunks within
    a byte budget. Decoding used to raise Failure "unsupported element type in
    repeat" and the schema mis-projected as a double [:byte-size]. *)
@@ -4183,6 +4204,8 @@ let suite =
         test_array_byte_array_element;
       Alcotest.test_case "array: byte_array element projection" `Quick
         test_array_byte_array_projection;
+      Alcotest.test_case "repeat/array reject bitfield element" `Quick
+        test_repeat_array_reject_bitfield;
       (* codec bitfields *)
       Alcotest.test_case "codec bitfield: wire_size" `Quick
         test_codec_bitfield_wire_size;


### PR DESCRIPTION
Re-lands two changes whose original PRs (#90, #91) were merged into intermediate stacked branches rather than `main`, so their content never reached `main`.

First commit (#90): `Field.repeat` / `Wire.array` over a bitfield element now raises `Invalid_argument` at construction instead of crashing at decode. Second commit (#91): rewrites the unreleased changelog entries to describe user-observable behaviour rather than internal 3D-projection mechanics.