### PR TITLE
codec: emit refined-byte typedef for a byte_array_where inside a nested region

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -107,6 +107,12 @@
   projected to its bare base integer with no refinement, so the verified C
   accepted out-of-range values the OCaml decoder rejects, including for an enum
   nested inside a sub-codec or record (#131, @samoht)
+- A `Wire.byte_array_where` inside a `Wire.nested` / `nested_at_most` region now
+  generates a verified EverParse validator. Its synthesised refined-byte typedef
+  was emitted only for a top-level field, so the nested region referenced an
+  undeclared type and EverParse rejected the schema. The typedef is now emitted
+  (before the wrapper that references it) wherever the refinement is nested
+  (#132, @samoht)
 - A `Wire.lookup` field now projects its index bound to 3D, so the
   EverParse-generated C validator rejects out-of-range indices exactly as the
   OCaml decoder does. Previously the projection emitted the underlying integer

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -1050,6 +1050,17 @@ let optional_casetype_decl : type a. string -> a typ -> decl =
         ];
     }
 
+(* The refined-byte element a wrapper struct holds, if any, seen through the
+   transparent [map] / [where] wrappers. Its synthesised [_RefByte_*] typedef
+   must be emitted before the wrapper that references it, or the wrapper names an
+   undeclared type (a [byte_array_where] inside a [nested] region). *)
+let rec wrapper_refined_byte : type a. a typ -> (string * bool expr) option =
+  function
+  | Byte_array_where { elt_var; cond; _ } -> Some (elt_var, cond)
+  | Map { inner; _ } -> wrapper_refined_byte inner
+  | Where { inner; _ } -> wrapper_refined_byte inner
+  | _ -> None
+
 let rec collect_casetype_decls : type a.
     (string, unit) Hashtbl.t -> decl list Stdlib.ref -> a typ -> unit =
  fun seen acc typ ->
@@ -1057,10 +1068,21 @@ let rec collect_casetype_decls : type a.
    fun t -> collect_casetype_decls seen acc t
   in
   (* A fixed-size element used inside [repeat] / [nested] needs a named wrapper
-     struct when it has no usable bare token; emit it once, deduped by name. *)
+     struct when it has no usable bare token; emit it once, deduped by name. A
+     refined-byte element inside the wrapper needs its own typedef emitted first. *)
   let emit_wrapper name elem =
     if not (Hashtbl.mem seen name) then begin
       Hashtbl.add seen name ();
+      (match wrapper_refined_byte elem with
+      | Some (elt_var, cond) ->
+          let synth = synth_name_of_elt_var elt_var in
+          if not (Hashtbl.mem seen synth) then begin
+            Hashtbl.add seen synth ();
+            acc :=
+              typedef (struct_ synth [ field elt_var ~constraint_:cond uint8 ])
+              :: !acc
+          end
+      | None -> ());
       acc := typedef (struct_ name [ field "v" elem ]) :: !acc
     end
   in

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -186,6 +186,23 @@ let test_3d_enum_membership () =
     "enum nested in a sub-codec bounds its value" true
     (contains ~sub:"(e == 1)" (to_3d (Everparse.schema arr).module_))
 
+let test_3d_nested_byte_array_where () =
+  (* A byte_array_where inside a nested region needs its synthesised refined-byte
+     typedef emitted, before the wrapper that references it, or the schema names
+     an undeclared type and EverParse rejects it. *)
+  let inner =
+    byte_array_where ~size:(int 4) ~per_byte:(fun b -> Expr.(b < int 10))
+  in
+  let c =
+    Codec.v "NBW"
+      (fun v -> v)
+      Codec.[ (Field.v "n" (nested ~size:(int 4) inner) $ fun v -> v) ]
+  in
+  let output = to_3d (Everparse.schema c).module_ in
+  Alcotest.(check bool)
+    "refined-byte typedef is defined, not just referenced" true
+    (contains ~sub:"} _RefByte_" output)
+
 (* -- Codec definitions for 3D extraction tests --
    The shared codecs ([inner], [outer], [l0]/[l1]/[l2], [opt_record],
    [container]/[repeat_codec], [packet]/[packet_codec]) live in
@@ -697,4 +714,6 @@ let suite =
         test_3d_array_enum_element_decl;
       Alcotest.test_case "3d: enum membership refinement" `Quick
         test_3d_enum_membership;
+      Alcotest.test_case "3d: nested byte_array_where refined typedef" `Quick
+        test_3d_nested_byte_array_where;
     ] )


### PR DESCRIPTION
A `Wire.byte_array_where` wrapped in a `Wire.nested` / `nested_at_most` region failed EverParse schema generation: the nested wrapper struct referenced the synthesised refined-byte typedef (`_RefByte_*`), but that typedef was emitted only for a top-level `byte_array_where` field, so the wrapper named an undeclared type. The wrapper emission now declares the refined-byte typedef first, so the shape generates a verified validator. Closes a cataloged composites-over-composites projection gap; found while sweeping the nested combinator over every element.