### PR TITLE
codec: reject a repeat element that is a greedy-tail sub-codec

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -98,6 +98,11 @@
 
 ### Fixed
 
+- `Field.repeat` / `Field.repeat_seq` / `Wire.array` now reject an element that
+  is a sub-codec ending in a greedy field (`all_bytes` / `all_zeros`). Such a
+  tail reads the rest of the buffer, so the first element would consume
+  everything; the codec built but decode returned a parse error. The codec is
+  still valid standalone (#111, @samoht)
 - `Codec.v` now rejects a greedy field (`all_bytes` / `all_zeros`) that is not
   the last field, with `Invalid_argument`. A greedy field reads the rest of the
   buffer, so an earlier one starved every field after it: the codec built but

--- a/lib/field.ml
+++ b/lib/field.ml
@@ -31,6 +31,14 @@ let optional_or name ?constraint_ ?self_constraint ?action ~present ~default typ
   v name ?constraint_ ?self_constraint ?action
     (Types.optional_or present ~default typ)
 
+(* A sub-codec ending in a greedy field ([all_bytes] / [all_zeros]) reads "the
+   rest of the buffer" as its tail, so it cannot be iterated as a repeat element
+   (the first element would consume everything). *)
+let codec_ends_greedy (s : Types.struct_) =
+  match List.rev s.fields with
+  | Types.Field f :: _ -> Types.is_greedy f.field_typ
+  | [] -> false
+
 (* Types decodable as a casetype case body inside a repeat: exactly the set
    [Codec.read_elem] handles. Unlike a bare repeat element, a lone [bits] field
    and a bounded [zeroterm_at_most] are allowed here, because the enclosing
@@ -46,7 +54,7 @@ let rec is_repeat_case_body : type a. a Types.typ -> bool =
   | Uint_var { size = Int _; _ } -> true
   | Byte_array { size = Int _ } | Byte_slice { size = Int _ } -> true
   | Zeroterm_at_most { size = Int _ } -> true
-  | Codec _ -> true
+  | Codec { codec_struct; _ } -> not (codec_ends_greedy codec_struct)
   | Casetype { cases; _ } ->
       List.for_all
         (fun (Case_branch { cb_inner; _ }) -> is_repeat_case_body cb_inner)
@@ -73,7 +81,7 @@ let rec is_repeat_element : type a. a Types.typ -> bool =
   | Int64 _ | Float32 _ | Float64 _ | Uint_var _ | Unit | Zeroterm ->
       true
   | Byte_array { size = Int _ } | Byte_slice { size = Int _ } -> true
-  | Codec _ -> true
+  | Codec { codec_struct; _ } -> not (codec_ends_greedy codec_struct)
   | Casetype { cases; _ } ->
       List.for_all
         (fun (Case_branch { cb_inner; _ }) -> is_repeat_case_body cb_inner)

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -605,6 +605,25 @@ let test_repeat_rejects_unprojectable () =
     (repeat_rejects
        (byte_array_where ~size:(int 2) ~per_byte:(fun _ -> Expr.true_)))
 
+(* A sub-codec whose last field is greedy ([all_bytes] / [all_zeros]) reads the
+   rest of the buffer as its tail, so it cannot be a repeat element (the first
+   element would consume everything). It is fine standalone. *)
+let test_repeat_rejects_greedy_tail_codec () =
+  let greedy =
+    Codec.v "GreedyTail"
+      (fun a b -> (a, b))
+      Codec.[ Field.v "n" uint8 $ fst; Field.v "rest" all_bytes $ snd ]
+  in
+  Alcotest.(check bool)
+    "repeat over codec ending in all_bytes rejected" true
+    (repeat_rejects (codec greedy));
+  let plain =
+    Codec.v "Plain" (fun a -> a) Codec.[ Field.v "n" uint8 $ Fun.id ]
+  in
+  Alcotest.(check bool)
+    "repeat over a non-greedy codec allowed" false
+    (repeat_rejects (codec plain))
+
 (* [optional] / [optional_or] project either a conditional byte-size region (a
    sized inner) or a gate-dispatched casetype (a self-delimiting inner). An
    inner that is neither, such as [all_bytes], has no projection and is refused
@@ -4712,6 +4731,8 @@ let suite =
         test_repeat_byte_array_projection;
       Alcotest.test_case "repeat: rejects unprojectable element" `Quick
         test_repeat_rejects_unprojectable;
+      Alcotest.test_case "repeat: rejects greedy-tail sub-codec" `Quick
+        test_repeat_rejects_greedy_tail_codec;
       Alcotest.test_case "array: byte_array element roundtrip" `Quick
         test_array_byte_array_element;
       Alcotest.test_case "array: byte_array element projection" `Quick


### PR DESCRIPTION
A sub-codec whose last field is `all_bytes` or `all_zeros` reads the rest of the buffer as its tail, so it cannot be iterated as a `Field.repeat` / `Field.repeat_seq` / `Wire.array` element: the first element would consume everything and later elements would starve. The codec built but decoding returned a parse error. [codec_ends_greedy](https://github.com/parsimoni-labs/ocaml-wire/blob/reject-greedy-repeat-element/lib/field.ml#L37) now refuses such an element at construction with `Invalid_argument`. The sub-codec remains valid standalone (a trailing greedy field is fine as the last field of a struct). Same family as #110.