### PR TITLE
codec: reject array/repeat over a byte-span-only sub-codec element

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -97,6 +97,13 @@
 
 ### Fixed
 
+- `Wire.array` / `Wire.array_seq` / `Field.repeat` / `Field.repeat_seq` over a
+  sub-codec built only from byte-span fields (`byte_array`, `byte_slice`, a
+  varint) now raise `Invalid_argument` at construction. EverParse projects such
+  an element as a byte-budget list whose entries may be empty, which its
+  validator rejects, so the codec previously built but failed schema
+  generation. A sub-codec with at least one fixed-size field is accepted as
+  before (#115, @samoht)
 - A greedy field (`all_bytes` / `all_zeros`) reads the rest of the buffer, so it
   is now rejected with `Invalid_argument` anywhere it is not the final field: a
   non-last field of a codec, a `Field.repeat` / `Wire.array` element (or a

--- a/lib/field.ml
+++ b/lib/field.ml
@@ -69,10 +69,13 @@ let rec is_repeat_case_body : type a. a Types.typ -> bool =
    string, or a self-bounded sub-codec / casetype. [Map] / [Where] / [Enum]
    are transparent wrappers, so look through them. A casetype is repeatable
    only when every case body is itself decodable as a repeat element
-   ([is_repeat_case_body]). Everything else (a sub-byte [bits] field, a refined
-   or at-most byte span whose per-element validation the byte-budget loop does
-   not run, greedy [all_zeros], a nested [array] / [nested]) has no clean
-   per-element 3D projection. *)
+   ([is_repeat_case_body]). A sub-codec must also be [nz] (have a fixed-size
+   field): EverParse projects [repeat] as a byte-budget list of the codec's
+   named struct, and a list over a possibly-empty element does not extract.
+   Everything else (a sub-byte [bits] field, a refined or at-most byte span
+   whose per-element validation the byte-budget loop does not run, greedy
+   [all_zeros], a nested [array] / [nested]) has no clean per-element 3D
+   projection. *)
 let rec is_repeat_element : type a. a Types.typ -> bool =
  fun typ ->
   let open Types in
@@ -81,7 +84,8 @@ let rec is_repeat_element : type a. a Types.typ -> bool =
   | Int64 _ | Float32 _ | Float64 _ | Uint_var _ | Unit | Zeroterm ->
       true
   | Byte_array { size = Int _ } | Byte_slice { size = Int _ } -> true
-  | Codec { codec_struct; _ } -> not (codec_ends_greedy codec_struct)
+  | Codec { codec_struct; _ } ->
+      (not (codec_ends_greedy codec_struct)) && Types.struct_nz codec_struct
   | Casetype { cases; _ } ->
       List.for_all
         (fun (Case_branch { cb_inner; _ }) -> is_repeat_case_body cb_inner)

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -401,14 +401,56 @@ let rec has_wire_size_expr : type a. a typ -> bool = function
   | Codec { codec_fixed_size; _ } -> codec_fixed_size <> None
   | _ -> false
 
+(* EverParse's byte-budget array ([T_nlist], the [array]/[repeat] lowering)
+   requires its element parser to consume a positive minimum number of bytes:
+   the [nz] index of [parser_kind nz wk]. A byte-budget array, a [nested] region
+   ([T_exact]), and the all-bytes / all-zeros tails all have kind
+   [parser_kind false _] -- their parser may consume zero bytes -- regardless of
+   a positive constant budget, so none of them is [nz]. A struct/codec is [nz]
+   iff some field is (sizes add, so one positive-minimum field anchors the rest);
+   a casetype is [nz] iff its tag is or every case body is (it parses [tag] then
+   a switch, and the tag alone anchors it). [map]/[where]/[enum] are transparent.
+   This is what makes a named composite usable as an element: a [T_nlist] over a
+   non-[nz] element fails EverParse extraction. *)
+let rec nz : type a. a typ -> bool = function
+  | Uint8 | Uint16 _ | Uint32 _ | Uint63 _ | Uint64 _ -> true
+  | Int8 | Int16 _ | Int32 _ | Int64 _ -> true
+  | Float32 _ | Float64 _ -> true
+  | Bits _ -> true
+  | Zeroterm -> true
+  | Uint_var _ -> false (* lowers to a UINT8 byte-budget array *)
+  | Zeroterm_at_most _ -> false (* T_at_most kind: parser_kind false _ *)
+  | Byte_array _ | Byte_array_where _ | Byte_slice _ -> false
+  | Unit -> false
+  | All_bytes | All_zeros -> false
+  | Array _ | Repeat _ -> false (* nlist kind *)
+  | Single_elem _ -> false (* T_exact kind *)
+  | Optional _ | Optional_or _ -> false
+  | Where { inner; _ } -> nz inner
+  | Map { inner; _ } -> nz inner
+  | Enum { base; _ } -> nz base
+  | Apply { typ; _ } -> nz typ
+  | Codec { codec_struct; _ } -> struct_nz codec_struct
+  | Struct s -> struct_nz s
+  | Casetype { tag; cases; _ } ->
+      nz tag
+      || List.for_all (fun (Case_branch { cb_inner; _ }) -> nz cb_inner) cases
+  | Type_ref _ | Qualified_ref _ -> false (* opaque ref: be conservative *)
+
+and struct_nz (s : struct_) =
+  List.exists (fun (Field f) -> nz f.field_typ) s.fields
+
 (* An [array]/[array_seq] element must be fixed-width AND decodable one element
    at a time by the array loop: a scalar, a fixed-size byte span, or a
    fixed-size sub-codec. [Map]/[Where]/[Enum] are transparent wrappers, so look
    through them. A [nested] region, a refined byte span ([byte_array_where]), a
    nested [array], or a variable / self-delimiting inner has no array
    projection (3D rejects it) and the decoder has no element reader, so they are
-   refused at construction. This is stricter than [has_wire_size_expr], which
-   admits sized-but-undecodable elements for the [optional] byte-size suffix. *)
+   refused at construction. A fixed-size sub-codec must additionally be [nz]:
+   EverParse projects the array as a byte-budget list of the codec's named
+   struct, and a list over a possibly-empty element does not extract. This is
+   stricter than [has_wire_size_expr], which admits sized-but-undecodable
+   elements for the [optional] byte-size suffix. *)
 let rec is_array_element : type a. a typ -> bool = function
   | Uint8 | Uint16 _ | Uint32 _ | Uint63 _ | Uint64 _ -> true
   | Int8 | Int16 _ | Int32 _ | Int64 _ -> true
@@ -416,7 +458,8 @@ let rec is_array_element : type a. a typ -> bool = function
   | Unit -> true
   | Uint_var { size = Int _; _ } -> true
   | Byte_array { size = Int _ } | Byte_slice { size = Int _ } -> true
-  | Codec { codec_fixed_size; _ } -> codec_fixed_size <> None
+  | Codec { codec_fixed_size; codec_struct; _ } ->
+      codec_fixed_size <> None && struct_nz codec_struct
   | Map { inner; _ } -> is_array_element inner
   | Where { inner; _ } -> is_array_element inner
   | Enum { base; _ } -> is_array_element base
@@ -427,8 +470,9 @@ let reject_non_array_element ~combinator t =
     Fmt.invalid_arg
       "Wire.%s: element type is not a fixed-width array element -- 3D projects \
        %s as a count of fixed-size elements (a scalar, a fixed byte span, or a \
-       fixed-size sub-codec); a nested region, refined span, or variable inner \
-       has no array projection."
+       fixed-size sub-codec with at least one fixed-size field); a nested \
+       region, refined span, variable inner, or a sub-codec made only of \
+       byte-span fields has no array projection."
       combinator combinator
 
 (* A self-delimiting inner carries its own length / structure, so it decodes a
@@ -1387,6 +1431,44 @@ let rec inner_wire_size_expr : type a. a typ -> int expr option = function
   | Apply { typ; _ } -> inner_wire_size_expr typ
   | t -> ( match inner_wire_size t with Some n -> Some (Int n) | None -> None)
 
+(* Strip transparent wrappers to see whether a byte-budget list element renders
+   as a named composite (sub-codec / casetype). Those are the only list elements
+   whose [nz]-ness matters: a flat scalar / byte / varint element renders as
+   [UINT8] / [UINTnn], itself [nz], so the emitted list is always well-kinded. *)
+let rec renders_as_named_composite : type a. a typ -> bool = function
+  | Codec _ | Casetype _ -> true
+  | Map { inner; _ } -> renders_as_named_composite inner
+  | Where { inner; _ } -> renders_as_named_composite inner
+  | _ -> false
+
+(* 3d-model boundary for a byte-budget list ([T_nlist]) element's base type
+   printer. [Nlist_elem.t] is abstract, so the only way to obtain one is
+   [Nlist_elem.make], which refuses a named-composite element that is not [nz] --
+   EverParse rejects a list whose element parser may consume zero bytes. Routing
+   both list emit sites ([array] / [repeat]) through here means the projection
+   cannot hand {!pp_field} a base for an ill-kinded list. [is_array_element] /
+   [is_repeat_element] reject such elements at construction, so for user-built
+   codecs the proof always succeeds; this is the backstop one layer in. *)
+module Nlist_elem : sig
+  type t
+
+  val make : 'a typ -> (Format.formatter -> unit) -> t
+  val pp : t -> Format.formatter -> unit
+end = struct
+  type t = Format.formatter -> unit
+
+  let make : type a. a typ -> (Format.formatter -> unit) -> t =
+   fun elem pp ->
+    if (not (renders_as_named_composite elem)) || nz elem then pp
+    else
+      Fmt.invalid_arg
+        "Everparse: byte-budget list over %a, whose parser may consume zero \
+         bytes; EverParse rejects a non-[nz] list element"
+        pp_typ elem
+
+  let pp t = t
+end
+
 let rec optional_suffix : type a.
     bool expr -> a typ -> field_suffix * (Format.formatter -> unit) =
  fun present inner ->
@@ -1439,8 +1521,10 @@ and field_suffix : type a. a typ -> field_suffix * (Format.formatter -> unit) =
       | _, Some s ->
           (* A wider element is emitted as its bare base under a byte budget of
              [len * width]; its own [:byte-size] suffix (e.g. for a [byte_array]
-             chunk) is dropped so it is not duplicated. *)
-          (Byte_array (Mul (len, s)), snd (field_suffix elem))
+             chunk) is dropped so it is not duplicated. A named-composite base
+             must be [nz] (see {!nlist_base}). *)
+          ( Byte_array (Mul (len, s)),
+            Nlist_elem.pp (Nlist_elem.make elem (snd (field_suffix elem))) )
       | _ ->
           (* Unreachable: [array] rejects variable-size elem at construction. *)
           assert false)
@@ -1468,7 +1552,8 @@ and field_suffix : type a. a typ -> field_suffix * (Format.formatter -> unit) =
       let pp_elem ppf =
         match repeat_elem_struct elem with
         | Some name -> Fmt.string ppf name
-        | None -> (snd (field_suffix elem)) ppf
+        | None ->
+            Nlist_elem.pp (Nlist_elem.make elem (snd (field_suffix elem))) ppf
       in
       (Byte_array size, pp_elem)
   | Zeroterm -> (Zeroterm, fun ppf -> Fmt.string ppf "UINT8")

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -750,6 +750,20 @@ val is_greedy : 'a typ -> bool
     transparent wrappers). Such a field is only valid as the last field of a
     struct or codec. *)
 
+val nz : 'a typ -> bool
+(** Whether the type's parser always consumes a positive minimum number of bytes
+    (EverParse's [nz] parser-kind index). [false] for a byte span, a
+    {!val-nested} region, an optional, or an all-bytes / all-zeros tail: their
+    parser may consume zero bytes regardless of any positive constant size. A
+    struct/codec is [nz] iff one of its fields is; a casetype iff its tag or
+    every case body is. EverParse's byte-budget array ([T_nlist]) rejects a
+    non-[nz] element, so a sub-codec must be [nz] to be an {!val-array} /
+    {!val-repeat} element. *)
+
+val struct_nz : struct_ -> bool
+(** [struct_nz s] is [true] iff some field of [s] is {!nz}, i.e. the struct's
+    parser has a positive minimum size. *)
+
 val size_of_typ_value : 'a typ -> 'a -> int
 (** [size_of_typ_value typ v] is the encoded byte size of [v] under [typ],
     computed from the value rather than from a buffer. Falls back to [0] for

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -659,6 +659,39 @@ let test_array_reject_nonprojectable_element () =
     "array over array rejected" true
     (raises_invalid (fun () -> array ~len:(int 2) (array ~len:(int 2) uint8)))
 
+(* EverParse projects [array] / [repeat] of a sub-codec as a byte-budget list of
+   the codec's named struct, and its [T_nlist] requires the element parser to
+   consume a positive minimum of bytes. A sub-codec made only of byte-span
+   fields has a possibly-empty parser, so the list does not extract -- such an
+   element is refused at construction. One fixed-size field is enough to anchor
+   it. *)
+let lone_byte_codec =
+  Codec.v "LoneBytes" Fun.id
+    Codec.[ Field.v "blob" (byte_array ~size:(int 4)) $ Fun.id ]
+
+let scalar_bearing_codec =
+  Codec.v "Anchored"
+    (fun a b -> (a, b))
+    Codec.
+      [
+        Field.v "tag" uint8 $ fst;
+        Field.v "blob" (byte_array ~size:(int 3)) $ snd;
+      ]
+
+let test_array_repeat_reject_non_nz_codec () =
+  Alcotest.(check bool)
+    "array over byte-span-only codec rejected" true
+    (raises_invalid (fun () -> array ~len:(int 2) (codec lone_byte_codec)));
+  Alcotest.(check bool)
+    "repeat over byte-span-only codec rejected" true
+    (repeat_rejects (codec lone_byte_codec));
+  Alcotest.(check bool)
+    "array over a codec with a fixed-size field allowed" false
+    (raises_invalid (fun () -> array ~len:(int 2) (codec scalar_bearing_codec)));
+  Alcotest.(check bool)
+    "repeat over a codec with a fixed-size field allowed" false
+    (repeat_rejects (codec scalar_bearing_codec))
+
 (* A bitfield has no standalone wire form, so it cannot be an [optional] inner
    any more than an [array] / [repeat] / [nested] element. *)
 let test_optional_reject_bitfield () =
@@ -4753,6 +4786,8 @@ let suite =
         test_casetype_nested_case_body;
       Alcotest.test_case "array rejects non-projectable element" `Quick
         test_array_reject_nonprojectable_element;
+      Alcotest.test_case "array/repeat reject byte-span-only sub-codec" `Quick
+        test_array_repeat_reject_non_nz_codec;
       Alcotest.test_case "optional rejects unprojectable inner" `Quick
         test_optional_reject_unprojectable;
       Alcotest.test_case "optional rejects bitfield inner" `Quick


### PR DESCRIPTION
`Wire.array` and `Field.repeat` over a sub-codec built only from byte-span fields (a lone `byte_array`, `byte_slice`, or varint, with no fixed-size field) used to build successfully but then fail EverParse schema generation. EverParse lowers the element to a byte-budget list (`T_nlist`) whose entries may be empty, and its validator rejects a list over a possibly-empty element, so the codec never produced a verified C parser.

[is_array_element](https://github.com/parsimoni-labs/ocaml-wire/blob/reject-non-nz-list-element/lib/types.ml#L454) and [is_repeat_element](https://github.com/parsimoni-labs/ocaml-wire/blob/reject-non-nz-list-element/lib/field.ml#L88) now require such a sub-codec to have a positive minimum size before accepting it, rejecting it at construction with `Invalid_argument`. The same rule ([nz](https://github.com/parsimoni-labs/ocaml-wire/blob/reject-non-nz-list-element/lib/types.ml#L415)) guards the projection so the emitter cannot hand the printer a base for an ill-kinded list. A sub-codec with at least one fixed-size field is unaffected.

Same family as #107.