### PR TITLE
codec: project a conditional on_success action as terminal if/else

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -104,6 +104,12 @@
 
 ### Fixed
 
+- An `Action.on_success` ending in a conditional `Action.return_bool` (an
+  `Action.if_` with a `return` branch) now generates a verified EverParse
+  validator. 3D allows a `return` only as the terminal statement or in the
+  branches of a terminal `if`/`else` that both return; the projection now moves
+  the field setter ahead of the `if`, keeps the `if` terminal, and synthesises
+  an `else { return true }` when none was given (@samoht)
 - An `Action.on_act` whose body ends in `Action.return_bool` now generates a
   verified EverParse validator. It projected to an `:act` block (which is unit
   in 3D) ending in a Bool `return`, with the auto field setter emitted after the

--- a/fuzz/3d/fuzz_everparse.ml
+++ b/fuzz/3d/fuzz_everparse.ml
@@ -32,9 +32,6 @@ let nested_pp_cases =
    honest: every gap is either closed or explicitly tracked, never silent. *)
 let known_gaps =
   [
-    (* A conditional action ([if (...) {...}] inside [:on-success]) is not valid
-       3D action syntax. *)
-    "action";
     (* [~where] / [~self_constraint] expressions use operators 3D's grammar
        rejects: shifts, bitwise not, casts, [sizeof(this)], [field_pos]. *)
     "expr_ops";

--- a/lib/everparse.ml
+++ b/lib/everparse.ml
@@ -152,6 +152,28 @@ let act_stmts stmts call =
   in
   stmts @ [ call ]
 
+let ends_in_return stmts =
+  match List.rev stmts with Types.Return _ :: _ -> true | _ -> false
+
+(* Build the statements of an [:on-success] block (which returns a Bool) from a
+   user action plus the auto setter call. 3D is stricter than wire's action
+   model: a [return] may only appear as the terminal statement or in the
+   branches of a terminal [if/else] whose branches both return Bool. So the
+   setter (which must always fire on success) is moved to the front, and:
+   - a user action ending in a conditional [return] keeps that [if] terminal,
+     with an [else { return true }] synthesised when the user gave none;
+   - one ending in a plain [return] keeps it terminal;
+   - otherwise the setter and a [return true] are appended as before. *)
+let on_success_stmts stmts call =
+  match List.rev stmts with
+  | Types.If (cond, then_, else_opt) :: before when ends_in_return then_ ->
+      let else_ =
+        match else_opt with Some e -> e | None -> [ Types.Return Types.true_ ]
+      in
+      (call :: List.rev before) @ [ Types.If (cond, then_, Some else_) ]
+  | Types.Return _ :: _ -> call :: stmts
+  | _ -> stmts @ [ call; Types.Return Types.true_ ]
+
 let map_field_action schema_name idx byte_off (Types.Field f) =
   let field_size = Types.field_wire_size f.field_typ in
   let next_off =
@@ -181,8 +203,7 @@ let map_field_action schema_name idx byte_off (Types.Field f) =
             match f.action with
             | None -> Some (Types.On_success [ call; Types.Return Types.true_ ])
             | Some (Types.On_success stmts) ->
-                Some
-                  (Types.On_success (stmts @ [ call; Types.Return Types.true_ ]))
+                Some (Types.On_success (on_success_stmts stmts call))
             | Some (Types.On_act stmts) ->
                 Some (Types.On_act (act_stmts stmts call))
         in

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -264,6 +264,32 @@ let test_3d_on_act_drops_bool_return () =
     "the :act block has no bool return" false
     (contains ~sub:"return" out3d)
 
+let test_3d_on_success_conditional_return () =
+  (* An [on_success] ending in a conditional [return] (a bare [if]) projects to
+     a terminal [if]/[else] both returning Bool (3D rejects a bare [if] with a
+     Bool return, and forbids statements after it). The setter is moved before
+     the [if] and an [else { return true }] is synthesised. *)
+  let out = Param.output "out" uint8 in
+  let f_v = Field.v "v" uint8 in
+  let f =
+    Field.v "v" uint8
+      ~action:
+        (Action.on_success
+           [
+             Action.assign out (Field.ref f_v);
+             Action.if_ Expr.true_ [ Action.return_bool Expr.true_ ] None;
+           ])
+  in
+  let codec = Codec.v "ActIf" (fun v -> v) Codec.[ (f $ fun v -> v) ] in
+  let out3d = to_3d (Everparse.schema codec).module_ in
+  Alcotest.(check bool) "if is present" true (contains ~sub:"if (" out3d);
+  Alcotest.(check bool)
+    "an else branch is synthesised" true
+    (contains ~sub:"else {" out3d);
+  Alcotest.(check bool)
+    "the field setter runs before the if" true
+    (contains ~sub:"ActIfSetU8" out3d)
+
 (* -- Codec definitions for 3D extraction tests --
    The shared codecs ([inner], [outer], [l0]/[l1]/[l2], [opt_record],
    [container]/[repeat_codec], [packet]/[packet_codec]) live in
@@ -783,4 +809,6 @@ let suite =
         test_3d_absent_optional_projects_to_unit;
       Alcotest.test_case "3d: on_act drops the trailing bool return" `Quick
         test_3d_on_act_drops_bool_return;
+      Alcotest.test_case "3d: on_success conditional return to if/else" `Quick
+        test_3d_on_success_conditional_return;
     ] )


### PR DESCRIPTION
An `Action.on_success` ending in an `Action.if_` with a `return` branch projected to a bare `if` returning Bool (a 3D type error, since the implicit empty else is unit) followed by the field setter and another `return` (3D forbids statements after such an `if`). 3D accepts a `return` only as the terminal statement or in the branches of a terminal `if`/`else` that both return. The projection now runs the setter before the `if`, keeps the `if` terminal, and synthesises an `else { return true }` when the user gave none.

Third of the six projection gaps from #136. Stacked on #138; retarget to main once it merges.