### PR TITLE
codec: emit enum declarations for enums inside containers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -121,6 +121,11 @@
   value type was fixed to the first field's width, so EverParse rejected the
   schema on the width mismatch and the codec had no verified C parser at all.
   Each field width now routes to its own callback (#127, @samoht)
+- A `Wire.enum` used as a `Wire.array` or `Field.repeat` element (or inside an
+  optional or sized region) now generates a verified EverParse validator. Its
+  enumeration declaration was only emitted for scalar fields, so the schema
+  referenced an undeclared type and EverParse rejected it, leaving the codec
+  with no verified C parser at all (#128, @samoht)
 - Decoding no longer crashes with `Invalid_argument` on adversarial input where
   a `Field.repeat` byte budget, or a variable field's cross-field size, exceeds
   the buffer (an out-of-range `Bytes.sub`). Such an oversized length now fails

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -851,6 +851,14 @@ let enum_decls (s : struct_) : decl list =
             decls := Enum_decl { name; cases; base = Pack_typ base } :: !decls
         | Map { inner; _ } -> extract inner
         | Where { inner; _ } -> extract inner
+        (* An enum can sit inside a container (an array or repeat element, an
+           optional, a sized region); its declaration is still needed, or the
+           schema references an undeclared type. *)
+        | Array { elem; _ } -> extract elem
+        | Repeat { elem; _ } -> extract elem
+        | Optional { inner; _ } -> extract inner
+        | Optional_or { inner; _ } -> extract inner
+        | Single_elem { elem; _ } -> extract elem
         | _ -> ()
       in
       extract f.field_typ)

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -138,6 +138,25 @@ let test_3d_signed_float_setters () =
     "no scalar falls through to SetBytes" false
     (contains ~sub:"SetBytes" output)
 
+let test_3d_array_enum_element_decl () =
+  (* An enum used as an array element still needs its declaration emitted. The
+     decl collection only looked through Map/Where wrappers, so an enum inside an
+     array left the schema referencing an undeclared type, which EverParse
+     rejects. *)
+  let e = enum "Color" [ ("Red", 1); ("Green", 2); ("Blue", 3) ] uint8 in
+  let c =
+    Codec.v "ArrE"
+      (fun v -> v)
+      Codec.[ (Field.v "v" (array ~len:(int 4) e) $ fun v -> v) ]
+  in
+  let output = to_3d (Everparse.schema c).module_ in
+  Alcotest.(check bool)
+    "enum declaration emitted" true
+    (contains ~sub:"enum Color" output);
+  Alcotest.(check bool)
+    "array element references the enum" true
+    (contains ~sub:"Color v[" output)
+
 (* -- Codec definitions for 3D extraction tests --
    The shared codecs ([inner], [outer], [l0]/[l1]/[l2], [opt_record],
    [container]/[repeat_codec], [packet]/[packet_codec]) live in
@@ -645,4 +664,6 @@ let suite =
         test_3d_uint63_projects_to_uint64;
       Alcotest.test_case "3d: signed and float setters" `Quick
         test_3d_signed_float_setters;
+      Alcotest.test_case "3d: array enum element decl" `Quick
+        test_3d_array_enum_element_decl;
     ] )


### PR DESCRIPTION
A `Wire.enum` used as a `Wire.array` or `Field.repeat` element (or inside an optional or sized region) failed EverParse schema generation, so the codec had no verified C validator at all. The enumeration-declaration collection in [`enum_decls`](https://github.com/parsimoni-labs/ocaml-wire/blob/fix-array-enum-decl/lib/types.ml#L854) only looked through `Map` and `Where` wrappers, so an enum inside a container was never declared and the schema referenced an undeclared type (`Variable E not found`). The collection now also recurses into array, repeat, optional, and sized-region elements. Same class as #125 and #127.

Stacked on #127; retarget to main once that merges.