### PR TITLE
codec: project array over float and wrapped byte-span elements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -104,6 +104,11 @@
   validator rejects, so the codec previously built but failed schema
   generation. A sub-codec with at least one fixed-size field is accepted as
   before (#115, @samoht)
+- `Wire.array` / `Wire.array_seq` over a float, a signed integer, a `uint63`, or
+  a `Wire.where` / `Wire.map` wrapping a fixed byte span no longer crashes 3D
+  projection with an assertion failure. Such an array built and round-tripped
+  but the projector could not size its element, so generating a schema raised.
+  All fixed-width scalars and wrapped byte spans now project (#116, @samoht)
 - A greedy field (`all_bytes` / `all_zeros`) reads the rest of the buffer, so it
   is now rejected with `Invalid_argument` anywhere it is not the final field: a
   non-last field of a codec, a `Field.repeat` / `Wire.array` element (or a

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -1398,10 +1398,10 @@ type field_suffix =
   | Zeroterm_at_most of int expr
 
 let rec inner_wire_size : type a. a typ -> int option = function
-  | Uint8 -> Some 1
-  | Uint16 _ -> Some 2
-  | Uint32 _ -> Some 4
-  | Uint64 _ -> Some 8
+  | Uint8 | Int8 -> Some 1
+  | Uint16 _ | Int16 _ -> Some 2
+  | Uint32 _ | Int32 _ | Float32 _ -> Some 4
+  | Uint63 _ | Uint64 _ | Int64 _ | Float64 _ -> Some 8
   | Bits { base = BF_U8; _ } -> Some 1
   | Bits { base = BF_U16 _; _ } -> Some 2
   | Bits { base = BF_U32 _; _ } -> Some 4
@@ -1429,6 +1429,14 @@ let rec inner_wire_size_expr : type a. a typ -> int expr option = function
       | Some s -> Some (Mul (len, s))
       | None -> None)
   | Apply { typ; _ } -> inner_wire_size_expr typ
+  (* Transparent wrappers carry the inner's wire size, including the byte-span
+     family that [inner_wire_size] does not size. Without this an [array] over a
+     [where] / [map] / [enum] of a byte span builds (the element passes
+     [is_array_element], which looks through wrappers) but has no projectable
+     size. *)
+  | Where { inner; _ } -> inner_wire_size_expr inner
+  | Map { inner; _ } -> inner_wire_size_expr inner
+  | Enum { base; _ } -> inner_wire_size_expr base
   | t -> ( match inner_wire_size t with Some n -> Some (Int n) | None -> None)
 
 (* Strip transparent wrappers to see whether a byte-budget list element renders

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -692,6 +692,50 @@ let test_array_repeat_reject_non_nz_codec () =
     "repeat over a codec with a fixed-size field allowed" false
     (repeat_rejects (codec scalar_bearing_codec))
 
+let projects c = match render_3d c with _ -> true | exception _ -> false
+let arr_field elem = Codec.v "Arr" Fun.id Codec.[ Field.v "x" elem $ Fun.id ]
+
+(* An [array] over a float, signed integer, or [uint63] element used to build
+   and round-trip but crash 3D projection with [assert false]: [inner_wire_size]
+   sized only the unsigned [uint8/16/32/64] and bitfields, so the projector
+   could not size the element. All fixed-width scalars now project. *)
+let test_array_scalar_element_projects () =
+  let yes name c =
+    Alcotest.(check bool) (name ^ " array projects") true (projects c)
+  in
+  yes "float64be" (arr_field (array ~len:(int 2) float64be));
+  yes "float32be" (arr_field (array ~len:(int 2) float32be));
+  yes "int8" (arr_field (array ~len:(int 2) int8));
+  yes "int16be" (arr_field (array ~len:(int 2) int16be));
+  yes "int32be" (arr_field (array ~len:(int 2) int32be));
+  yes "int64be" (arr_field (array ~len:(int 2) int64be));
+  yes "uint63be" (arr_field (array ~len:(int 2) uint63be));
+  (* and it still round-trips *)
+  let c = arr_field (array ~len:(int 2) float64be) in
+  let v = [ 1.5; -2.25 ] in
+  let buf = Bytes.create (Codec.size_of_value c v) in
+  Codec.encode c v buf 0;
+  match Codec.decode c buf 0 with
+  | Ok d -> Alcotest.(check (list (float 0.0))) "float array" v d
+  | Error e -> Alcotest.failf "decode: %a" pp_parse_error e
+
+(* An [array] over a [where] / [map] wrapping a byte span used to crash 3D
+   projection with [assert false]: [is_array_element] looks through the
+   transparent wrapper to accept it, but [inner_wire_size_expr] did not recurse
+   through the wrapper to find the span's size. *)
+let test_array_wrapped_byte_span_projects () =
+  Alcotest.(check bool)
+    "array over where(byte_slice) projects" true
+    (projects
+       (arr_field
+          (array ~len:(int 2) (where Expr.true_ (byte_slice ~size:(int 4))))));
+  Alcotest.(check bool)
+    "array over map(byte_array) projects" true
+    (projects
+       (arr_field
+          (array ~len:(int 2)
+             (map ~decode:Fun.id ~encode:Fun.id (byte_array ~size:(int 4))))))
+
 (* A bitfield has no standalone wire form, so it cannot be an [optional] inner
    any more than an [array] / [repeat] / [nested] element. *)
 let test_optional_reject_bitfield () =
@@ -4788,6 +4832,10 @@ let suite =
         test_array_reject_nonprojectable_element;
       Alcotest.test_case "array/repeat reject byte-span-only sub-codec" `Quick
         test_array_repeat_reject_non_nz_codec;
+      Alcotest.test_case "array over scalar element projects" `Quick
+        test_array_scalar_element_projects;
+      Alcotest.test_case "array over wrapped byte span projects" `Quick
+        test_array_wrapped_byte_span_projects;
       Alcotest.test_case "optional rejects unprojectable inner" `Quick
         test_optional_reject_unprojectable;
       Alcotest.test_case "optional rejects bitfield inner" `Quick


### PR DESCRIPTION
An `array` / `array_seq` over a float, a signed integer, a `uint63`, or a `Wire.where` / `Wire.map` wrapping a fixed byte span used to build and round-trip but crash 3D projection with an assertion failure. [inner_wire_size](https://github.com/parsimoni-labs/ocaml-wire/blob/fix-array-element-projection/lib/types.ml#L1400) sized only the unsigned scalars and bitfields, and [inner_wire_size_expr](https://github.com/parsimoni-labs/ocaml-wire/blob/fix-array-element-projection/lib/types.ml#L1421) did not recurse through transparent wrappers, so the projector reached an element it could not size and hit the "unreachable" branch in `field_suffix`.

Both functions now cover every fixed-width scalar and look through `where` / `map` / `enum`, so these arrays project to a schema EverParse verifies. The shapes were already accepted at construction (`is_array_element` looks through the wrappers), so this is purely a projection fix. Same family as #115.