### PR TITLE
codec: zeroterm case body in a repeated casetype

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -77,6 +77,13 @@
 
 ### Fixed
 
+- A `Wire.casetype` whose case body is a NUL-terminated string (`zeroterm` or
+  `zeroterm_at_most`) now encodes, decodes, and sizes correctly as a
+  `Field.repeat` element. The element encoder had no `zeroterm` case (so encode
+  raised `Failure "unsupported type"`), the element decoder no
+  `zeroterm_at_most` case, and the element sizer reported "cannot determine
+  element size", so a list of such tag-dispatched options could not round-trip
+  (#103, @samoht)
 - A `byte_array` / `byte_slice` (or any field) whose `~size` reads a
   `Field.optional_or` field no longer resolves that size to 0. The optional_or
   field exposed a const-0 reader to cross-field size/offset expressions, so the

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -136,6 +136,28 @@ and build_field_encoder : type a. a typ -> bytes -> int -> a -> int =
         let cur = Stdlib.ref start_off in
         s.iter (fun v -> cur := enc_elem buf !cur v) vs;
         !cur
+  (* NUL-terminated string element / casetype case body: the bytes then a NUL.
+     [zeroterm_at_most] pads the rest of its fixed [n]-byte region with zeros. *)
+  | Zeroterm ->
+      fun buf off v ->
+        let n = String.length v in
+        if String.contains v '\000' then
+          invalid_arg "Codec.encode: zeroterm string contains a NUL byte";
+        Bytes.blit_string v 0 buf off n;
+        Bytes.set_uint8 buf (off + n) 0;
+        off + n + 1
+  | Zeroterm_at_most { size = Int region } ->
+      fun buf off v ->
+        let n = String.length v in
+        if String.contains v '\000' then
+          invalid_arg "Codec.encode: zeroterm string contains a NUL byte";
+        if n + 1 > region then
+          Fmt.invalid_arg
+            "Codec.encode: zeroterm string needs %d bytes but region is %d"
+            (n + 1) region;
+        Bytes.blit_string v 0 buf off n;
+        Bytes.fill buf (off + n) (region - n) '\x00';
+        off + region
   | _ ->
       (* Fallback for complex types - not specialized *)
       fun _buf _off _v -> failwith "build_field_encoder: unsupported type"
@@ -1032,6 +1054,11 @@ let rec read_elem : type a. a typ -> bytes -> int -> a =
   | Zeroterm ->
       let nul = zeroterm_nul_pos buf ~first:off ~limit:(Bytes.length buf) in
       Bytes.sub_string buf off (nul - off)
+  (* Same, bounded to a fixed [n]-byte region (the element spans the whole
+     region; the value is the bytes up to the NUL within it). *)
+  | Zeroterm_at_most { size = Int n } ->
+      let nul = zeroterm_nul_pos buf ~first:off ~limit:(off + n) in
+      Bytes.sub_string buf off (nul - off)
   (* Fixed-size byte spans as repeat / array elements: a list of n-byte
      chunks. The size is the element's own constant width. *)
   | Byte_array { size = Int n } -> Bytes.sub_string buf off n
@@ -1113,6 +1140,8 @@ let rec elem_size_of : type a. a typ -> bytes -> int -> int =
   | Zeroterm ->
       let nul = zeroterm_nul_pos buf ~first:off ~limit:(Bytes.length buf) in
       nul - off + 1
+  (* A bounded NUL-terminated string spans its whole fixed [n]-byte region. *)
+  | Zeroterm_at_most { size = Int n } -> n
   | _ -> (
       match field_wire_size typ with
       | Some n -> n

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -4248,6 +4248,47 @@ let test_repeat_casetype_empty () =
   let opts = decode_ok (Codec.decode dhcp_codec buf 0) in
   Alcotest.(check int) "empty" 0 (List.length opts)
 
+(* A casetype case body that is a NUL-terminated string bounded to a fixed
+   region ([zeroterm_at_most]), used as a repeat element. read_elem,
+   build_field_encoder, and elem_size_of all lacked the zeroterm_at_most case,
+   so encode raised "unsupported type" and sizing raised "cannot determine
+   element size". *)
+type zt_opt = Str of string | Num of int
+
+let zt_opt_typ : zt_opt typ =
+  casetype "ZtOpt" uint8
+    [
+      case ~index:1
+        (zeroterm_at_most ~size:(int 6))
+        ~inject:(fun s -> Str s)
+        ~project:(function Str s -> Some s | _ -> None);
+      case ~index:2 uint8
+        ~inject:(fun n -> Num n)
+        ~project:(function Num n -> Some n | _ -> None);
+    ]
+
+let zt_opt_size = function Str _ -> 1 + 6 | Num _ -> 1 + 1
+let zt_f_total = Field.v "total" uint16be
+let zt_f_opts = Field.repeat "opts" ~size:(Field.ref zt_f_total) zt_opt_typ
+
+let zt_codec =
+  Codec.v "ZtOpts"
+    (fun _t xs -> xs)
+    Codec.
+      [
+        ( zt_f_total $ fun xs ->
+          List.fold_left (fun a o -> a + zt_opt_size o) 0 xs );
+        (zt_f_opts $ fun xs -> xs);
+      ]
+
+let test_repeat_casetype_zeroterm_at_most () =
+  let v = [ Str "hi"; Num 7; Str "" ] in
+  let buf = Bytes.create (Codec.size_of_value zt_codec v) in
+  Codec.encode zt_codec v buf 0;
+  Alcotest.(check bool)
+    "roundtrip" true
+    (decode_ok (Codec.decode zt_codec buf 0) = v)
+
 (* -- Zero-terminated strings ([zeroterm] / [zeroterm_at_most]) -- *)
 
 type zt_rec = { zt_name : string; zt_tag : string; zt_n : int }
@@ -4660,6 +4701,8 @@ let suite =
         test_repeat_casetype_roundtrip;
       Alcotest.test_case "repeat: casetype TLV empty" `Quick
         test_repeat_casetype_empty;
+      Alcotest.test_case "repeat: casetype with zeroterm_at_most case" `Quick
+        test_repeat_casetype_zeroterm_at_most;
       (* zero-terminated strings *)
       Alcotest.test_case "zeroterm: roundtrip" `Quick test_zeroterm_roundtrip;
       Alcotest.test_case "zeroterm: empty" `Quick test_zeroterm_empty;


### PR DESCRIPTION
A `Wire.casetype` whose case body is a NUL-terminated string (`zeroterm` or `zeroterm_at_most`) could not be used as a `Field.repeat` element. The three repeat-element handlers each had a hole: the encoder (`build_field_encoder`) had no `zeroterm` case at all, so encode raised `Failure "build_field_encoder: unsupported type"`; the decoder (`read_elem`) had `zeroterm` but no `zeroterm_at_most`; and the sizer (`elem_size_of`) had `zeroterm` but no `zeroterm_at_most`, reporting "cannot determine element size". So a list of tag-dispatched options where one case is a bounded C-string could not round-trip, even though the casetype projects to 3D fine.

Adds the missing cases, mirroring the field-level encode/decode/size semantics (string then NUL; `zeroterm_at_most` pads its fixed region with zeros). A regression test round-trips a repeated casetype mixing a `zeroterm_at_most` case with a scalar case.

Surfaced by the nested-composition fuzzer (the `ct:zt6|enum` shape).