### PR TITLE
codec: reject a greedy field that is not the last field

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -98,6 +98,11 @@
 
 ### Fixed
 
+- `Codec.v` now rejects a greedy field (`all_bytes` / `all_zeros`) that is not
+  the last field, with `Invalid_argument`. A greedy field reads the rest of the
+  buffer, so an earlier one starved every field after it: the codec built but
+  decode returned a parse error and 3D would reject the `[:consume-all]`
+  similarly (#110, @samoht)
 - An embedded sub-codec's `where` clause and field constraints are now enforced
   when the codec is decoded as a field or element. They were silently dropped
   on the embedded path (only the buffer-size and field readers ran), so a

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -2459,6 +2459,24 @@ let build_checked_decode raw_decode wire_size_info min_size =
         raise_eof ~expected:(end_off - off) ~got:(Bytes.length buf - off));
   raw_decode buf off
 
+(* A greedy field ([all_bytes] / [all_zeros]) consumes the rest of the buffer,
+   so it is only meaningful as the last field: an earlier one starves every
+   field after it (and 3D's [:consume-all] must be last too). Reject it at
+   construction rather than silently truncating later fields at decode. *)
+let reject_greedy_not_last name fields =
+  let rec check = function
+    | [] | [ _ ] -> ()
+    | Types.Field f :: rest ->
+        if is_greedy f.field_typ then
+          Fmt.invalid_arg
+            "Codec.v %s: a greedy field (all_bytes / all_zeros) must be the \
+             last field, but %s is followed by more fields"
+            name
+            (Option.value ~default:"<anon>" f.field_name);
+        check rest
+  in
+  check fields
+
 let seal : type r. (r, r) record -> r t =
  fun (Record r) ->
   let codec_id = Atomic.fetch_and_add id_counter 1 in
@@ -2476,6 +2494,7 @@ let seal : type r. (r, r) record -> r t =
   let param_base = r.n_array_slots in
   (* Collect and index params *)
   let struct_fields = List.rev r.fields_rev in
+  reject_greedy_not_last r.name struct_fields;
   let param_handles = collect_param_handles struct_fields r.where in
   let n_params = List.length param_handles in
   fill_param_slots r.param_slots param_base param_handles;

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -745,6 +745,11 @@ val pp_parse_error : Format.formatter -> parse_error -> unit
 val field_wire_size : 'a typ -> int option
 (** Fixed wire size of a field type, if determinable. *)
 
+val is_greedy : 'a typ -> bool
+(** Whether a type reads "the rest of the buffer" (a greedy byte span, through
+    transparent wrappers). Such a field is only valid as the last field of a
+    struct or codec. *)
+
 val size_of_typ_value : 'a typ -> 'a -> int
 (** [size_of_typ_value typ v] is the encoded byte size of [v] under [typ],
     computed from the value rather than from a buffer. Falls back to [0] for

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -667,6 +667,35 @@ let test_casetype_reject_greedy_case_body () =
     "casetype with all_zeros case body rejected" true
     (raises_invalid (fun () -> build all_zeros))
 
+(* A greedy field ([all_bytes] / [all_zeros]) reads the rest of the buffer, so
+   it is only valid as the last field; an earlier one is refused at
+   construction (it would starve every field after it at decode). *)
+let test_greedy_not_last_rejected () =
+  Alcotest.(check bool)
+    "all_zeros before another field rejected" true
+    (raises_invalid (fun () ->
+         Codec.v "GnlA"
+           (fun a b -> (a, b))
+           Codec.[ Field.v "z" all_zeros $ fst; Field.v "n" uint8 $ snd ]));
+  Alcotest.(check bool)
+    "all_bytes before another field rejected" true
+    (raises_invalid (fun () ->
+         Codec.v "GnlB"
+           (fun a b -> (a, b))
+           Codec.[ Field.v "b" all_bytes $ fst; Field.v "n" uint8 $ snd ]));
+  (* A greedy last field is fine and round-trips. *)
+  let c =
+    Codec.v "GnlOk"
+      (fun a b -> (a, b))
+      Codec.[ Field.v "n" uint8 $ fst; Field.v "rest" all_bytes $ snd ]
+  in
+  let v = (5, "tail") in
+  let buf = Bytes.create (Codec.size_of_value c v) in
+  Codec.encode c v buf 0;
+  Alcotest.(check bool)
+    "greedy last roundtrip" true
+    (decode_ok (Codec.decode c buf 0) = v)
+
 (* [uint] is a 1-to-7-byte unsigned integer; a literal size outside that range
    is refused at construction. *)
 let test_uint_size_bounds () =
@@ -4709,6 +4738,8 @@ let suite =
         test_optional_reject_bitfield;
       Alcotest.test_case "casetype rejects greedy case body" `Quick
         test_casetype_reject_greedy_case_body;
+      Alcotest.test_case "greedy field must be last" `Quick
+        test_greedy_not_last_rejected;
       Alcotest.test_case "uint rejects out-of-range size" `Quick
         test_uint_size_bounds;
       Alcotest.test_case "casetype case requires ~index" `Quick


### PR DESCRIPTION
A `Codec.v` field that is `all_bytes` or `all_zeros` reads the rest of the buffer, so it only makes sense as the last field. An earlier one built a codec that starved every field after it: encoding ran but decoding returned a parse error (the greedy field consumed the bytes the later fields needed), and 3D rejects a `[:consume-all]` that is not last for the same reason. [reject_greedy_not_last](https://github.com/parsimoni-labs/ocaml-wire/blob/reject-greedy-not-last/lib/codec.ml#L2466) now refuses it at construction with a clear `Invalid_argument`. A greedy last field is unchanged.