### PR TITLE
ci: run the 3d.exe projection checks under EverParse

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,3 +158,31 @@ jobs:
         with:
           name: afl-diff-findings
           path: afl-diff-findings.tar.gz
+
+  # Run the test suite with the EverParse toolchain installed so the 3d.exe
+  # projection checks actually execute: test/3d compiles and runs the generated
+  # C end to end, and fuzz/3d runs every covered schema through 3d.exe. Without
+  # 3d.exe both are skipped, so a shape that builds but does not project to a
+  # validator EverParse verifies (a composite-over-composite gap) would slip
+  # past the plain build job, which only string-checks the projection.
+  everparse-3d:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: '5.3'
+          dune-version: '3.21'
+
+      - run: opam install . --deps-only --with-test
+
+      - name: Install EverParse
+        run: |
+          mkdir -p "$HOME/.local"
+          url=https://github.com/project-everest/everparse/releases/download/v2026.02.25/everparse_v2026.02.25_Linux_x86_64.tar.gz
+          curl -sL "$url" | tar xz -C "$HOME/.local"
+          echo "$HOME/.local/everparse/bin" >> "$GITHUB_PATH"
+
+      - name: Run tests with 3d.exe projection checks
+        run: opam exec -- dune runtest

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -101,6 +101,12 @@
 
 ### Fixed
 
+- The generated dune rule now compiles the EverParse C under strict C11
+  (`-std=c11 -D_DEFAULT_SOURCE`, without `-Wextra`) instead of `-std=c99`, so
+  the verified validators build on Linux glibc: the BSD endian helpers
+  (`be16toh`, ...) the C uses need `_DEFAULT_SOURCE` declared, and `-Wextra`'s
+  `-Wtype-limits` rejected the always-true bound check EverParse emits for an
+  optional's absent zero-byte case (@samoht)
 - A `Wire.enum` field now projects its membership to 3D, so the
   EverParse-generated C validator rejects values outside the named cases,
   exactly as `Codec.decode` does (raising `Invalid_enum`). The field previously

--- a/lib/3d/wire_3d.ml
+++ b/lib/3d/wire_3d.ml
@@ -503,8 +503,15 @@ let run ?(quiet = true) ~outdir schemas =
   generate_3d ~outdir schemas;
   generate_c ~quiet ~outdir schemas
 
+(* Strict C11 with warnings-as-errors. [_DEFAULT_SOURCE] declares the BSD endian
+   helpers (be16toh, ...) the generated C uses from <endian.h> on Linux glibc.
+   [-Wextra] is deliberately omitted: its [-Wtype-limits] flags the always-true
+   [0U <= unsigned] bound check EverParse emits for an optional's absent 0-byte
+   case (an empty case is a 3D syntax error, so the zero-byte field is forced),
+   which is not a strict-C11 violation. The generated validators compile clean
+   under this set. *)
 let strict_cc_flags =
-  "-std=c99 -Wall -Wextra -Werror -Wpedantic -Wstrict-prototypes \
+  "-std=c11 -D_DEFAULT_SOURCE -Wall -Werror -Wpedantic -Wstrict-prototypes \
    -Wmissing-prototypes -Wshadow -Wcast-qual"
 
 let emit_gen_rules ppf three_d_files c_files ctx_files =

--- a/lib/3d/wire_3d.mli
+++ b/lib/3d/wire_3d.mli
@@ -115,3 +115,8 @@ val has_3d_exe : unit -> bool
 
 val ensure_dir : string -> unit
 (** [ensure_dir path] creates the directory [path] if it does not exist. *)
+
+val strict_cc_flags : string
+(** The strict-C11 [cc] flags the generated dune rule compiles the EverParse C
+    with (and the e2e test mirrors), so the generated validators are checked
+    under the same standard a downstream caller would use. *)

--- a/test/3d/test_wire_3d.ml
+++ b/test/3d/test_wire_3d.ml
@@ -98,11 +98,12 @@ let compile_and_run ~name codec =
     Wire_3d.generate_c ~outdir:tmpdir [ schema ];
     let base = String.capitalize_ascii schema.Everparse.name in
     let cmd =
+      (* Compile with the exact strict-C11 flags the generated dune emits, so
+         the e2e checks the validators under the same standard a downstream
+         caller would. *)
       Fmt.str
-        "cd %s && cc -std=c99 -Wall -Wextra -Werror -Wpedantic \
-         -Wstrict-prototypes -Wmissing-prototypes -Wshadow -Wcast-qual -o \
-         test_bin test.c %s.c %s_Fields.c 2>&1 && ./test_bin"
-        tmpdir base base
+        "cd %s && cc %s -o test_bin test.c %s.c %s_Fields.c 2>&1 && ./test_bin"
+        tmpdir Wire_3d.strict_cc_flags base base
     in
     let ic = Unix.open_process_in cmd in
     let output = In_channel.input_all ic in


### PR DESCRIPTION
The `build` job runs `dune runtest` without the EverParse toolchain, so the checks that need `3d.exe` are skipped: `test/3d` (compile + run the generated C end to end) and `fuzz/3d` (run every covered schema through `3d.exe`). A projection that builds but does not verify therefore slips past CI, which is how the variable-inner optional projection (now #133) stayed broken behind a string-only check. This adds an `everparse-3d` job that installs EverParse and runs the suite, so those checks execute on every PR.

Running it immediately caught a real Linux-compile gap, fixed here too: the EverParse-generated C uses the BSD endian helpers (`be16toh`, ...) from `<endian.h>`, which strict `-std=c99` hides on Linux glibc unless `_DEFAULT_SOURCE` is defined, so the e2e `cc` failed under `-Werror` (macOS clang declares them regardless). The e2e now compiles with `-D_DEFAULT_SOURCE`.