### PR TITLE
codec: encode does not require env for output-only params

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -80,6 +80,11 @@
 
 ### Fixed
 
+- `Codec.encode` no longer requires an `?env` for a codec whose only
+  parameters are decode-side outputs (a field with an `Action.assign` into a
+  `Param.output`). Output params are never read when encoding, so demanding an
+  env raised `Invalid_argument` spuriously, and an output-param sub-codec
+  embedded as a field could not be encoded at all (#95, @samoht)
 - `Field.repeat` over a `zeroterm` element (a list of NUL-terminated strings
   within a byte budget) now encodes, decodes, and generates a verified
   EverParse validator. It previously raised `Failure` when decoding (#93, @samoht)

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -2699,11 +2699,20 @@ let unbound_params (t : 'r t) (env : Param.env) : string list =
       else None)
     t.param_handles
 
+(* Input params (read from the env) drive field sizes/offsets, so encoding
+   without their values would resolve those to 0. Output params are written
+   by decode-side actions and never consulted on encode, so a codec whose only
+   params are outputs needs no env. *)
+let has_input_params (t : 'r t) =
+  List.exists
+    (fun (Param.Pack p) -> (not p.Types.ph_mutable) && p.ph_env_idx >= 0)
+    t.param_handles
+
 let require_env t = function
-  | None when t.n_params = 0 -> ()
+  | None when not (has_input_params t) -> ()
   | None ->
       Fmt.invalid_arg
-        "Codec.encode: codec %s has parameters; pass ?env (e.g. [Codec.env c \
+        "Codec.encode: codec %s has input params; pass ?env (e.g. [Codec.env c \
          |> Param.bind p N])."
         t.name
   | Some env -> (

--- a/test/test_action.ml
+++ b/test/test_action.ml
@@ -456,6 +456,58 @@ let test_action_on_bitfield () =
   let out_val = Param.get env out in
   Alcotest.(check bool) "out <= 15" true (out_val <= 15)
 
+(* -- Encode -- *)
+
+let test_encode_output_no_env () =
+  (* A codec whose only param is a decode-side output encodes without an env:
+     encode never reads output params, so demanding one was spurious. Before
+     the fix [Codec.encode] raised Invalid_argument here. *)
+  let out = Param.output "out" uint8 in
+  let f_x = Field.v "x" uint8 in
+  let codec =
+    let open Codec in
+    v "EncOut"
+      (fun x -> x)
+      [
+        ( Field.v "x"
+            ~action:(Action.on_success [ Action.assign out (Field.ref f_x) ])
+            uint8
+        $ fun x -> x );
+      ]
+  in
+  let buf = Bytes.create (Codec.size_of_value codec 7) in
+  Codec.encode codec 7 buf 0;
+  Alcotest.(check int) "encoded byte" 7 (Bytes.get_uint8 buf 0);
+  let env = Codec.env codec in
+  Alcotest.(check int) "decoded" 7 (decode_ok (Codec.decode ~env codec buf 0));
+  Alcotest.(check int) "out" 7 (Param.get env out)
+
+(* An embedded output-param sub-codec encodes from the parent without an env,
+   too: the parent forwards no env and the sub-codec needs none. *)
+let test_encode_embedded_output_no_env () =
+  let out = Param.output "out" uint8 in
+  let f_x = Field.v "x" uint8 in
+  let inner =
+    let open Codec in
+    v "EncOutInner"
+      (fun x -> x)
+      [
+        ( Field.v "x"
+            ~action:(Action.on_success [ Action.assign out (Field.ref f_x) ])
+            uint8
+        $ fun x -> x );
+      ]
+  in
+  let outer =
+    let open Codec in
+    v "EncOutOuter"
+      (fun i -> i)
+      [ (Field.v "inner" (codec inner) $ fun i -> i) ]
+  in
+  let buf = Bytes.create (Codec.size_of_value outer 7) in
+  Codec.encode outer 7 buf 0;
+  Alcotest.(check int) "encoded byte" 7 (Bytes.get_uint8 buf 0)
+
 (* -- Suite -- *)
 
 let suite =
@@ -493,4 +545,9 @@ let suite =
       (* edge cases *)
       Alcotest.test_case "empty action" `Quick test_empty_action;
       Alcotest.test_case "action on bitfield" `Quick test_action_on_bitfield;
+      (* encode *)
+      Alcotest.test_case "encode output param without env" `Quick
+        test_encode_output_no_env;
+      Alcotest.test_case "encode embedded output param without env" `Quick
+        test_encode_embedded_output_no_env;
     ] )


### PR DESCRIPTION
`Codec.encode` used to reject any codec with parameters when no `?env` was passed, but a field whose `~action` assigns into a `Param.output` is a decode-side effect that encoding never reads. So a codec whose only parameter was such an output raised `Invalid_argument` on encode, and the same codec embedded as a `Wire.codec` field could not be encoded from its parent at all (the parent forwards no env to the sub-codec).

`require_env` now keys off whether the codec has an *input* param that needs a value, leaving the unbound-input-param error and all input-param behaviour unchanged.

Surfaced by the nested-composition fuzzer, which round-trips an `Action.on_success` leaf inside a record.