### PR TITLE
codec: project a statically-absent optional as a unit field

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -104,6 +104,11 @@
 
 ### Fixed
 
+- A statically-absent `Field.optional` / `Field.optional_or` (`~present:false`)
+  now generates a verified EverParse validator. It projected to a zero-length
+  byte-size list EverParse refused to name ("Expected a named type, got
+  Parse_nlist"), leaving the codec with no validator; it now projects as a
+  zero-byte `unit` field, the same form `Wire.empty` uses (@samoht)
 - The generated dune rule now compiles the EverParse C under strict C11
   (`-std=c11 -D_DEFAULT_SOURCE`, without `-Wextra`) instead of `-std=c99`, so
   the verified validators build on Linux glibc: the BSD endian helpers

--- a/fuzz/3d/fuzz_everparse.ml
+++ b/fuzz/3d/fuzz_everparse.ml
@@ -32,10 +32,6 @@ let nested_pp_cases =
    honest: every gap is either closed or explicitly tracked, never silent. *)
 let known_gaps =
   [
-    (* A statically-absent optional projects to [T[:byte-size 0]], a zero-length
-       nlist EverParse will not name ("Expected a named type, got Parse_nlist"). *)
-    "optional(false)";
-    "optional_or(false)";
     (* The auto [WireSet*] setter is emitted after the user action's terminal
        [return true]; in 3D the return must be last, so F* rejects it. *)
     "action_on_act";

--- a/lib/everparse.ml
+++ b/lib/everparse.ml
@@ -376,7 +376,21 @@ let refined_byte_typedefs (s : Types.struct_) : Types.decl list =
       | None -> None)
     s.fields
 
+(* A statically-absent optional ([~present:false]) contributes no bytes: its
+   inner is never parsed. Project it as a [unit] field (the same 0-byte form
+   [Wire.empty] uses), not as [<inner>[:byte-size 0]] -- the latter is a
+   zero-length list EverParse refuses to name ("Expected a named type, got
+   Parse_nlist"). A statically-present optional is handled transparently
+   elsewhere; only the absent case needs this rewrite. *)
+let rewrite_absent_optional (Types.Field f) =
+  match f.field_typ with
+  | Types.Optional { present = Types.Bool false; _ }
+  | Types.Optional_or { present = Types.Bool false; _ } ->
+      Types.Field { f with field_typ = Types.Unit; constraint_ = None }
+  | _ -> Types.Field f
+
 let with_output (s : Types.struct_) : Types.decl list =
+  let s = { s with fields = List.map rewrite_absent_optional s.fields } in
   (* Extern declarations for the callback mechanism *)
   let ctx_struct = Types.struct_ "WireCtx" [] in
   let ctx_decl = Types.typedef ~extern_:true ctx_struct in

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -227,6 +227,23 @@ let test_3d_static_optional_transparent () =
     "byte_array_where optional emits its refined typedef" true
     (contains ~sub:"} _RefByte_" out_baw)
 
+let test_3d_absent_optional_projects_to_unit () =
+  (* A statically-absent optional contributes no bytes, so it projects as a
+     [unit] field, not as [<inner>[:byte-size 0]] (a zero-length list EverParse
+     refuses to name). *)
+  let c inner =
+    Codec.v "AbsentOpt"
+      (fun v -> v)
+      Codec.[ (Field.optional "o" ~present:Expr.false_ inner $ fun v -> v) ]
+  in
+  let out = to_3d (Everparse.schema (c uint8)).module_ in
+  Alcotest.(check bool)
+    "absent optional projects as unit" true
+    (contains ~sub:"unit o" out);
+  Alcotest.(check bool)
+    "absent optional has no zero-length byte-size suffix" false
+    (contains ~sub:"[:byte-size 0]" out)
+
 (* -- Codec definitions for 3D extraction tests --
    The shared codecs ([inner], [outer], [l0]/[l1]/[l2], [opt_record],
    [container]/[repeat_codec], [packet]/[packet_codec]) live in
@@ -742,4 +759,6 @@ let suite =
         test_3d_nested_byte_array_where;
       Alcotest.test_case "3d: static optional transparent projection" `Quick
         test_3d_static_optional_transparent;
+      Alcotest.test_case "3d: absent optional projects to unit" `Quick
+        test_3d_absent_optional_projects_to_unit;
     ] )


### PR DESCRIPTION
A `Field.optional` / `Field.optional_or` with `~present:false` (statically absent) projected to `<inner>[:byte-size 0]`, a zero-length list EverParse refuses to name (`Expected a named type, got Parse_nlist`), so the codec was left with no verified validator. Since an absent optional contributes no bytes, it now projects as a zero-byte `unit` field, the same form `Wire.empty` uses, which EverParse verifies.

First of the six projection gaps surfaced by #136. Stacked on it; retarget to main once it merges.