### PR TITLE
codec: reject a bitfield element in nested/nested_at_most

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -75,6 +75,11 @@
   other byte spans, and a byte-span or `enum` inner goes through a synthesised
   wrapper struct so the single-element-array element is a single named type
   (scalar, sub-record, and casetype inners render inline) (#99, @samoht)
+- `Wire.nested` / `Wire.nested_at_most` over a bitfield element (`Wire.bits` or
+  `Wire.bit`) now raises `Invalid_argument` when the codec is built, instead of
+  crashing at decode with `Failure`. A bitfield only exists packed inside a
+  record, so it cannot be a `nested` inner, matching the existing `array` /
+  `repeat` behaviour (#98, @samoht)
 - `Codec.encode` no longer requires an `?env` for a codec whose only
   parameters are decode-side outputs (a field with an `Action.assign` into a
   `Param.output`). Output params are never read when encoding, so demanding an

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -495,8 +495,14 @@ let repeat_seq seq ~size elem =
   reject_bitfield_element ~combinator:"repeat_seq" elem;
   Repeat { size; elem; seq }
 
-let nested ~size elem = Single_elem { size; elem; at_most = false }
-let nested_at_most ~size elem = Single_elem { size; elem; at_most = true }
+let nested ~size elem =
+  reject_bitfield_element ~combinator:"nested" elem;
+  Single_elem { size; elem; at_most = false }
+
+let nested_at_most ~size elem =
+  reject_bitfield_element ~combinator:"nested_at_most" elem;
+  Single_elem { size; elem; at_most = true }
+
 let enum name cases base = Enum { name; cases; base }
 
 let fail_parse_error fmt =

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -475,6 +475,16 @@ let test_array_record_projection () =
     "sub-struct element under byte-size on the array field" true
     (contains ~sub:"Pt pts[:byte-size (2 * 3)]" out)
 
+(* [nested] / [nested_at_most] over a bitfield is likewise rejected at
+   construction; it used to build a codec that raised Failure deep in decode. *)
+let test_nested_reject_bitfield () =
+  Alcotest.(check bool)
+    "nested over bits rejected" true
+    (raises_invalid (fun () -> nested ~size:(int 1) (bits ~width:3 U8)));
+  Alcotest.(check bool)
+    "nested_at_most over bits rejected" true
+    (raises_invalid (fun () -> nested_at_most ~size:(int 1) (bits ~width:3 U8)))
+
 (* Field.repeat over a fixed byte_array element: a list of n-byte chunks within
    a byte budget. Decoding used to raise Failure "unsupported element type in
    repeat" and the schema mis-projected as a double [:byte-size]. *)
@@ -4279,6 +4289,8 @@ let suite =
         test_array_record_element;
       Alcotest.test_case "array: record element projection" `Quick
         test_array_record_projection;
+      Alcotest.test_case "nested reject bitfield element" `Quick
+        test_nested_reject_bitfield;
       (* codec bitfields *)
       Alcotest.test_case "codec bitfield: wire_size" `Quick
         test_codec_bitfield_wire_size;


### PR DESCRIPTION
`Wire.nested` / `Wire.nested_at_most` accepted a bitfield inner (`Wire.bits` or `Wire.bit`), then raised `Failure "read_elem: unsupported element type in repeat"` deep in decode (a `Single_elem` decodes its inner through the element reader, which has no sub-byte case). A bitfield only exists packed inside a record, so it cannot be a standalone `nested` inner; this now raises `Invalid_argument` at construction, matching the existing `array` / `repeat` reject (#90).

Also lifts the casetype-declaration walker inside `casetype_decls_of_struct` to a top-level `collect_casetype_decls` (no behaviour change) so the function stays under the length limit.

Surfaced by the nested-composition fuzzer.