### PR TITLE
types: reject more non-projectable constructs at construction

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -97,6 +97,21 @@
   on the embedded path (only the buffer-size and field readers ran), so a
   value the sub-codec would reject standalone was accepted when embedded
   (#108, @samoht)
+- `Wire.array` / `Wire.array_seq` now reject a non-fixed-width element (a
+  `Wire.nested` region, a `Wire.byte_array_where` refined span, or a nested
+  `Wire.array`) at construction with `Invalid_argument`, instead of building a
+  codec that failed schema generation or raised `Failure` at decode. An array
+  projects as a count of fixed-size elements, so the element must be a scalar,
+  a fixed byte span, or a fixed-size sub-codec, matching `Field.repeat`'s
+  element rule (#107, @samoht)
+- `Field.optional` / `Field.optional_or` over a bitfield (`Wire.bits` /
+  `Wire.bit`) now raise `Invalid_argument` at construction. A bitfield has no
+  standalone wire form, so it cannot be conditionally present, matching the
+  existing `array` / `repeat` / `nested` behaviour (#107, @samoht)
+- `Wire.casetype` now rejects a bare greedy case body (`all_bytes` /
+  `all_zeros`) at construction. A greedy field reads the rest of the buffer and
+  has no determinate type for a `switch` case; wrap it in a sub-codec, which is
+  the supported form (#107, @samoht)
 - A `Wire.casetype` whose case body is a NUL-terminated string (`zeroterm` or
   `zeroterm_at_most`) now encodes, decodes, and sizes correctly as a
   `Field.repeat` element. The element encoder had no `zeroterm` case (so encode

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -401,11 +401,34 @@ let rec has_wire_size_expr : type a. a typ -> bool = function
   | Codec { codec_fixed_size; _ } -> codec_fixed_size <> None
   | _ -> false
 
-let reject_variable_size ~combinator t =
-  if not (has_wire_size_expr t) then
+(* An [array]/[array_seq] element must be fixed-width AND decodable one element
+   at a time by the array loop: a scalar, a fixed-size byte span, or a
+   fixed-size sub-codec. [Map]/[Where]/[Enum] are transparent wrappers, so look
+   through them. A [nested] region, a refined byte span ([byte_array_where]), a
+   nested [array], or a variable / self-delimiting inner has no array
+   projection (3D rejects it) and the decoder has no element reader, so they are
+   refused at construction. This is stricter than [has_wire_size_expr], which
+   admits sized-but-undecodable elements for the [optional] byte-size suffix. *)
+let rec is_array_element : type a. a typ -> bool = function
+  | Uint8 | Uint16 _ | Uint32 _ | Uint63 _ | Uint64 _ -> true
+  | Int8 | Int16 _ | Int32 _ | Int64 _ -> true
+  | Float32 _ | Float64 _ -> true
+  | Unit -> true
+  | Uint_var { size = Int _; _ } -> true
+  | Byte_array { size = Int _ } | Byte_slice { size = Int _ } -> true
+  | Codec { codec_fixed_size; _ } -> codec_fixed_size <> None
+  | Map { inner; _ } -> is_array_element inner
+  | Where { inner; _ } -> is_array_element inner
+  | Enum { base; _ } -> is_array_element base
+  | _ -> false
+
+let reject_non_array_element ~combinator t =
+  if not (is_array_element t) then
     Fmt.invalid_arg
-      "Wire.%s: inner type must expose a wire size -- 3D projects %s through a \
-       [byte-size] suffix that needs the element width."
+      "Wire.%s: element type is not a fixed-width array element -- 3D projects \
+       %s as a count of fixed-size elements (a scalar, a fixed byte span, or a \
+       fixed-size sub-codec); a nested region, refined span, or variable inner \
+       has no array projection."
       combinator combinator
 
 (* A self-delimiting inner carries its own length / structure, so it decodes a
@@ -448,16 +471,33 @@ let reject_bitfield_element ~combinator t =
        within an enclosing word); it cannot be an element of %s."
       combinator combinator
 
+(* A bare greedy field ([all_bytes] / [all_zeros]) reads "the rest of the
+   buffer". It has no 3D type of its own, so it only projects as the trailing
+   field of a struct or sub-codec, never as a casetype case body (the switch
+   case needs a determinate type) and never with a determinate element size. *)
+let rec is_greedy : type a. a typ -> bool = function
+  | All_bytes | All_zeros -> true
+  | Map { inner; _ } -> is_greedy inner
+  | Where { inner; _ } -> is_greedy inner
+  | Enum { base; _ } -> is_greedy base
+  | _ -> false
+
+let reject_greedy_case_body t =
+  if is_greedy t then
+    invalid_arg
+      "Wire.casetype: a case body cannot be a bare all_bytes / all_zeros \
+       greedy field; it has no determinate type. Wrap it in a sub-codec."
+
 let array ~len elem =
   reject_decoration ~combinator:"array" elem;
   reject_bitfield_element ~combinator:"array" elem;
-  reject_variable_size ~combinator:"array" elem;
+  reject_non_array_element ~combinator:"array" elem;
   Array { len; elem; seq = seq_list }
 
 let array_seq seq ~len elem =
   reject_decoration ~combinator:"array_seq" elem;
   reject_bitfield_element ~combinator:"array_seq" elem;
-  reject_variable_size ~combinator:"array_seq" elem;
+  reject_non_array_element ~combinator:"array_seq" elem;
   Array { len; elem; seq }
 
 let byte_array ~size = Byte_array { size }
@@ -484,10 +524,12 @@ let synth_name_of_elt_var ev =
 let byte_slice ~size = Byte_slice { size }
 
 let optional present inner =
+  reject_bitfield_element ~combinator:"optional" inner;
   reject_unprojectable_optional ~combinator:"optional" inner;
   Optional { present; inner }
 
 let optional_or present ~default inner =
+  reject_bitfield_element ~combinator:"optional_or" inner;
   reject_unprojectable_optional ~combinator:"optional_or" inner;
   Optional_or { present; inner; default }
 
@@ -566,6 +608,7 @@ let casetype name tag defs =
   let resolve = function
     | Case_def { cd_index; cd_inner; cd_inject; cd_project } ->
         reject_decoration ~combinator:"casetype" cd_inner;
+        reject_greedy_case_body cd_inner;
         let tag_val =
           match cd_index with
           | Some k -> k
@@ -586,6 +629,7 @@ let casetype name tag defs =
           }
     | Default_def { dd_inner; dd_inject; dd_project } ->
         reject_decoration ~combinator:"casetype" dd_inner;
+        reject_greedy_case_body dd_inner;
         Case_branch
           {
             cb_tag = None;

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -551,6 +551,55 @@ let test_optional_reject_unprojectable () =
     (raises_invalid (fun () ->
          Field.optional_or "x" ~present:Expr.true_ ~default:"" all_bytes))
 
+(* An [array] / [array_seq] element must be a fixed-width type the array loop
+   can read one element at a time. A [nested] region, a refined byte span, and
+   a nested array all carry a wire size but have no array projection and no
+   element reader, so they are refused at construction (unlike [repeat], whose
+   byte budget admits self-delimiting variable elements). *)
+let test_array_reject_nonprojectable_element () =
+  Alcotest.(check bool)
+    "array over nested rejected" true
+    (raises_invalid (fun () -> array ~len:(int 2) (nested ~size:(int 4) uint8)));
+  Alcotest.(check bool)
+    "array_seq over nested_at_most rejected" true
+    (raises_invalid (fun () ->
+         array_seq seq_list ~len:(int 2) (nested_at_most ~size:(int 4) uint8)));
+  Alcotest.(check bool)
+    "array over byte_array_where rejected" true
+    (raises_invalid (fun () ->
+         array ~len:(int 2)
+           (byte_array_where ~size:(int 2) ~per_byte:(fun _ -> Expr.true_))));
+  Alcotest.(check bool)
+    "array over array rejected" true
+    (raises_invalid (fun () -> array ~len:(int 2) (array ~len:(int 2) uint8)))
+
+(* A bitfield has no standalone wire form, so it cannot be an [optional] inner
+   any more than an [array] / [repeat] / [nested] element. *)
+let test_optional_reject_bitfield () =
+  Alcotest.(check bool)
+    "optional over bits rejected" true
+    (raises_invalid (fun () ->
+         Field.optional "x" ~present:Expr.true_ (bits ~width:3 U8)));
+  Alcotest.(check bool)
+    "optional_or over bits rejected" true
+    (raises_invalid (fun () ->
+         Field.optional_or "x" ~present:Expr.true_ ~default:0 (bits ~width:3 U8)))
+
+(* A bare greedy field ([all_bytes] / [all_zeros]) reads the rest of the buffer;
+   it has no determinate type, so it cannot be a casetype case body (a sub-codec
+   that ends in [all_bytes] is the supported form). *)
+let test_casetype_reject_greedy_case_body () =
+  let build inner =
+    casetype "Greedy" uint8
+      [ case ~index:1 inner ~inject:(fun s -> s) ~project:Option.some ]
+  in
+  Alcotest.(check bool)
+    "casetype with all_bytes case body rejected" true
+    (raises_invalid (fun () -> build all_bytes));
+  Alcotest.(check bool)
+    "casetype with all_zeros case body rejected" true
+    (raises_invalid (fun () -> build all_zeros))
+
 (* [uint] is a 1-to-7-byte unsigned integer; a literal size outside that range
    is refused at construction. *)
 let test_uint_size_bounds () =
@@ -4579,8 +4628,14 @@ let suite =
         test_array_record_projection;
       Alcotest.test_case "nested reject bitfield element" `Quick
         test_nested_reject_bitfield;
+      Alcotest.test_case "array rejects non-projectable element" `Quick
+        test_array_reject_nonprojectable_element;
       Alcotest.test_case "optional rejects unprojectable inner" `Quick
         test_optional_reject_unprojectable;
+      Alcotest.test_case "optional rejects bitfield inner" `Quick
+        test_optional_reject_bitfield;
+      Alcotest.test_case "casetype rejects greedy case body" `Quick
+        test_casetype_reject_greedy_case_body;
       Alcotest.test_case "uint rejects out-of-range size" `Quick
         test_uint_size_bounds;
       Alcotest.test_case "casetype case requires ~index" `Quick


### PR DESCRIPTION
Three composer-surfaced shapes built a codec that then failed schema generation or raised at decode rather than being refused up front. [is_array_element](https://github.com/parsimoni-labs/ocaml-wire/blob/reject-nonprojectable-constructs/lib/types.ml#L405) tightens `Wire.array` / `Wire.array_seq` so a non-fixed-width element (a `Wire.nested` region, a `Wire.byte_array_where` refined span, or a nested `Wire.array`) is rejected, since an array projects as a count of fixed-size elements and the array loop has no reader for those. `Field.optional` / `Field.optional_or` over a `Wire.bits` field is rejected the same way `array` / `repeat` / `nested` already reject a bitfield element. And [reject_greedy_case_body](https://github.com/parsimoni-labs/ocaml-wire/blob/reject-nonprojectable-constructs/lib/types.ml#L478) refuses a bare `all_bytes` / `all_zeros` case body in a `Wire.casetype`, which emitted invalid 3D and could not be sized; a sub-codec ending in `all_bytes` remains the supported form.

Each rejection raises `Invalid_argument` at the combinator with a unit test asserting it. Same family as #97, #98, and #105.