### PR TITLE
codec: add Codec.rename

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ### Added
 
+- `Wire.Codec.rename` returns a codec with a new name, leaving its wire
+  encoding and field constraints unchanged. The name only determines the
+  generated 3D struct name, so it lets a generically built codec be given a
+  unique, meaningful name before projection or code generation (@samoht)
 - `Wire.nested` / `Wire.nested_at_most` now accept a composite inner (a
   `Wire.array`, or another nested region), and a `Wire.casetype` field's case
   body may be such a region. Both round-trip and generate a verified EverParse

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -3150,6 +3150,7 @@ let[@inline] set (type a r) (codec : r t) (f : (a, r) field) :
   Staged.stage (build_staged_writer f.typ access)
 
 let name (t : _ t) = t.name
+let rename new_name (t : _ t) = { t with name = new_name }
 let field_readers (t : _ t) = t.field_readers
 let pp ppf (t : _ t) = Fmt.string ppf t.name
 let field_ref (type a r) (f : (a, r) field) : int expr = Ref f.name

--- a/lib/codec.mli
+++ b/lib/codec.mli
@@ -157,6 +157,13 @@ val wire_size_info : 'r t -> [ `Fixed of int | `Variable of bytes -> int -> int 
 val name : 'r t -> string
 (** [name c] returns the codec's name. *)
 
+val rename : string -> 'r t -> 'r t
+(** [rename n c] is [c] with its name set to [n]. The name is metadata: it only
+    determines the generated 3D struct name (via {!Everparse.struct_of_codec}),
+    not the wire encoding, so renaming leaves encode/decode and all field
+    constraints unchanged. Use it to give a generically built codec a unique,
+    meaningful name for projection or code generation. *)
+
 val field_readers : 'r t -> (string * (bytes -> int -> int)) list
 (** [field_readers c] returns the int-valued field readers of [c], indexed by
     field name. Used for cross-codec name resolution when [c] is embedded as a

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -827,6 +827,13 @@ module Codec : sig
             [ (f_version $ fun p -> p.version); (f_length $ fun p -> p.length) ]
       ]} *)
 
+  val rename : string -> 'r t -> 'r t
+  (** [rename n c] is [c] with its name set to [n]. The name only determines the
+      generated 3D struct name, not the wire encoding, so renaming leaves
+      encode/decode and all field constraints unchanged. Use it to give a
+      generically built codec a unique, meaningful name for projection or code
+      generation. *)
+
   val wire_size : 'r t -> int
   (** Fixed wire size of the codec.
 

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -4828,11 +4828,55 @@ let test_zeroterm_missing_terminator () =
   | Error _ -> ()
   | Ok _ -> Alcotest.fail "expected decode error on unterminated string"
 
+(* -- Codec.rename -- *)
+
+type rename_rec = { ra : int; rb : int }
+
+let rename_codec =
+  Codec.v "OrigName"
+    (fun ra rb -> { ra; rb })
+    Codec.
+      [
+        (Field.v "ra" uint8 $ fun r -> r.ra);
+        (Field.v "rb" uint16be $ fun r -> r.rb);
+      ]
+
+let test_rename_projection () =
+  let renamed = Codec.rename "NewName" rename_codec in
+  let r2 = render_3d renamed in
+  Alcotest.(check bool)
+    "new name in projection" true
+    (contains ~sub:"NewName" r2);
+  Alcotest.(check bool) "old name absent" false (contains ~sub:"OrigName" r2);
+  (* Renaming only substitutes the struct name: putting it back recovers the
+     original projection byte for byte, so fields, layout, and any field
+     constraints are untouched. *)
+  let back =
+    Re.replace_string (Re.compile (Re.str "NewName")) ~by:"OrigName" r2
+  in
+  Alcotest.(check string)
+    "rename is a pure name substitution" (render_3d rename_codec) back
+
+let test_rename_roundtrip () =
+  let renamed = Codec.rename "NewName" rename_codec in
+  let v = { ra = 7; rb = 1000 } in
+  match (encode_record rename_codec v, encode_record renamed v) with
+  | Ok b1, Ok b2 -> (
+      Alcotest.(check string) "encode unchanged by rename" b1 b2;
+      match decode_record renamed b2 with
+      | Ok d -> Alcotest.(check bool) "decode unchanged by rename" true (d = v)
+      | Error _ -> Alcotest.fail "decode failed after rename")
+  | _ -> Alcotest.fail "encode failed"
+
 (* -- Suite -- *)
 
 let suite =
   ( "codec",
     [
+      (* Codec.rename *)
+      Alcotest.test_case "rename: projection name" `Quick test_rename_projection;
+      Alcotest.test_case "rename: roundtrip unchanged" `Quick
+        test_rename_roundtrip;
       (* record *)
       Alcotest.test_case "record: encode" `Quick test_record_encode;
       Alcotest.test_case "record: decode" `Quick test_record_decode;


### PR DESCRIPTION
`Wire.Codec.rename n c` returns `c` with its name set to `n`. The name is metadata: it only determines the generated 3D struct name (via `Everparse.struct_of_codec`), not the wire encoding, so renaming leaves encode, decode, and every field constraint unchanged.

This is useful when a codec is built generically and needs a unique, meaningful name before projection or code generation, where the original `Codec.v` name would otherwise be a fixed placeholder. `struct_project` cannot serve this need: renaming through it drops field constraints, whereas `rename` preserves them.
