### PR TITLE
codec: reject unprojectable repeat elements at build time

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -72,6 +72,13 @@
   `Param.output`). Output params are never read when encoding, so demanding an
   env raised `Invalid_argument` spuriously, and an output-param sub-codec
   embedded as a field could not be encoded at all (#95, @samoht)
+- `Field.repeat` / `Field.repeat_seq` now reject an element type that has no
+  clean per-element 3D projection (a sub-byte `bits` field, a refined or
+  at-most byte span, `all_zeros`, or a nested `array` / `nested`) at
+  construction with a clear `Invalid_argument`, instead of building a codec
+  that raised `Failure` deep in decode or emitted a schema EverParse could not
+  verify. Supported elements are unchanged: fixed-width scalars and byte spans,
+  `zeroterm`, sub-codecs, and casetypes (#97, @samoht)
 - `Field.repeat` over a `zeroterm` element (a list of NUL-terminated strings
   within a byte budget) now encodes, decodes, and generates a verified
   EverParse validator. It previously raised `Failure` when decoding (#93, @samoht)

--- a/lib/field.ml
+++ b/lib/field.ml
@@ -31,10 +31,41 @@ let optional_or name ?constraint_ ?self_constraint ?action ~present ~default typ
   v name ?constraint_ ?self_constraint ?action
     (Types.optional_or present ~default typ)
 
+(* An element [repeat]/[repeat_seq] can both project to 3D and decode one
+   element at a time: a fixed-width scalar / byte span, a NUL-terminated
+   string, or a self-bounded sub-codec / casetype. [Map] / [Where] / [Enum]
+   are transparent wrappers, so look through them. Everything else (a sub-byte
+   [bits] field, a refined or at-most byte span whose per-element validation
+   the byte-budget loop does not run, greedy [all_zeros], a nested [array] /
+   [nested]) has no clean per-element 3D projection. *)
+let rec is_repeat_element : type a. a Types.typ -> bool =
+ fun typ ->
+  let open Types in
+  match typ with
+  | Uint8 | Uint16 _ | Uint32 _ | Uint63 _ | Uint64 _ | Int8 | Int16 _ | Int32 _
+  | Int64 _ | Float32 _ | Float64 _ | Uint_var _ | Unit | Zeroterm ->
+      true
+  | Byte_array { size = Int _ } | Byte_slice { size = Int _ } -> true
+  | Codec _ | Casetype _ -> true
+  | Map { inner; _ } -> is_repeat_element inner
+  | Where { inner; _ } -> is_repeat_element inner
+  | Enum { base; _ } -> is_repeat_element base
+  | _ -> false
+
+let reject_unprojectable_repeat ~combinator typ =
+  if not (is_repeat_element typ) then
+    Fmt.invalid_arg
+      "Wire.%s: element type does not project to 3D as a repeat element -- the \
+       byte-budget loop only supports fixed-width scalars and byte spans, \
+       NUL-terminated strings, sub-codecs, and casetypes."
+      combinator
+
 let repeat name ?constraint_ ?self_constraint ?action ~size typ =
+  reject_unprojectable_repeat ~combinator:"repeat" typ;
   v name ?constraint_ ?self_constraint ?action (Types.repeat ~size typ)
 
 let repeat_seq name ?constraint_ ?self_constraint ?action ~seq ~size typ =
+  reject_unprojectable_repeat ~combinator:"repeat_seq" typ;
   v name ?constraint_ ?self_constraint ?action (Types.repeat_seq seq ~size typ)
 
 let anon typ = { anon_typ = typ }

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -461,6 +461,25 @@ let test_repeat_byte_array_projection () =
     "single byte-size on the chunks field" true
     (contains ~sub:"UINT8 chunks[:byte-size n]" out)
 
+(* An element with no clean per-element 3D projection is refused at
+   construction, rather than failing late with Failure at decode/encode or
+   emitting a schema EverParse cannot verify. *)
+let repeat_rejects elem =
+  match Field.repeat "items" ~size:(int 4) elem with
+  | _ -> false
+  | exception Invalid_argument _ -> true
+
+let test_repeat_rejects_unprojectable () =
+  Alcotest.(check bool) "bits element" true (repeat_rejects (bits ~width:3 U8));
+  Alcotest.(check bool) "all_zeros element" true (repeat_rejects all_zeros);
+  Alcotest.(check bool)
+    "zeroterm_at_most element" true
+    (repeat_rejects (zeroterm_at_most ~size:(int 6)));
+  Alcotest.(check bool)
+    "byte_array_where element" true
+    (repeat_rejects
+       (byte_array_where ~size:(int 2) ~per_byte:(fun _ -> Expr.true_)))
+
 (* -- Codec bitfield tests -- *)
 
 type bf32_record = { bf_a : int; bf_b : int; bf_c : int; bf_d : int }
@@ -4200,6 +4219,8 @@ let suite =
         test_repeat_byte_array_element;
       Alcotest.test_case "repeat: byte_array element projection" `Quick
         test_repeat_byte_array_projection;
+      Alcotest.test_case "repeat: rejects unprojectable element" `Quick
+        test_repeat_rejects_unprojectable;
       Alcotest.test_case "array: byte_array element roundtrip" `Quick
         test_array_byte_array_element;
       Alcotest.test_case "array: byte_array element projection" `Quick


### PR DESCRIPTION
`Field.repeat` / `Field.repeat_seq` accepted any element type, then failed late: an element with no clean per-element 3D projection raised `Failure "read_elem/write_elem: unsupported element type in repeat"` deep in decode/encode, or built a codec whose schema EverParse could not verify (a missing refined-byte typedef, a sub-byte field in a byte loop).

`Field.repeat`/`repeat_seq` now check the element at construction and raise `Invalid_argument` for anything that does not project: a sub-byte `bits` field, a refined or at-most byte span (whose per-element validation the byte-budget loop does not run), `all_zeros`, and nested `array` / `nested`. The supported set is unchanged: fixed-width scalars and byte spans, `zeroterm`, sub-codecs, and casetypes.

Surfaced by the nested-composition fuzzer.