### PR TITLE
codec: read an optional_or field's value in cross-field sizes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -77,6 +77,11 @@
 
 ### Fixed
 
+- A `byte_array` / `byte_slice` (or any field) whose `~size` reads a
+  `Field.optional_or` field no longer resolves that size to 0. The optional_or
+  field exposed a const-0 reader to cross-field size/offset expressions, so the
+  span decoded as empty (silent truncation) and `Codec.encode` raised a length
+  mismatch. It now reads the present-or-default value (#101, @samoht)
 - A `Wire.nested` / `Wire.nested_at_most` field now projects to a schema
   EverParse accepts. It previously emitted an extern setter typed
   `UINT8[:byte-size-single-element-array N]`, which is not valid 3D, so any

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -1430,13 +1430,16 @@ let next_off_pos : next_off -> bytes -> int -> int = function
 
 let optional_compiled : type a r.
     layout_ctx ->
+    ?int_reader:(bytes -> int -> int) ->
     raw_reader:(bytes -> int -> a) ->
     raw_writer:(r -> bytes -> int -> int -> int) ->
     size_delta:int ->
     next_off:next_off ->
     populate:(int array -> bytes -> int -> unit) ->
+    unit ->
     (a, r) compiled_field =
- fun ctx ~raw_reader ~raw_writer ~size_delta ~next_off ~populate ->
+ fun ctx ?(int_reader = null_int_reader) ~raw_reader ~raw_writer ~size_delta
+     ~next_off ~populate () ->
   {
     raw_reader;
     raw_writer;
@@ -1445,7 +1448,11 @@ let optional_compiled : type a r.
     size_delta;
     next_off;
     bf_after = None;
-    int_reader = null_int_reader;
+    (* [int_reader] is the entry cross-field size/offset expressions read this
+       field through. For an [optional_or] with an int inner it must read the
+       present-or-default value, not the [null_int_reader] const 0 that left a
+       byte_array sized by an optional_or field resolving to length 0. *)
+    int_reader;
     nested_readers = [];
     validator_off = validator_off_of ctx;
     populate;
@@ -1874,12 +1881,12 @@ and compile_optional : type a r.
           | None -> write_off + fsize)
         ~size_delta:fsize
         ~next_off:(advance_next_off ctx.next_off fsize)
-        ~populate:inner_populate
+        ~populate:inner_populate ()
   | Bool false, _ ->
       optional_compiled ctx
         ~raw_reader:(fun _buf _base -> None)
         ~raw_writer:(fun _v _buf _base write_off -> write_off)
-        ~size_delta:0 ~next_off:ctx.next_off ~populate:no_populate
+        ~size_delta:0 ~next_off:ctx.next_off ~populate:no_populate ()
   | _, Some fsize ->
       let present_fn = compile_bool_expr ctx.field_readers present in
       let inner_reader, inner_writer = inner_codec_accessors inner ctx in
@@ -1904,6 +1911,7 @@ and compile_optional : type a r.
         ~next_off:(dynamic_optional_next_off ctx present_fn fsize)
         ~populate:(fun arr buf base ->
           if present_fn buf base then inner_populate arr buf base)
+        ()
   | _ -> compile_optional_variable ctx fld present inner
 
 (* Variable-size inner: compile it as its own field and gate that compiled plan
@@ -1936,8 +1944,6 @@ and compile_optional_variable : type a r.
     }
   in
   let cf = compile_field ctx inner_fld in
-  let present_end = next_off_pos cf.next_off in
-  let absent_end = next_off_pos ctx.next_off in
   optional_compiled ctx
     ~raw_reader:(fun buf base ->
       if present_fn buf base then Some (cf.raw_reader buf base) else None)
@@ -1956,10 +1962,11 @@ and compile_optional_variable : type a r.
     ~next_off:
       (Dynamic
          (fun buf base ->
-           if present_fn buf base then present_end buf base
-           else absent_end buf base))
+           if present_fn buf base then next_off_pos cf.next_off buf base
+           else next_off_pos ctx.next_off buf base))
     ~populate:(fun arr buf base ->
       if present_fn buf base then cf.populate arr buf base)
+    ()
 
 and compile_optional_or : type a r.
     layout_ctx ->
@@ -1976,16 +1983,19 @@ and compile_optional_or : type a r.
       let get = fld.get in
       let populate = build_populate fld.typ ctx.n_fields inner_reader in
       optional_compiled ctx ~raw_reader:inner_reader
+        ~int_reader:(fun buf base ->
+          int_of_typ_value inner (inner_reader buf base))
         ~raw_writer:(fun v buf _base write_off ->
           inner_writer buf write_off (get v))
         ~size_delta:fsize
         ~next_off:(advance_next_off ctx.next_off fsize)
-        ~populate
+        ~populate ()
   | Bool false, _ ->
       optional_compiled ctx
         ~raw_reader:(fun _buf _base -> default)
+        ~int_reader:(fun _buf _base -> int_of_typ_value inner default)
         ~raw_writer:(fun _v _buf _base write_off -> write_off)
-        ~size_delta:0 ~next_off:ctx.next_off ~populate:no_populate
+        ~size_delta:0 ~next_off:ctx.next_off ~populate:no_populate ()
   | _, Some fsize ->
       let present_fn = compile_bool_expr ctx.field_readers present in
       let inner_reader, inner_writer = inner_codec_accessors inner ctx in
@@ -2004,9 +2014,12 @@ and compile_optional_or : type a r.
       let raw_writer v buf _base write_off =
         inner_writer buf write_off (get v)
       in
-      optional_compiled ctx ~raw_reader ~raw_writer ~size_delta:fsize
+      optional_compiled ctx ~raw_reader
+        ~int_reader:(fun buf base ->
+          int_of_typ_value inner (raw_reader buf base))
+        ~raw_writer ~size_delta:fsize
         ~next_off:(advance_next_off ctx.next_off fsize)
-        ~populate
+        ~populate ()
   | _ -> compile_optional_or_variable ctx fld present inner default
 
 (* Variable-size inner. As in the fixed case [optional_or] is value-driven and
@@ -2035,7 +2048,8 @@ and compile_optional_or_variable : type a r.
     ~raw_reader:(fun buf base ->
       if present_fn buf base then cf.raw_reader buf base else default)
     ~raw_writer:(fun v buf base write_off -> cf.raw_writer v buf base write_off)
-    ~size_delta:0 ~next_off:cf.next_off ~populate:cf.populate
+    ~int_reader:cf.int_reader ~size_delta:0 ~next_off:cf.next_off
+    ~populate:cf.populate ()
 
 (* -- Apply a compiled plan to the record state -- *)
 

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -2810,6 +2810,41 @@ let test_optional_absent_roundtrip () =
   Alcotest.(check (option int)) "payload" original.payload decoded.payload;
   Alcotest.(check int) "trail" original.trail decoded.trail
 
+(* A byte_array whose ~size reads an optional_or field. The size expression
+   used to resolve to 0 (the optional_or's int_reader was a const 0), so encode
+   raised a length mismatch and decode silently truncated the span to empty.
+   It now reads the present-or-default value. *)
+let test_bytearray_sized_by_optional_or () =
+  let f_gate = Field.v "gate" uint8 in
+  let f_len =
+    Field.optional_or "len"
+      ~present:Expr.(Field.ref f_gate <> int 0)
+      ~default:3 uint8
+  in
+  let f_data = Field.v "data" (byte_array ~size:(Field.ref f_len)) in
+  let c =
+    Codec.v "OoSized"
+      (fun gate len data -> (gate, len, data))
+      Codec.
+        [
+          (f_gate $ fun (g, _, _) -> g);
+          (f_len $ fun (_, l, _) -> l);
+          (f_data $ fun (_, _, d) -> d);
+        ]
+  in
+  let rt v expected =
+    let buf = Bytes.create (Codec.size_of_value c v) in
+    Codec.encode c v buf 0;
+    Alcotest.(check string) "encoded bytes" expected (Bytes.to_string buf);
+    match Codec.decode c buf 0 with
+    | Ok d -> Alcotest.(check bool) "round-trip" true (d = v)
+    | Error e -> Alcotest.failf "decode: %a" pp_parse_error e
+  in
+  (* gate set: len present (2), data is 2 bytes *)
+  rt (1, 2, "ab") "\x01\x02ab";
+  (* gate clear: len falls back to the default (3), data is 3 bytes *)
+  rt (0, 3, "xyz") "\x00\x03xyz"
+
 let test_optional_wire_size_present () =
   Alcotest.(check int) "wire_size present" 4 (Codec.wire_size opt_codec_present)
 
@@ -4546,6 +4581,8 @@ let suite =
         test_optional_wire_size_present;
       Alcotest.test_case "optional: wire_size absent" `Quick
         test_optional_wire_size_absent;
+      Alcotest.test_case "byte_array sized by optional_or field" `Quick
+        test_bytearray_sized_by_optional_or;
       Alcotest.test_case "optional: codec present" `Quick
         test_optional_codec_present;
       Alcotest.test_case "optional: codec absent" `Quick


### PR DESCRIPTION
Two commits.

`d75aafc1` is the fix. A `byte_array` / `byte_slice` whose `~size` reads a `Field.optional_or` field resolved that size to 0: cross-field size and offset expressions read a field through its `int_reader`, but `optional_compiled` hardwired `null_int_reader` (const 0) for every optional and optional_or field. So a span sized by an optional_or field decoded as empty (silent truncation) and `Codec.encode` raised `byte field length N does not match expected 0`. The optional_or path now exposes an int reader over its present-or-default value.

`0c34e4f1` extends `fuzz_gen` so this class is caught in future: `sized_cases` round-trips a length/data codec whose byte span is sized by a cross-field reference to a preceding length field, over several int-valued size-source field types (scalar, mapped, static optional_or, refined). The composer only ever sized byte spans by a constant or by a plain uint16 repeat budget, so the optional_or-as-size-source class was outside its generated space.

Regression tests: a unit test round-trips an optional_or-sized byte_array in the present and default cases, and the optional_or `sized_cases` entry fails without the fix.