### PR TITLE
codec: project the lookup index bound to 3D

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -101,6 +101,11 @@
 
 ### Fixed
 
+- A `Wire.lookup` field now projects its index bound to 3D, so the
+  EverParse-generated C validator rejects out-of-range indices exactly as the
+  OCaml decoder does. Previously the projection emitted the underlying integer
+  with no bound, so the verified C accepted indices the OCaml decoder rejects
+  (@samoht)
 - Decoding no longer crashes with `Invalid_argument` on adversarial input where
   a `Field.repeat` byte budget, or a variable field's cross-field size, exceeds
   the buffer (an out-of-range `Bytes.sub`). Such an oversized length now fails

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -1949,7 +1949,7 @@ let rec compile_field : type a r.
     layout_ctx -> (a, r) field -> (a, r) compiled_field =
  fun ctx fld ->
   match fld.typ with
-  | Map { inner; decode; encode } -> compile_map ctx fld inner decode encode
+  | Map { inner; decode; encode; _ } -> compile_map ctx fld inner decode encode
   | Enum { base; _ } -> compile_field ctx { fld with typ = base }
   | Where { inner; _ } -> compile_field ctx { fld with typ = inner }
   | Bits { width; base; bit_order } -> compile_bits ctx fld width base bit_order

--- a/lib/param.ml
+++ b/lib/param.ml
@@ -34,7 +34,7 @@ let rec int_cvt : type a. a Types.typ -> a int_cvt =
   | Enum { base; _ } -> int_cvt base
   | Where { inner; _ } -> int_cvt inner
   | Single_elem { elem; _ } -> int_cvt elem
-  | Map { inner; encode; decode } ->
+  | Map { inner; encode; decode; _ } ->
       let c = int_cvt inner in
       { fwd = (fun v -> c.fwd (encode v)); bwd = (fun v -> decode (c.bwd v)) }
   | Apply { typ; _ } -> int_cvt typ

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -125,7 +125,17 @@ and _ typ =
   | Struct : struct_ -> unit typ
   | Type_ref : string -> 'a typ
   | Qualified_ref : { module_ : string; name : string } -> 'a typ
-  | Map : { inner : 'w typ; decode : 'w -> 'a; encode : 'a -> 'w } -> 'a typ
+  | Map : {
+      inner : 'w typ;
+      decode : 'w -> 'a;
+      encode : 'a -> 'w;
+      index_bound : int option;
+          (* When [Some n] the raw [inner] value is a valid index only when
+             [< n] (set by {!cases} / lookup). [decode] enforces this on the
+             OCaml side; the 3D projection emits it as a field refinement so the
+             generated C validator rejects the same out-of-range inputs. *)
+    }
+      -> 'a typ
   | Apply : { typ : 'a typ; args : packed_expr list } -> 'a typ
   | Codec : {
       codec_name : string;
@@ -322,9 +332,10 @@ let reject_decoration ~combinator t =
 
 let map decode encode inner =
   reject_decoration ~combinator:"map" inner;
-  Map { inner; decode; encode }
+  Map { inner; decode; encode; index_bound = None }
 
-let bool inner = Map { inner; decode = is_set; encode = bit }
+let bool inner =
+  Map { inner; decode = is_set; encode = bit; index_bound = None }
 
 (* Parse errors -- moved here so combinators like [cases] can raise them
    directly rather than through intermediate exceptions. *)
@@ -356,7 +367,7 @@ let cases variants inner =
     let i = variants_lookup arr v 0 in
     if i < 0 then invalid_arg "Wire.lookup: unknown variant" else i
   in
-  Map { inner; decode; encode }
+  Map { inner; decode; encode; index_bound = Some len }
 
 let unit = Unit
 let all_bytes = All_bytes
@@ -724,7 +735,7 @@ let rec ocaml_kind_of : type a. a typ -> ocaml_kind = function
   | Float32 _ -> Float32
   | Float64 _ -> Float64
   | Bits _ -> Int
-  | Map { inner = Bits _; decode = _; encode = _ } ->
+  | Map { inner = Bits _; decode = _; encode = _; _ } ->
       (* bool (bits ~width:1 ...) maps to bool; other maps stay int *)
       (* We can't distinguish bool from other maps here without checking
          the decode function. Use Int as safe default -- the EverParse
@@ -1602,19 +1613,43 @@ let pp_field_suffix ppf = function
       Fmt.pf ppf "[:zeroterm-byte-size-at-most %a]" pp_expr size
   | Array len -> Fmt.pf ppf "[%a]" pp_expr len
 
+(* The index bound a [cases] / lookup typ carries, seen through the transparent
+   [Map] / [Where] / [Apply] wrappers. [Some n] means the decoded raw value is a
+   valid index only when [< n]; the projection emits that as a field refinement
+   so the generated C validator rejects the same out-of-range inputs the OCaml
+   decoder does. *)
+let rec index_bound_of : type a. a typ -> int option = function
+  | Map { index_bound = Some _ as b; _ } -> b
+  | Map { inner; index_bound = None; _ } -> index_bound_of inner
+  | Where { inner; _ } -> index_bound_of inner
+  | Apply { typ; _ } -> index_bound_of typ
+  | _ -> None
+
 let pp_field ppf (Field f) =
-  let name =
+  let raw_name, name =
     match f.field_name with
-    | Some name -> escape_3d name
+    | Some name -> (name, escape_3d name)
     | None ->
         let n = !anon_counter in
         incr anon_counter;
-        Fmt.str "_anon_%d" n
+        let s = Fmt.str "_anon_%d" n in
+        (s, s)
   in
   (* Extract Where constraints from the type so they appear as field
      constraints in the 3D output, not inline in the type. *)
   let where_cond, typ = extract_where_constraint f.field_typ in
-  let constraint_ = combine_constraints f.constraint_ where_cond in
+  (* A lookup / cases field is valid only for in-range indices; emit that bound
+     as a refinement (the OCaml decoder enforces it via the [Map] decode). *)
+  let bound_cond =
+    match index_bound_of f.field_typ with
+    | Some len -> Some (Lt (Ref raw_name, Int len))
+    | None -> None
+  in
+  let constraint_ =
+    combine_constraints
+      (combine_constraints f.constraint_ where_cond)
+      bound_cond
+  in
   let suffix, pp_base = field_suffix typ in
   Fmt.pf ppf "@,%t %s%a" pp_base name pp_field_suffix suffix;
   Option.iter (Fmt.pf ppf " { %a }" pp_expr) constraint_;

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -158,8 +158,16 @@ and _ typ =
   | Type_ref : string -> 'a typ  (** Forward reference by name. *)
   | Qualified_ref : { module_ : string; name : string } -> 'a typ
       (** Qualified reference. *)
-  | Map : { inner : 'w typ; decode : 'w -> 'a; encode : 'a -> 'w } -> 'a typ
-      (** Mapped type. *)
+  | Map : {
+      inner : 'w typ;
+      decode : 'w -> 'a;
+      encode : 'a -> 'w;
+      index_bound : int option;
+          (** When [Some n] the raw [inner] value is a valid index only when
+              [< n] (set by {!cases}). [decode] enforces it on the OCaml side;
+              the 3D projection emits it as a field refinement. *)
+    }
+      -> 'a typ  (** Mapped type. *)
   | Apply : { typ : 'a typ; args : packed_expr list } -> 'a typ
       (** Parameterised type application. *)
   | Codec : {

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -508,9 +508,26 @@ let test_3d_byte_array_where () =
   in
   Alcotest.(check bool) "Data references synth not raw UINT8" true synth_ref
 
+(* A lookup / cases field decodes only in-range indices (OCaml raises
+   [Invalid_tag] otherwise); the 3D projection must emit the matching [< len]
+   refinement so the generated C validator rejects the same out-of-range inputs.
+   Without it the verified C is more permissive than the OCaml decoder. *)
+let test_lookup_index_bound () =
+  let codec =
+    Codec.v "Lk"
+      (fun v -> v)
+      Codec.[ (Field.v "v" (lookup [ 'a'; 'b'; 'c'; 'd' ] uint8) $ fun v -> v) ]
+  in
+  let output = to_3d (module_ [ typedef (Everparse.struct_of_codec codec) ]) in
+  Alcotest.(check bool)
+    "lookup field bounds its index" true
+    (contains ~sub:"(v < 4)" output)
+
 let suite =
   ( "everparse",
     [
+      Alcotest.test_case "generation: lookup index bound" `Quick
+        test_lookup_index_bound;
       Alcotest.test_case "generation: bitfields" `Quick test_bitfields;
       Alcotest.test_case "generation: enumerations" `Quick test_enumerations;
       Alcotest.test_case "generation: field dependence" `Quick


### PR DESCRIPTION
A `Wire.lookup` field decodes only in-range indices (the OCaml decoder raises `Invalid_tag` for an index past the table), but its 3D projection emitted the underlying integer with no bound. So the EverParse-generated C validator accepted out-of-range indices the OCaml decoder rejects: the verified C was strictly more permissive than the OCaml specification.

The fix carries the table length as a projection-only `index_bound` on `Map` (set by `cases` / `lookup`) and emits it in `pp_field` as a field refinement, so the generated C rejects exactly the inputs OCaml does. The OCaml decode path is unchanged (it already enforced the bound via the `Map` decode), and no other projection is affected.

Found by a registry-driven differential fuzzer (OCaml `Codec.decode_exn` vs the EverParse C validator), which is the first divergence it surfaced.
