### PR TITLE
codec: forward params into embedded sub-codecs and enforce their constraints

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,13 @@
 
 ### Added
 
+- An embedded sub-codec (`Wire.codec c` used as a field or `Field.repeat` /
+  `array` element) that takes `Param.input` parameters now works: the outer
+  codec surfaces the sub-codec's input params as its own, so `Codec.env` /
+  `Param.bind` reach them and the values are threaded into the sub-codec on
+  encode, decode, and 3D projection. Previously the sub-codec's params were
+  invisible to the outer codec and binding them raised `Invalid_argument`
+  (#108, @samoht)
 - A `Wire.casetype` used as a `Field.repeat` element may now have a case body
   that is a bitfield, alongside the scalar, byte-span, NUL-terminated, and
   sub-codec bodies already allowed. Such a casetype previously failed at
@@ -85,6 +92,11 @@
 
 ### Fixed
 
+- An embedded sub-codec's `where` clause and field constraints are now enforced
+  when the codec is decoded as a field or element. They were silently dropped
+  on the embedded path (only the buffer-size and field readers ran), so a
+  value the sub-codec would reject standalone was accepted when embedded
+  (#108, @samoht)
 - A `Wire.casetype` whose case body is a NUL-terminated string (`zeroterm` or
   `zeroterm_at_most`) now encodes, decodes, and sizes correctly as a
   `Field.repeat` element. The element encoder had no `zeroterm` case (so encode

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -600,6 +600,9 @@ type compile_ctx = {
          with different slots. *)
 }
 
+let mk_ctx ?(sizeof_this = 0) ?(field_pos = 0) ~param_slots idx =
+  { idx; sizeof_this; field_pos; param_slots }
+
 let array_leaves (cc : compile_ctx) : (int array, unit) leaves =
   {
     ref_ =
@@ -1011,12 +1014,17 @@ let rec iter_param_refs_typ : type a. (Param.packed -> unit) -> a typ -> unit =
         (fun (Types.Case_branch { cb_inner; _ }) ->
           iter_param_refs_typ f cb_inner)
         cases
+  (* An embedded sub-codec carries its own params (in field sizes / where) that
+     the outer codec must surface so its env can bind them. Walk the sub-codec's
+     structural form. *)
+  | Codec { codec_struct; _ } ->
+      iter_param_refs_fields f codec_struct.fields codec_struct.where
   | Uint8 | Uint16 _ | Uint32 _ | Uint63 _ | Uint64 _ | Int8 | Int16 _ | Int32 _
   | Int64 _ | Float32 _ | Float64 _ | Bits _ | Unit | All_bytes | All_zeros
-  | Zeroterm | Struct _ | Type_ref _ | Qualified_ref _ | Codec _ ->
+  | Zeroterm | Struct _ | Type_ref _ | Qualified_ref _ ->
       ()
 
-let iter_param_refs_fields f fields where =
+and iter_param_refs_fields f fields where =
   List.iter
     (fun (Types.Field fld) ->
       iter_param_refs_typ f fld.field_typ;
@@ -2145,12 +2153,8 @@ let apply_compiled : type a f r.
   in
   let idx = build_idx cc_readers in
   let cc =
-    {
-      idx;
-      sizeof_this = cf.validator_off;
-      field_pos = field_idx;
-      param_slots = r.param_slots;
-    }
+    mk_ctx ~sizeof_this:cf.validator_off ~field_pos:field_idx
+      ~param_slots:r.param_slots idx
   in
   let check =
     match fld.constraint_ with
@@ -2339,7 +2343,7 @@ let compile_where_clause param_slots field_readers where =
   | Some cond ->
       let rev_readers = List.rev field_readers in
       let idx name = lookup_reader_idx rev_readers name in
-      let cc = { idx; sizeof_this = 0; field_pos = 0; param_slots } in
+      let cc = mk_ctx ~param_slots idx in
       Some (compile_bool_arr cc cond)
 
 let build_validators validators_rev checkers_rev compiled_where struct_fields
@@ -2399,6 +2403,15 @@ let collect_param_handles struct_fields where =
   iter_param_refs_fields visit struct_fields where;
   List.rev !handles
 
+(* Fill a codec's param name to decode-slot map: handle [i] sits at
+   [param_base + i] in the decode array (and at env slot [i]). *)
+let fill_param_slots tbl param_base handles =
+  Hashtbl.reset tbl;
+  List.iteri
+    (fun i (Param.Pack p) ->
+      Hashtbl.replace tbl p.Types.ph_name (param_base + i))
+    handles
+
 let build_checked_decode raw_decode wire_size_info min_size =
  fun buf off ->
   if off + min_size > Bytes.length buf then
@@ -2436,11 +2449,7 @@ let seal : type r. (r, r) record -> r t =
   let struct_fields = List.rev r.fields_rev in
   let param_handles = collect_param_handles struct_fields r.where in
   let n_params = List.length param_handles in
-  Hashtbl.reset r.param_slots;
-  List.iteri
-    (fun i (Param.Pack p) ->
-      Hashtbl.replace r.param_slots p.Types.ph_name (param_base + i))
-    param_handles;
+  fill_param_slots r.param_slots param_base param_handles;
   let n_total = param_base + n_params in
   let compiled_where =
     compile_where_clause r.param_slots r.field_readers r.where
@@ -2588,12 +2597,8 @@ let build_field_checks acc ~populate ~validator_off ~name ~action ~constraint_ =
   in
   let idx = build_idx cc_readers in
   let cc =
-    {
-      idx;
-      sizeof_this = validator_off;
-      field_pos = acc.n_fields;
-      param_slots = acc.param_slots;
-    }
+    mk_ctx ~sizeof_this:validator_off ~field_pos:acc.n_fields
+      ~param_slots:acc.param_slots idx
   in
   let check = Option.map (compile_bool_arr cc) constraint_ in
   let act = compile_action cc action in
@@ -2689,11 +2694,7 @@ and validator_of_struct (s : Types.struct_) : validator =
   let param_handles = collect_param_handles s.fields s.where in
   let n_params = List.length param_handles in
   let param_base = acc.n_array_slots in
-  Hashtbl.reset acc.param_slots;
-  List.iteri
-    (fun i (Param.Pack p) ->
-      Hashtbl.replace acc.param_slots p.Types.ph_name (param_base + i))
-    param_handles;
+  fill_param_slots acc.param_slots param_base param_handles;
   let n_total = param_base + n_params in
   let compiled_where =
     compile_where_clause acc.param_slots acc.field_readers s.where
@@ -2822,6 +2823,25 @@ let raw_encode ?env:e t v buf off =
   require_env t e;
   (match e with Some env -> load_env_into_cells t env | None -> ());
   t.encode v buf off
+
+(* Encode a sub-codec embedded as a field/element. The enclosing codec has
+   already seeded every input param's [ph_cell] from its own env (its
+   [param_handles] include the sub's, see [iter_param_refs_typ]), so the sub
+   must not re-run [require_env] (it has no env of its own here). *)
+let embed_encode (t : 'r t) v buf off = t.encode v buf off
+
+(* Decode a sub-codec embedded as a field/element, enforcing its [where] and
+   field constraints (the plain field-reader decode skips them). Param values
+   come from the [ph_cell]s the enclosing codec seeded; copy them into the
+   sub's per-decode slots so its constraints resolve correctly. *)
+let embed_decode (t : 'r t) buf off =
+  let v = t.decode buf off in
+  let env_slots =
+    Array.of_list
+      (List.map (fun (Param.Pack p) -> !(p.Types.ph_cell)) t.param_handles)
+  in
+  t.validate ~env_slots buf off;
+  v
 
 let wire_size_info (t : _ t) =
   match t.wire_size with

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -588,7 +588,17 @@ let compile_bool_expr ?sizeof_this env e =
    constraints / where clauses where the validator has already populated
    the per-decode int_array. *)
 type idx = string -> int
-type compile_ctx = { idx : idx; sizeof_this : int; field_pos : int }
+
+type compile_ctx = {
+  idx : idx;
+  sizeof_this : int;
+  field_pos : int;
+  param_slots : (string, int) Hashtbl.t;
+      (* Per-codec map from param name to its slot in this codec's decode
+         array, filled at seal. Resolution lives here, not on the shared
+         handle, so one handle can serve a standalone codec and an embedding
+         with different slots. *)
+}
 
 let array_leaves (cc : compile_ctx) : (int array, unit) leaves =
   {
@@ -598,10 +608,13 @@ let array_leaves (cc : compile_ctx) : (int array, unit) leaves =
         fun a () -> a.(i));
     param_ref =
       (fun (Pack_param p) a () ->
-        (* [ph_slot] is assigned during sealing, after the leaves are built,
-           so it must be read per call rather than captured here. *)
-        let i = p.ph_slot in
-        if i >= 0 then a.(i) else !(p.ph_cell));
+        (* The per-codec slot map is filled at seal, after these leaves are
+           built, so it must be consulted per call. A param not in this
+           codec's map (e.g. one only reachable via [ph_cell] forwarding from
+           an embedding) falls back to the shared cell. *)
+        match Hashtbl.find_opt cc.param_slots p.Types.ph_name with
+        | Some i -> a.(i)
+        | None -> !(p.ph_cell));
     sizeof_typ =
       (fun (Pack_typ t) ->
         let n = field_wire_size t |> Option.value ~default:0 in
@@ -634,12 +647,13 @@ exception Return_true
 let rec compile_stmt (cc : compile_ctx) (s : Types.action_stmt) :
     compiled_action =
   match s with
-  | Assign (p, e) ->
+  | Assign (p, e) -> (
       let fe = compile_int_arr cc e in
       fun arr ->
         let v = fe arr in
-        let slot = p.Types.ph_slot in
-        if slot >= 0 then arr.(slot) <- v else p.Types.ph_cell := v
+        match Hashtbl.find_opt cc.param_slots p.Types.ph_name with
+        | Some slot -> arr.(slot) <- v
+        | None -> p.Types.ph_cell := v)
   | Field_assign (_, _, _) | Extern_call (_, _) -> fun _ -> ()
   | Return e ->
       let fe = compile_bool_arr cc e in
@@ -715,6 +729,8 @@ type ('f, 'r) record =
       field_access_rev : (string * field_access) list;
       field_readers : field_reader list;
       where : bool expr option;
+      param_slots : (string, int) Hashtbl.t;
+          (* Per-codec param name to decode-array slot, filled at seal. *)
     }
       -> ('f, 'r) record
 
@@ -768,6 +784,7 @@ let record_start ?where name make =
       field_access_rev = [];
       field_readers = [];
       where;
+      param_slots = Hashtbl.create 4;
     }
 
 let bind (f : 'a Field.t) get =
@@ -2127,7 +2144,14 @@ let apply_compiled : type a f r.
     List.fold_left (fun acc vn -> (vn, dummy_reader) :: acc) base action_vanames
   in
   let idx = build_idx cc_readers in
-  let cc = { idx; sizeof_this = cf.validator_off; field_pos = field_idx } in
+  let cc =
+    {
+      idx;
+      sizeof_this = cf.validator_off;
+      field_pos = field_idx;
+      param_slots = r.param_slots;
+    }
+  in
   let check =
     match fld.constraint_ with
     | None -> None
@@ -2191,6 +2215,7 @@ let apply_compiled : type a f r.
       field_access_rev = (fld.name, cf.field_access) :: r.field_access_rev;
       field_readers = new_field_readers;
       where = r.where;
+      param_slots = r.param_slots;
     }
 
 let add_field : type a f r. (a -> f, r) record -> (a, r) field -> (f, r) record
@@ -2308,13 +2333,13 @@ let lookup_reader_idx rev_readers name =
   in
   find 0 rev_readers
 
-let compile_where_clause field_readers where =
+let compile_where_clause param_slots field_readers where =
   match where with
   | None -> None
   | Some cond ->
       let rev_readers = List.rev field_readers in
       let idx name = lookup_reader_idx rev_readers name in
-      let cc = { idx; sizeof_this = 0; field_pos = 0 } in
+      let cc = { idx; sizeof_this = 0; field_pos = 0; param_slots } in
       Some (compile_bool_arr cc cond)
 
 let build_validators validators_rev checkers_rev compiled_where struct_fields
@@ -2411,13 +2436,15 @@ let seal : type r. (r, r) record -> r t =
   let struct_fields = List.rev r.fields_rev in
   let param_handles = collect_param_handles struct_fields r.where in
   let n_params = List.length param_handles in
+  Hashtbl.reset r.param_slots;
   List.iteri
     (fun i (Param.Pack p) ->
-      p.ph_slot <- param_base + i;
-      p.ph_env_idx <- i)
+      Hashtbl.replace r.param_slots p.Types.ph_name (param_base + i))
     param_handles;
   let n_total = param_base + n_params in
-  let compiled_where = compile_where_clause r.field_readers r.where in
+  let compiled_where =
+    compile_where_clause r.param_slots r.field_readers r.where
+  in
   let validate_arr, populate, validate =
     build_validators validators (List.rev r.checkers_rev) compiled_where
       struct_fields n_total
@@ -2488,9 +2515,10 @@ type validator_acc = {
   min_size : int;
   next_off : next_off;
   bf : bf_codec_state option;
+  param_slots : (string, int) Hashtbl.t;
 }
 
-let empty_validator_acc =
+let empty_validator_acc () =
   {
     validators_rev = [];
     checkers_rev = [];
@@ -2500,6 +2528,7 @@ let empty_validator_acc =
     min_size = 0;
     next_off = Static 0;
     bf = None;
+    param_slots = Hashtbl.create 4;
   }
 
 let layout_ctx_of_validator_acc acc =
@@ -2558,7 +2587,14 @@ let build_field_checks acc ~populate ~validator_off ~name ~action ~constraint_ =
       base action_vanames
   in
   let idx = build_idx cc_readers in
-  let cc = { idx; sizeof_this = validator_off; field_pos = acc.n_fields } in
+  let cc =
+    {
+      idx;
+      sizeof_this = validator_off;
+      field_pos = acc.n_fields;
+      param_slots = acc.param_slots;
+    }
+  in
   let check = Option.map (compile_bool_arr cc) constraint_ in
   let act = compile_action cc action in
   let raise_check_failed () =
@@ -2601,6 +2637,7 @@ let rec apply_struct_field acc inner_struct =
     min_size = acc.min_size + size_delta;
     next_off;
     bf = None;
+    param_slots = acc.param_slots;
   }
 
 and apply_field_to_validator_acc acc (Types.Field f) =
@@ -2636,11 +2673,13 @@ and apply_field_to_validator_acc acc (Types.Field f) =
         min_size = acc.min_size + cf.size_delta;
         next_off = cf.next_off;
         bf = cf.bf_after;
+        param_slots = acc.param_slots;
       }
 
 and validator_of_struct (s : Types.struct_) : validator =
   let acc =
-    List.fold_left apply_field_to_validator_acc empty_validator_acc s.fields
+    List.fold_left apply_field_to_validator_acc (empty_validator_acc ())
+      s.fields
   in
   let wire_size_info =
     match acc.next_off with
@@ -2650,13 +2689,15 @@ and validator_of_struct (s : Types.struct_) : validator =
   let param_handles = collect_param_handles s.fields s.where in
   let n_params = List.length param_handles in
   let param_base = acc.n_array_slots in
+  Hashtbl.reset acc.param_slots;
   List.iteri
     (fun i (Param.Pack p) ->
-      p.ph_slot <- param_base + i;
-      p.ph_env_idx <- i)
+      Hashtbl.replace acc.param_slots p.Types.ph_name (param_base + i))
     param_handles;
   let n_total = param_base + n_params in
-  let compiled_where = compile_where_clause acc.field_readers s.where in
+  let compiled_where =
+    compile_where_clause acc.param_slots acc.field_readers s.where
+  in
   let validate_arr, _populate, _validate =
     build_validators
       (List.rev acc.validators_rev)
@@ -2734,9 +2775,10 @@ let raw_decode (t : _ t) buf off = t.decode buf off
    parametric field sizes. Mirror of the env -> array blit in
    [decode_exn]. *)
 let load_env_into_cells (t : 'r t) (env : Param.env) =
-  List.iter
-    (fun (Param.Pack p) ->
-      if p.ph_env_idx >= 0 then p.ph_cell := env.slots.(p.ph_env_idx))
+  (* The env slot of [param_handles.(i)] is [i] (the env is built in the same
+     order, see [env] below). *)
+  List.iteri
+    (fun i (Param.Pack p) -> p.ph_cell := env.slots.(i))
     t.param_handles
 
 (* Reject [encode] on a parametric codec without an env, and reject envs
@@ -2745,23 +2787,19 @@ let load_env_into_cells (t : 'r t) (env : Param.env) =
    regions for byte_array / byte_slice / uint_var fields and writing the
    rest of the record at the wrong offsets. *)
 let unbound_params (t : 'r t) (env : Param.env) : string list =
-  List.filter_map
-    (fun (Param.Pack p) ->
-      if
-        (not p.Types.ph_mutable) && p.ph_env_idx >= 0
-        && not env.bound.(p.ph_env_idx)
-      then Some p.ph_name
+  List.mapi
+    (fun i (Param.Pack p) ->
+      if (not p.Types.ph_mutable) && not env.bound.(i) then Some p.ph_name
       else None)
     t.param_handles
+  |> List.filter_map Fun.id
 
 (* Input params (read from the env) drive field sizes/offsets, so encoding
    without their values would resolve those to 0. Output params are written
    by decode-side actions and never consulted on encode, so a codec whose only
    params are outputs needs no env. *)
 let has_input_params (t : 'r t) =
-  List.exists
-    (fun (Param.Pack p) -> (not p.Types.ph_mutable) && p.ph_env_idx >= 0)
-    t.param_handles
+  List.exists (fun (Param.Pack p) -> not p.Types.ph_mutable) t.param_handles
 
 let require_env t = function
   | None when not (has_input_params t) -> ()
@@ -2793,6 +2831,9 @@ let wire_size_info (t : _ t) =
 let env (t : _ t) : Param.env =
   {
     Types.codec_id = t.id;
+    names =
+      Array.of_list
+        (List.map (fun (Param.Pack p) -> p.Types.ph_name) t.param_handles);
     slots = Array.make t.n_params 0;
     bound = Array.make t.n_params false;
   }
@@ -2807,10 +2848,12 @@ let decode_exn ?env:e t buf off =
   t.validate_arr arr buf off;
   (match e with
   | Some (e : Param.env) ->
-      List.iter
-        (fun (Param.Pack p) ->
-          let v = arr.(p.ph_slot) in
-          e.slots.(p.ph_env_idx) <- v;
+      (* Array slot of [param_handles.(i)] is [param_base + i]; its env slot is
+         [i]. Write decoded output params back into the env (and the cell). *)
+      List.iteri
+        (fun i (Param.Pack p) ->
+          let v = arr.(t.param_base + i) in
+          e.slots.(i) <- v;
           p.ph_cell := v)
         t.param_handles
   | None -> ());
@@ -2989,10 +3032,10 @@ let[@inline] get (type a r) ?env (codec : r t) (f : (a, r) field) :
             let param_handles = codec.param_handles in
             let param_base = codec.param_base in
             ( (fun arr ->
-                List.iter
-                  (fun (Param.Pack p) ->
-                    let v = arr.(p.ph_slot) in
-                    e.slots.(p.ph_env_idx) <- v;
+                List.iteri
+                  (fun i (Param.Pack p) ->
+                    let v = arr.(param_base + i) in
+                    e.slots.(i) <- v;
                     p.ph_cell := v)
                   param_handles),
               fun arr ->

--- a/lib/codec.mli
+++ b/lib/codec.mli
@@ -136,6 +136,16 @@ val raw_encode : ?env:Param.env -> 'r t -> 'r -> bytes -> int -> int
     validation and returns the offset after the written bytes. Same env
     semantics as {!encode}. Internal use. *)
 
+val embed_encode : 'r t -> 'r -> bytes -> int -> int
+(** Encode a sub-codec embedded as a field/element. Assumes the enclosing codec
+    has already seeded any input param cells from its env, so it skips the env
+    check {!encode} performs. Internal use. *)
+
+val embed_decode : 'r t -> bytes -> int -> 'r
+(** Decode a sub-codec embedded as a field/element, enforcing its [where] and
+    field constraints against param values seeded by the enclosing codec.
+    Internal use. *)
+
 val wire_size_info : 'r t -> [ `Fixed of int | `Variable of bytes -> int -> int ]
 (** Wire size information for embedding. *)
 

--- a/lib/param.ml
+++ b/lib/param.ml
@@ -70,8 +70,6 @@ let input name typ =
     ph_packed_typ = Types.Pack_typ typ;
     ph_mutable = false;
     ph_cell = ref 0;
-    ph_slot = -1;
-    ph_env_idx = -1;
   }
 
 let output name typ =
@@ -82,8 +80,6 @@ let output name typ =
     ph_packed_typ = Types.Pack_typ typ;
     ph_mutable = true;
     ph_cell = ref 0;
-    ph_slot = -1;
-    ph_env_idx = -1;
   }
 
 let decl (t : ('a, 'k) t) : Types.param =
@@ -100,19 +96,30 @@ let expr t : int Types.expr = Types.Param_ref t
 
 type env = Types.param_env
 
+(* Slot of a handle within an env, by name. [-1] when the env's codec does not
+   reference the param (e.g. binding a param the codec does not use). *)
+let env_idx (env : env) name =
+  let rec find i =
+    if i >= Array.length env.Types.names then -1
+    else if env.names.(i) = name then i
+    else find (i + 1)
+  in
+  find 0
+
 let bind (p : ('a, input) t) (v : 'a) (env : env) : env =
   let iv = to_int p.Types.ph_typ v in
   let slots = Array.copy env.slots in
   let bound = Array.copy env.bound in
-  if p.ph_env_idx >= 0 then begin
-    slots.(p.ph_env_idx) <- iv;
-    bound.(p.ph_env_idx) <- true
+  let i = env_idx env p.Types.ph_name in
+  if i >= 0 then begin
+    slots.(i) <- iv;
+    bound.(i) <- true
   end;
   p.ph_cell := iv;
-  { Types.codec_id = env.codec_id; slots; bound }
+  { env with Types.slots; bound }
 
 let get (env : env) (p : ('a, 'k) t) : 'a =
-  if p.Types.ph_env_idx < 0 then of_int p.ph_typ !(p.ph_cell)
-  else of_int p.ph_typ env.slots.(p.ph_env_idx)
+  let i = env_idx env p.Types.ph_name in
+  if i < 0 then of_int p.ph_typ !(p.ph_cell) else of_int p.ph_typ env.slots.(i)
 
 type packed = Pack : ('a, 'k) t -> packed

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -1150,7 +1150,17 @@ and pp_typ : type a. a typ Fmt.t =
   | Apply { typ; args } ->
       Fmt.pf ppf "%a(%a)" pp_typ typ Fmt.(list ~sep:comma pp_packed_expr) args
   | Map { inner; _ } -> pp_typ ppf inner
-  | Codec { codec_name; _ } -> Fmt.string ppf codec_name
+  (* A parametric sub-codec is emitted as a typedef with formals (see
+     [extract]), so the use site must apply them: [Sub(p1, p2)]. The outer
+     codec surfaces the same-named params, so each formal resolves to the
+     outer's matching parameter. *)
+  | Codec { codec_name; codec_struct; _ } -> (
+      match codec_struct.params with
+      | [] -> Fmt.string ppf codec_name
+      | params ->
+          Fmt.pf ppf "%s(%a)" codec_name
+            Fmt.(list ~sep:comma string)
+            (List.map (fun (p : param) -> p.param_name) params))
   (* [Optional]/[Optional_or]/[Repeat] are field decorations: their
      wrapping combinators ([map], [where], [array], [casetype], [apply])
      reject them at construction, so reaching this branch from a typ

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -22,8 +22,11 @@ type ('a, 'k) param_handle = {
   ph_packed_typ : packed_typ;
   ph_mutable : bool;
   ph_cell : int ref;
-  mutable ph_slot : int;
-  mutable ph_env_idx : int;
+      (* [ph_cell] is the per-handle backing read by encode/size expressions and
+         the value-forwarding vehicle for embedded sub-codecs. Slot resolution
+         (decode array index, env index) is NOT stored here: it is per-codec,
+         since one handle may be referenced both standalone and from an
+         embedding, which would clash on a single mutable field. *)
 }
 
 and packed_typ = Pack_typ : 'a typ -> packed_typ
@@ -210,6 +213,10 @@ and action_stmt =
 
 type param_env = {
   codec_id : int;
+  names : string array;
+      (* Parallel to [slots]: the param name at each slot. [Param.bind] / [get]
+         resolve a handle to its slot by name, so resolution is per-env (hence
+         per-codec) rather than via a mutable field on the shared handle. *)
   slots : int array;
   bound : bool array;
       (* Parallel to [slots]: one bit per slot, set by [Param.bind] so

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -45,8 +45,6 @@ type ('a, 'k) param_handle = {
   ph_packed_typ : packed_typ;
   ph_mutable : bool;
   ph_cell : int ref;
-  mutable ph_slot : int;
-  mutable ph_env_idx : int;
 }
 
 and packed_typ = Pack_typ : 'a typ -> packed_typ
@@ -240,6 +238,9 @@ and action_stmt =
 
 type param_env = {
   codec_id : int;
+  names : string array;
+      (** Parallel to [slots]: the param name at each slot, so a handle resolves
+          to its slot by name (per-env, hence per-codec). *)
   slots : int array;
   bound : bool array;
       (** Parallel to [slots]; set by [Param.bind] so consumers can detect

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -61,8 +61,8 @@ let is_nan (f : float Field.t) : bool Types.expr =
     && Land (r, Int mant_mask) <> Int 0)
 
 let codec (c : 'r Codec.t) : 'r typ =
-  let codec_decode = Codec.raw_decode c in
-  let codec_encode = Codec.raw_encode c in
+  let codec_decode = Codec.embed_decode c in
+  let codec_encode = Codec.embed_encode c in
   let codec_field_readers = Codec.field_readers c in
   let codec_struct = Codec.to_struct c in
   let codec_size_of_value = Codec.size_of_value c in

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -1332,6 +1332,93 @@ let test_get_action_inputparam_noenv () =
   | _ -> Alcotest.fail "expected rejection without env"
   | exception Validation_error (Constraint_failed _) -> ()
 
+(* -- Param forwarding into embedded sub-codecs -- *)
+
+(* A sub-codec whose field is sized by an input param, embedded as a field of an
+   outer codec. The outer surfaces the sub's param; binding it on the outer env
+   drives the embedded field width on both encode and decode. *)
+let test_embed_param_sized () =
+  let elen = Param.input "elen" uint8 in
+  let sub =
+    Codec.v "EmbSub"
+      (fun d -> d)
+      Codec.[ Field.v "data" (byte_array ~size:(Param.expr elen)) $ Fun.id ]
+  in
+  let outer =
+    Codec.v "EmbOuter" (fun s -> s) Codec.[ Field.v "s" (codec sub) $ Fun.id ]
+  in
+  let env = Codec.env outer |> Param.bind elen 3 in
+  let n = Codec.size_of_value outer "abc" in
+  Alcotest.(check int) "wire size" 3 n;
+  let buf = Bytes.create n in
+  Codec.encode ~env outer "abc" buf 0;
+  Alcotest.(check string)
+    "roundtrip" "abc"
+    (decode_ok (Codec.decode ~env outer buf 0))
+
+(* The outer codec inherits the embedded sub-codec's input param, so encoding it
+   without an env is rejected. *)
+let test_embed_param_requires_env () =
+  let elen = Param.input "elen2" uint8 in
+  let sub =
+    Codec.v "EmbSub2"
+      (fun d -> d)
+      Codec.[ Field.v "data" (byte_array ~size:(Param.expr elen)) $ Fun.id ]
+  in
+  let outer =
+    Codec.v "EmbOuter2" (fun s -> s) Codec.[ Field.v "s" (codec sub) $ Fun.id ]
+  in
+  Alcotest.(check bool)
+    "encode without env rejected" true
+    (raises_invalid (fun () -> Codec.encode outer "ab" (Bytes.create 8) 0))
+
+(* A sub-codec's [where] is enforced when the sub is embedded, matching its
+   standalone behaviour (it used to be silently dropped). *)
+let test_embed_where_enforced () =
+  let f_v = Field.v "v" uint8 in
+  let sub =
+    Codec.v "WSub"
+      ~where:Expr.(Field.ref f_v <= int 10)
+      (fun v -> v)
+      Codec.[ f_v $ Fun.id ]
+  in
+  let outer =
+    Codec.v "WOuter" (fun s -> s) Codec.[ Field.v "s" (codec sub) $ Fun.id ]
+  in
+  Alcotest.(check bool)
+    "violating value rejected when embedded" true
+    (match Codec.decode outer (Bytes.make 1 '\xFF') 0 with
+    | Ok _ -> false
+    | _ -> true);
+  Alcotest.(check int)
+    "satisfying value accepted" 5
+    (decode_ok (Codec.decode outer (Bytes.make 1 '\x05') 0))
+
+(* A list of param-constrained sub-records within a byte budget, the param
+   forwarded through the repeat (the shape that first exposed the gap). *)
+let test_embed_param_repeat () =
+  let rlim = Param.input "rlim" uint8 in
+  let f_v = Field.v "v" uint8 in
+  let sub =
+    Codec.v "RSub"
+      ~where:Expr.(Field.ref f_v <= Param.expr rlim)
+      (fun v -> v)
+      Codec.[ f_v $ Fun.id ]
+  in
+  let f_n = Field.v "n" uint8 in
+  let f_items = Field.repeat "items" ~size:(Field.ref f_n) (codec sub) in
+  let outer =
+    Codec.v "RepOuter" (fun n xs -> (n, xs)) Codec.[ f_n $ fst; f_items $ snd ]
+  in
+  let v = (3, [ 1; 5; 9 ]) in
+  let env = Codec.env outer |> Param.bind rlim 100 in
+  let n = Codec.size_of_value outer v in
+  let buf = Bytes.create n in
+  Codec.encode ~env outer v buf 0;
+  Alcotest.(check bool)
+    "roundtrip" true
+    (decode_ok (Codec.decode ~env outer buf 0) = v)
+
 let test_get_action_output_only () =
   (* Action with only assign (no return_bool/abort) -- should never fail *)
   let out = Param.output "out_only" uint8 in
@@ -4549,6 +4636,14 @@ let suite =
         test_get_action_with_inputparam;
       Alcotest.test_case "action: input param no env" `Quick
         test_get_action_inputparam_noenv;
+      Alcotest.test_case "embed: param-sized sub-codec forwards param" `Quick
+        test_embed_param_sized;
+      Alcotest.test_case "embed: param sub-codec requires env" `Quick
+        test_embed_param_requires_env;
+      Alcotest.test_case "embed: sub-codec where enforced" `Quick
+        test_embed_where_enforced;
+      Alcotest.test_case "embed: param forwarded through repeat" `Quick
+        test_embed_param_repeat;
       Alcotest.test_case "action: output only" `Quick
         test_get_action_output_only;
       Alcotest.test_case "action: var then assign" `Quick

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -390,6 +390,29 @@ let test_3d_param_in_size () =
     (contains ~sub:"UINT16BE len" s);
   Alcotest.(check bool) "size uses len" true (contains ~sub:":byte-size len" s)
 
+(* A codec embedding a parametric sub-codec must surface the sub's param as its
+   own formal and apply it at the use site, else 3D rejects the reference. *)
+let test_3d_param_embed () =
+  let lim = Param.input "lim" uint8 in
+  let sub =
+    Codec.v "PSub"
+      ~where:Expr.(Field.ref (Field.v "v" uint8) <= Param.expr lim)
+      (fun v -> v)
+      Codec.[ Field.v "v" uint8 $ Fun.id ]
+  in
+  let outer =
+    Codec.v "PEmbed"
+      (fun s -> s)
+      Codec.[ Field.v "s" (Wire.codec sub) $ Fun.id ]
+  in
+  let s = Wire.Everparse.Raw.to_3d (Everparse.schema outer).module_ in
+  Alcotest.(check bool)
+    "sub typedef carries the formal" true
+    (contains ~sub:"_PSub(UINT8 lim)" s);
+  Alcotest.(check bool)
+    "use site applies the formal" true
+    (contains ~sub:"PSub(lim) s" s)
+
 (* -- Reserved word escaping -- *)
 
 let test_reserved_word_escaping () =
@@ -491,6 +514,7 @@ let suite =
       Alcotest.test_case "3d: dep-size roundtrip" `Quick
         test_3d_dep_size_roundtrip;
       Alcotest.test_case "3d: param in size" `Quick test_3d_param_in_size;
+      Alcotest.test_case "3d: param embed" `Quick test_3d_param_embed;
       Alcotest.test_case "3d: reserved word escaping" `Quick
         test_reserved_word_escaping;
       Alcotest.test_case "3d: byte_array_where synth typedef" `Quick


### PR DESCRIPTION
An embedded sub-codec (`Wire.codec c` used as a field or `Field.repeat` / `array` element) that referenced `Param.input` was unusable: the outer codec never saw the sub-codec's params, so `Param.bind` against `Codec.env outer` resolved to the wrong slot and decoding/encoding could not thread the value. The blocker was that param slot and env indices lived in mutable fields on the shared handle, assigned at one codec's seal time, so a handle referenced by both a standalone codec and an embedding clashed.

The first commit moves resolution off the handle: each codec builds a seal-time name to slot map for its where clauses and actions, and the env carries a parallel `names` array so `Param.bind` / `Param.get` resolve by name. Behaviour is unchanged for existing codecs. The second commit then surfaces an embedded sub-codec's input params on the outer codec, threads the bound values through [embed_encode](https://github.com/parsimoni-labs/ocaml-wire/blob/param-forwarding-subcodecs/lib/codec.ml#L2831) / [embed_decode](https://github.com/parsimoni-labs/ocaml-wire/blob/param-forwarding-subcodecs/lib/codec.ml#L2837), and renders a parametric sub-codec as `Name(args)` at its 3D use site.

The embedded decode path also now runs the sub-codec's `where` and field constraints, which were silently skipped before (only the buffer-size guard and field readers ran), so a value the sub-codec rejects standalone is now also rejected when embedded.