### PR TITLE
fuzz: composer-driven everparse suite, fix rest_bytes projection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -97,6 +97,12 @@
 
 ### Fixed
 
+- `Wire.rest_bytes` now generates a verified EverParse validator. Its
+  `total - sizeof(this)` byte-size failed EverParse verification ("cannot verify
+  u32 subtraction"), so any codec with a `rest_bytes` field failed schema
+  generation regardless of width. The projection now emits a `total >=
+  sizeof(this)` guard on the preceding field, which discharges the subtraction
+  (#117, @samoht)
 - `Wire.array` / `Wire.array_seq` / `Field.repeat` / `Field.repeat_seq` over a
   sub-codec built only from byte-span fields (`byte_array`, `byte_slice`, a
   varint) now raise `Invalid_argument` at construction. EverParse projects such

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -97,6 +97,10 @@
 
 ### Fixed
 
+- Decoding no longer crashes with `Invalid_argument` on adversarial input where
+  a `Field.repeat` byte budget, or a variable field's cross-field size, exceeds
+  the buffer (an out-of-range `Bytes.sub`). Such an oversized length now fails
+  with a clean `Parse_error` (#117, @samoht)
 - `Wire.rest_bytes` now generates a verified EverParse validator. Its
   `total - sizeof(this)` byte-size failed EverParse verification ("cannot verify
   u32 subtraction"), so any codec with a `rest_bytes` field failed schema

--- a/fuzz/dune
+++ b/fuzz/dune
@@ -1,6 +1,6 @@
 (executable
  (name fuzz)
- (libraries wire alcobar fuzz_gen))
+ (libraries wire wire.3d unix alcobar fuzz_gen))
 
 (rule
  (alias runtest)

--- a/fuzz/fuzz_everparse.ml
+++ b/fuzz/fuzz_everparse.ml
@@ -39,10 +39,7 @@ let extract_names =
     "optional(uint8)";
     "optional_or(uint8)";
     "record";
-    (* [rest_bytes] sized by a [Param.input] minus a sizeof projects to a u32
-       subtraction EverParse cannot prove non-underflowing (Error 19). That is a
-       separate projection-soundness finding, not exercised here; it stays in the
-       pp pass above. *)
+    "rest_bytes";
   ]
 
 (* EverParse derives the module name from the .3d filename and requires it to

--- a/fuzz/fuzz_everparse.ml
+++ b/fuzz/fuzz_everparse.ml
@@ -1,786 +1,117 @@
-(** Fuzz tests for 3D/C projection: pretty-printing and code generation. *)
+(** Fuzz tests for 3D / EverParse projection, driven entirely by {!Fuzz_gen}.
+
+    Every generated codec is projected to a 3D schema and pretty-printed
+    ({!Fuzz_gen.everparse_cases}), so the projection and code-generation path is
+    exercised on the same compositions the OCaml round-trip suite uses, plus
+    arbitrary nested ones. When [3d.exe] is available, a bounded set of the
+    composite schemas is additionally run through EverParse ([3d.exe --batch]):
+    every codec that builds must also project to a schema EverParse verifies.
+    That extraction pass is the only check that catches kind errors (a list over
+    a possibly-empty element), which surface during F* verification, not during
+    pretty-printing. It is skipped where [3d.exe] is absent (CI, AFL). *)
 
 open Alcobar
 
-(** {1 Pretty-printing Tests} *)
-
-let test_pp_uint8 () =
-  let _ = Fmt.str "%a" Wire.Everparse.Raw.pp_typ Wire.uint8 in
-  ()
-
-let test_pp_uint16 () =
-  let _ = Fmt.str "%a" Wire.Everparse.Raw.pp_typ Wire.uint16 in
-  ()
-
-let test_pp_uint16be () =
-  let _ = Fmt.str "%a" Wire.Everparse.Raw.pp_typ Wire.uint16be in
-  ()
-
-let test_pp_uint32 () =
-  let _ = Fmt.str "%a" Wire.Everparse.Raw.pp_typ Wire.uint32 in
-  ()
-
-let test_pp_uint32be () =
-  let _ = Fmt.str "%a" Wire.Everparse.Raw.pp_typ Wire.uint32be in
-  ()
-
-let test_pp_uint63 () =
-  let _ = Fmt.str "%a" Wire.Everparse.Raw.pp_typ Wire.uint63 in
-  ()
-
-let test_pp_uint63be () =
-  let _ = Fmt.str "%a" Wire.Everparse.Raw.pp_typ Wire.uint63be in
-  ()
-
-let test_pp_uint64 () =
-  let _ = Fmt.str "%a" Wire.Everparse.Raw.pp_typ Wire.uint64 in
-  ()
-
-let test_pp_uint64be () =
-  let _ = Fmt.str "%a" Wire.Everparse.Raw.pp_typ Wire.uint64be in
-  ()
-
-let test_pp_bitfield width =
-  if width > 0 && width <= 32 then begin
-    let t = Wire.bits ~width Wire.U32 in
-    let _ = Fmt.str "%a" Wire.Everparse.Raw.pp_typ t in
-    ()
-  end
-
-let test_pp_bf_uint8 width =
-  let width = (abs width mod 8) + 1 in
-  let t = Wire.bits ~width Wire.U8 in
-  let _ = Fmt.str "%a" Wire.Everparse.Raw.pp_typ t in
-  ()
-
-let test_pp_bf_uint16 width =
-  let width = (abs width mod 16) + 1 in
-  let t = Wire.bits ~width Wire.U16 in
-  let _ = Fmt.str "%a" Wire.Everparse.Raw.pp_typ t in
-  ()
-
-let test_pp_bf_uint16be width =
-  let width = (abs width mod 16) + 1 in
-  let t = Wire.bits ~width Wire.U16be in
-  let _ = Fmt.str "%a" Wire.Everparse.Raw.pp_typ t in
-  ()
-
-let test_pp_bf_uint32be width =
-  let width = (abs width mod 32) + 1 in
-  let t = Wire.bits ~width Wire.U32be in
-  let _ = Fmt.str "%a" Wire.Everparse.Raw.pp_typ t in
-  ()
-
-let test_pp_map () =
-  let t =
-    Wire.map ~decode:(fun n -> n * 2) ~encode:(fun n -> n / 2) Wire.uint8
-  in
-  let _ = Fmt.str "%a" Wire.Everparse.Raw.pp_typ t in
-  ()
-
-let test_pp_bool () =
-  let t = Wire.bit (Wire.bits ~width:1 Wire.U8) in
-  let _ = Fmt.str "%a" Wire.Everparse.Raw.pp_typ t in
-  ()
-
-let test_pp_variants () =
-  let t =
-    Wire.variants "Test" [ ("A", "a"); ("B", "b"); ("C", "c") ] Wire.uint8
-  in
-  let _ = Fmt.str "%a" Wire.Everparse.Raw.pp_typ t in
-  ()
-
-let test_pp_unit () =
-  let _ = Fmt.str "%a" Wire.Everparse.Raw.pp_typ Wire.empty in
-  ()
-
-(** Test pp_module doesn't crash on valid modules. *)
-let test_pp_module_simple () =
-  let s =
-    Wire.Everparse.Raw.struct_ "Test"
-      [
-        Wire.Everparse.Raw.field "a" Wire.uint8;
-        Wire.Everparse.Raw.field "b" Wire.uint16;
-      ]
-  in
-  let m = Wire.Everparse.Raw.module_ [ Wire.Everparse.Raw.typedef s ] in
-  let _ = Wire.Everparse.Raw.to_3d m in
-  ()
-
-(** {1 3D Code Generation Tests} *)
-
-(** Test struct with random field count. *)
-let test_struct_random_fields n =
-  let n = (n mod 10) + 1 in
-  let fields =
-    List.init n (fun i -> Wire.Everparse.Raw.field (Fmt.str "f%d" i) Wire.uint8)
-  in
-  let s = Wire.Everparse.Raw.struct_ "Random" fields in
-  let m = Wire.Everparse.Raw.module_ [ Wire.Everparse.Raw.typedef s ] in
-  let _ = Wire.Everparse.Raw.to_3d m in
-  ()
-
-(** Test enum with random cases. *)
-let test_enum_random_cases n =
-  let n = (n mod 10) + 1 in
-  let cases = List.init n (fun i -> (Fmt.str "C%d" i, i)) in
-  let e = Wire.Everparse.Raw.enum_decl "RandEnum" cases Wire.uint8 in
-  let m = Wire.Everparse.Raw.module_ [ e ] in
-  let _ = Wire.Everparse.Raw.to_3d m in
-  ()
-
-(** Test casetype with random cases. *)
-let test_casetype_random n =
-  let n = (n mod 5) + 1 in
-  let cases =
-    List.init n (fun i -> Wire.Everparse.Raw.decl_case i Wire.uint8)
-  in
-  let ct =
-    Wire.Everparse.Raw.casetype_decl "_RandCase"
-      [ Wire.Everparse.Raw.param "tag" Wire.uint8 ]
-      Wire.uint8 cases
-  in
-  let m = Wire.Everparse.Raw.module_ [ ct ] in
-  let _ = Wire.Everparse.Raw.to_3d m in
-  ()
-
-type ep_case_val = [ `U16 of int | `U32 of int | `Default of int ]
-(** Test inline casetype. *)
-
-let test_casetype_inline () =
-  let t : ep_case_val Wire.typ =
-    Wire.casetype "Tag" Wire.uint8
-      [
-        Wire.case ~index:0 Wire.uint16
-          ~inject:(fun v -> `U16 v)
-          ~project:(function `U16 v -> Some v | _ -> None);
-        Wire.case ~index:1 Wire.uint32
-          ~inject:(fun v -> `U32 (Wire.Private.UInt32.to_int v))
-          ~project:(function
-            | `U32 v -> Some (Wire.Private.UInt32.of_int v) | _ -> None);
-        Wire.default Wire.uint8
-          ~inject:(fun _tag v -> `Default v)
-          ~project:(function `Default v -> Some (0xFF, v) | _ -> None);
-      ]
-  in
-  let s =
-    Wire.Everparse.Raw.struct_ "WithCase"
-      [
-        Wire.Everparse.Raw.field "tag" Wire.uint8;
-        Wire.Everparse.Raw.field "data" t;
-      ]
-  in
-  let m = Wire.Everparse.Raw.module_ [ Wire.Everparse.Raw.typedef s ] in
-  let _ = Wire.Everparse.Raw.to_3d m in
-  ()
-
-(* Render a one-field struct constrained by [build_cond f_x] through the
-   3D emitter. The fuzz target is "does this typecheck and produce output";
-   the actual rendered string is dropped. *)
-let render_constrained_x ~name typ build_cond =
-  let f_x = Wire.Everparse.Raw.field "x" typ in
-  let cond = build_cond f_x in
-  let s =
-    Wire.Everparse.Raw.struct_ name
-      [ Wire.Everparse.Raw.field "x" ~constraint_:cond typ ]
-  in
-  let m = Wire.Everparse.Raw.module_ [ Wire.Everparse.Raw.typedef s ] in
-  let _ = Wire.Everparse.Raw.to_3d m in
-  ()
-
-(** Test constraint expression generation. *)
-let test_constraint_expr a =
-  let v = abs a mod 1000 in
-  render_constrained_x ~name:"Constrained" Wire.uint16 (fun f_x ->
-      Wire.Expr.(Wire.Everparse.Raw.field_ref f_x <= Wire.int v))
-
-(** Test bitfield constraints. *)
-let test_bitfield_constraint width =
-  let width = (width mod 16) + 1 in
-  let t = Wire.bits ~width Wire.U16 in
-  render_constrained_x ~name:"BFConstrained" t (fun f_x ->
-      Wire.Expr.(Wire.Everparse.Raw.field_ref f_x <= Wire.int 100))
-
-(** Test bitwise expression operators in 3D output. *)
-let test_bitwise_expr a =
-  let v = abs a mod 256 in
-  render_constrained_x ~name:"Bitwise" Wire.uint16 (fun f_x ->
-      let open Wire.Expr in
-      Wire.Everparse.Raw.field_ref f_x land Wire.int 0xFF <= Wire.int v)
-
-(** Test logical expression operators. *)
-let test_logical_expr () =
-  let f_x = Wire.Everparse.Raw.field "x" Wire.uint8 in
-  let open Wire.Expr in
-  let cond =
-    Wire.Everparse.Raw.field_ref f_x <= Wire.int 100
-    && Wire.Everparse.Raw.field_ref f_x >= Wire.int 0
-  in
-  let s =
-    Wire.Everparse.Raw.struct_ "Logical"
-      [ Wire.Everparse.Raw.field "x" ~constraint_:cond Wire.uint8 ]
-  in
-  let m = Wire.Everparse.Raw.module_ [ Wire.Everparse.Raw.typedef s ] in
-  let _ = Wire.Everparse.Raw.to_3d m in
-  ()
-
-(** Test all bitwise/shift operators. *)
-let test_bitwise_ops () =
-  let f_x = Wire.Everparse.Raw.field "x" Wire.uint8 in
-  let open Wire.Expr in
-  let _ = Wire.Everparse.Raw.field_ref f_x lor Wire.int 1 in
-  let _ = Wire.Everparse.Raw.field_ref f_x lxor Wire.int 0xFF in
-  let _ = lnot (Wire.Everparse.Raw.field_ref f_x) in
-  let _ = Wire.Everparse.Raw.field_ref f_x lsl Wire.int 2 in
-  let _ = Wire.Everparse.Raw.field_ref f_x lsr Wire.int 3 in
-  ()
-
-(** Test logical operators. *)
-let test_logical_ops () =
-  let f_x = Wire.Everparse.Raw.field "x" Wire.uint8 in
-  let open Wire.Expr in
-  let _ = Wire.Expr.true_ || Wire.Expr.false_ in
-  let _ = Wire.Expr.not Wire.Expr.true_ in
-  let _ =
-    Wire.Everparse.Raw.field_ref f_x = Wire.int 0
-    || Wire.Everparse.Raw.field_ref f_x <> Wire.int 1
-  in
-  ()
-
-(** Test cast operators in 3D output. *)
-let test_cast_expr () =
-  let f_x = Wire.Everparse.Raw.field "x" Wire.uint16 in
-  let open Wire.Expr in
-  let cond = to_uint8 (Wire.Everparse.Raw.field_ref f_x) <= Wire.int 100 in
-  let s =
-    Wire.Everparse.Raw.struct_ "Cast"
-      [ Wire.Everparse.Raw.field "x" ~constraint_:cond Wire.uint16 ]
-  in
-  let m = Wire.Everparse.Raw.module_ [ Wire.Everparse.Raw.typedef s ] in
-  let _ = Wire.Everparse.Raw.to_3d m in
-  ()
-
-(** Test all cast variants. *)
-let test_cast_variants () =
-  let open Wire.Expr in
-  let _ = to_uint8 (Wire.int 42) in
-  let _ = to_uint16 (Wire.int 42) in
-  let _ = to_uint32 (Wire.int 42) in
-  let _ = to_uint64 (Wire.int 42) in
-  ()
-
-(** Test sizeof expression. *)
-let test_sizeof_expr () =
-  let _ = Wire.sizeof Wire.uint32 in
-  let _ = Wire.sizeof_this in
-  let _ = Wire.field_pos in
-  ()
-
-let render_single_field_struct ~struct_name ~field_name typ =
-  let s =
-    Wire.Everparse.Raw.struct_ struct_name
-      [ Wire.Everparse.Raw.field field_name typ ]
-  in
-  let m = Wire.Everparse.Raw.module_ [ Wire.Everparse.Raw.typedef s ] in
-  let _ = Wire.Everparse.Raw.to_3d m in
-  ()
-
-(** Test array types. *)
-let test_array_type len =
-  let len = (abs len mod 100) + 1 in
-  render_single_field_struct ~struct_name:"WithArray" ~field_name:"arr"
-    (Wire.array ~len:(Wire.int len) Wire.uint8)
-
-(** Test byte_array types. *)
-let test_byte_array size =
-  let size = (abs size mod 1000) + 1 in
-  render_single_field_struct ~struct_name:"WithByteArray" ~field_name:"data"
-    (Wire.byte_array ~size:(Wire.int size))
-
-(** Test nested. *)
-let test_nested () =
-  render_single_field_struct ~struct_name:"WithSingle" ~field_name:"x"
-    (Wire.nested ~size:(Wire.int 4) Wire.uint32)
-
-(** Test nested_at_most. *)
-let test_single_elem_at_most () =
-  render_single_field_struct ~struct_name:"WithAtMost" ~field_name:"x"
-    (Wire.nested_at_most ~size:(Wire.int 8) Wire.uint32)
-
-(** Test anon_field (padding). *)
-let test_anon_field () =
-  let s =
-    Wire.Everparse.Raw.struct_ "WithPadding"
-      [
-        Wire.Everparse.Raw.field "x" Wire.uint8;
-        Wire.Everparse.Raw.anon_field Wire.uint8;
-        Wire.Everparse.Raw.field "y" Wire.uint16;
-      ]
-  in
-  let m = Wire.Everparse.Raw.module_ [ Wire.Everparse.Raw.typedef s ] in
-  let _ = Wire.Everparse.Raw.to_3d m in
-  ()
-
-(** Test parameterized struct. *)
-let test_param_struct n =
-  let n = (n mod 5) + 1 in
-  let params =
-    List.init n (fun i ->
-        Wire.Everparse.Raw.param (Fmt.str "p%d" i) Wire.uint32)
-  in
-  let ps =
-    Wire.Everparse.Raw.param_struct "Parametric" params
-      [ Wire.Everparse.Raw.field "x" Wire.uint8 ]
-  in
-  let m = Wire.Everparse.Raw.module_ [ Wire.Everparse.Raw.typedef ps ] in
-  let _ = Wire.Everparse.Raw.to_3d m in
-  ()
-
-(** Test mutable_param. *)
-let test_mutable_param () =
-  let ps =
-    Wire.Everparse.Raw.param_struct "MutParam"
-      [ Wire.Everparse.Raw.mutable_param "out" Wire.uint32 ]
-      [ Wire.Everparse.Raw.field "x" Wire.uint8 ]
-  in
-  let m = Wire.Everparse.Raw.module_ [ Wire.Everparse.Raw.typedef ps ] in
-  let _ = Wire.Everparse.Raw.to_3d m in
-  ()
-
-(** Test apply (parameterized type application). *)
-let test_apply () =
-  let t =
-    Wire.Everparse.Raw.apply
-      (Wire.Everparse.Raw.type_ref "Param")
-      [ Wire.int 42 ]
-  in
-  let s =
-    Wire.Everparse.Raw.struct_ "WithApply" [ Wire.Everparse.Raw.field "x" t ]
-  in
-  let m = Wire.Everparse.Raw.module_ [ Wire.Everparse.Raw.typedef s ] in
-  let _ = Wire.Everparse.Raw.to_3d m in
-  ()
-
-(** Test type_ref. *)
-let test_type_ref () =
-  let t : int Wire.typ = Wire.Everparse.Raw.type_ref "SomeType" in
-  render_single_field_struct ~struct_name:"WithRef" ~field_name:"x" t
-
-(** Test qualified_ref. *)
-let test_qualified_ref () =
-  let t : int Wire.typ = Wire.Everparse.Raw.qualified_ref "Other" "SomeType" in
-  render_single_field_struct ~struct_name:"WithQRef" ~field_name:"x" t
-
-let render_action_struct ~name ptr act =
-  let s =
-    Wire.Everparse.Raw.param_struct name
-      [ Wire.Param.decl ptr ]
-      [ Wire.Everparse.Raw.field "x" ~action:act Wire.uint8 ]
-  in
-  let m = Wire.Everparse.Raw.module_ [ Wire.Everparse.Raw.typedef s ] in
-  let _ = Wire.Everparse.Raw.to_3d m in
-  ()
-
-(** Test action generation. *)
-let test_action () =
-  let ptr = Wire.Param.output "ptr" Wire.uint32 in
-  let act =
-    Wire.Action.on_success
-      [
-        Wire.Action.assign ptr (Wire.int 42);
-        Wire.Action.return_bool Wire.Expr.true_;
-      ]
-  in
-  render_action_struct ~name:"WithAction" ptr act
-
-(** Test Action.on_act action. *)
-let test_on_act () =
-  let ptr = Wire.Param.output "ptr" Wire.uint32 in
-  let act = Wire.Action.on_act [ Wire.Action.assign ptr (Wire.int 0) ] in
-  render_action_struct ~name:"WithOnAct" ptr act
-
-(** Test Action.abort action. *)
-let test_abort () =
-  let act = Wire.Action.on_success [ Wire.Action.abort ] in
-  let s =
-    Wire.Everparse.Raw.struct_ "WithAbort"
-      [ Wire.Everparse.Raw.field "x" ~action:act Wire.uint8 ]
-  in
-  let m = Wire.Everparse.Raw.module_ [ Wire.Everparse.Raw.typedef s ] in
-  let _ = Wire.Everparse.Raw.to_3d m in
-  ()
-
-(** Test Action.if_. *)
-let test_action_if () =
-  let ptr = Wire.Param.output "ptr" Wire.uint32 in
-  let f_x = Wire.Everparse.Raw.field "x" Wire.uint8 in
-  let stmt =
-    Wire.Action.if_
-      Wire.Expr.(Wire.Everparse.Raw.field_ref f_x > Wire.int 10)
-      [ Wire.Action.assign ptr (Wire.int 1) ]
-      (Some [ Wire.Action.assign ptr (Wire.int 0) ])
-  in
-  let act = Wire.Action.on_success [ stmt ] in
-  let s =
-    Wire.Everparse.Raw.param_struct "WithIf"
-      [ Wire.Param.decl ptr ]
-      [ Wire.Everparse.Raw.field "x" ~action:act Wire.uint8 ]
-  in
-  let m = Wire.Everparse.Raw.module_ [ Wire.Everparse.Raw.typedef s ] in
-  let _ = Wire.Everparse.Raw.to_3d m in
-  ()
-
-(** Test Action.var action statement. *)
-let test_var () =
-  let ptr = Wire.Param.output "ptr" Wire.uint32 in
-  let f_tmp = Wire.Everparse.Raw.field "tmp" Wire.uint32 in
-  let act =
-    Wire.Action.on_success
-      [
-        Wire.Action.var "tmp" (Wire.int 42);
-        Wire.Action.assign ptr (Wire.Everparse.Raw.field_ref f_tmp);
-      ]
-  in
-  let s =
-    Wire.Everparse.Raw.param_struct "WithVar"
-      [ Wire.Param.decl ptr ]
-      [ Wire.Everparse.Raw.field "x" ~action:act Wire.uint8 ]
-  in
-  let m = Wire.Everparse.Raw.module_ [ Wire.Everparse.Raw.typedef s ] in
-  let _ = Wire.Everparse.Raw.to_3d m in
-  ()
-
-(** Test define declaration. *)
-let test_define () =
-  let m =
-    Wire.Everparse.Raw.module_
-      [
-        Wire.Everparse.Raw.define "MAX_SIZE" 1024;
-        Wire.Everparse.Raw.typedef
-          (Wire.Everparse.Raw.struct_ "S"
-             [ Wire.Everparse.Raw.field "x" Wire.uint8 ]);
-      ]
-  in
-  let _ = Wire.Everparse.Raw.to_3d m in
-  ()
-
-(** Test extern_fn declaration. *)
-let test_extern_fn () =
-  let m =
-    Wire.Everparse.Raw.module_
-      [
-        Wire.Everparse.Raw.extern_fn "validate"
-          [ Wire.Everparse.Raw.param "len" Wire.uint32 ]
-          Wire.uint8;
-        Wire.Everparse.Raw.typedef
-          (Wire.Everparse.Raw.struct_ "S"
-             [ Wire.Everparse.Raw.field "x" Wire.uint8 ]);
-      ]
-  in
-  let _ = Wire.Everparse.Raw.to_3d m in
-  ()
-
-(** Test extern_probe declaration. *)
-let test_extern_probe () =
-  let m =
-    Wire.Everparse.Raw.module_
-      [
-        Wire.Everparse.Raw.extern_probe "my_probe";
-        Wire.Everparse.Raw.extern_probe ~init:true "my_init_probe";
-        Wire.Everparse.Raw.typedef
-          (Wire.Everparse.Raw.struct_ "S"
-             [ Wire.Everparse.Raw.field "x" Wire.uint8 ]);
-      ]
-  in
-  let _ = Wire.Everparse.Raw.to_3d m in
-  ()
-
-(** Test complex nested structure. *)
-let test_complex_nested () =
-  let inner =
-    Wire.Everparse.Raw.struct_ "Inner"
-      [ Wire.Everparse.Raw.field "a" Wire.uint8 ]
-  in
-  let outer =
-    Wire.Everparse.Raw.struct_ "Outer"
-      [
-        Wire.Everparse.Raw.field "i" (Wire.Everparse.Raw.struct_typ inner);
-        Wire.Everparse.Raw.field "b" Wire.uint16;
-      ]
-  in
-  let m =
-    Wire.Everparse.Raw.module_
-      [ Wire.Everparse.Raw.typedef inner; Wire.Everparse.Raw.typedef outer ]
-  in
-  let _ = Wire.Everparse.Raw.to_3d m in
-  ()
-
-(** Field-level decorations through {!Field.optional} / {!Field.repeat}.
-    Verifies that the construction-time invariant ("decorations only at field
-    top level") doesn't degrade for arbitrary inner sizes. *)
-let test_field_optional_random size =
-  let size = (abs size mod 32) + 1 in
-  let f_p = Wire.Field.v "p" Wire.uint8 in
-  let f =
-    Wire.Field.optional "Body"
-      ~present:Wire.Expr.(Wire.Field.ref f_p <> Wire.int 0)
-      (Wire.byte_array ~size:(Wire.int size))
-  in
-  let codec =
-    Wire.Codec.v "OptR"
-      (fun p body -> (p, body))
-      Wire.Codec.[ f_p $ fst; f $ snd ]
-  in
-  let s = Wire.Everparse.struct_of_codec codec in
-  let m =
-    Wire.Everparse.Raw.module_ [ Wire.Everparse.Raw.typedef ~entrypoint:true s ]
-  in
-  let _ = Wire.Everparse.Raw.to_3d m in
-  ()
-
-let test_field_repeat_random size =
-  let size = (abs size mod 64) + 1 in
-  let f_n = Wire.Field.v "n" Wire.uint16be in
-  let f = Wire.Field.repeat "Items" ~size:(Wire.int size) Wire.uint32be in
-  let codec =
-    Wire.Codec.v "RepR"
-      (fun n items -> (n, items))
-      Wire.Codec.[ f_n $ fst; f $ snd ]
-  in
-  let s = Wire.Everparse.struct_of_codec codec in
-  let m =
-    Wire.Everparse.Raw.module_ [ Wire.Everparse.Raw.typedef ~entrypoint:true s ]
-  in
-  let _ = Wire.Everparse.Raw.to_3d m in
-  ()
-
-(** Reserved-name escaping holds across the projection: any name from the
-    keyword set, used as a param or field, must round-trip through
-    [pp_typ]/[to_3d] without raising. *)
-let test_keyword_param_random idx =
-  let names =
-    [|
-      "total";
-      "let";
-      "fun";
-      "match";
-      "type";
-      "true";
-      "false";
-      "module";
-      "open";
-      "include";
-      "with";
-      "when";
-      "as";
-      "of";
-      "and";
-      "or";
-      "rec";
-      "begin";
-      "end";
-      "ghost";
-      "noeq";
-      "private";
-      "abstract";
-      "synth";
-    |]
-  in
-  let name = names.(abs idx mod Array.length names) in
-  let p = Wire.Param.input name Wire.uint32be in
-  let s =
-    Wire.Everparse.Raw.param_struct "KwParam"
-      [ Wire.Param.decl p ]
-      [
-        Wire.Everparse.Raw.field "x" Wire.uint8;
-        Wire.Everparse.Raw.field "rest"
-          (Wire.byte_array ~size:(Wire.Param.expr p));
-      ]
-  in
-  let m = Wire.Everparse.Raw.module_ [ Wire.Everparse.Raw.typedef s ] in
-  let _ = Wire.Everparse.Raw.to_3d m in
-  ()
-
-let test_keyword_field_random idx =
-  let names =
-    [|
-      "let";
-      "fun";
-      "match";
-      "type";
-      "with";
-      "when";
-      "as";
-      "of";
-      "and";
-      "or";
-      "rec";
-      "begin";
-      "end";
-      "ghost";
-      "noeq";
-      "private";
-    |]
-  in
-  let name = names.(abs idx mod Array.length names) in
-  let s =
-    Wire.Everparse.Raw.struct_ "KwField"
-      [
-        Wire.Everparse.Raw.field name Wire.uint8;
-        Wire.Everparse.Raw.field "tail" Wire.uint16;
-      ]
-  in
-  let m = Wire.Everparse.Raw.module_ [ Wire.Everparse.Raw.typedef s ] in
-  let _ = Wire.Everparse.Raw.to_3d m in
-  ()
-
-(** Where-clause lowering: a struct-level [where] referencing fields must
-    project through without raising, regardless of the field arrangement or how
-    many of them the predicate touches. *)
-let test_where_lowering n =
-  let n = (abs n mod 4) + 1 in
-  let max_ = Wire.Param.input "max" Wire.uint16be in
-  let f_len = Wire.Everparse.Raw.field "Length" Wire.uint16be in
-  let f_len_ref = Wire.Everparse.Raw.field "Length" Wire.uint16be in
-  let extras =
-    List.init n (fun i ->
-        Wire.Everparse.Raw.field (Fmt.str "extra%d" i) Wire.uint8)
-  in
-  let s =
-    Wire.Everparse.Raw.param_struct "WhereLower"
-      [ Wire.Param.decl max_ ]
-      ~where:
-        Wire.Expr.(
-          Wire.Everparse.Raw.field_ref f_len_ref <= Wire.Param.expr max_)
-      (f_len :: extras)
-  in
-  let m = Wire.Everparse.Raw.module_ [ Wire.Everparse.Raw.typedef s ] in
-  let _ = Wire.Everparse.Raw.to_3d m in
-  ()
-
-(** [Action.var name e]: substitution into use sites must hold across arbitrary
-    expression shapes. *)
-let test_action_var_random k =
-  let f_a = Wire.Everparse.Raw.field "Tag" Wire.uint8 in
-  let f_b = Wire.Everparse.Raw.field "Value" Wire.uint16be in
-  let f_x = Wire.Everparse.Raw.field "x" Wire.uint16be in
-  let n = abs k mod 4 in
-  let bound =
-    let open Wire.Expr in
-    match n with
-    | 0 -> Wire.Everparse.Raw.field_ref f_a + Wire.Everparse.Raw.field_ref f_b
-    | 1 -> Wire.Everparse.Raw.field_ref f_a * Wire.int 2
-    | 2 ->
-        Wire.Everparse.Raw.field_ref f_a
-        - (Wire.Everparse.Raw.field_ref f_b / Wire.int 4)
-    | _ -> Wire.Everparse.Raw.field_ref f_a land Wire.int 0xff
-  in
-  let out_value = Wire.Param.output "out" Wire.uint32be in
-  let s =
-    Wire.Everparse.Raw.param_struct "VarFuzz"
-      [ Wire.Param.decl out_value ]
-      [
-        Wire.Everparse.Raw.field "Tag" Wire.uint8;
-        Wire.Everparse.Raw.field "Value" Wire.uint16be
-          ~action:
-            (Wire.Action.on_act
-               [
-                 Wire.Action.var "x" bound;
-                 Wire.Action.if_
-                   Wire.Expr.(Wire.Everparse.Raw.field_ref f_x > Wire.int 0)
-                   [
-                     Wire.Action.assign out_value
-                       (Wire.Everparse.Raw.field_ref f_x);
-                   ]
-                   None;
-               ]);
-      ]
-  in
-  let m = Wire.Everparse.Raw.module_ [ Wire.Everparse.Raw.typedef s ] in
-  let _ = Wire.Everparse.Raw.to_3d m in
-  ()
-
-(** Test big-endian struct with all BE types. *)
-let test_be_struct () =
-  let s =
-    Wire.Everparse.Raw.struct_ "BigEndian"
-      [
-        Wire.Everparse.Raw.field "a" Wire.uint16be;
-        Wire.Everparse.Raw.field "b" Wire.uint32be;
-        Wire.Everparse.Raw.field "c" Wire.uint64be;
-        Wire.Everparse.Raw.field "d" Wire.uint63be;
-      ]
-  in
-  let m = Wire.Everparse.Raw.module_ [ Wire.Everparse.Raw.typedef s ] in
-  let _ = Wire.Everparse.Raw.to_3d m in
-  ()
-
-(** {1 Test Registration} *)
-
-let pp_tests =
+(* Projection + pretty-print coverage: cheap, no subprocess, always runs. *)
+let pp_cases =
+  List.concat_map
+    (fun (name, Fuzz_gen.Pack g) -> Fuzz_gen.everparse_cases name g)
+    Fuzz_gen.registry
+
+let nested_pp_cases =
+  Fuzz_gen.everparse_nested_cases "nested(d2)" 2
+  @ Fuzz_gen.everparse_nested_cases "nested(d3)" 3
+  @ Fuzz_gen.everparse_nested_cases "nested(d4)" 4
+
+(* The bounded set run through real EverParse: the composite / structural
+   families, where a projection that builds but does not verify can hide. Plain
+   scalars project trivially, so they are left to the pp pass. *)
+let extract_names =
   [
-    test_case "pp uint8" [ const () ] test_pp_uint8;
-    test_case "pp uint16" [ const () ] test_pp_uint16;
-    test_case "pp uint16be" [ const () ] test_pp_uint16be;
-    test_case "pp uint32" [ const () ] test_pp_uint32;
-    test_case "pp uint32be" [ const () ] test_pp_uint32be;
-    test_case "pp uint63" [ const () ] test_pp_uint63;
-    test_case "pp uint63be" [ const () ] test_pp_uint63be;
-    test_case "pp uint64" [ const () ] test_pp_uint64;
-    test_case "pp uint64be" [ const () ] test_pp_uint64be;
-    test_case "pp bitfield" [ range 33 ] test_pp_bitfield;
-    test_case "pp U8" [ int ] test_pp_bf_uint8;
-    test_case "pp U16" [ int ] test_pp_bf_uint16;
-    test_case "pp U16be" [ int ] test_pp_bf_uint16be;
-    test_case "pp U32be" [ int ] test_pp_bf_uint32be;
-    test_case "pp map" [ const () ] test_pp_map;
-    test_case "pp bool" [ const () ] test_pp_bool;
-    test_case "pp cases" [ const () ] test_pp_variants;
-    test_case "pp unit" [ const () ] test_pp_unit;
-    test_case "pp module" [ const () ] test_pp_module_simple;
+    "array(3,uint16be)";
+    "array_seq(3,uint16be)";
+    "array(2,record)";
+    "repeat(8,uint8)";
+    "repeat_seq(8,uint8)";
+    "casetype_u8";
+    "nested(4,uint16be)";
+    "nested_at_most(4,uint16be)";
+    "optional(uint8)";
+    "optional_or(uint8)";
+    "record";
+    (* [rest_bytes] sized by a [Param.input] minus a sizeof projects to a u32
+       subtraction EverParse cannot prove non-underflowing (Error 19). That is a
+       separate projection-soundness finding, not exercised here; it stays in the
+       pp pass above. *)
   ]
 
-let codegen_tests =
-  [
-    test_case "struct random fields" [ range 100 ] test_struct_random_fields;
-    test_case "enum random cases" [ range 100 ] test_enum_random_cases;
-    test_case "casetype random" [ range 100 ] test_casetype_random;
-    test_case "casetype inline" [ const () ] test_casetype_inline;
-    test_case "constraint expr" [ int ] test_constraint_expr;
-    test_case "bitfield constraint" [ range 32 ] test_bitfield_constraint;
-    test_case "bitwise expr" [ int ] test_bitwise_expr;
-    test_case "logical expr" [ const () ] test_logical_expr;
-    test_case "bitwise ops" [ const () ] test_bitwise_ops;
-    test_case "logical ops" [ const () ] test_logical_ops;
-    test_case "cast expr" [ const () ] test_cast_expr;
-    test_case "cast variants" [ const () ] test_cast_variants;
-    test_case "sizeof expr" [ const () ] test_sizeof_expr;
-    test_case "array type" [ int ] test_array_type;
-    test_case "byte array" [ int ] test_byte_array;
-    test_case "nested" [ const () ] test_nested;
-    test_case "nested at most" [ const () ] test_single_elem_at_most;
-    test_case "anon field" [ const () ] test_anon_field;
-    test_case "param struct" [ range 20 ] test_param_struct;
-    test_case "mutable param" [ const () ] test_mutable_param;
-    test_case "apply" [ const () ] test_apply;
-    test_case "type ref" [ const () ] test_type_ref;
-    test_case "qualified ref" [ const () ] test_qualified_ref;
-    test_case "action" [ const () ] test_action;
-    test_case "Action.on_act" [ const () ] test_on_act;
-    test_case "Action.abort" [ const () ] test_abort;
-    test_case "Action.if_" [ const () ] test_action_if;
-    test_case "Action.var" [ const () ] test_var;
-    test_case "define" [ const () ] test_define;
-    test_case "extern_fn" [ const () ] test_extern_fn;
-    test_case "extern_probe" [ const () ] test_extern_probe;
-    test_case "complex nested" [ const () ] test_complex_nested;
-    test_case "be struct" [ const () ] test_be_struct;
-    test_case "field optional random" [ int ] test_field_optional_random;
-    test_case "field repeat random" [ int ] test_field_repeat_random;
-    test_case "keyword param random" [ int ] test_keyword_param_random;
-    test_case "keyword field random" [ int ] test_keyword_field_random;
-    test_case "where lowering random" [ int ] test_where_lowering;
-    test_case "action var random" [ int ] test_action_var_random;
-  ]
+(* EverParse derives the module name from the .3d filename and requires it to
+   start with a capital letter; the composer names its codecs [_leaf] / [_opt] /
+   etc. Sanitise to a valid module name for the file (the internal struct names
+   are unaffected and need no change). *)
+let valid_module_name n =
+  match String.concat "" (String.split_on_char '_' n) with
+  | "" -> "Schema"
+  | s -> String.capitalize_ascii s
 
-let suite = ("everparse", pp_tests @ codegen_tests)
+(* Run one schema through [3d.exe --batch] in its own temp directory and return
+   the verdict. The generated C is incidental and discarded: only EverParse's
+   acceptance matters. [parse_3d ~batch:true] verifies without [run_everparse]'s
+   endianness-header copy, so it works on a bare directory. *)
+let rm_quietly f = try Sys.remove f with Sys_error _ -> ()
+let err fmt = Fmt.kstr (fun s -> Error s) fmt
+
+let extract_one g =
+  match Wire.Everparse.schema (Fuzz_gen.codec g) with
+  | exception e -> err "3D projection raised %s" (Printexc.to_string e)
+  | schema0 ->
+      let schema = { schema0 with name = valid_module_name schema0.name } in
+      let outdir = Filename.temp_dir "wire_fuzz3d_" ("_" ^ schema.name) in
+      Fun.protect
+        ~finally:(fun () ->
+          (try
+             Array.iter
+               (fun f -> rm_quietly (Filename.concat outdir f))
+               (Sys.readdir outdir)
+           with Sys_error _ -> ());
+          try Unix.rmdir outdir with Unix.Unix_error _ -> ())
+        (fun () ->
+          try
+            Wire_3d.generate_3d ~outdir [ schema ];
+            Wire_3d.parse_3d ~batch:true ~outdir
+              (Wire.Everparse.filename schema)
+          with (Failure _ | Sys_error _ | Unix.Unix_error _) as e ->
+            Error (Printexc.to_string e))
+
+(* [3d.exe --batch] takes seconds per schema, so it cannot run inside Alcobar's
+   repeat/timeout loop. Run each check once, eagerly, when this module loads, and
+   let the test cases report the cached verdict instantly. Skipped without
+   [3d.exe] (CI) and in corpus / AFL modes, where the long startup is unwanted. *)
+let normal_mode () =
+  let argv = Sys.argv in
+  let n = Array.length argv in
+  (not (Array.exists (String.equal "--gen-corpus") argv))
+  && not (n > 1 && Sys.file_exists argv.(n - 1))
+
+let extract_results =
+  if not (Wire_3d.has_3d_exe () && normal_mode ()) then []
+  else
+    List.filter_map
+      (fun (name, Fuzz_gen.Pack g) ->
+        if List.mem name extract_names then Some (name, extract_one g) else None)
+      Fuzz_gen.registry
+
+let extract_cases =
+  List.map
+    (fun (name, res) ->
+      Alcobar.test_case ("3d.exe " ^ name)
+        [ const () ]
+        (fun () ->
+          match res with
+          | Ok () -> ()
+          | Error m ->
+              Alcobar.failf "%s: EverParse rejected a schema that built: %s"
+                name m))
+    extract_results
+
+let suite = ("everparse", pp_cases @ nested_pp_cases @ extract_cases)

--- a/fuzz/gen/fuzz_gen.ml
+++ b/fuzz/gen/fuzz_gen.ml
@@ -1421,12 +1421,19 @@ module Codec = struct
 
   let ( $ ) gen getter = { name = "_"; gen; getter }
 
-  let rec wire_codec_fields : type f r.
-      (f, r) fields -> (f, r) Wire.Codec.fields = function
-    | [] -> Wire.Codec.[]
-    | f :: rest ->
-        Wire.Codec.( $ ) (Wire.Field.v f.name f.gen.typ) f.getter
-        :: wire_codec_fields rest
+  (* Assign each field a unique name by position: the [$] above leaves every
+     field [_], which round-trips fine (getters, not names) but projects to
+     clashing anonymous declarations in 3D. *)
+  let wire_codec_fields fields =
+    let rec go : type f r. int -> (f, r) fields -> (f, r) Wire.Codec.fields =
+     fun i -> function
+       | [] -> Wire.Codec.[]
+       | f :: rest ->
+           let name = if f.name = "_" then Fmt.str "f%d" i else f.name in
+           Wire.Codec.( $ ) (Wire.Field.v name f.gen.typ) f.getter
+           :: go (i + 1) rest
+    in
+    go 0 fields
 
   (* Walk the field list applying each field's positive sample to the
      partial builder and accumulating the bytes. Mirrors [Wire.Codec.v]'s
@@ -2129,4 +2136,121 @@ let reject_cases label g =
     Alcobar.test_case (label ^ " adversarial")
       Alcobar.[ g.adversarial; env_stream ]
       check_reject;
+  ]
+
+(* {1 Canonical registry and EverParse drivers}
+
+   Every fuzz suite drives off [registry] rather than its own hand-written
+   list, so a generated codec is exercised on the OCaml round-trip path
+   ([test_cases]) and the 3D projection path ([everparse_cases] /
+   [everparse_3d_cases]) from one source. *)
+
+type packed = Pack : 'a t -> packed
+
+let codec g = g.codec
+
+let registry_record =
+  Codec.v "RegRecord" (fun a b -> (a, b)) Codec.[ uint8 $ fst; uint16be $ snd ]
+
+let registry_casetype =
+  casetype_u8 "RegPayload"
+    [
+      case ~index:1 uint16be
+        ~inject:(fun v -> `A v)
+        ~project:(function `A v -> Some v | _ -> None);
+      case ~index:2 uint32be
+        ~inject:(fun v -> `B v)
+        ~project:(function `B v -> Some v | _ -> None);
+      default_case ~tag:0xFF uint8
+        ~inject:(fun v -> `Other v)
+        ~project:(function `Other v -> Some v | _ -> None);
+    ]
+
+let registry : (string * packed) list =
+  [
+    ("uint8", Pack uint8);
+    ("uint16", Pack uint16);
+    ("uint16be", Pack uint16be);
+    ("uint32be", Pack uint32be);
+    ("uint63be", Pack uint63be);
+    ("uint64be", Pack uint64be);
+    ("int8", Pack int8);
+    ("int32be", Pack int32be);
+    ("int64be", Pack int64be);
+    ("float32be", Pack float32be);
+    ("float64be", Pack float64be);
+    ("empty", Pack empty);
+    ("byte_array(5)", Pack (byte_array 5));
+    ("byte_slice(3)", Pack (byte_slice 3));
+    ( "byte_array_where(4)",
+      Pack
+        (byte_array_where 4 ~per_byte:(fun b ->
+             Wire.Expr.(b >= Wire.int 0x20 && b <= Wire.int 0x7e))) );
+    ("uint_var(3,big)", Pack (uint_var ~endian:Wire.Big 3));
+    ("zeroterm", Pack zeroterm);
+    ("zeroterm_at_most(8)", Pack (zeroterm_at_most 8));
+    ("bits(3,U8)", Pack (bits ~width:3 Wire.U8));
+    ("bits(10,U16be)", Pack (bits ~width:10 Wire.U16be));
+    ( "map(uint8)",
+      Pack (map ~decode:(fun n -> n * 2) ~encode:(fun n -> n / 2) uint8) );
+    ("variants", Pack (variants "Flag" [ ("A", `A); ("B", `B); ("C", `C) ]));
+    ("enum", Pack (enum "Color" [ ("Red", 1); ("Green", 2); ("Blue", 3) ]));
+    ("bounded_u8", Pack (bounded_u8 ~min:10 ~max:100));
+    ("where(uint8)", Pack (where uint8));
+    ("lookup", Pack (lookup [ 'a'; 'b'; 'c'; 'd' ] uint8));
+    ("optional(uint8)", Pack (optional uint8));
+    ("optional_or(uint8)", Pack (optional_or ~default:0 uint8));
+    ("nested(4,uint16be)", Pack (nested 4 uint16be));
+    ("nested_at_most(4,uint16be)", Pack (nested_at_most 4 uint16be));
+    ("array(3,uint16be)", Pack (array 3 uint16be));
+    ("array_seq(3,uint16be)", Pack (array_seq 3 uint16be));
+    ("repeat(8,uint8)", Pack (repeat ~bytes:8 uint8));
+    ("repeat_seq(8,uint8)", Pack (repeat_seq ~bytes:8 uint8));
+    ("array(2,record)", Pack (array 2 registry_record));
+    ("record", Pack registry_record);
+    ("casetype_u8", Pack registry_casetype);
+    ("action", Pack action);
+    ("expr_ops", Pack expr_ops);
+    ("sizeof", Pack sizeof);
+    ("codec_where", Pack codec_where);
+    ("rest_bytes", Pack rest_bytes);
+    ("param_input", Pack param_input);
+  ]
+
+(* Project a gen's codec to a 3D schema and pretty-print it: covers the whole
+   projection + code-generation path without invoking 3d.exe. A projection that
+   raises is a bug (every codec that builds must project). *)
+let everparse_cases label g =
+  [
+    Alcobar.test_case
+      (label ^ " projects+prints")
+      Alcobar.[ Alcobar.const () ]
+      (fun () ->
+        match Wire.Everparse.schema g.codec with
+        | s -> ignore (Wire.Everparse.Raw.to_3d s.module_ : string)
+        | exception e ->
+            Alcobar.failf "%s: 3D projection raised %s" label
+              (Printexc.to_string e));
+  ]
+
+(* Same, over a freshly generated nested composition per sample: arbitrary
+   nestings must all project and print. *)
+let everparse_nested_cases label depth =
+  let draw =
+    Alcobar.map
+      Alcobar.[ gen_any depth ]
+      (fun (Any a) ->
+        let comp = a.label and codec = a.g.codec in
+        fun () ->
+          match Wire.Everparse.schema codec with
+          | s -> ignore (Wire.Everparse.Raw.to_3d s.module_ : string)
+          | exception e ->
+              Alcobar.failf "%s [%s]: 3D projection raised %s" label comp
+                (Printexc.to_string e))
+  in
+  [
+    Alcobar.test_case
+      (label ^ " projects+prints")
+      Alcobar.[ draw ]
+      (fun run -> run ());
   ]

--- a/fuzz/gen/fuzz_gen.mli
+++ b/fuzz/gen/fuzz_gen.mli
@@ -43,6 +43,29 @@ val validate_cases : string -> 'a t -> Alcobar.test_case list
     pass; random and adversarial inputs may pass or fail but must not crash.
     Threads the env via {!Wire.Codec.validate}'s [?env] when [g] needs one. *)
 
+type packed =
+  | Pack : 'a t -> packed
+      (** A gen with its value type hidden, for uniform iteration over
+          {!registry}. *)
+
+val codec : 'a t -> 'a Wire.Codec.t
+(** [codec g] is the codec [g] generates for. *)
+
+val registry : (string * packed) list
+(** The canonical curated gens, one per combinator family. Every suite drives
+    off this list so a generated codec is exercised on both the OCaml round-trip
+    path ({!test_cases}) and the 3D projection path ({!everparse_cases}) from
+    one source. *)
+
+val everparse_cases : string -> 'a t -> Alcobar.test_case list
+(** [everparse_cases label g] projects [g]'s codec to a 3D schema and
+    pretty-prints it, asserting neither raises. Covers the projection and
+    code-generation path without invoking [3d.exe]. *)
+
+val everparse_nested_cases : string -> int -> Alcobar.test_case list
+(** [everparse_nested_cases label depth] is {!everparse_cases} over a freshly
+    generated nested composition per sample (cf. {!nested_cases}). *)
+
 val sized_cases : string -> Alcobar.test_case list
 (** [sized_cases group] round-trips a two-field length/data codec whose data
     byte span is sized by a cross-field reference to the preceding length field,

--- a/lib/3d/wire_3d.ml
+++ b/lib/3d/wire_3d.ml
@@ -315,7 +315,7 @@ let run_everparse ?(quiet = true) ~outdir schemas =
     schemas;
   copy_everparse_endianness ~outdir
 
-let parse_3d ~outdir file =
+let parse_3d ?(batch = false) ~outdir file =
   let exe =
     match locate_3d_exe () with
     | Some e -> e
@@ -323,7 +323,10 @@ let parse_3d ~outdir file =
   in
   let log_path = Filename.temp_file "wire_parse_3d" ".log" in
   (* 3d.exe emits diagnostics to stdout, so capture both streams. *)
-  let cmd = Fmt.str "cd %s && %s %s > %s 2>&1" outdir exe file log_path in
+  let flag = if batch then "--batch " else "" in
+  let cmd =
+    Fmt.str "cd %s && %s %s%s > %s 2>&1" outdir exe flag file log_path
+  in
   let ret = Sys.command cmd in
   let captured =
     try In_channel.with_open_text log_path In_channel.input_all

--- a/lib/3d/wire_3d.mli
+++ b/lib/3d/wire_3d.mli
@@ -61,12 +61,18 @@ val run_everparse :
 
     Requires [3d.exe] in PATH. *)
 
-val parse_3d : outdir:string -> string -> (unit, string) result
-(** [parse_3d ~outdir file] runs [3d.exe] (without [--batch]) on a single [.3d]
-    file in [outdir]. Returns [Ok ()] when 3D accepts the file, or
-    [Error stderr] with the captured error message otherwise. Faster than
-    {!run_everparse} -- it stops after the 3D type-checker, before F* and
-    KaRaMeL. Intended for projection coverage tests.
+val parse_3d : ?batch:bool -> outdir:string -> string -> (unit, string) result
+(** [parse_3d ~outdir file] runs [3d.exe] on a single [.3d] file in [outdir].
+    Returns [Ok ()] when 3D accepts the file, or [Error stderr] with the
+    captured error message otherwise.
+
+    With [~batch:false] (the default) it stops after the 3D type-checker, before
+    F* and KaRaMeL: fast, but it does not catch kind errors that only fail F*
+    verification (e.g. a list over a possibly-empty element). With [~batch:true]
+    it runs the full [--batch] verification (F* and C extraction), catching
+    those, and discarding the generated C. Unlike {!run_everparse} it does no
+    endianness-header copy, so it works on a bare output directory. Intended for
+    projection coverage tests.
 
     Requires [3d.exe] in PATH. *)
 

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -1576,8 +1576,15 @@ let repeat_raw_fixed : type elt seq.
     seq =
  fun (Seq_map seq) elem esz ~off_fn ~size_fn buf base ->
   let budget = size_fn buf base in
-  let n = if esz > 0 then budget / esz else 0 in
   let start = base + off_fn buf base in
+  (* The budget comes from a length field, i.e. untrusted input. Bound it to the
+     buffer before reading so an oversized length fails cleanly instead of
+     crashing [read_elem] with an out-of-range [Bytes.sub]. *)
+  if budget < 0 || start + budget > Bytes.length buf then
+    raise
+      (Parse_error
+         (Unexpected_eof { expected = start + budget; got = Bytes.length buf }));
+  let n = if esz > 0 then budget / esz else 0 in
   let rec loop acc i =
     if i >= n then seq.finish acc
     else loop (seq.add acc (read_elem elem buf (start + (i * esz)))) (i + 1)
@@ -1594,6 +1601,12 @@ let repeat_raw_variable : type elt seq.
     seq =
  fun (Seq_map seq) elem ~off_fn ~size_fn buf base ->
   let budget = size_fn buf base in
+  let start = base + off_fn buf base in
+  (* Bound the untrusted budget to the buffer (see [repeat_raw_fixed]). *)
+  if budget < 0 || start + budget > Bytes.length buf then
+    raise
+      (Parse_error
+         (Unexpected_eof { expected = start + budget; got = Bytes.length buf }));
   let rec loop acc pos remaining =
     if remaining <= 0 then seq.finish acc
     else
@@ -1601,7 +1614,7 @@ let repeat_raw_variable : type elt seq.
       let esz = elem_size_of elem buf pos in
       loop (seq.add acc v) (pos + esz) (remaining - esz)
   in
-  loop seq.empty (base + off_fn buf base) budget
+  loop seq.empty start budget
 
 let repeat_raw_reader : type elt seq.
     (elt, seq) seq_map ->
@@ -1691,6 +1704,18 @@ let var_bytes_reader : type a.
  fun typ off_fn size_fn buf base ->
   let fo = off_fn buf base in
   let sz = size_fn buf base in
+  let first = base + fo in
+  (* [fo] and [sz] derive from length fields, i.e. untrusted input. A field
+     sized past the buffer (or a negative size from an overrun offset) would
+     crash [Bytes.sub]; fail cleanly instead. [Byte_slice] is handled by
+     [make_or_eod]. *)
+  (match typ with
+  | Byte_slice _ -> ()
+  | _ ->
+      if sz < 0 || first < 0 || first + sz > Bytes.length buf then
+        raise
+          (Parse_error
+             (Unexpected_eof { expected = first + sz; got = Bytes.length buf })));
   match typ with
   | Byte_slice _ -> Slice.make_or_eod buf ~first:(base + fo) ~length:sz
   | Byte_array _ -> Bytes.sub_string buf (base + fo) sz

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -1704,10 +1704,43 @@ let lower_where_to_field_constraint where fields =
         in
         (None, attach_where_to_target w target fields)
 
+(* EverParse cannot prove that a byte span sized [a - sizeof(this)] (as produced
+   by [rest_bytes]) does not underflow the u32 subtraction. Emit the guard
+   [a >= sizeof(this)] as a refinement on the immediately preceding field;
+   EverParse uses it to discharge the subtraction (a non-scalar field cannot be
+   refined, so this relies on the span following a scalar field, the usual
+   header). This is a 3D-projection concern only: the OCaml decoder already
+   knows [a]. *)
+let guard_subtraction_sizes fields =
+  let guard_of : type a. a typ -> bool expr option = function
+    | Byte_array { size = Sub (a, Sizeof_this) } -> Some (Ge (a, Sizeof_this))
+    | _ -> None
+  in
+  let add_guard g (Field f) =
+    Field
+      {
+        f with
+        constraint_ =
+          (match f.constraint_ with
+          | None -> Some g
+          | Some c -> Some (And (c, g)));
+      }
+  in
+  let rec go = function
+    | f :: (Field nf :: _ as rest) ->
+        let f =
+          match guard_of nf.field_typ with Some g -> add_guard g f | None -> f
+        in
+        f :: go rest
+    | fs -> fs
+  in
+  go fields
+
 let pp_struct ppf (s : struct_) =
   anon_counter := 0;
   let name = escape_3d s.name in
   let where, fields = lower_where_to_field_constraint s.where s.fields in
+  let fields = guard_subtraction_sizes fields in
   Fmt.pf ppf "typedef struct _%s%a" name pp_params s.params;
   Option.iter (Fmt.pf ppf "@,where (%a)" pp_expr) where;
   Fmt.pf ppf "@,{@[<v 2>";

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -406,6 +406,30 @@ let test_array_byte_array_projection () =
     "single byte-size on the array field" true
     (contains ~sub:"UINT8 addrs[:byte-size (3 * 4)]" out)
 
+(* A [rest_bytes] tail projects to [byte-size (total - sizeof(this))]. EverParse
+   cannot prove that subtraction non-underflowing on its own, so the projection
+   emits the guard [total >= sizeof(this)] as a refinement on the preceding
+   scalar field, which discharges it. Without the guard the schema fails
+   EverParse verification ("cannot verify u32 subtraction"). *)
+let rest_bytes_codec =
+  let total = Param.input "msglen" uint16be in
+  Codec.v "RestProj"
+    (fun h t -> (h, t))
+    Codec.
+      [
+        (Field.v "hdr" uint8 $ fun (h, _) -> h);
+        (Field.v "rest" (rest_bytes total) $ fun (_, t) -> t);
+      ]
+
+let test_rest_bytes_projection_guard () =
+  let out = render_3d rest_bytes_codec in
+  Alcotest.(check bool)
+    "rest field is sized by the subtraction" true
+    (contains ~sub:"rest[:byte-size (msglen - sizeof (this))]" out);
+  Alcotest.(check bool)
+    "preceding field guards the subtraction" true
+    (contains ~sub:"msglen >= sizeof (this)" out)
+
 (* A bitfield has no standalone element form, so [array] / [Field.repeat] over
    one is rejected at construction rather than crashing at decode. *)
 let raises_invalid f =
@@ -4814,6 +4838,8 @@ let suite =
         test_array_byte_array_element;
       Alcotest.test_case "array: byte_array element projection" `Quick
         test_array_byte_array_projection;
+      Alcotest.test_case "rest_bytes projection guard" `Quick
+        test_rest_bytes_projection_guard;
       Alcotest.test_case "repeat/array reject bitfield element" `Quick
         test_repeat_array_reject_bitfield;
       Alcotest.test_case "array: record element roundtrip" `Quick

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -430,6 +430,48 @@ let test_rest_bytes_projection_guard () =
     "preceding field guards the subtraction" true
     (contains ~sub:"msglen >= sizeof (this)" out)
 
+(* A [Field.repeat] byte-budget comes from a length field, i.e. untrusted input.
+   A length larger than the buffer (or an offset overrun past it from a
+   preceding variable field) must fail with a clean [Parse_error], not crash the
+   decoder with an out-of-range [Bytes.sub]. *)
+let f_rep_len = Field.v "len" uint16be
+
+(* An embedded sub-codec whose length field overruns the buffer leaves the
+   following field at an offset past the end; the trailing [all_zeros] then read
+   a negative-length span. This is the [(rep, all_zeros)] shape the composer
+   found. *)
+let rep_subcodec =
+  Codec.v "Rep"
+    (fun n xs -> (n, xs))
+    Codec.
+      [
+        (f_rep_len $ fun (n, _) -> n);
+        ( Field.repeat "items" ~size:(Field.ref f_rep_len)
+            (byte_array ~size:(int 3))
+        $ fun (_, xs) -> xs );
+      ]
+
+let oversized_repeat_codec =
+  Codec.v "OverRep"
+    (fun r z -> (r, z))
+    Codec.
+      [
+        (Field.v "rep" (codec rep_subcodec) $ fun (r, _) -> r);
+        (Field.v "az" all_zeros $ fun (_, z) -> z);
+      ]
+
+let test_repeat_oversized_length_rejected () =
+  let decodes bs =
+    match Codec.decode oversized_repeat_codec (Bytes.of_string bs) 0 with
+    | Ok _ | Error _ -> true
+    | exception Invalid_argument _ -> false
+  in
+  Alcotest.(check bool)
+    "oversized embedded length fails cleanly, no crash" true
+    (decodes "\xff\xff");
+  Alcotest.(check bool)
+    "length past buffer fails cleanly" true (decodes "\x00\x10abc")
+
 (* A bitfield has no standalone element form, so [array] / [Field.repeat] over
    one is rejected at construction rather than crashing at decode. *)
 let raises_invalid f =
@@ -4840,6 +4882,8 @@ let suite =
         test_array_byte_array_projection;
       Alcotest.test_case "rest_bytes projection guard" `Quick
         test_rest_bytes_projection_guard;
+      Alcotest.test_case "repeat oversized length rejected" `Quick
+        test_repeat_oversized_length_rejected;
       Alcotest.test_case "repeat/array reject bitfield element" `Quick
         test_repeat_array_reject_bitfield;
       Alcotest.test_case "array: record element roundtrip" `Quick


### PR DESCRIPTION
Drives the 3D fuzz suite off a canonical gen registry in [fuzz_gen](https://github.com/parsimoni-labs/ocaml-wire/blob/fuzz-composer-everywhere/fuzz/gen/fuzz_gen.ml#L2169) instead of hand-written fixed cases: every generated codec (registry plus arbitrary nested draws) is projected and pretty-printed, and a bounded set of the composite schemas is run through real EverParse verification (`3d.exe --batch`), gated on `has_3d_exe` so it skips in CI and AFL. The old suite only asserted that pretty-printing never crashed, so it could not catch a codec that builds in OCaml but fails EverParse extraction.

The suite immediately found three real bugs, each fixed here:

- 10ac6e8b adds the suite ([parse_3d](https://github.com/parsimoni-labs/ocaml-wire/blob/fuzz-composer-everywhere/lib/3d/wire_3d.ml#L318) gains a `?batch` flag for the verify-without-endianness-copy check it uses).
- 55544d4d fixes `Wire.rest_bytes`: its `total - sizeof(this)` byte-size failed EverParse ("cannot verify u32 subtraction") for any width, so every codec with a `rest_bytes` field failed schema generation. [guard_subtraction_sizes](https://github.com/parsimoni-labs/ocaml-wire/blob/fuzz-composer-everywhere/lib/types.ml#L1714) now emits a `total >= sizeof(this)` guard on the preceding field.
- b7843a83 fixes a decoder crash: a `Field.repeat` byte budget or a variable field's cross-field size taken from an oversized length field crashed the decoder with an out-of-range `Bytes.sub` on adversarial input, instead of returning `Parse_error`. Both are now bounded against the buffer.

Same family as #116, also surfaced by this suite and merged separately.