### PR TITLE
codec: bitfield casetype case bodies as repeat elements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ### Added
 
+- A `Wire.casetype` used as a `Field.repeat` element may now have a case body
+  that is a bitfield, alongside the scalar, byte-span, NUL-terminated, and
+  sub-codec bodies already allowed. Such a casetype previously failed at
+  decode (#105, @samoht)
 - `Field.optional` and `Field.optional_or` now accept a variable-size inner,
   so an optional field can be a length-prefixed string or a whole sub-message,
   not just a fixed-width value. Building such a codec previously raised
@@ -38,6 +42,10 @@
 
 ### Changed
 
+- `Field.repeat` and `Wire.array` over a `Wire.casetype` now raise
+  `Invalid_argument` at construction when a case body has no per-element
+  projection (a nested region, array, or optional), instead of building a
+  codec that fails later at decode (#105, @samoht)
 - `Wire.default` (a casetype's default branch) no longer takes a fixed `~tag`;
   instead it threads the matched discriminator through `inject` and `project`,
   so an arbitrary unclaimed tag round-trips. `inject` is now `'k -> 'w -> 'a`

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -31,6 +31,18 @@ let setter_off_int32 n set buf off v =
   set buf off (Int32.of_int v);
   off + n
 
+(* Encode a lone bitfield occupying its base word: range-check, place the value
+   at its bit offset, advance by the base width. *)
+let bits_field_encoder ~width ~base ~bit_order buf off v =
+  let total = Bitfield.total_bits base in
+  let shift = Bitfield.shift ~bit_order ~total ~bits_used:0 ~width in
+  let mask = (1 lsl width) - 1 in
+  if v land lnot mask <> 0 then
+    Fmt.invalid_arg "Codec.encode: value 0x%X exceeds %d-bit field width" v
+      width;
+  Bitfield.write_word base buf off ((v land mask) lsl shift);
+  off + Bitfield.byte_size base
+
 let rec build_casetype_encoder : type a k.
     k typ -> (a, k) case_branch list -> bytes -> int -> a -> int =
  fun tag cases ->
@@ -158,6 +170,10 @@ and build_field_encoder : type a. a typ -> bytes -> int -> a -> int =
         Bytes.blit_string v 0 buf off n;
         Bytes.fill buf (off + n) (region - n) '\x00';
         off + region
+  (* A lone bitfield (e.g. a casetype case body) occupies its whole base word;
+     write the value at its bit offset into an otherwise-zero word. *)
+  | Bits { width; base; bit_order } ->
+      bits_field_encoder ~width ~base ~bit_order
   | _ ->
       (* Fallback for complex types - not specialized *)
       fun _buf _off _v -> failwith "build_field_encoder: unsupported type"
@@ -1063,6 +1079,12 @@ let rec read_elem : type a. a typ -> bytes -> int -> a =
      chunks. The size is the element's own constant width. *)
   | Byte_array { size = Int n } -> Bytes.sub_string buf off n
   | Byte_slice { size = Int n } -> Slice.make buf ~first:off ~length:n
+  (* A lone bitfield occupies its base word; extract the value at its bit
+     offset. *)
+  | Bits { width; base; bit_order } ->
+      let total = bf_base_total_bits base in
+      let shift = Bitfield.shift ~bit_order ~total ~bits_used:0 ~width in
+      build_bf_reader base 0 shift width buf off
   | _ -> failwith "read_elem: unsupported element type in repeat"
 
 (* Write one element of a typ at a given buffer position. Used by Repeat. *)
@@ -1142,6 +1164,8 @@ let rec elem_size_of : type a. a typ -> bytes -> int -> int =
       nul - off + 1
   (* A bounded NUL-terminated string spans its whole fixed [n]-byte region. *)
   | Zeroterm_at_most { size = Int n } -> n
+  (* A lone bitfield occupies its base word. *)
+  | Bits { base; _ } -> bf_base_byte_size base
   | _ -> (
       match field_wire_size typ with
       | Some n -> n

--- a/lib/field.ml
+++ b/lib/field.ml
@@ -31,13 +31,40 @@ let optional_or name ?constraint_ ?self_constraint ?action ~present ~default typ
   v name ?constraint_ ?self_constraint ?action
     (Types.optional_or present ~default typ)
 
+(* Types decodable as a casetype case body inside a repeat: exactly the set
+   [Codec.read_elem] handles. Unlike a bare repeat element, a lone [bits] field
+   and a bounded [zeroterm_at_most] are allowed here, because the enclosing
+   casetype packs them after the tag with a fixed footprint. A nested [array] /
+   [nested] region or an [optional] has no fixed footprint and is rejected. *)
+let rec is_repeat_case_body : type a. a Types.typ -> bool =
+ fun typ ->
+  let open Types in
+  match typ with
+  | Uint8 | Uint16 _ | Uint32 _ | Uint63 _ | Uint64 _ | Int8 | Int16 _ | Int32 _
+  | Int64 _ | Float32 _ | Float64 _ | Unit | Zeroterm | Bits _ ->
+      true
+  | Uint_var { size = Int _; _ } -> true
+  | Byte_array { size = Int _ } | Byte_slice { size = Int _ } -> true
+  | Zeroterm_at_most { size = Int _ } -> true
+  | Codec _ -> true
+  | Casetype { cases; _ } ->
+      List.for_all
+        (fun (Case_branch { cb_inner; _ }) -> is_repeat_case_body cb_inner)
+        cases
+  | Map { inner; _ } -> is_repeat_case_body inner
+  | Where { inner; _ } -> is_repeat_case_body inner
+  | Enum { base; _ } -> is_repeat_case_body base
+  | _ -> false
+
 (* An element [repeat]/[repeat_seq] can both project to 3D and decode one
    element at a time: a fixed-width scalar / byte span, a NUL-terminated
    string, or a self-bounded sub-codec / casetype. [Map] / [Where] / [Enum]
-   are transparent wrappers, so look through them. Everything else (a sub-byte
-   [bits] field, a refined or at-most byte span whose per-element validation
-   the byte-budget loop does not run, greedy [all_zeros], a nested [array] /
-   [nested]) has no clean per-element 3D projection. *)
+   are transparent wrappers, so look through them. A casetype is repeatable
+   only when every case body is itself decodable as a repeat element
+   ([is_repeat_case_body]). Everything else (a sub-byte [bits] field, a refined
+   or at-most byte span whose per-element validation the byte-budget loop does
+   not run, greedy [all_zeros], a nested [array] / [nested]) has no clean
+   per-element 3D projection. *)
 let rec is_repeat_element : type a. a Types.typ -> bool =
  fun typ ->
   let open Types in
@@ -46,7 +73,11 @@ let rec is_repeat_element : type a. a Types.typ -> bool =
   | Int64 _ | Float32 _ | Float64 _ | Uint_var _ | Unit | Zeroterm ->
       true
   | Byte_array { size = Int _ } | Byte_slice { size = Int _ } -> true
-  | Codec _ | Casetype _ -> true
+  | Codec _ -> true
+  | Casetype { cases; _ } ->
+      List.for_all
+        (fun (Case_branch { cb_inner; _ }) -> is_repeat_case_body cb_inner)
+        cases
   | Map { inner; _ } -> is_repeat_element inner
   | Where { inner; _ } -> is_repeat_element inner
   | Enum { base; _ } -> is_repeat_element base

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -4289,6 +4289,64 @@ let test_repeat_casetype_zeroterm_at_most () =
     "roundtrip" true
     (decode_ok (Codec.decode zt_codec buf 0) = v)
 
+(* A casetype case body that is a lone bitfield, as a repeat element.
+   read_elem / build_field_encoder / elem_size_of lacked the Bits case, so the
+   casetype could not encode/decode as a repeat element. A bitfield case body
+   projects to 3D inside a repeated casetype (the casetype packs it into its
+   base word); a list of bare bitfields, by contrast, has no projection and is
+   rejected. *)
+type bf_opt = Bf of int | Raw of int
+
+let bf_opt_typ : bf_opt typ =
+  casetype "BfOpt" uint8
+    [
+      case ~index:1 (bits ~width:3 U8)
+        ~inject:(fun b -> Bf b)
+        ~project:(function Bf b -> Some b | _ -> None);
+      case ~index:2 uint8
+        ~inject:(fun v -> Raw v)
+        ~project:(function Raw v -> Some v | _ -> None);
+    ]
+
+let bf_f_total = Field.v "total" uint16be
+let bf_f_opts = Field.repeat "opts" ~size:(Field.ref bf_f_total) bf_opt_typ
+
+(* each case is a 1-byte body after the 1-byte tag *)
+let bf_codec =
+  Codec.v "BfOpts"
+    (fun _t xs -> xs)
+    Codec.
+      [
+        (bf_f_total $ fun xs -> List.length xs * 2); (bf_f_opts $ fun xs -> xs);
+      ]
+
+let test_repeat_casetype_bits_case () =
+  let v = [ Bf 5; Raw 9; Bf 0 ] in
+  let buf = Bytes.create (Codec.size_of_value bf_codec v) in
+  Codec.encode bf_codec v buf 0;
+  Alcotest.(check bool)
+    "roundtrip" true
+    (decode_ok (Codec.decode bf_codec buf 0) = v)
+
+(* A casetype is repeatable only when every case body decodes one element at a
+   time. A nested region case body has no per-element 3D projection inside a
+   repeat (EverParse cannot extract a single-element-array nested in a repeated
+   casetype), so the casetype is rejected at construction rather than failing
+   at decode. *)
+let test_repeat_casetype_unprojectable_case_rejected () =
+  let nested_case =
+    casetype "NestCaseOpt" uint8
+      [
+        case ~index:1
+          (nested ~size:(int 1) int8)
+          ~inject:(fun v -> `N v)
+          ~project:(function `N v -> Some v);
+      ]
+  in
+  Alcotest.(check bool)
+    "repeat over casetype with nested case body rejected" true
+    (raises_invalid (fun () -> Field.repeat "opts" ~size:(int 4) nested_case))
+
 (* -- Zero-terminated strings ([zeroterm] / [zeroterm_at_most]) -- *)
 
 type zt_rec = { zt_name : string; zt_tag : string; zt_n : int }
@@ -4703,6 +4761,10 @@ let suite =
         test_repeat_casetype_empty;
       Alcotest.test_case "repeat: casetype with zeroterm_at_most case" `Quick
         test_repeat_casetype_zeroterm_at_most;
+      Alcotest.test_case "repeat: casetype with bitfield case" `Quick
+        test_repeat_casetype_bits_case;
+      Alcotest.test_case "repeat: casetype with unprojectable case rejected"
+        `Quick test_repeat_casetype_unprojectable_case_rejected;
       (* zero-terminated strings *)
       Alcotest.test_case "zeroterm: roundtrip" `Quick test_zeroterm_roundtrip;
       Alcotest.test_case "zeroterm: empty" `Quick test_zeroterm_empty;


### PR DESCRIPTION
[Codec.read_elem](https://github.com/parsimoni-labs/ocaml-wire/blob/fix-casetype-case-bodies/lib/codec.ml#L1021) and its encode and size counterparts handle a casetype as a repeat element by dispatching on each case body, but they had no case for a bitfield body, so a `Wire.casetype` whose case is a `bits` field crashed at decode when used inside a `Field.repeat`. A bitfield body projects cleanly to 3D inside a repeated casetype (the casetype packs it after the tag into its base word), so the element handlers now encode, decode, and size it.

The same dispatch has no clean per-element projection for a case body that is a nested region, an array, or an optional: EverParse cannot extract a single-element-array nested in a repeated casetype. Rather than build a codec that fails at decode, [is_repeat_case_body](https://github.com/parsimoni-labs/ocaml-wire/blob/fix-casetype-case-bodies/lib/field.ml#L39) now rejects such a casetype at the `Field.repeat` and `Wire.array` call, raising `Invalid_argument`.