### PR TITLE
codec: project enum membership as a 3D refinement

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -101,6 +101,12 @@
 
 ### Fixed
 
+- A `Wire.enum` field now projects its membership to 3D, so the
+  EverParse-generated C validator rejects values outside the named cases,
+  exactly as `Codec.decode` does (raising `Invalid_enum`). The field previously
+  projected to its bare base integer with no refinement, so the verified C
+  accepted out-of-range values the OCaml decoder rejects, including for an enum
+  nested inside a sub-codec or record (#131, @samoht)
 - A `Wire.lookup` field now projects its index bound to 3D, so the
   EverParse-generated C validator rejects out-of-range indices exactly as the
   OCaml decoder does. Previously the projection emitted the underlying integer

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -1511,6 +1511,18 @@ let rec index_bound_of : type a. a typ -> int option = function
   | Apply { typ; _ } -> index_bound_of typ
   | _ -> None
 
+(* The case values an [enum] field admits, seen through the transparent
+   [Map] / [Where] / [Apply] wrappers. The projection emits membership as a
+   field refinement so the generated C validator rejects values outside the
+   named cases, exactly as the OCaml decoder does (a bare base value otherwise
+   slips through C while [Codec.decode] raises [Invalid_enum]). *)
+let rec enum_cases_of : type a. a typ -> int list option = function
+  | Enum { cases; _ } -> Some (List.map snd cases)
+  | Map { inner; _ } -> enum_cases_of inner
+  | Where { inner; _ } -> enum_cases_of inner
+  | Apply { typ; _ } -> enum_cases_of typ
+  | _ -> None
+
 (* A 1-byte array / repeat element that carries an index bound (a lookup index
    into an [n]-entry table) projects like a [byte_array_where]: every byte is
    refined to [< n] through a synthesised element struct. Returns the element
@@ -1683,10 +1695,24 @@ let pp_field ppf (Field f) =
     | Some len -> Some (Lt (Ref raw_name, Int len))
     | None -> None
   in
+  (* An [enum] field is valid only for one of its named values; emit that
+     membership as a refinement (the OCaml decoder enforces it on decode). *)
+  let enum_cond =
+    match enum_cases_of f.field_typ with
+    | Some (v0 :: rest) ->
+        Some
+          (List.fold_left
+             (fun acc v -> Or (acc, Eq (Ref raw_name, Int v)))
+             (Eq (Ref raw_name, Int v0))
+             rest)
+    | Some [] | None -> None
+  in
   let constraint_ =
     combine_constraints
-      (combine_constraints f.constraint_ where_cond)
-      bound_cond
+      (combine_constraints
+         (combine_constraints f.constraint_ where_cond)
+         bound_cond)
+      enum_cond
   in
   let suffix, pp_base = field_suffix typ in
   Fmt.pf ppf "@,%t %s%a" pp_base name pp_field_suffix suffix;

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -157,6 +157,35 @@ let test_3d_array_enum_element_decl () =
     "array element references the enum" true
     (contains ~sub:"Color v[" output)
 
+let test_3d_enum_membership () =
+  (* An enum field must enforce membership in the verified C, on a scalar field
+     and inside a sub-codec, or the validator accepts values that Codec.decode
+     rejects with Invalid_enum. *)
+  let e = enum "Color" [ ("Red", 1); ("Green", 2); ("Blue", 3) ] uint8 in
+  let scalar =
+    Codec.v "ES" (fun v -> v) Codec.[ (Field.v "v" e $ fun v -> v) ]
+  in
+  Alcotest.(check bool)
+    "scalar enum bounds its value" true
+    (contains ~sub:"(v == 1)" (to_3d (Everparse.schema scalar).module_));
+  let rec_ =
+    Codec.v "Rec"
+      (fun a b -> (a, b))
+      Codec.
+        [
+          (Field.v "e" e $ fun (a, _) -> a);
+          (Field.v "u" uint64be $ fun (_, b) -> b);
+        ]
+  in
+  let arr =
+    Codec.v "ArrRec"
+      (fun v -> v)
+      Codec.[ (Field.v "v" (array ~len:(int 4) (codec rec_)) $ fun v -> v) ]
+  in
+  Alcotest.(check bool)
+    "enum nested in a sub-codec bounds its value" true
+    (contains ~sub:"(e == 1)" (to_3d (Everparse.schema arr).module_))
+
 (* -- Codec definitions for 3D extraction tests --
    The shared codecs ([inner], [outer], [l0]/[l1]/[l2], [opt_record],
    [container]/[repeat_codec], [packet]/[packet_codec]) live in
@@ -666,4 +695,6 @@ let suite =
         test_3d_signed_float_setters;
       Alcotest.test_case "3d: array enum element decl" `Quick
         test_3d_array_enum_element_decl;
+      Alcotest.test_case "3d: enum membership refinement" `Quick
+        test_3d_enum_membership;
     ] )


### PR DESCRIPTION
A `Wire.enum` field projected to its bare base integer with no refinement, so the EverParse-generated C validator accepted any value, while `Codec.decode` raises `Invalid_enum` for a value outside the named cases (and `enum` is documented to validate). The verified C was therefore more permissive than the OCaml decoder. [`enum_cases_of`](https://github.com/parsimoni-labs/ocaml-wire/blob/fix-enum-membership/lib/types.ml#L1519) now feeds a membership refinement into the field constraint, so the field carries `(v == c1) || (v == c2) || ...`: a scalar enum field, and an enum nested inside a sub-codec or record, both reject the same values OCaml does. Found by the differential fuzzer on an `array(record(...,enum,...))` whose verified C accepted an out-of-range enum byte. Same family as #125, #126, #130.