### PR TITLE
codec: treat a statically-present optional as transparent in projection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,8 +24,11 @@
   decode (#105, @samoht)
 - `Field.optional` and `Field.optional_or` now accept a variable-size inner,
   so an optional field can be a length-prefixed string or a whole sub-message,
-  not just a fixed-width value. Building such a codec previously raised
-  `Invalid_argument` (#88, @samoht)
+  not just a fixed-width value, and generate a verified EverParse validator.
+  Building such a codec previously raised `Invalid_argument`; afterwards a
+  statically-present optional over a byte-span, refined (`byte_array_where`), or
+  composite inner still projected to C that EverParse rejected, because the
+  optional was not treated as transparent in the projection (#88, #133, @samoht)
 - `Wire.zeroterm` and `Wire.zeroterm_at_most ~size` for NUL-terminated
   strings: the bytes up to a terminator, optionally bounded to a
   fixed-size region (#77, @samoht)

--- a/lib/everparse.ml
+++ b/lib/everparse.ml
@@ -25,9 +25,15 @@ let rec is_byte_field : type a. a Types.typ -> bool = function
       true
   | Types.All_bytes | Types.All_zeros -> true
   | Types.Zeroterm | Types.Zeroterm_at_most _ -> true
-  | Types.Optional { present = Types.Bool _; _ } -> false
+  (* A statically-present optional is transparent: it projects as its inner
+     (see [field_suffix]), so a byte-span / composite inner keeps its offset
+     callback. A statically-absent one is a zero-byte region. *)
+  | Types.Optional { present = Types.Bool true; inner } -> is_byte_field inner
+  | Types.Optional { present = Types.Bool false; _ } -> false
   | Types.Optional _ -> true
-  | Types.Optional_or { present = Types.Bool _; _ } -> false
+  | Types.Optional_or { present = Types.Bool true; inner; _ } ->
+      is_byte_field inner
+  | Types.Optional_or { present = Types.Bool false; _ } -> false
   | Types.Optional_or _ -> true
   | Types.Map { inner; _ } -> is_byte_field inner
   (* Casetype projects to a struct value, which is not "readable" in 3D
@@ -338,14 +344,22 @@ let collect_extern_setters schema_name ctx_struct u32 fields =
 let refined_byte_typedefs (s : Types.struct_) : Types.decl list =
   (* The refined-byte element a field needs synthesised, if any: an explicit
      [byte_array_where], or an [array] / [repeat] whose 1-byte element carries a
-     lookup index bound (which projects the same way). *)
-  let synth_of (Types.Field f) =
-    match f.field_typ with
+     lookup index bound (which projects the same way). Look through the
+     transparent wrappers a field can put it under (a statically-present
+     [optional], [map] / [where]) so the typedef is still emitted. *)
+  let rec synth_of_typ : type a.
+      a Types.typ -> (string * bool Types.expr) option = function
     | Types.Byte_array_where { elt_var; cond; _ } -> Some (elt_var, cond)
     | Types.Array { elem; _ } -> Types.index_bound_elt elem
     | Types.Repeat { elem; _ } -> Types.index_bound_elt elem
+    | Types.Optional { present = Types.Bool true; inner } -> synth_of_typ inner
+    | Types.Optional_or { present = Types.Bool true; inner; _ } ->
+        synth_of_typ inner
+    | Types.Map { inner; _ } -> synth_of_typ inner
+    | Types.Where { inner; _ } -> synth_of_typ inner
     | _ -> None
   in
+  let synth_of (Types.Field f) = synth_of_typ f.field_typ in
   (* Equal index bounds share one synthesised typedef, so emit each name once. *)
   let seen = Hashtbl.create 8 in
   List.filter_map

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -203,6 +203,30 @@ let test_3d_nested_byte_array_where () =
     "refined-byte typedef is defined, not just referenced" true
     (contains ~sub:"} _RefByte_" output)
 
+let test_3d_static_optional_transparent () =
+  (* A statically-present optional projects as its inner: a byte-span or
+     composite inner keeps its offset setter (passing the field value made
+     EverParse reject the schema), and a byte_array_where inner still emits its
+     refined typedef. *)
+  let opt inner =
+    Codec.v "Opt"
+      (fun v -> v)
+      Codec.[ (Field.optional "o" ~present:Expr.true_ inner $ fun v -> v) ]
+  in
+  let out_ba =
+    to_3d (Everparse.schema (opt (byte_array ~size:(int 4)))).module_
+  in
+  Alcotest.(check bool)
+    "byte-span optional uses an offset setter" true
+    (contains ~sub:"(UINT32) 0, (UINT32) 0" out_ba);
+  let baw =
+    byte_array_where ~size:(int 4) ~per_byte:(fun b -> Expr.(b < int 10))
+  in
+  let out_baw = to_3d (Everparse.schema (opt baw)).module_ in
+  Alcotest.(check bool)
+    "byte_array_where optional emits its refined typedef" true
+    (contains ~sub:"} _RefByte_" out_baw)
+
 (* -- Codec definitions for 3D extraction tests --
    The shared codecs ([inner], [outer], [l0]/[l1]/[l2], [opt_record],
    [container]/[repeat_codec], [packet]/[packet_codec]) live in
@@ -716,4 +740,6 @@ let suite =
         test_3d_enum_membership;
       Alcotest.test_case "3d: nested byte_array_where refined typedef" `Quick
         test_3d_nested_byte_array_where;
+      Alcotest.test_case "3d: static optional transparent projection" `Quick
+        test_3d_static_optional_transparent;
     ] )


### PR DESCRIPTION
A `Field.optional` / `optional_or` with a statically-true gate projects as its inner (`field_suffix` already collapses it), but two projection helpers did not treat it as transparent: `is_byte_field` returned `false` for it, so a byte-span or composite inner got a by-value extraction callback EverParse rejects (`tag not readable`, or a `UINT32` vs byte-span mismatch), and `refined_byte_typedefs` did not look through it, so a `byte_array_where` inner left its synthesised typedef undeclared. Both now look through a statically-present optional, so `optional` over a byte span, a record, or a `byte_array_where` generates a verified validator. Completes the #88 variable-inner optional, whose projection was string-checked but never run through `3d.exe`.