### PR TITLE
codec: project the lookup index bound on array and repeat elements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -106,6 +106,10 @@
   OCaml decoder does. Previously the projection emitted the underlying integer
   with no bound, so the verified C accepted indices the OCaml decoder rejects
   (@samoht)
+- A `Wire.lookup` used as a `Wire.array` or `Field.repeat` element now projects
+  its index bound to every element, not just to a scalar field. Previously the
+  verified C validator accepted out-of-range indices in array or repeat elements
+  that the OCaml decoder rejects (#126, @samoht)
 - Decoding no longer crashes with `Invalid_argument` on adversarial input where
   a `Field.repeat` byte budget, or a variable field's cross-field size, exceeds
   the buffer (an out-of-range `Bytes.sub`). Such an oversized length now fails

--- a/lib/everparse.ml
+++ b/lib/everparse.ml
@@ -321,14 +321,30 @@ let collect_extern_setters schema_name ctx_struct u32 fields =
    [Types.synth_name_of_elt_var] keeps the field rendering and the typedef
    name in sync without threading state. *)
 let refined_byte_typedefs (s : Types.struct_) : Types.decl list =
+  (* The refined-byte element a field needs synthesised, if any: an explicit
+     [byte_array_where], or an [array] / [repeat] whose 1-byte element carries a
+     lookup index bound (which projects the same way). *)
+  let synth_of (Types.Field f) =
+    match f.field_typ with
+    | Types.Byte_array_where { elt_var; cond; _ } -> Some (elt_var, cond)
+    | Types.Array { elem; _ } -> Types.index_bound_elt elem
+    | Types.Repeat { elem; _ } -> Types.index_bound_elt elem
+    | _ -> None
+  in
+  (* Equal index bounds share one synthesised typedef, so emit each name once. *)
+  let seen = Hashtbl.create 8 in
   List.filter_map
-    (fun (Types.Field f) ->
-      match f.field_typ with
-      | Types.Byte_array_where { elt_var; cond; _ } ->
+    (fun field ->
+      match synth_of field with
+      | Some (elt_var, cond) ->
           let synth = Types.synth_name_of_elt_var elt_var in
-          let elt_field = Types.field elt_var ~constraint_:cond Types.uint8 in
-          Some (Types.typedef (Types.struct_ synth [ elt_field ]))
-      | _ -> None)
+          if Hashtbl.mem seen synth then None
+          else begin
+            Hashtbl.add seen synth ();
+            let elt_field = Types.field elt_var ~constraint_:cond Types.uint8 in
+            Some (Types.typedef (Types.struct_ synth [ elt_field ]))
+          end
+      | None -> None)
     s.fields
 
 let with_output (s : Types.struct_) : Types.decl list =

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -1488,6 +1488,31 @@ end = struct
   let pp t = t
 end
 
+(* The index bound a [cases] / lookup typ carries, seen through the transparent
+   [Map] / [Where] / [Apply] wrappers. [Some n] means the decoded raw value is a
+   valid index only when [< n], which the projection emits as a refinement so
+   the generated C validator rejects the same out-of-range inputs the OCaml
+   decoder does. *)
+let rec index_bound_of : type a. a typ -> int option = function
+  | Map { index_bound = Some _ as b; _ } -> b
+  | Map { inner; index_bound = None; _ } -> index_bound_of inner
+  | Where { inner; _ } -> index_bound_of inner
+  | Apply { typ; _ } -> index_bound_of typ
+  | _ -> None
+
+(* A 1-byte array / repeat element that carries an index bound (a lookup index
+   into an [n]-entry table) projects like a [byte_array_where]: every byte is
+   refined to [< n] through a synthesised element struct. Returns the element
+   variable and its constraint, keyed on the bound so equal bounds share a
+   single synthesised typedef. *)
+let index_bound_elt : type a. a typ -> (string * bool expr) option =
+ fun elem ->
+  match (inner_wire_size elem, index_bound_of elem) with
+  | Some 1, Some bound ->
+      let elt_var = Fmt.str "%slk%d" elt_var_prefix bound in
+      Some (elt_var, Lt (Ref elt_var, Int bound))
+  | _ -> None
+
 let rec optional_suffix : type a.
     bool expr -> a typ -> field_suffix * (Format.formatter -> unit) =
  fun present inner ->
@@ -1536,7 +1561,16 @@ and field_suffix : type a. a typ -> field_suffix * (Format.formatter -> unit) =
          [inner_wire_size_expr] handles fixed scalars, [byte_array]-style
          sized payloads, codec-with-fixed-size, and nested arrays. *)
       match (inner_wire_size elem, inner_wire_size_expr elem) with
-      | Some 1, _ -> (Array len, fun ppf -> pp_typ ppf elem)
+      | Some 1, _ -> (
+          match index_bound_elt elem with
+          | Some (elt_var, _) ->
+              (* A bounded byte element (a lookup index) projects like a
+                 [byte_array_where]: a byte-budget array of the synthesised
+                 refined-byte struct, so every element carries the [< n] bound
+                 the OCaml decoder enforces. *)
+              ( Byte_array len,
+                fun ppf -> Fmt.string ppf (synth_name_of_elt_var elt_var) )
+          | None -> (Array len, fun ppf -> pp_typ ppf elem))
       | _, Some s ->
           (* A wider element is emitted as its bare base under a byte budget of
              [len * width]; its own [:byte-size] suffix (e.g. for a [byte_array]
@@ -1569,10 +1603,15 @@ and field_suffix : type a. a typ -> field_suffix * (Format.formatter -> unit) =
          dropped) so the only suffix is the budget: a list of fixed n-byte
          chunks is just bytes on the wire, like a repeat of [UINT8]. *)
       let pp_elem ppf =
-        match repeat_elem_struct elem with
-        | Some name -> Fmt.string ppf name
-        | None ->
-            Nlist_elem.pp (Nlist_elem.make elem (snd (field_suffix elem))) ppf
+        match index_bound_elt elem with
+        | Some (elt_var, _) -> Fmt.string ppf (synth_name_of_elt_var elt_var)
+        | None -> (
+            match repeat_elem_struct elem with
+            | Some name -> Fmt.string ppf name
+            | None ->
+                Nlist_elem.pp
+                  (Nlist_elem.make elem (snd (field_suffix elem)))
+                  ppf)
       in
       (Byte_array size, pp_elem)
   | Zeroterm -> (Zeroterm, fun ppf -> Fmt.string ppf "UINT8")
@@ -1612,18 +1651,6 @@ let pp_field_suffix ppf = function
   | Zeroterm_at_most size ->
       Fmt.pf ppf "[:zeroterm-byte-size-at-most %a]" pp_expr size
   | Array len -> Fmt.pf ppf "[%a]" pp_expr len
-
-(* The index bound a [cases] / lookup typ carries, seen through the transparent
-   [Map] / [Where] / [Apply] wrappers. [Some n] means the decoded raw value is a
-   valid index only when [< n]; the projection emits that as a field refinement
-   so the generated C validator rejects the same out-of-range inputs the OCaml
-   decoder does. *)
-let rec index_bound_of : type a. a typ -> int option = function
-  | Map { index_bound = Some _ as b; _ } -> b
-  | Map { inner; index_bound = None; _ } -> index_bound_of inner
-  | Where { inner; _ } -> index_bound_of inner
-  | Apply { typ; _ } -> index_bound_of typ
-  | _ -> None
 
 let pp_field ppf (Field f) =
   let raw_name, name =

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -508,6 +508,13 @@ val synth_name_of_elt_var : string -> string
     name derived from a {!byte_array_where} element variable. Internal: used by
     the EverParse projection. *)
 
+val index_bound_elt : 'a typ -> (string * bool expr) option
+(** [index_bound_elt elem] is [Some (elt_var, cond)] when [elem] is a 1-byte
+    array / repeat element carrying a lookup index bound: it then projects like
+    a {!byte_array_where} whose synthesised element struct is named
+    [synth_name_of_elt_var elt_var] and refines its byte with [cond]. Internal:
+    used by the EverParse projection. *)
+
 val byte_slice : size:int expr -> Bytesrw.Bytes.Slice.t typ
 (** Zero-copy byte span. *)
 

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -523,11 +523,38 @@ let test_lookup_index_bound () =
     "lookup field bounds its index" true
     (contains ~sub:"(v < 4)" output)
 
+let test_array_lookup_element_bound () =
+  (* A lookup as an array element must bound every element, not just a scalar
+     field, or the verified C validator accepts out-of-range indices the OCaml
+     decoder rejects. The element projects through a synthesised refined-byte
+     struct, as a byte_array_where does. *)
+  let codec =
+    Codec.v "ArrLk"
+      (fun v -> v)
+      Codec.
+        [
+          ( Field.v "a"
+              (array ~len:(int 3) (lookup [ 'a'; 'b'; 'c'; 'd' ] uint8))
+          $ fun v -> v );
+        ]
+  in
+  (* The synthesised element struct is emitted by the full schema projection,
+     not [struct_of_codec] alone, so render the whole module. *)
+  let output = to_3d (Everparse.schema codec).module_ in
+  Alcotest.(check bool)
+    "array element bounds its index" true
+    (contains ~sub:"(__elt_lk4 < 4)" output);
+  Alcotest.(check bool)
+    "element refined via synth struct" true
+    (contains ~sub:"_RefByte_lk4 a" output)
+
 let suite =
   ( "everparse",
     [
       Alcotest.test_case "generation: lookup index bound" `Quick
         test_lookup_index_bound;
+      Alcotest.test_case "generation: array lookup element bound" `Quick
+        test_array_lookup_element_bound;
       Alcotest.test_case "generation: bitfields" `Quick test_bitfields;
       Alcotest.test_case "generation: enumerations" `Quick test_enumerations;
       Alcotest.test_case "generation: field dependence" `Quick


### PR DESCRIPTION
Sibling of #123. A `Wire.lookup` used as a `Wire.array` or `Field.repeat` element projected the bare underlying byte with no bound, so the verified C validator accepted out-of-range indices the OCaml decoder rejects: an unsafe projection, since a verified parser certified inputs the decoder treats as invalid. An index-bound byte element now projects exactly like a `byte_array_where` ([`index_bound_elt`](https://github.com/parsimoni-labs/ocaml-wire/blob/fix-lookup-array-element-bound/lib/types.ml#L1508)), through a synthesised refined-byte struct that constrains every element to the table size, so `3d.exe` generates a validator that rejects the same indices OCaml does.

Stacked on #123, which adds the `index_bound` metadata this reuses; retarget to main once that merges.