### PR TITLE
codec: project nested over composite inners via wrapper structs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,12 @@
 
 ### Added
 
+- `Wire.nested` / `Wire.nested_at_most` now accept a composite inner (a
+  `Wire.array`, or another nested region): the fixed-size region projects to 3D
+  through a synthesised wrapper struct so the single-element-array element is a
+  named type, instead of crashing at decode or emitting malformed 3D. A
+  `Wire.casetype` field whose case body is such a region likewise decodes and
+  sizes correctly (#109, @samoht)
 - An embedded sub-codec (`Wire.codec c` used as a field or `Field.repeat` /
   `array` element) that takes `Param.input` parameters now works: the outer
   codec surfaces the sub-codec's input params as its own, so `Codec.env` /

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -31,6 +31,14 @@ let setter_off_int32 n set buf off v =
   set buf off (Int32.of_int v);
   off + n
 
+(* Encode a value into a fixed [n]-byte region: write it with [enc], then
+   zero-pad the remainder. Used for [nested] regions. *)
+let single_elem_pad n enc buf off v =
+  let inner_end = enc buf off v in
+  if inner_end < off + n then
+    Bytes.fill buf inner_end (off + n - inner_end) '\x00';
+  off + n
+
 (* Encode a lone bitfield occupying its base word: range-check, place the value
    at its bit offset, advance by the base width. *)
 let bits_field_encoder ~width ~base ~bit_order buf off v =
@@ -174,6 +182,10 @@ and build_field_encoder : type a. a typ -> bytes -> int -> a -> int =
      write the value at its bit offset into an otherwise-zero word. *)
   | Bits { width; base; bit_order } ->
       bits_field_encoder ~width ~base ~bit_order
+  (* A nested region (e.g. a casetype case body): encode the inner at the
+     region start, then zero-pad the rest of the fixed [n]-byte region. *)
+  | Single_elem { size = Int n; elem; _ } ->
+      single_elem_pad n (build_field_encoder elem)
   | _ ->
       (* Fallback for complex types - not specialized *)
       fun _buf _off _v -> failwith "build_field_encoder: unsupported type"
@@ -1103,6 +1115,7 @@ let rec read_elem : type a. a typ -> bytes -> int -> a =
   (* Fixed-size byte spans as repeat / array elements: a list of n-byte
      chunks. The size is the element's own constant width. *)
   | Byte_array { size = Int n } -> Bytes.sub_string buf off n
+  | Byte_array_where { size = Int n; _ } -> Bytes.sub_string buf off n
   | Byte_slice { size = Int n } -> Slice.make buf ~first:off ~length:n
   (* A lone bitfield occupies its base word; extract the value at its bit
      offset. *)
@@ -1110,6 +1123,20 @@ let rec read_elem : type a. a typ -> bytes -> int -> a =
       let total = bf_base_total_bits base in
       let shift = Bitfield.shift ~bit_order ~total ~bits_used:0 ~width in
       build_bf_reader base 0 shift width buf off
+  (* A fixed-count array inside a [nested] region (or a casetype case body):
+     decode each element at its stride. *)
+  | Array { len = Int n; elem; seq = Seq_map s } -> (
+      match field_wire_size elem with
+      | None -> failwith "read_elem: variable-size array element"
+      | Some esz ->
+          let acc = Stdlib.ref s.empty in
+          for i = 0 to n - 1 do
+            acc := s.add !acc (read_elem elem buf (off + (i * esz)))
+          done;
+          s.finish !acc)
+  (* A nested region as an element: decode its inner at the region start; the
+     enclosing region size (padding) is accounted for by the caller. *)
+  | Single_elem { elem; _ } -> read_elem elem buf off
   | _ -> failwith "read_elem: unsupported element type in repeat"
 
 (* Write one element of a typ at a given buffer position. Used by Repeat. *)
@@ -1191,6 +1218,8 @@ let rec elem_size_of : type a. a typ -> bytes -> int -> int =
   | Zeroterm_at_most { size = Int n } -> n
   (* A lone bitfield occupies its base word. *)
   | Bits { base; _ } -> bf_base_byte_size base
+  (* A nested region spans its whole fixed size, regardless of the inner. *)
+  | Single_elem { size = Int n; _ } -> n
   | _ -> (
       match field_wire_size typ with
       | Some n -> n

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -890,16 +890,69 @@ let repeat_elem_struct : type a. a typ -> string option = function
    declaration ([enum]) cannot. Those go through a synthesised wrapper struct,
    named deterministically from the element so the field renderer and the
    typedef emitter agree without shared state. *)
-let single_elem_struct : type a. a typ -> string option =
-  let some fmt = Fmt.kstr (fun s -> Some s) fmt in
-  function
+(* A deterministic, collision-free identifier fragment for an inner type, used
+   to name its synthesised wrapper struct. Two structurally equal inners get the
+   same fragment (so their wrapper is shared); different shapes differ. *)
+let rec wrap_tag : type a. a typ -> string = function
+  | Uint8 -> "u8"
+  | Uint16 Little -> "u16l"
+  | Uint16 Big -> "u16b"
+  | Uint32 Little -> "u32l"
+  | Uint32 Big -> "u32b"
+  | Uint63 Little -> "u63l"
+  | Uint63 Big -> "u63b"
+  | Uint64 Little -> "u64l"
+  | Uint64 Big -> "u64b"
+  | Int8 -> "i8"
+  | Int16 Little -> "i16l"
+  | Int16 Big -> "i16b"
+  | Int32 Little -> "i32l"
+  | Int32 Big -> "i32b"
+  | Int64 Little -> "i64l"
+  | Int64 Big -> "i64b"
+  | Float32 _ -> "f32"
+  | Float64 _ -> "f64"
+  | Uint_var { size = Int n; _ } -> Fmt.str "uv%d" n
+  | Bits { width; _ } -> Fmt.str "bf%d" width
+  | Byte_array { size = Int n } -> Fmt.str "ba%d" n
+  | Byte_slice { size = Int n } -> Fmt.str "bs%d" n
+  | Byte_array_where { size = Int n; _ } -> Fmt.str "rb%d" n
+  | Zeroterm -> "zt"
+  | Zeroterm_at_most { size = Int n } -> Fmt.str "ztam%d" n
+  | Unit -> "unit"
+  | Enum { name; _ } -> "e" ^ name
+  | Map { inner; _ } -> wrap_tag inner
+  | Where { inner; _ } -> wrap_tag inner
+  | Array { len = Int n; elem; _ } -> Fmt.str "arr%d_%s" n (wrap_tag elem)
+  | Single_elem { size = Int n; elem; _ } -> Fmt.str "se%d_%s" n (wrap_tag elem)
+  | Optional { inner; _ } -> "opt_" ^ wrap_tag inner
+  | Optional_or { inner; _ } -> "optd_" ^ wrap_tag inner
+  | Repeat { elem; _ } -> "rep_" ^ wrap_tag elem
+  | Codec { codec_name; _ } -> codec_name
+  | Casetype { name; _ } -> name
+  | _ -> "x"
+
+(* The synthesised wrapper-struct name for a [nested] inner that has no valid
+   bare single-element-array token. A scalar, sub-codec, or casetype renders
+   inline ([None]); everything else (byte spans, arrays, optionals, nested
+   regions, ...) is lifted into a named [struct { v : inner }]. *)
+let some fmt = Fmt.kstr (fun s -> Some s) fmt
+
+let rec single_elem_struct : type a. a typ -> string option = function
+  | Uint8 | Uint16 _ | Uint32 _ | Uint63 _ | Uint64 _ | Int8 | Int16 _ | Int32 _
+  | Int64 _ | Float32 _ | Float64 _ | Codec _ | Casetype _ ->
+      None
+  | Map { inner; _ } -> single_elem_struct inner
+  | Where { inner; _ } -> single_elem_struct inner
+  (* Keep the historical names for the byte-span family so existing schemas and
+     tests are unchanged; everything else gets a structural name. *)
   | Byte_array { size = Int n } -> some "SeBytes%d" n
   | Byte_slice { size = Int n } -> some "SeSlice%d" n
   | Byte_array_where { size = Int n; _ } -> some "SeRBytes%d" n
   | Uint_var { size = Int n; _ } -> some "SeUvar%d" n
   | Zeroterm_at_most { size = Int n } -> some "SeZtam%d" n
   | Enum { name; _ } -> Some ("Se_" ^ name)
-  | _ -> None
+  | other -> Some ("Se_" ^ wrap_tag other)
 
 (* The synthesised gate-dispatch casetype name for an [optional] whose inner is
    self-delimiting (no wire-size expression). Derived from the inner so two

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -485,6 +485,73 @@ let test_nested_reject_bitfield () =
     "nested_at_most over bits rejected" true
     (raises_invalid (fun () -> nested_at_most ~size:(int 1) (bits ~width:3 U8)))
 
+(* A [nested] / [nested_at_most] region over a composite inner (an array, or
+   another nested region) round-trips: the inner decodes at the region start
+   and the region is zero-padded to its fixed size. 3D projects it through a
+   synthesised wrapper struct (see test_everparse). *)
+let test_nested_over_array () =
+  let codec =
+    Codec.v "NestArr" Fun.id
+      Codec.
+        [
+          Field.v "xs" (nested ~size:(int 16) (array ~len:(int 2) uint64be))
+          $ Fun.id;
+        ]
+  in
+  let v = [ 1L; 2L ] in
+  let buf = Bytes.create (Codec.size_of_value codec v) in
+  Codec.encode codec v buf 0;
+  Alcotest.(check bool)
+    "roundtrip" true
+    (decode_ok (Codec.decode codec buf 0) = v)
+
+let test_nested_at_most_over_array () =
+  let codec =
+    Codec.v "NestAtmArr" Fun.id
+      Codec.
+        [
+          Field.v "xs"
+            (nested_at_most ~size:(int 16)
+               (array_seq seq_list ~len:(int 2) uint64be))
+          $ Fun.id;
+        ]
+  in
+  let v = [ 7L; 9L ] in
+  let buf = Bytes.create (Codec.size_of_value codec v) in
+  Codec.encode codec v buf 0;
+  Alcotest.(check bool)
+    "roundtrip" true
+    (decode_ok (Codec.decode codec buf 0) = v)
+
+(* A casetype whose case body is a [nested] region (a scalar in a fixed span):
+   the tag-dispatched case decodes and sizes through the region. *)
+type nest_case = Nc_n of int | Nc_u of int
+
+let nest_case_codec =
+  let ct =
+    casetype "NcT" uint8
+      [
+        case ~index:1
+          (nested ~size:(int 4) int32be)
+          ~inject:(fun v -> Nc_n v)
+          ~project:(function Nc_n v -> Some v | _ -> None);
+        case ~index:2 uint8
+          ~inject:(fun v -> Nc_u v)
+          ~project:(function Nc_u v -> Some v | _ -> None);
+      ]
+  in
+  Codec.v "Nc" Fun.id Codec.[ Field.v "b" ct $ Fun.id ]
+
+let test_casetype_nested_case_body () =
+  List.iter
+    (fun v ->
+      let buf = Bytes.create (Codec.size_of_value nest_case_codec v) in
+      Codec.encode nest_case_codec v buf 0;
+      Alcotest.(check bool)
+        "roundtrip" true
+        (decode_ok (Codec.decode nest_case_codec buf 0) = v))
+    [ Nc_n 12345; Nc_u 7 ]
+
 (* Field.repeat over a fixed byte_array element: a list of n-byte chunks within
    a byte budget. Decoding used to raise Failure "unsupported element type in
    repeat" and the schema mis-projected as a double [:byte-size]. *)
@@ -4628,6 +4695,12 @@ let suite =
         test_array_record_projection;
       Alcotest.test_case "nested reject bitfield element" `Quick
         test_nested_reject_bitfield;
+      Alcotest.test_case "nested over array roundtrip" `Quick
+        test_nested_over_array;
+      Alcotest.test_case "nested_at_most over array roundtrip" `Quick
+        test_nested_at_most_over_array;
+      Alcotest.test_case "casetype nested case body roundtrip" `Quick
+        test_casetype_nested_case_body;
       Alcotest.test_case "array rejects non-projectable element" `Quick
         test_array_reject_nonprojectable_element;
       Alcotest.test_case "optional rejects unprojectable inner" `Quick

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -413,6 +413,27 @@ let test_3d_param_embed () =
     "use site applies the formal" true
     (contains ~sub:"PSub(lim) s" s)
 
+(* A [nested] region over a composite inner (an array) projects through a
+   synthesised wrapper struct so the single-element-array element is a named
+   type, not a malformed inline array. *)
+let test_3d_nested_over_array () =
+  let codec =
+    Codec.v "NAEmbed"
+      (fun xs -> xs)
+      Codec.
+        [
+          Field.v "xs" (nested ~size:(int 16) (array ~len:(int 2) uint64be))
+          $ Fun.id;
+        ]
+  in
+  let s = Wire.Everparse.Raw.to_3d (Everparse.schema codec).module_ in
+  Alcotest.(check bool)
+    "wrapper struct holds the array" true
+    (contains ~sub:"UINT64BE v[:byte-size" s);
+  Alcotest.(check bool)
+    "use site is a single-element-array of the named wrapper" true
+    (contains ~sub:"xs[:byte-size-single-element-array 16]" s)
+
 (* -- Reserved word escaping -- *)
 
 let test_reserved_word_escaping () =
@@ -515,6 +536,8 @@ let suite =
         test_3d_dep_size_roundtrip;
       Alcotest.test_case "3d: param in size" `Quick test_3d_param_in_size;
       Alcotest.test_case "3d: param embed" `Quick test_3d_param_embed;
+      Alcotest.test_case "3d: nested over array" `Quick
+        test_3d_nested_over_array;
       Alcotest.test_case "3d: reserved word escaping" `Quick
         test_reserved_word_escaping;
       Alcotest.test_case "3d: byte_array_where synth typedef" `Quick


### PR DESCRIPTION
A `Wire.nested` / `Wire.nested_at_most` region over a composite inner (a `Wire.array`, or another nested region), and a `Wire.casetype` field whose case body is such a region, used to crash at decode ([read_elem](https://github.com/parsimoni-labs/ocaml-wire/blob/nested-over-composite-indirection/lib/codec.ml#L1058) and `elem_size_of` had no case for the composite) or emit a malformed inline single-element-array that EverParse rejected.

The region inner now decodes, encodes, and sizes through the element machinery, and [single_elem_struct](https://github.com/parsimoni-labs/ocaml-wire/blob/nested-over-composite-indirection/lib/types.ml#L941) lifts a composite inner into a synthesised wrapper struct so the single-element-array element is a named type. This generalises the wrapper indirection #99 introduced for byte-span and enum inners. A structural tag keeps wrapper names collision-free per inner shape.