### PR TITLE
codec: project on_act ending in a return as a unit :act block

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -104,6 +104,11 @@
 
 ### Fixed
 
+- An `Action.on_act` whose body ends in `Action.return_bool` now generates a
+  verified EverParse validator. It projected to an `:act` block (which is unit
+  in 3D) ending in a Bool `return`, with the auto field setter emitted after the
+  return, so EverParse rejected it; the trailing return is now dropped (a no-op
+  success, matching how OCaml evaluates it) and the setter runs last (@samoht)
 - A statically-absent `Field.optional` / `Field.optional_or` (`~present:false`)
   now generates a verified EverParse validator. It projected to a zero-length
   byte-size list EverParse refused to name ("Expected a named type, got

--- a/fuzz/3d/fuzz_everparse.ml
+++ b/fuzz/3d/fuzz_everparse.ml
@@ -32,9 +32,6 @@ let nested_pp_cases =
    honest: every gap is either closed or explicitly tracked, never silent. *)
 let known_gaps =
   [
-    (* The auto [WireSet*] setter is emitted after the user action's terminal
-       [return true]; in 3D the return must be last, so F* rejects it. *)
-    "action_on_act";
     (* A conditional action ([if (...) {...}] inside [:on-success]) is not valid
        3D action syntax. *)
     "action";

--- a/lib/everparse.ml
+++ b/lib/everparse.ml
@@ -140,6 +140,18 @@ let setter_call : type a.
   in
   Types.Extern_call (setter, [ "ctx"; Fmt.str "(UINT32) %d" field_idx; value ])
 
+(* Build the statements of an [:act] block from a user action plus the auto
+   setter call. An [:act] block is unit, so a trailing [return] is dropped: in
+   OCaml [on_act] and [on_success] evaluate identically and a trailing
+   [return true] is a no-op success, while the setter (also unit) runs last. *)
+let act_stmts stmts call =
+  let stmts =
+    match List.rev stmts with
+    | Types.Return _ :: rest -> List.rev rest
+    | _ -> stmts
+  in
+  stmts @ [ call ]
+
 let map_field_action schema_name idx byte_off (Types.Field f) =
   let field_size = Types.field_wire_size f.field_typ in
   let next_off =
@@ -161,9 +173,9 @@ let map_field_action schema_name idx byte_off (Types.Field f) =
             match f.action with
             | None -> Some (Types.On_act [ call ])
             | Some (Types.On_act stmts) ->
-                Some (Types.On_act (stmts @ [ call ]))
+                Some (Types.On_act (act_stmts stmts call))
             | Some (Types.On_success stmts) ->
-                Some (Types.On_act (stmts @ [ call ]))
+                Some (Types.On_act (act_stmts stmts call))
           else
             (* Scalars and byte-size fields: :on-success *)
             match f.action with
@@ -172,7 +184,7 @@ let map_field_action schema_name idx byte_off (Types.Field f) =
                 Some
                   (Types.On_success (stmts @ [ call; Types.Return Types.true_ ]))
             | Some (Types.On_act stmts) ->
-                Some (Types.On_act (stmts @ [ call ]))
+                Some (Types.On_act (act_stmts stmts call))
         in
         Types.Field
           {

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -244,6 +244,26 @@ let test_3d_absent_optional_projects_to_unit () =
     "absent optional has no zero-length byte-size suffix" false
     (contains ~sub:"[:byte-size 0]" out)
 
+let test_3d_on_act_drops_bool_return () =
+  (* An [on_act] body that ends in [return_bool] projects to an [:act] block,
+     which is unit in 3D: the trailing return is dropped (a no-op success in
+     OCaml) and the auto setter runs last, so EverParse does not see a
+     Bool-returning :act. *)
+  let out = Param.output "out" uint8 in
+  let f_v = Field.v "v" uint8 in
+  let f =
+    Field.v "v" uint8
+      ~action:
+        (Action.on_act
+           [ Action.assign out (Field.ref f_v); Action.return_bool Expr.true_ ])
+  in
+  let codec = Codec.v "ActOnAct" (fun v -> v) Codec.[ (f $ fun v -> v) ] in
+  let out3d = to_3d (Everparse.schema codec).module_ in
+  Alcotest.(check bool) "emits an :act block" true (contains ~sub:":act" out3d);
+  Alcotest.(check bool)
+    "the :act block has no bool return" false
+    (contains ~sub:"return" out3d)
+
 (* -- Codec definitions for 3D extraction tests --
    The shared codecs ([inner], [outer], [l0]/[l1]/[l2], [opt_record],
    [container]/[repeat_codec], [packet]/[packet_codec]) live in
@@ -761,4 +781,6 @@ let suite =
         test_3d_static_optional_transparent;
       Alcotest.test_case "3d: absent optional projects to unit" `Quick
         test_3d_absent_optional_projects_to_unit;
+      Alcotest.test_case "3d: on_act drops the trailing bool return" `Quick
+        test_3d_on_act_drops_bool_return;
     ] )


### PR DESCRIPTION
An `Action.on_act` whose body ends in `Action.return_bool` projected to an `:act` block, which is unit in 3D, ending in a Bool `return` (with the auto field setter emitted after the return). EverParse rejected both the ordering and the non-unit return. OCaml evaluates `on_act` and `on_success` identically, where a trailing `return true` is a no-op success, so the projection now drops that trailing return and emits the setter last, giving a valid unit `:act`.

Second of the six projection gaps from #136. Stacked on #137; retarget to main once it merges.