### PR TITLE
codec: project a nested field to a valid 3D schema

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -67,6 +67,14 @@
 
 ### Fixed
 
+- A `Wire.nested` / `Wire.nested_at_most` field now projects to a schema
+  EverParse accepts. It previously emitted an extern setter typed
+  `UINT8[:byte-size-single-element-array N]`, which is not valid 3D, so any
+  codec with a `nested` field failed schema generation regardless of the inner.
+  The fixed region is now handed to its `WireSet*` callback by offset like
+  other byte spans, and a byte-span or `enum` inner goes through a synthesised
+  wrapper struct so the single-element-array element is a single named type
+  (scalar, sub-record, and casetype inners render inline) (#99, @samoht)
 - `Codec.encode` no longer requires an `?env` for a codec whose only
   parameters are decode-side outputs (a field with an `Action.assign` into a
   `Param.output`). Output params are never read when encoding, so demanding an

--- a/lib/everparse.ml
+++ b/lib/everparse.ml
@@ -46,6 +46,12 @@ let rec is_byte_field : type a. a Types.typ -> bool = function
      setter makes EverParse fail with "Parse_with_dep_action: tag not
      readable". Expose its bytes via the [SetBytes] offset instead. *)
   | Types.Codec _ -> true
+  (* A [nested ~size] is a fixed-size byte region holding one inner value. 3D
+     parses it with a [:byte-size-single-element-array] suffix, which is not a
+     readable value in an action; expose the region through the [SetBytes]
+     offset like other byte spans, so the extern setter takes an offset rather
+     than the (unrepresentable) array-typed value. *)
+  | Types.Single_elem _ -> true
   | _ -> false
 
 type setter_info = { setter_name : string; setter_val_typ : Types.packed_typ }

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -821,6 +821,25 @@ let repeat_elem_struct : type a. a typ -> string option = function
   | Zeroterm -> Some "ZtElem"
   | _ -> None
 
+(* A [nested ~size] projects to [<elem>[:byte-size-single-element-array n]],
+   whose element must be a single type token. A bare scalar or an already-named
+   struct ([codec] / [casetype]) works inline, but an element that renders with
+   its own array / refinement qualifier ([byte_array], [byte_slice],
+   [byte_array_where], [zeroterm_at_most], [uint_var]) or that needs its own
+   declaration ([enum]) cannot. Those go through a synthesised wrapper struct,
+   named deterministically from the element so the field renderer and the
+   typedef emitter agree without shared state. *)
+let single_elem_struct : type a. a typ -> string option =
+  let some fmt = Fmt.kstr (fun s -> Some s) fmt in
+  function
+  | Byte_array { size = Int n } -> some "SeBytes%d" n
+  | Byte_slice { size = Int n } -> some "SeSlice%d" n
+  | Byte_array_where { size = Int n; _ } -> some "SeRBytes%d" n
+  | Uint_var { size = Int n; _ } -> some "SeUvar%d" n
+  | Zeroterm_at_most { size = Int n } -> some "SeZtam%d" n
+  | Enum { name; _ } -> Some ("Se_" ^ name)
+  | _ -> None
+
 (* The synthesised gate-dispatch casetype name for an [optional] whose inner is
    self-delimiting (no wire-size expression). Derived from the inner so two
    optionals over the same inner share one declaration. *)
@@ -854,57 +873,71 @@ let optional_casetype_decl : type a. string -> a typ -> decl =
         ];
     }
 
+let rec collect_casetype_decls : type a.
+    (string, unit) Hashtbl.t -> decl list Stdlib.ref -> a typ -> unit =
+ fun seen acc typ ->
+  let extract : type b. b typ -> unit =
+   fun t -> collect_casetype_decls seen acc t
+  in
+  (* A fixed-size element used inside [repeat] / [nested] needs a named wrapper
+     struct when it has no usable bare token; emit it once, deduped by name. *)
+  let emit_wrapper name elem =
+    if not (Hashtbl.mem seen name) then begin
+      Hashtbl.add seen name ();
+      acc := typedef (struct_ name [ field "v" elem ]) :: !acc
+    end
+  in
+  match typ with
+  | Casetype { name; tag; cases }
+    when is_int_dispatch_typ tag && not (Hashtbl.mem seen name) ->
+      Hashtbl.add seen name ();
+      (* Visit case inners first so any sub-codecs / nested casetypes they
+         reference are declared before the dispatch that names them. *)
+      List.iter (fun (Case_branch { cb_inner; _ }) -> extract cb_inner) cases;
+      let dispatch, wrapper = casetype_pair name tag cases in
+      acc := wrapper :: dispatch :: !acc
+  | Casetype { cases; _ } ->
+      (* String-tagged casetype: handled by [split_string_casetype_fields].
+         Still walk inner case typs for nested int-tagged casetypes. *)
+      List.iter (fun (Case_branch { cb_inner; _ }) -> extract cb_inner) cases
+  | Codec { codec_name; codec_struct; _ } when not (Hashtbl.mem seen codec_name)
+    ->
+      (* Embedded sub-codec: emit its struct alongside the parent so 3D
+         references to [codec_name] resolve. Recurse into the sub-codec's
+         own fields to catch nested casetype / sub-codec dependencies. *)
+      Hashtbl.add seen codec_name ();
+      acc := typedef codec_struct :: !acc;
+      List.iter (fun (Field f) -> extract f.field_typ) codec_struct.fields
+  | Codec _ -> ()
+  | Map { inner; _ } -> extract inner
+  | Where { inner; _ } -> extract inner
+  | Optional { inner; _ } when not (has_wire_size_expr inner) ->
+      (* Self-delimiting inner: declare its dependencies, then the
+         gate-dispatch casetype that references them. *)
+      extract inner;
+      let opt_name = optional_casetype_name inner in
+      if not (Hashtbl.mem seen opt_name) then begin
+        Hashtbl.add seen opt_name ();
+        acc := optional_casetype_decl opt_name inner :: !acc
+      end
+  | Optional { inner; _ } -> extract inner
+  | Optional_or { inner; _ } -> extract inner
+  | Apply { typ; _ } -> extract typ
+  | Repeat { elem; _ } ->
+      extract elem;
+      Option.iter (fun n -> emit_wrapper n elem) (repeat_elem_struct elem)
+  | Array { elem; _ } -> extract elem
+  | Single_elem { elem; _ } ->
+      extract elem;
+      Option.iter (fun n -> emit_wrapper n elem) (single_elem_struct elem)
+  | _ -> ()
+
 let casetype_decls_of_struct (s : struct_) : decl list =
   let seen = Hashtbl.create 4 in
   let acc = Stdlib.ref [] in
-  let rec extract : type a. a typ -> unit = function
-    | Casetype { name; tag; cases }
-      when is_int_dispatch_typ tag && not (Hashtbl.mem seen name) ->
-        Hashtbl.add seen name ();
-        (* Visit case inners first so any sub-codecs / nested casetypes they
-           reference are declared before the dispatch that names them. *)
-        List.iter (fun (Case_branch { cb_inner; _ }) -> extract cb_inner) cases;
-        let dispatch, wrapper = casetype_pair name tag cases in
-        acc := wrapper :: dispatch :: !acc
-    | Casetype { cases; _ } ->
-        (* String-tagged casetype: handled by [split_string_casetype_fields].
-           Still walk inner case typs for nested int-tagged casetypes. *)
-        List.iter (fun (Case_branch { cb_inner; _ }) -> extract cb_inner) cases
-    | Codec { codec_name; codec_struct; _ }
-      when not (Hashtbl.mem seen codec_name) ->
-        (* Embedded sub-codec: emit its struct alongside the parent so 3D
-           references to [codec_name] resolve. Recurse into the sub-codec's
-           own fields to catch nested casetype / sub-codec dependencies. *)
-        Hashtbl.add seen codec_name ();
-        acc := typedef codec_struct :: !acc;
-        List.iter (fun (Field f) -> extract f.field_typ) codec_struct.fields
-    | Codec _ -> ()
-    | Map { inner; _ } -> extract inner
-    | Where { inner; _ } -> extract inner
-    | Optional { inner; _ } when not (has_wire_size_expr inner) ->
-        (* Self-delimiting inner: declare its dependencies, then the
-           gate-dispatch casetype that references them. *)
-        extract inner;
-        let opt_name = optional_casetype_name inner in
-        if not (Hashtbl.mem seen opt_name) then begin
-          Hashtbl.add seen opt_name ();
-          acc := optional_casetype_decl opt_name inner :: !acc
-        end
-    | Optional { inner; _ } -> extract inner
-    | Optional_or { inner; _ } -> extract inner
-    | Apply { typ; _ } -> extract typ
-    | Repeat { elem; _ } -> (
-        extract elem;
-        match repeat_elem_struct elem with
-        | Some name when not (Hashtbl.mem seen name) ->
-            Hashtbl.add seen name ();
-            acc := typedef (struct_ name [ field "v" elem ]) :: !acc
-        | _ -> ())
-    | Array { elem; _ } -> extract elem
-    | Single_elem { elem; _ } -> extract elem
-    | _ -> ()
-  in
-  List.iter (fun (Field f) -> extract f.field_typ) s.fields;
+  List.iter
+    (fun (Field f) -> collect_casetype_decls seen acc f.field_typ)
+    s.fields;
   List.rev !acc
 
 (* Two-step projection for string-tagged casetype: split the field into
@@ -1264,7 +1297,14 @@ and field_suffix : type a. a typ -> field_suffix * (Format.formatter -> unit) =
       let synth = synth_name_of_elt_var elt_var in
       (Byte_array size, fun ppf -> Fmt.string ppf synth)
   | Single_elem { size; elem; at_most } ->
-      (Single_elem { size; at_most }, fun ppf -> pp_typ ppf elem)
+      (* A wrapper-needing element goes through its synthesised struct name; a
+         bare scalar or named struct renders inline. *)
+      let pp_elem ppf =
+        match single_elem_struct elem with
+        | Some name -> Fmt.string ppf name
+        | None -> pp_typ ppf elem
+      in
+      (Single_elem { size; at_most }, pp_elem)
   | Array { len; elem; _ } -> (
       (* 3D's [name[len]] suffix only accepts byte-sized elements; for wider
          elements the size in bytes must be made explicit via [:byte-size].

--- a/test/3d/test_wire_3d.ml
+++ b/test/3d/test_wire_3d.ml
@@ -811,6 +811,42 @@ let test_field_optional_byte_array () =
   Alcotest.(check bool)
     "byte-size suffix uses inner size" true (contains out "8")
 
+(* A [nested ~size] / [nested_at_most] field projects through EverParse. It used
+   to emit an extern setter param typed [UINT8[:byte-size-single-element-array]],
+   which is invalid 3D and made [3d.exe] reject the whole module. Byte-span and
+   enum inners go through a synthesised wrapper struct; scalar and sub-record
+   inners render inline. [generate_c] runs [3d.exe] and raises if the .3d is
+   rejected, so this is the regression guard. *)
+let test_nested_field_projects () =
+  if not (Wire_3d.has_3d_exe ()) then ()
+  else begin
+    let inner =
+      Codec.v "NInner"
+        (fun a b -> (a, b))
+        Codec.[ Field.v "a" uint8 $ fst; Field.v "b" uint16be $ snd ]
+    in
+    let codec =
+      Codec.v "NestedProj"
+        (fun scalar bytes sub -> (scalar, bytes, sub))
+        Codec.
+          [
+            (Field.v "scalar" (nested ~size:(int 4) uint8) $ fun (s, _, _) -> s);
+            ( Field.v "bytes" (nested ~size:(int 4) (byte_array ~size:(int 3)))
+            $ fun (_, b, _) -> b );
+            ( Field.v "sub" (nested ~size:(int 8) (codec inner))
+            $ fun (_, _, s) -> s );
+          ]
+    in
+    let dir = Filename.temp_dir "wire_3d_nested" "" in
+    let s = Everparse.schema codec in
+    Wire_3d.generate_3d ~outdir:dir [ s ];
+    (* Runs 3d.exe; raises if EverParse rejects the generated .3d. *)
+    Wire_3d.generate_c ~outdir:dir [ s ];
+    Alcotest.(check bool)
+      "C generated for nested fields" true
+      (Sys.file_exists (Filename.concat dir "NestedProj.c"))
+  end
+
 let test_keyword_field_escaped () =
   let s =
     struct_ "Esc2"
@@ -856,6 +892,8 @@ let suite =
         test_array_rejects_unsized_elem;
       Alcotest.test_case "Field.optional: byte_array inner projects" `Quick
         test_field_optional_byte_array;
+      Alcotest.test_case "nested field projects through EverParse" `Slow
+        test_nested_field_projects;
       Alcotest.test_case "e2e: compile + run across naming conventions" `Slow
         test_e2e_compile_run;
     ] )


### PR DESCRIPTION
A `Wire.nested` / `Wire.nested_at_most` field never projected to a schema EverParse accepts: it emitted an extern setter param typed `UINT8[:byte-size-single-element-array N]`, which is invalid 3D (a syntax error in a param position), so any codec with a `nested` field failed schema generation regardless of the inner. It went unnoticed because no example schema used a standalone `nested` field.

Two changes make it project: the fixed region is now treated as a byte field (`is_byte_field`), so its `WireSet*` callback takes an offset like other byte spans rather than the unrepresentable array-typed value; and a byte-span or `enum` inner is routed through a synthesised wrapper struct so the `[:byte-size-single-element-array]` element is a single named type (scalar, sub-record, and casetype inners already render inline). The casetype-declaration walker in `casetype_decls_of_struct` is lifted to a top-level `collect_casetype_decls` (no behaviour change) so it stays under the length limit while gaining the wrapper case.

A new `test/3d` case builds a codec with scalar, byte-span, and sub-record nested fields and runs it through `3d.exe`. Surfaced by a (combinator x element) projection catalog over the nested-composition fuzzer's leaves; the lone remaining gap is a `byte_array_where` inner (its refined typedef is not yet emitted inside the wrapper).