### PR TITLE
fuzz: differential AFL fuzzer for wire codec vs EverParse C

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,3 +100,61 @@ jobs:
         with:
           name: afl-findings
           path: afl-findings.tar.gz
+
+  # Differential fuzzer (fuzz/diff/, the wire_diff library): AFL feeds bytes to
+  # both the OCaml codec and the EverParse-generated C parser and crashes on any
+  # divergence. This is a separate job because it needs the EverParse toolchain
+  # (to generate and compile the C parsers), which the wire / wire_3d fuzzers do
+  # not, so installing it here keeps that job fast and its signal independent.
+  fuzz-afl-diff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: '5.3'
+          dune-version: '3.21'
+
+      - run: opam install . --deps-only --with-test
+
+      - name: Install afl-fuzz
+        run: sudo apt-get update && sudo apt-get install -y afl++
+
+      - name: Install EverParse
+        run: |
+          mkdir -p "$HOME/.local"
+          url=https://github.com/project-everest/everparse/releases/download/v2026.02.25/everparse_v2026.02.25_Linux_x86_64.tar.gz
+          curl -sL "$url" | tar xz -C "$HOME/.local"
+          echo "$HOME/.local/everparse/bin" >> "$GITHUB_PATH"
+
+      - name: Fuzz diff (OCaml codec vs EverParse C)
+        run: |
+          sudo sh -c 'echo core > /proc/sys/kernel/core_pattern'
+          export AFL_SKIP_CPUFREQ=1 AFL_NO_AFFINITY=1
+          BUILD_EVERPARSE=1 opam exec -- dune build --profile afl @fuzz/diff/fuzz
+
+      - name: Fail on crashes
+        run: |
+          out=_build/default/fuzz/diff/_fuzz
+          crashes=$(find "$out" -path '*/crashes/id:*' 2>/dev/null || true)
+          if [ -n "$crashes" ]; then
+            echo "::error::afl-fuzz found a differential divergence"
+            for f in $crashes; do
+              echo "--- replaying $f ---"
+              _build/default/fuzz/diff/fuzz.exe "$f" || true
+            done
+            exit 1
+          fi
+          echo "No crashes found."
+
+      - name: Package findings
+        if: failure()
+        run: tar czf afl-diff-findings.tar.gz -C _build/default/fuzz/diff _fuzz || true
+
+      - name: Upload findings on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: afl-diff-findings
+          path: afl-diff-findings.tar.gz

--- a/fuzz/diff/dune
+++ b/fuzz/diff/dune
@@ -1,0 +1,53 @@
+; Differential AFL fuzzer: OCaml wire codec vs EverParse C parser.
+;
+; The EverParse C parsers and FFI stubs are generated, so the fuzzer only
+; builds when EverParse is available (BUILD_EVERPARSE=1, with 3d.exe in PATH).
+; The generator (gen/) is pure OCaml and always builds; only this rule, which
+; runs it, needs EverParse.
+
+(rule
+ (enabled_if
+  (= %{env:BUILD_EVERPARSE=} "1"))
+ (targets
+  (dir schemas)
+  wire_ffi.c
+  stubs.ml)
+ (deps gen/gen_diff.exe)
+ (action
+  (run %{dep:gen/gen_diff.exe} schemas)))
+
+(executable
+ (name fuzz)
+ (modules fuzz stubs)
+ (enabled_if
+  (= %{env:BUILD_EVERPARSE=} "1"))
+ (libraries wire wire.diff diff_codecs alcobar)
+ (foreign_stubs
+  (language c)
+  (names wire_ffi)
+  (flags :standard -I schemas)))
+
+(rule
+ (alias runtest)
+ (enabled_if
+  (and
+   (= %{env:BUILD_EVERPARSE=} "1")
+   (<> %{profile} afl)))
+ (deps fuzz.exe)
+ (action
+  (run %{exe:fuzz.exe})))
+
+; afl-fuzz searches PATH for a target with no '/', so pass [./fuzz.exe] (the
+; cwd is this dir in the build tree, where fuzz.exe is built).
+
+(rule
+ (alias fuzz)
+ (enabled_if
+  (and
+   (= %{env:BUILD_EVERPARSE=} "1")
+   (= %{profile} afl)))
+ (deps fuzz.exe)
+ (action
+  (progn
+   (run %{exe:fuzz.exe} --gen-corpus corpus)
+   (run afl-fuzz -V 60 -i corpus -o _fuzz -- ./fuzz.exe @@))))

--- a/fuzz/diff/fuzz.ml
+++ b/fuzz/diff/fuzz.ml
@@ -1,0 +1,79 @@
+(** Differential AFL fuzzer for the wire_diff library.
+
+    For each codec in {!Diff_codecs}, feed the AFL input to both the OCaml
+    {!Wire.Codec} decoder and the EverParse-generated C parser, then compare via
+    {!Wire_diff.harness}. The codecs are unconstrained, so the only sound
+    outcomes are [Match] (both decode equal values) and [Both_failed] (both
+    reject a too-short input). [Value_mismatch] / [Only_c_ok] / [Only_ocaml_ok]
+    mean the OCaml and verified-C decoders disagree, i.e. a projection bug. *)
+
+let c_read parse_k cont buf =
+  try Some (parse_k cont (Bytes.of_string buf) 0) with Failure _ -> None
+
+let check name = function
+  | Wire_diff.Match | Wire_diff.Both_failed -> ()
+  | Wire_diff.Value_mismatch m -> Alcobar.failf "%s: value mismatch (%s)" name m
+  | Wire_diff.Only_c_ok m ->
+      Alcobar.failf "%s: C accepted, OCaml rejected (%s)" name m
+  | Wire_diff.Only_ocaml_ok m ->
+      Alcobar.failf "%s: OCaml accepted, C rejected (%s)" name m
+
+let h_u8 =
+  Wire_diff.harness ~name:"DiffU8" ~codec:Diff_codecs.c_u8
+    ~read:(c_read Stubs.diffu8_parse_k Fun.id)
+    ~write:(fun _ -> None)
+    ~project:(fun (r : Diff_codecs.u8) -> r.u8)
+    ~equal:Int.equal ()
+
+let h_u16 =
+  Wire_diff.harness ~name:"DiffU16" ~codec:Diff_codecs.c_u16
+    ~read:(c_read Stubs.diffu16_parse_k Fun.id)
+    ~write:(fun _ -> None)
+    ~project:(fun (r : Diff_codecs.u16) -> r.u16)
+    ~equal:Int.equal ()
+
+let h_u32 =
+  Wire_diff.harness ~name:"DiffU32" ~codec:Diff_codecs.c_u32
+    ~read:(c_read Stubs.diffu32_parse_k Fun.id)
+    ~write:(fun _ -> None)
+    ~project:(fun (r : Diff_codecs.u32) -> r.u32)
+    ~equal:Int.equal ()
+
+let h_u64 =
+  Wire_diff.harness ~name:"DiffU64" ~codec:Diff_codecs.c_u64
+    ~read:(c_read Stubs.diffu64_parse_k Fun.id)
+    ~write:(fun _ -> None)
+    ~project:(fun (r : Diff_codecs.u64) -> r.u64)
+    ~equal:Int64.equal ()
+
+let h_bits =
+  Wire_diff.harness ~name:"DiffBits" ~codec:Diff_codecs.c_bits
+    ~read:(c_read Stubs.diffbits_parse_k (fun hi lo -> (hi, lo)))
+    ~write:(fun _ -> None)
+    ~project:(fun (r : Diff_codecs.bits2) -> (r.hi, r.lo))
+    ~equal:( = ) ()
+
+let h_triple =
+  Wire_diff.harness ~name:"DiffTriple" ~codec:Diff_codecs.c_triple
+    ~read:(c_read Stubs.difftriple_parse_k (fun a b c -> (a, b, c)))
+    ~write:(fun _ -> None)
+    ~project:(fun (r : Diff_codecs.triple) -> (r.a, r.b, r.c))
+    ~equal:( = ) ()
+
+let case h =
+  Alcobar.test_case h.Wire_diff.name [ Alcobar.bytes ] (fun buf ->
+      check h.Wire_diff.name (h.Wire_diff.test_read buf))
+
+let () =
+  Alcobar.run "diff"
+    [
+      ( "diff",
+        [
+          case h_u8;
+          case h_u16;
+          case h_u32;
+          case h_u64;
+          case h_bits;
+          case h_triple;
+        ] );
+    ]

--- a/fuzz/diff/gen/diff_codecs.ml
+++ b/fuzz/diff/gen/diff_codecs.ml
@@ -1,0 +1,67 @@
+(** Codecs shared by the differential generator and fuzzer.
+
+    Each is a small record of fixed-width scalars or bitfields: shapes that
+    project to an EverParse default-plug validator, so the same definition feeds
+    both the OCaml {!Wire.Codec} decode path and the generated C parser the
+    fuzzer compares it against. No field carries a constraint, so for any input
+    of sufficient length both sides must accept and decode identical values; a
+    divergence is a real projection bug (endianness, width, sign, or bit
+    layout). *)
+
+open Wire
+
+type u8 = { u8 : int }
+
+let c_u8 =
+  Codec.(v "DiffU8" (fun u8 -> { u8 }) [ (Field.v "v" uint8 $ fun r -> r.u8) ])
+
+type u16 = { u16 : int }
+
+let c_u16 =
+  Codec.(
+    v "DiffU16" (fun u16 -> { u16 }) [ (Field.v "v" uint16be $ fun r -> r.u16) ])
+
+type u32 = { u32 : int }
+
+let c_u32 =
+  Codec.(
+    v "DiffU32" (fun u32 -> { u32 }) [ (Field.v "v" uint32be $ fun r -> r.u32) ])
+
+type u64 = { u64 : int64 }
+
+let c_u64 =
+  Codec.(
+    v "DiffU64" (fun u64 -> { u64 }) [ (Field.v "v" uint64be $ fun r -> r.u64) ])
+
+type bits2 = { hi : int; lo : int }
+
+let c_bits =
+  Codec.(
+    v "DiffBits"
+      (fun hi lo -> { hi; lo })
+      [
+        (Field.v "hi" (bits ~width:4 U8) $ fun r -> r.hi);
+        (Field.v "lo" (bits ~width:4 U8) $ fun r -> r.lo);
+      ])
+
+type triple = { a : int; b : int; c : int }
+
+let c_triple =
+  Codec.(
+    v "DiffTriple"
+      (fun a b c -> { a; b; c })
+      [
+        (Field.v "a" uint8 $ fun r -> r.a);
+        (Field.v "b" uint16be $ fun r -> r.b);
+        (Field.v "c" uint32be $ fun r -> r.c);
+      ])
+
+let schemas =
+  [
+    Everparse.schema c_u8;
+    Everparse.schema c_u16;
+    Everparse.schema c_u32;
+    Everparse.schema c_u64;
+    Everparse.schema c_bits;
+    Everparse.schema c_triple;
+  ]

--- a/fuzz/diff/gen/diff_codecs.mli
+++ b/fuzz/diff/gen/diff_codecs.mli
@@ -1,0 +1,42 @@
+(** Codecs shared by the differential generator and fuzzer.
+
+    Each is a small record of fixed-width scalars or bitfields: shapes that
+    project to an EverParse default-plug validator, so the same definition feeds
+    both the OCaml {!Wire.Codec} decode path and the generated C parser the
+    fuzzer compares it against. No field carries a constraint, so for any input
+    of sufficient length both sides must accept and decode identical values. *)
+
+type u8 = { u8 : int }
+
+val c_u8 : u8 Wire.Codec.t
+(** A single unsigned 8-bit field. *)
+
+type u16 = { u16 : int }
+
+val c_u16 : u16 Wire.Codec.t
+(** A single unsigned 16-bit big-endian field. *)
+
+type u32 = { u32 : int }
+
+val c_u32 : u32 Wire.Codec.t
+(** A single unsigned 32-bit big-endian field. *)
+
+type u64 = { u64 : int64 }
+
+val c_u64 : u64 Wire.Codec.t
+(** A single unsigned 64-bit big-endian field. *)
+
+type bits2 = { hi : int; lo : int }
+
+val c_bits : bits2 Wire.Codec.t
+(** Two 4-bit bitfields packed into one byte. *)
+
+type triple = { a : int; b : int; c : int }
+
+val c_triple : triple Wire.Codec.t
+(** A multi-field record (u8, u16be, u32be) exercising offsets and endianness.
+*)
+
+val schemas : Wire.Everparse.t list
+(** The codecs projected to 3D schemas, in the order the generator emits them.
+*)

--- a/fuzz/diff/gen/dune
+++ b/fuzz/diff/gen/dune
@@ -1,0 +1,9 @@
+(library
+ (name diff_codecs)
+ (modules diff_codecs)
+ (libraries wire))
+
+(executable
+ (name gen_diff)
+ (modules gen_diff)
+ (libraries diff_codecs wire wire.3d wire.stubs unix))

--- a/fuzz/diff/gen/gen_diff.ml
+++ b/fuzz/diff/gen/gen_diff.ml
@@ -1,0 +1,21 @@
+(** Generate the EverParse C parsers and FFI stubs the differential fuzzer
+    compares against. Run by the [gen] dune rule when EverParse is available.
+
+    Writes the EverParse C into [<argv1>/] (default [schemas/]) and [wire_ffi.c]
+    + [stubs.ml] into the current directory. *)
+
+let () =
+  let schema_dir =
+    if Array.length Sys.argv > 1 then Sys.argv.(1) else "schemas"
+  in
+  Wire_3d.run ~outdir:schema_dir Diff_codecs.schemas;
+  Wire_stubs.generate ~schema_dir ~outdir:"."
+    Wire_stubs.
+      [
+        C Diff_codecs.c_u8;
+        C Diff_codecs.c_u16;
+        C Diff_codecs.c_u32;
+        C Diff_codecs.c_u64;
+        C Diff_codecs.c_bits;
+        C Diff_codecs.c_triple;
+      ]


### PR DESCRIPTION
[`fuzz/diff/fuzz.ml`](https://github.com/parsimoni-labs/ocaml-wire/blob/fuzz-diff/fuzz/diff/fuzz.ml) feeds each AFL input to both the OCaml `Wire.Codec` decoder and the EverParse-generated C parser for the same codec, then compares them through the `wire_diff` harness; a divergence in accept/reject or in the decoded values is reported as a crash. The codecs are small unconstrained scalar and bitfield records ([`diff_codecs`](https://github.com/parsimoni-labs/ocaml-wire/blob/fuzz-diff/fuzz/diff/gen/diff_codecs.ml)), so the invariant is exact: both sides accept any input of sufficient length and decode identical values, and a mismatch is a real projection bug (endianness, width, sign, or bit layout).

Because it generates and compiles EverParse C, the fuzzer is gated on `BUILD_EVERPARSE=1` and built by its own CI job that installs the EverParse toolchain; the normal build skips it. Locally the 10-minute campaign ran 1.27M differential comparisons across 418 full cycles at 100% stability with no divergence.

Stacked on #119, which it shares the `afl` dune profile and the per-library `fuzz/` layout with.
