### PR TITLE
codec: route signed-int and float fields to width-typed setters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -115,6 +115,12 @@
   EverParse has no notion of, so schema generation failed and the codec silently
   had no verified C parser at all. It now projects to the 8-byte `UINT64`, which
   both decoders accept identically (#125, @samoht)
+- A codec mixing signed-integer or float fields of different widths (e.g. a
+  `float32` then a `float64`, or an `int8` then an `int32`) now generates a
+  verified EverParse validator. Such fields shared one extraction callback whose
+  value type was fixed to the first field's width, so EverParse rejected the
+  schema on the width mismatch and the codec had no verified C parser at all.
+  Each field width now routes to its own callback (#127, @samoht)
 - Decoding no longer crashes with `Invalid_argument` on adversarial input where
   a `Field.repeat` byte budget, or a variable field's cross-field size, exceeds
   the buffer (an out-of-range `Bytes.sub`). Such an oversized length now fails

--- a/lib/everparse.ml
+++ b/lib/everparse.ml
@@ -67,6 +67,21 @@ let rec type_suffix : type a. a Types.typ -> string = function
   | Types.Uint63 Types.Big -> "U63BE"
   | Types.Uint64 Types.Little -> "U64"
   | Types.Uint64 Types.Big -> "U64BE"
+  (* Signed integers and floats project to the same-width [UINT*] (the
+     reinterpretation lives in the OCaml decoder), so they route to the matching
+     width setter rather than the generic [SetBytes], whose single value type
+     cannot hold two scalar fields of different widths. *)
+  | Types.Int8 -> "U8"
+  | Types.Int16 Types.Little -> "U16"
+  | Types.Int16 Types.Big -> "U16BE"
+  | Types.Int32 Types.Little -> "U32"
+  | Types.Int32 Types.Big -> "U32BE"
+  | Types.Int64 Types.Little -> "U64"
+  | Types.Int64 Types.Big -> "U64BE"
+  | Types.Float32 Types.Little -> "U32"
+  | Types.Float32 Types.Big -> "U32BE"
+  | Types.Float64 Types.Little -> "U64"
+  | Types.Float64 Types.Big -> "U64BE"
   | Types.Bits { base = Types.BF_U8; _ } -> "U8"
   | Types.Bits { base = Types.BF_U16 Types.Little; _ } -> "U16"
   | Types.Bits { base = Types.BF_U16 Types.Big; _ } -> "U16BE"

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -107,6 +107,37 @@ let test_3d_uint63_projects_to_uint64 () =
     "uint63be projects to UINT64BE" true
     (contains ~sub:"UINT64BE b" output)
 
+let test_3d_signed_float_setters () =
+  (* Signed-int and float fields must each route to a width-typed setter. They
+     used to fall through to the generic SetBytes, whose single value type could
+     not hold two scalar fields of different widths, so EverParse rejected any
+     record mixing widths (e.g. float32 then float64) and the codec got no
+     verified validator. *)
+  let c =
+    Codec.v "Mix"
+      (fun a b c d -> (a, b, c, d))
+      Codec.
+        [
+          (Field.v "a" float32be $ fun (a, _, _, _) -> a);
+          (Field.v "b" float64be $ fun (_, b, _, _) -> b);
+          (Field.v "c" int8 $ fun (_, _, c, _) -> c);
+          (Field.v "d" int32be $ fun (_, _, _, d) -> d);
+        ]
+  in
+  let output = to_3d (Everparse.schema c).module_ in
+  Alcotest.(check bool)
+    "float32be routes to SetU32BE" true
+    (contains ~sub:"SetU32BE" output);
+  Alcotest.(check bool)
+    "float64be routes to SetU64BE" true
+    (contains ~sub:"SetU64BE" output);
+  Alcotest.(check bool)
+    "int8 routes to SetU8" true
+    (contains ~sub:"SetU8" output);
+  Alcotest.(check bool)
+    "no scalar falls through to SetBytes" false
+    (contains ~sub:"SetBytes" output)
+
 (* -- Codec definitions for 3D extraction tests --
    The shared codecs ([inner], [outer], [l0]/[l1]/[l2], [opt_record],
    [container]/[repeat_codec], [packet]/[packet_codec]) live in
@@ -612,4 +643,6 @@ let suite =
         test_3d_byte_array_where;
       Alcotest.test_case "3d: uint63 projects to UINT64" `Quick
         test_3d_uint63_projects_to_uint64;
+      Alcotest.test_case "3d: signed and float setters" `Quick
+        test_3d_signed_float_setters;
     ] )


### PR DESCRIPTION
A codec mixing signed-integer or float fields of different widths (a `float32` then a `float64`, an `int8` then an `int32`, ...) failed EverParse schema generation, so it had no verified C validator at all. [`type_suffix`](https://github.com/parsimoni-labs/ocaml-wire/blob/fix-signed-float-setters/lib/everparse.ml#L70) only enumerated the `Uint*` types, so every `Int*` and `Float*` field fell through to the generic `SetBytes` extraction callback, whose single value parameter was fixed to the first such field's width. A second field of a different width then mismatched (`expected UINT32BE whereas f1 has type UINT64BE`). Each width now routes to its own width-typed setter, matching the projected `UINT` width, so the schema verifies. Same class as #125.