### PR TITLE
codec: project uint63 to UINT64 for a verified validator

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -110,6 +110,11 @@
   its index bound to every element, not just to a scalar field. Previously the
   verified C validator accepted out-of-range indices in array or repeat elements
   that the OCaml decoder rejects (#126, @samoht)
+- A codec with a `Wire.uint63` or `Wire.uint63be` field now generates a
+  verified EverParse validator. It projected to an invalid `UINT63` type that
+  EverParse has no notion of, so schema generation failed and the codec silently
+  had no verified C parser at all. It now projects to the 8-byte `UINT64`, which
+  both decoders accept identically (#125, @samoht)
 - Decoding no longer crashes with `Invalid_argument` on adversarial input where
   a `Field.repeat` byte budget, or a variable field's cross-field size, exceeds
   the buffer (an out-of-range `Bytes.sub`). Such an oversized length now fails

--- a/fuzz/3d/fuzz_everparse.ml
+++ b/fuzz/3d/fuzz_everparse.ml
@@ -28,6 +28,11 @@ let nested_pp_cases =
    scalars project trivially, so they are left to the pp pass. *)
 let extract_names =
   [
+    (* uint63 is the one scalar that does not project trivially: it has no
+       native 3D type and must go through UINT64, so it gets a real EverParse
+       check rather than the pp pass. *)
+    "uint63";
+    "uint63be";
     "array(3,uint16be)";
     "array_seq(3,uint16be)";
     "array(2,record)";

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -1261,7 +1261,10 @@ and pp_typ : type a. a typ Fmt.t =
   | Uint8 -> Fmt.string ppf "UINT8"
   | Uint16 e -> Fmt.pf ppf "UINT16%a" pp_endian e
   | Uint32 e -> Fmt.pf ppf "UINT32%a" pp_endian e
-  | Uint63 e -> Fmt.pf ppf "UINT63%a" pp_endian e
+  (* 3D has no 63-bit type. Project to the 8-byte UINT64: both decoders then
+     accept every 8-byte input (the OCaml reader keeps the low 63 bits), so the
+     C validator never accepts more than the OCaml one. *)
+  | Uint63 e -> Fmt.pf ppf "UINT64%a" pp_endian e
   | Uint64 e -> Fmt.pf ppf "UINT64%a" pp_endian e
   (* 3D has no native signed types: project to the same-width UINT*. The
      two's-complement reinterpretation lives in the OCaml decoder. *)

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -83,6 +83,30 @@ let test_pretty_print () =
     "contains UINT16BE" true
     (contains ~sub:"UINT16BE" output)
 
+let test_3d_uint63_projects_to_uint64 () =
+  (* 3D has no 63-bit type. uint63/uint63be must project to the 8-byte UINT64,
+     not an invalid UINT63 that EverParse rejects (leaving the codec with no
+     verified validator at all). *)
+  let c =
+    Codec.v "U63"
+      (fun a b -> (a, b))
+      Codec.
+        [
+          (Field.v "a" uint63 $ fun (a, _) -> a);
+          (Field.v "b" uint63be $ fun (_, b) -> b);
+        ]
+  in
+  let output = to_3d (module_ [ typedef (Everparse.struct_of_codec c) ]) in
+  Alcotest.(check bool)
+    "no invalid UINT63" false
+    (contains ~sub:"UINT63" output);
+  Alcotest.(check bool)
+    "uint63 projects to UINT64" true
+    (contains ~sub:"UINT64 a" output);
+  Alcotest.(check bool)
+    "uint63be projects to UINT64BE" true
+    (contains ~sub:"UINT64BE b" output)
+
 (* -- Codec definitions for 3D extraction tests --
    The shared codecs ([inner], [outer], [l0]/[l1]/[l2], [opt_record],
    [container]/[repeat_codec], [packet]/[packet_codec]) live in
@@ -586,4 +610,6 @@ let suite =
         test_reserved_word_escaping;
       Alcotest.test_case "3d: byte_array_where synth typedef" `Quick
         test_3d_byte_array_where;
+      Alcotest.test_case "3d: uint63 projects to UINT64" `Quick
+        test_3d_uint63_projects_to_uint64;
     ] )


### PR DESCRIPTION
A codec with a `Wire.uint63` or `Wire.uint63be` field used to fail EverParse schema generation. The field projected to [`UINT63`](https://github.com/parsimoni-labs/ocaml-wire/blob/fix-uint63-projection/lib/types.ml#L1256), a type 3D has no notion of, so `3d.exe` rejected the schema and any codec using `uint63` silently ended up with no verified C validator at all. It now projects to the 8-byte `UINT64`, which carries the same bytes and which both the OCaml decoder and the verified C validator accept on exactly the same inputs.