### PR TITLE
codec: thread the matched tag through a casetype default branch

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,16 @@
 
 ### Changed
 
+- `Wire.default` (a casetype's default branch) no longer takes a fixed `~tag`;
+  instead it threads the matched discriminator through `inject` and `project`,
+  so an arbitrary unclaimed tag round-trips. `inject` is now `'k -> 'w -> 'a`
+  (it receives the matched tag along with the body) and `project` is now
+  `'a -> ('k * 'w) option` (it returns the tag to write back). The decoder used
+  to hand `inject` only the body and the encoder always wrote the one fixed
+  `~tag`, so a default branch could not recover or re-emit the actual tag it
+  caught (e.g. a DHCP or TCP option code). Migrate by taking the tag in
+  `inject` (`fun _tag body -> ...` to ignore it) and pairing it in `project`
+  (#100, @samoht)
 - Decoding a struct with variable-size fields (`byte_slice`, `byte_array`,
   or a `repeat` sized by a cross-field expression) no longer allocates on
   each field access. Pure speedup, no API change (#81, @samoht)

--- a/fuzz/fuzz_everparse.ml
+++ b/fuzz/fuzz_everparse.ml
@@ -158,9 +158,9 @@ let test_casetype_inline () =
           ~inject:(fun v -> `U32 (Wire.Private.UInt32.to_int v))
           ~project:(function
             | `U32 v -> Some (Wire.Private.UInt32.of_int v) | _ -> None);
-        Wire.default ~tag:0xFF Wire.uint8
-          ~inject:(fun v -> `Default v)
-          ~project:(function `Default v -> Some v | _ -> None);
+        Wire.default Wire.uint8
+          ~inject:(fun _tag v -> `Default v)
+          ~project:(function `Default v -> Some (0xFF, v) | _ -> None);
       ]
   in
   let s =

--- a/fuzz/fuzz_wire.ml
+++ b/fuzz/fuzz_wire.ml
@@ -364,10 +364,11 @@ let test_parse_casetype buf =
         Wire.case ~index:1 Wire.uint16
           ~inject:(fun v -> `U16 v)
           ~project:(function `U16 v -> Some v | _ -> None);
-        Wire.default ~tag:0xFF Wire.uint32
-          ~inject:(fun v -> `Default (Wire.Private.UInt32.to_int v))
+        Wire.default Wire.uint32
+          ~inject:(fun _tag v -> `Default (Wire.Private.UInt32.to_int v))
           ~project:(function
-            | `Default v -> Some (Wire.Private.UInt32.of_int v) | _ -> None);
+            | `Default v -> Some (0xFF, Wire.Private.UInt32.of_int v)
+            | _ -> None);
       ]
   in
   let _ = Wire.of_string t buf in

--- a/fuzz/gen/fuzz_gen.ml
+++ b/fuzz/gen/fuzz_gen.ml
@@ -1396,7 +1396,11 @@ let casetype_u8 name cases =
         | Some i, _ ->
             Wire.case ~index:i c.inner.typ ~inject:c.inject ~project:c.project
         | None, Some t ->
-            Wire.default ~tag:t c.inner.typ ~inject:c.inject ~project:c.project
+            (* The composer's default branch ignores the matched tag and always
+               re-encodes the fixed [t], so adapt to the tag-aware API. *)
+            Wire.default c.inner.typ
+              ~inject:(fun _tag w -> c.inject w)
+              ~project:(fun a -> Option.map (fun w -> (t, w)) (c.project a))
         | None, None ->
             invalid_arg "casetype_u8: case must supply ~index or ~tag")
       cases

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -31,36 +31,19 @@ let setter_off_int32 n set buf off v =
   set buf off (Int32.of_int v);
   off + n
 
-let rec encode_case_match : type k w.
-    (bytes -> int -> k -> int) ->
-    k option ->
-    k option ->
-    w typ ->
-    w ->
-    bytes ->
-    int ->
-    int =
- fun tag_enc cb_tag cb_default_tag cb_inner body buf off ->
-  let t =
-    match (cb_tag, cb_default_tag) with
-    | Some t, _ | _, Some t -> t
-    | None, None -> failwith "build_field_encoder: case missing tag"
-  in
-  let off' = tag_enc buf off t in
-  build_field_encoder cb_inner buf off' body
-
-and build_casetype_encoder : type a k.
+let rec build_casetype_encoder : type a k.
     k typ -> (a, k) case_branch list -> bytes -> int -> a -> int =
  fun tag cases ->
   let tag_enc = build_field_encoder tag in
   let rec find buf off v = function
     | [] -> failwith "build_field_encoder: casetype: no matching case"
-    | Case_branch { cb_tag; cb_default_tag; cb_inner; cb_project; _ } :: rest
-      -> (
+    | Case_branch { cb_inner; cb_project; _ } :: rest -> (
+        (* [cb_project] yields the tag to write (its fixed index for an explicit
+           case, or the value-carried tag for the default) and the body. *)
         match cb_project v with
-        | Some body ->
-            encode_case_match tag_enc cb_tag cb_default_tag cb_inner body buf
-              off
+        | Some (t, body) ->
+            let off' = tag_enc buf off t in
+            build_field_encoder cb_inner buf off' body
         | None -> find buf off v rest)
   in
   fun buf off v -> find buf off v cases
@@ -1038,9 +1021,9 @@ let rec read_elem : type a. a typ -> bytes -> int -> a =
             raise (Parse_error (Constraint_failed "casetype: no matching case"))
         | Case_branch { cb_tag = Some t; cb_inner; cb_inject; _ } :: _
           when t = tag_val ->
-            cb_inject (read_elem cb_inner buf body_off)
+            cb_inject tag_val (read_elem cb_inner buf body_off)
         | Case_branch { cb_tag = None; cb_inner; cb_inject; _ } :: _ ->
-            cb_inject (read_elem cb_inner buf body_off)
+            cb_inject tag_val (read_elem cb_inner buf body_off)
         | _ :: rest -> find rest
       in
       find cases

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -160,12 +160,16 @@ and _ typ =
 and ('a, 'k) case_branch =
   | Case_branch : {
       cb_tag : 'k option;
-      cb_default_tag : 'k option;
-          (* Encode-time tag for the default branch ([cb_tag = None]).
-             [None] means encoding this branch is unsupported. *)
+          (* Decode-match tag: [Some t] for an explicit case, [None] for the
+             default branch (matches any unclaimed tag). *)
       cb_inner : 'w typ;
-      cb_inject : 'w -> 'a;
-      cb_project : 'a -> 'w option;
+      cb_inject : 'k -> 'w -> 'a;
+          (* Receives the matched tag (so a default branch can recover the
+             actual tag it caught) and the decoded body. *)
+      cb_project : 'a -> ('k * 'w) option;
+          (* Yields the tag to encode and the body. An explicit case pairs its
+             own fixed tag; the default branch yields the tag carried by the
+             value, so an arbitrary unclaimed tag round-trips. *)
     }
       -> ('a, 'k) case_branch
 
@@ -527,10 +531,9 @@ type ('a, 'k) case_def =
     }
       -> ('a, 'k) case_def
   | Default_def : {
-      dd_tag : 'k;
       dd_inner : 'w typ;
-      dd_inject : 'w -> 'a;
-      dd_project : 'a -> 'w option;
+      dd_inject : 'k -> 'w -> 'a;
+      dd_project : 'a -> ('k * 'w) option;
     }
       -> ('a, 'k) case_def
 
@@ -543,35 +546,36 @@ let case ?index inner ~inject ~project =
       cd_project = project;
     }
 
-let default ~tag inner ~inject ~project =
-  Default_def
-    { dd_tag = tag; dd_inner = inner; dd_inject = inject; dd_project = project }
+let default inner ~inject ~project =
+  Default_def { dd_inner = inner; dd_inject = inject; dd_project = project }
 
 let casetype name tag defs =
   let resolve = function
     | Case_def { cd_index; cd_inner; cd_inject; cd_project } ->
         reject_decoration ~combinator:"casetype" cd_inner;
-        let cb_tag =
+        let tag_val =
           match cd_index with
-          | Some _ as k -> k
+          | Some k -> k
           | None ->
               invalid_arg
                 "Wire.casetype: every case must supply an explicit [~index]"
         in
         Case_branch
           {
-            cb_tag;
-            cb_default_tag = None;
+            cb_tag = Some tag_val;
+            (* [case] knows its tag from [~index], so its [inject] takes only the
+               body and its [project] yields only the body; pair the fixed tag
+               back on for the unified tag-aware branch. *)
             cb_inner = cd_inner;
-            cb_inject = cd_inject;
-            cb_project = cd_project;
+            cb_inject = (fun _matched body -> cd_inject body);
+            cb_project =
+              (fun a -> Option.map (fun w -> (tag_val, w)) (cd_project a));
           }
-    | Default_def { dd_tag; dd_inner; dd_inject; dd_project } ->
+    | Default_def { dd_inner; dd_inject; dd_project } ->
         reject_decoration ~combinator:"casetype" dd_inner;
         Case_branch
           {
             cb_tag = None;
-            cb_default_tag = Some dd_tag;
             cb_inner = dd_inner;
             cb_inject = dd_inject;
             cb_project = dd_project;
@@ -1673,7 +1677,7 @@ let rec size_of_typ_value : type a. a typ -> a -> int =
         | [] -> tag_size
         | Case_branch { cb_inner; cb_project; _ } :: rest -> (
             match cb_project v with
-            | Some body -> tag_size + size_of_typ_value cb_inner body
+            | Some (_tag, body) -> tag_size + size_of_typ_value cb_inner body
             | None -> find rest)
       in
       find cases

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -196,10 +196,9 @@ and _ typ =
 and ('a, 'k) case_branch =
   | Case_branch : {
       cb_tag : 'k option;
-      cb_default_tag : 'k option;
       cb_inner : 'w typ;
-      cb_inject : 'w -> 'a;
-      cb_project : 'a -> 'w option;
+      cb_inject : 'k -> 'w -> 'a;
+      cb_project : 'a -> ('k * 'w) option;
     }
       -> ('a, 'k) case_branch
 
@@ -539,15 +538,16 @@ val case :
 (** A branch matching a specific tag value. *)
 
 val default :
-  tag:'k ->
   'w typ ->
-  inject:('w -> 'a) ->
-  project:('a -> 'w option) ->
+  inject:('k -> 'w -> 'a) ->
+  project:('a -> ('k * 'w) option) ->
   ('a, 'k) case_def
-(** [default ~tag inner ~inject ~project] is the default branch of a casetype.
-    [~tag] is the discriminator value the encoder writes when projecting this
-    branch back to bytes; on decode the default branch still matches any tag the
-    explicit cases didn't claim. *)
+(** [default inner ~inject ~project] is the default branch of a casetype. On
+    decode it matches any tag the explicit cases didn't claim, and [inject]
+    receives that matched tag together with the decoded body, so the value can
+    record which unclaimed tag it caught. On encode, [project] yields the tag to
+    write back along with the body, so an arbitrary unclaimed tag round-trips
+    (there is no fixed encode tag). *)
 
 val casetype : string -> 'k typ -> ('a, 'k) case_def list -> 'a typ
 (** [casetype name tag defs] is a tag-dispatched union. Every case must supply

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -328,11 +328,11 @@ and parse_casetype : type a k.
     | Case_branch { cb_tag = Some expected; cb_inner; cb_inject; _ } :: rest ->
         if expected = tag_val then
           let body, off'' = parse_direct cb_inner buf off' len in
-          (cb_inject body, off'')
+          (cb_inject tag_val body, off'')
         else find_case rest
     | Case_branch { cb_tag = None; cb_inner; cb_inject; _ } :: _ ->
         let body, off'' = parse_direct cb_inner buf off' len in
-        (cb_inject body, off'')
+        (cb_inject tag_val body, off'')
   in
   find_case cases
 
@@ -635,15 +635,9 @@ and encode_casetype : type a k.
  fun tag cases v enc ->
   let rec find_case = function
     | [] -> failwith "casetype encoding: no matching case"
-    | Case_branch { cb_tag; cb_default_tag; cb_inner; cb_project; _ } :: rest
-      -> (
+    | Case_branch { cb_inner; cb_project; _ } :: rest -> (
         match cb_project v with
-        | Some body ->
-            let t =
-              match (cb_tag, cb_default_tag) with
-              | Some t, _ | _, Some t -> t
-              | None, None -> failwith "casetype encoding: case missing tag"
-            in
+        | Some (t, body) ->
             encode_into tag t enc;
             encode_into cb_inner body enc
         | None -> find_case rest)

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -671,16 +671,18 @@ val case :
 (** Tagged branch of a casetype. *)
 
 val default :
-  tag:'k ->
   'w typ ->
-  inject:('w -> 'a) ->
-  project:('a -> 'w option) ->
+  inject:('k -> 'w -> 'a) ->
+  project:('a -> ('k * 'w) option) ->
   ('a, 'k) case_def
-(** [default ~tag inner ~inject ~project] is the default branch of a casetype.
+(** [default inner ~inject ~project] is the default branch of a casetype.
 
-    The decoder uses the default branch when no [~index]-tagged case matches.
-    The encoder writes [~tag] when projecting the default variant back to bytes.
-*)
+    The decoder uses it when no [~index]-tagged case matches, passing the
+    matched tag to [inject] (so the decoded value can recover which unclaimed
+    tag it caught) together with the decoded body. The encoder writes the tag
+    [project] returns, so an arbitrary unclaimed tag round-trips, e.g. for DHCP
+    options: [inject = (fun code body -> Other (code, body))] and
+    [project = (function Other (c, d) -> Some (c, d) | _ -> None)]. *)
 
 val casetype : string -> 'k typ -> ('a, 'k) case_def list -> 'a typ
 (** [casetype name tag defs] is a tag-dispatched union. The discriminator typ

--- a/test/3d/test_wire_3d.ml
+++ b/test/3d/test_wire_3d.ml
@@ -178,9 +178,9 @@ let e2e_casetype_codec =
         case ~index:1 uint16
           ~inject:(fun v -> `U16 v)
           ~project:(function `U16 v -> Some v | _ -> None);
-        default ~tag:0xFF uint8
-          ~inject:(fun v -> `Default v)
-          ~project:(function `Default v -> Some v | _ -> None);
+        default uint8
+          ~inject:(fun _tag v -> `Default v)
+          ~project:(function `Default v -> Some (0xFF, v) | _ -> None);
       ]
   in
   let f = Field.v "msg" body in
@@ -201,9 +201,9 @@ let e2e_ssh_casetype_codec =
         case ~index:"publickey" uint8
           ~inject:(fun v -> `Publickey v)
           ~project:(function `Publickey v -> Some v | _ -> None);
-        default ~tag:"xxxxxxxxx" uint8
-          ~inject:(fun v -> `Other v)
-          ~project:(function `Other v -> Some v | _ -> None);
+        default uint8
+          ~inject:(fun _tag v -> `Other v)
+          ~project:(function `Other v -> Some ("xxxxxxxxx", v) | _ -> None);
       ]
   in
   let f = Field.v "method" body in

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -3395,9 +3395,9 @@ let casetype_field_event_typ : ev_payload Wire.typ =
       Wire.case ~index:2 Wire.uint32be
         ~inject:(fun v -> `Logout v)
         ~project:(function `Logout v -> Some v | _ -> None);
-      Wire.default ~tag:0xFF Wire.uint8
-        ~inject:(fun v -> `Other v)
-        ~project:(function `Other v -> Some v | _ -> None);
+      Wire.default Wire.uint8
+        ~inject:(fun _tag v -> `Other v)
+        ~project:(function `Other v -> Some (0xFF, v) | _ -> None);
     ]
 
 type ev_event = { ev_ts : int64; ev_data : ev_payload }
@@ -3435,6 +3435,38 @@ let test_casetype_field_default () =
   Bytes.set_uint8 buf 9 7;
   let r = decode_ok (Codec.decode casetype_field_codec buf 0) in
   Alcotest.(check bool) "Other 7" true (r.ev_data = `Other 7)
+
+(* The default branch recovers the matched tag and re-encodes it, so an
+   arbitrary unclaimed tag round-trips (the DHCP / TCP-options shape). *)
+type tlv = Known of int | Unknown of (int * string)
+
+let tlv_typ : tlv Wire.typ =
+  Wire.casetype "Tlv" Wire.uint8
+    [
+      Wire.case ~index:1 Wire.uint16be
+        ~inject:(fun v -> Known v)
+        ~project:(function Known v -> Some v | _ -> None);
+      Wire.default
+        (Wire.byte_array ~size:(int 2))
+        ~inject:(fun tag body -> Unknown (tag, body))
+        ~project:(function Unknown (t, b) -> Some (t, b) | _ -> None);
+    ]
+
+let tlv_codec =
+  Codec.v "Tlv" (fun x -> x) Codec.[ (Field.v "v" tlv_typ $ fun x -> x) ]
+
+let test_casetype_default_recovers_tag () =
+  let v = Unknown (0x42, "ab") in
+  let buf = Bytes.create (Codec.size_of_value tlv_codec v) in
+  Codec.encode tlv_codec v buf 0;
+  Alcotest.(check int)
+    "encode writes the captured tag" 0x42 (Bytes.get_uint8 buf 0);
+  match Codec.decode tlv_codec buf 0 with
+  | Ok (Unknown (t, b)) ->
+      Alcotest.(check int) "decode recovers the tag" 0x42 t;
+      Alcotest.(check string) "decode body" "ab" b
+  | Ok _ -> Alcotest.fail "expected Unknown"
+  | Error e -> Alcotest.failf "decode: %a" pp_parse_error e
 
 let test_casetype_field_roundtrip () =
   let buf = Bytes.create 11 in
@@ -4565,6 +4597,8 @@ let suite =
         test_casetype_field_logout;
       Alcotest.test_case "casetype field: default" `Quick
         test_casetype_field_default;
+      Alcotest.test_case "casetype default recovers matched tag" `Quick
+        test_casetype_default_recovers_tag;
       Alcotest.test_case "casetype field: roundtrip" `Quick
         test_casetype_field_roundtrip;
       Alcotest.test_case "casetype field: size_of_value" `Quick


### PR DESCRIPTION
A casetype decodes a tag, then dispatches; the default branch catches any tag with no explicit `~index`. But it handed `inject` only the decoded body, never the matched tag, and on encode always wrote the one fixed `~tag`. So a default branch could not recover the actual unclaimed tag it caught, nor re-emit it: an `Other code` variant lost `code`, and re-encoding wrote the placeholder tag.

`Wire.default` now drops `~tag` and threads the discriminator both ways: `inject` is `'k -> 'w -> 'a` (matched tag + body) and `project` is `'a -> ('k * 'w) option` (the tag to write + body). An arbitrary unclaimed tag now round-trips. DHCP / TCP option TLVs become a clean casetype: `inject = (fun code body -> Other (code, body))`, `project = (function Other (c, d) -> Some (c, d) | _ -> None)`.

Callers migrate by taking the tag in `inject` (`fun _tag body -> ...` to ignore it) and pairing it in `project`. A regression test round-trips an arbitrary tag (`0x42`) through the default branch, asserting both that decode recovers it and encode writes it back.