### PR TITLE
lib: dedup shared helpers (zeroterm NUL scan, diff-gen file boilerplate)

### DIFF
--- a/lib/codec.mli
+++ b/lib/codec.mli
@@ -128,6 +128,11 @@ val set : 'r t -> ('a, 'r) field -> (bytes -> int -> 'a -> unit) Staged.t
     call {!validate} after a batch of writes to verify constraints still hold.
 *)
 
+val zeroterm_nul_pos : bytes -> first:int -> limit:int -> int
+(** [zeroterm_nul_pos buf ~first ~limit] is the index of the first NUL byte in
+    [\[first, limit)], raising [Parse_error] on an unterminated run. Internal
+    use (shared with the streaming decoders). *)
+
 val raw_decode : 'r t -> bytes -> int -> 'r
 (** [raw_decode c buf off] decodes without validation. Internal use. *)
 

--- a/lib/diff-gen/wire_diff_gen.ml
+++ b/lib/diff-gen/wire_diff_gen.ml
@@ -21,9 +21,16 @@ let schema ~name ~struct_ ~module_ =
 let generate_3d_files = Wire_3d.generate_3d
 let run_everparse = Wire_3d.run_everparse
 
-let generate_c_stubs ~schema_dir ~outdir schemas =
-  let oc = open_out (Filename.concat outdir "stubs.c") in
+(* Open [outdir/name], hand the body a formatter, then flush and close. *)
+let with_out_file ~outdir name f =
+  let oc = open_out (Filename.concat outdir name) in
   let ppf = Format.formatter_of_out_channel oc in
+  f ppf;
+  Format.pp_print_flush ppf ();
+  close_out oc
+
+let generate_c_stubs ~schema_dir ~outdir schemas =
+  with_out_file ~outdir "stubs.c" @@ fun ppf ->
   let pr fmt = Fmt.pf ppf fmt in
   pr "#include <caml/mlvalues.h>\n";
   pr "#include <caml/memory.h>\n";
@@ -56,25 +63,19 @@ let generate_c_stubs ~schema_dir ~outdir schemas =
         ep ep;
       pr "  CAMLreturn(Val_bool(EverParseIsSuccess(result)));\n";
       pr "}\n\n")
-    schemas;
-  Format.pp_print_flush ppf ();
-  close_out oc
+    schemas
 
 let generate_ml_stubs ~outdir schemas =
-  let oc = open_out (Filename.concat outdir "stubs.ml") in
-  let ppf = Format.formatter_of_out_channel oc in
+  with_out_file ~outdir "stubs.ml" @@ fun ppf ->
   let pr fmt = Fmt.pf ppf fmt in
   List.iter
     (fun s ->
       let lower = String.lowercase_ascii s.name in
       pr "external %s_check : bytes -> bool = \"caml_%s_check\"\n" lower lower)
-    schemas;
-  Format.pp_print_flush ppf ();
-  close_out oc
+    schemas
 
 let generate_test_runner ~outdir ?(num_values = 1000) schemas =
-  let oc = open_out (Filename.concat outdir "diff_test.ml") in
-  let ppf = Format.formatter_of_out_channel oc in
+  with_out_file ~outdir "diff_test.ml" @@ fun ppf ->
   let pr fmt = Fmt.pf ppf fmt in
   pr "(* Auto-generated differential test runner *)\n\n";
   pr "let num_values = %d\n\n" num_values;
@@ -117,9 +118,7 @@ let generate_test_runner ~outdir ?(num_values = 1000) schemas =
   pr
     "  Printf.printf \"Tested %%d values across %%d schemas\\n\" !total_tests \
      (List.length schemas);\n";
-  pr "  Printf.printf \"All %%d tests passed\\n\" !passed\n";
-  Format.pp_print_flush ppf ();
-  close_out oc
+  pr "  Printf.printf \"All %%d tests passed\\n\" !passed\n"
 
 (** {1 Full Pipeline} *)
 

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -154,16 +154,6 @@ let parse_all_zeros buf off len =
   in
   (check 0, len)
 
-(* Index of the first NUL in [first, limit); raises on an unterminated run. *)
-let nul_pos buf ~first ~limit =
-  let rec go i =
-    if i >= limit then
-      raise (Parse_error (Constraint_failed "zeroterm: missing NUL terminator"))
-    else if Bytes.get_uint8 buf i = 0 then i
-    else go (i + 1)
-  in
-  go first
-
 let parse_codec_typ codec_decode fixed_size size_of buf off len =
   let sz = match fixed_size with Some n -> n | None -> size_of buf off in
   check_eof len (off + sz);
@@ -253,12 +243,12 @@ let rec parse_direct : type a. a typ -> bytes -> int -> int -> a * int =
   | All_bytes -> (Bytes.sub_string buf off (len - off), len)
   | All_zeros -> parse_all_zeros buf off len
   | Zeroterm ->
-      let nul = nul_pos buf ~first:off ~limit:len in
+      let nul = Codec.zeroterm_nul_pos buf ~first:off ~limit:len in
       (Bytes.sub_string buf off (nul - off), nul + 1)
   | Zeroterm_at_most { size } ->
       let n = Eval.expr Eval.empty size in
       check_eof len (off + n);
-      let nul = nul_pos buf ~first:off ~limit:(off + n) in
+      let nul = Codec.zeroterm_nul_pos buf ~first:off ~limit:(off + n) in
       (Bytes.sub_string buf off (nul - off), off + n)
   | Byte_array { size } ->
       let n = Eval.expr Eval.empty size in


### PR DESCRIPTION
Two small library-level duplications surfaced by dupfind. `Wire.nul_pos` was a byte-for-byte copy of `Codec.zeroterm_nul_pos`; the streaming decoders now call the one in `Codec` (exposed for internal use). The differential-test generators (`generate_c_stubs` / `generate_ml_stubs` / `generate_test_runner`) each repeated the open-formatter / flush / close boilerplate; a `with_out_file` helper captures it. No behaviour change. The remaining dupfind hits are all test/bench similarity, expected and left alone.