### PR TITLE
codec: reject negative literals and field_pos in projection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -104,6 +104,12 @@
 
 ### Fixed
 
+- Projecting an expression (a `~where` / field constraint / `~self_constraint`)
+  that uses a construct with no 3D form now raises a clear `Invalid_argument`
+  instead of emitting C that EverParse rejects with a cryptic error. The two
+  such constructs are a negative integer literal (3D has no negative literals)
+  and `field_pos` (no 3D keyword); every other operator (shifts, bitwise, casts,
+  mod, div, comparisons, `sizeof`, `sizeof_this`) projects (@samoht)
 - An `Action.on_success` ending in a conditional `Action.return_bool` (an
   `Action.if_` with a `return` branch) now generates a verified EverParse
   validator. 3D allows a `return` only as the terminal statement or in the

--- a/fuzz/3d/fuzz_everparse.ml
+++ b/fuzz/3d/fuzz_everparse.ml
@@ -5,38 +5,57 @@
     exercised on the same compositions the OCaml round-trip suite uses, plus
     arbitrary nested ones. When [3d.exe] is available, the {e whole} registry is
     additionally run through EverParse ([3d.exe --batch]): every codec that
-    builds must also project to a schema EverParse verifies, or be listed in
-    {!known_gaps}. That extraction pass is the only check that catches errors
+    builds must also project to a schema EverParse verifies, except the few in
+    {!no_3d_projection} that wire rejects at projection (asserted to reject
+    instead). That extraction pass is the only check that catches errors
     surfacing during F* verification rather than pretty-printing (a kind error
     on a possibly-empty list, an invalid action or expression). It is skipped
     where [3d.exe] is absent (the plain CI build, AFL). *)
 
 open Alcobar
 
-(* Projection + pretty-print coverage: cheap, no subprocess, always runs. *)
+(* Shapes wire rejects at projection: they use a construct with no 3D form, so
+   [to_3d] raises a clear [Invalid_argument]. [expr_ops] uses a negative integer
+   literal (3D has no negative literals); [sizeof] uses [field_pos] (no 3D
+   keyword). Every other operator they exercise (shifts, bitwise, casts, mod,
+   div, comparisons, logic, [sizeof(this)], [sizeof(<type>)]) does project and is
+   covered by the rest of the registry. These are the "reject with a clear
+   error" half of closing the gaps: asserted to reject (below), not swept through
+   [3d.exe]. *)
+let no_3d_projection = [ "expr_ops"; "sizeof" ]
+
+let to_3d_of g =
+  Wire.Everparse.Raw.to_3d (Wire.Everparse.schema (Fuzz_gen.codec g)).module_
+
+(* For a shape with no 3D projection: [to_3d] must raise [Invalid_argument] with
+   a clear message, not produce 3D EverParse would reject. *)
+let rejection_case name g =
+  [
+    Alcobar.test_case
+      ("rejects projection " ^ name)
+      [ const () ]
+      (fun () ->
+        match to_3d_of g with
+        | _ ->
+            Alcobar.failf
+              "%s: expected projection to be rejected, but it succeeded" name
+        | exception Invalid_argument _ -> ());
+  ]
+
+(* Projection + pretty-print coverage: cheap, no subprocess, always runs. A
+   shape with no 3D projection is asserted to reject; every other shape must
+   project and pretty-print. *)
 let pp_cases =
   List.concat_map
-    (fun (name, Fuzz_gen.Pack g) -> Fuzz_gen.everparse_cases name g)
+    (fun (name, Fuzz_gen.Pack g) ->
+      if List.mem name no_3d_projection then rejection_case name g
+      else Fuzz_gen.everparse_cases name g)
     Fuzz_gen.registry
 
 let nested_pp_cases =
   Fuzz_gen.everparse_nested_cases "nested(d2)" 2
   @ Fuzz_gen.everparse_nested_cases "nested(d3)" 3
   @ Fuzz_gen.everparse_nested_cases "nested(d4)" 4
-
-(* Known projection gaps: shapes that build in OCaml and project to 3D text but
-   that [3d.exe] still rejects. The whole registry is run through EverParse
-   (below); a shape NOT listed here that [3d.exe] rejects fails the gate (a new
-   build-but-fail-3d hole), and a listed shape that now passes also fails (it is
-   fixed, remove it). This keeps the projection half of "close all the gaps"
-   honest: every gap is either closed or explicitly tracked, never silent. *)
-let known_gaps =
-  [
-    (* [~where] / [~self_constraint] expressions use operators 3D's grammar
-       rejects: shifts, bitwise not, casts, [sizeof(this)], [field_pos]. *)
-    "expr_ops";
-    "sizeof";
-  ]
 
 (* EverParse derives the module name from the .3d filename and requires it to
    start with a capital letter; the composer names its codecs [_leaf] / [_opt] /
@@ -86,28 +105,25 @@ let normal_mode () =
   (not (Array.exists (String.equal "--gen-corpus") argv))
   && not (n > 1 && Sys.file_exists argv.(n - 1))
 
+(* Every shape that projects must verify: the whole registry except the shapes
+   wire rejects at projection (those are asserted to reject in [pp_cases]) is
+   run through [3d.exe], and any failure is a build-but-fail-3d hole. *)
 let extract_results =
   if not (Wire_3d.has_3d_exe () && normal_mode ()) then []
   else
-    List.map
-      (fun (name, Fuzz_gen.Pack g) -> (name, extract_one g))
-      Fuzz_gen.registry
+    Fuzz_gen.registry
+    |> List.filter (fun (name, _) -> not (List.mem name no_3d_projection))
+    |> List.map (fun (name, Fuzz_gen.Pack g) -> (name, extract_one g))
 
 let extract_cases =
   List.map
     (fun (name, res) ->
-      let known = List.mem name known_gaps in
       Alcobar.test_case ("3d.exe " ^ name)
         [ const () ]
         (fun () ->
-          match (res, known) with
-          | Ok (), false -> ()
-          | Error _, true -> () (* a tracked gap, still open *)
-          | Ok (), true ->
-              Alcobar.failf
-                "%s: now projects through 3d.exe; remove it from [known_gaps]"
-                name
-          | Error m, false ->
+          match res with
+          | Ok () -> ()
+          | Error m ->
               Alcobar.failf "%s: EverParse rejected a schema that built: %s"
                 name m))
     extract_results

--- a/fuzz/gen/fuzz_gen.ml
+++ b/fuzz/gen/fuzz_gen.ml
@@ -1676,10 +1676,12 @@ let fixed_leaves : any list =
     Any { g = bounded_u8 ~min:10 ~max:100; size = Some 1; label = "bnd" };
     Any { g = finite_float64; size = Some 8; label = "finf" };
     Any { g = nan_float64; size = Some 8; label = "nanf" };
-    (* Sub-codec leaves with a [~where] / [~self_constraint] over expressions,
-       so composing them exercises an embedded constrained sub-codec. *)
-    Any { g = expr_ops; size = Some 2; label = "expr" };
-    Any { g = sizeof; size = Some 2; label = "sizeof" };
+    (* A sub-codec leaf with a [~where] over a projectable expression, so
+       composing it exercises an embedded constrained sub-codec. ([expr_ops] and
+       [sizeof] are deliberately not nested here: they use a negative literal /
+       [field_pos], which have no 3D projection, so a composition embedding them
+       would not project. They are still exercised standalone via the registry,
+       where they are asserted to be rejected at projection.) *)
     Any { g = codec_where; size = Some 2; label = "cwhere" };
   ]
 

--- a/lib/everparse.ml
+++ b/lib/everparse.ml
@@ -410,11 +410,9 @@ let refined_byte_typedefs (s : Types.struct_) : Types.decl list =
     s.fields
 
 (* A statically-absent optional ([~present:false]) contributes no bytes: its
-   inner is never parsed. Project it as a [unit] field (the same 0-byte form
-   [Wire.empty] uses), not as [<inner>[:byte-size 0]] -- the latter is a
-   zero-length list EverParse refuses to name ("Expected a named type, got
-   Parse_nlist"). A statically-present optional is handled transparently
-   elsewhere; only the absent case needs this rewrite. *)
+   inner is never parsed. Project it as a [unit] field, the 0-byte form
+   [Wire.empty] uses and EverParse verifies. (A statically-present optional is
+   handled transparently elsewhere; only the absent case needs this rewrite.) *)
 let rewrite_absent_optional (Types.Field f) =
   match f.field_typ with
   | Types.Optional { present = Types.Bool false; _ }

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -1251,7 +1251,14 @@ let pp_cast_type ppf = function
 let rec pp_expr : type a. a expr Fmt.t =
  fun ppf expr ->
   match expr with
-  | Int n when n < 0 -> Fmt.pf ppf "(%d)" n
+  | Int n when n < 0 ->
+      (* 3D has no negative integer literals in any syntax, so an expression with
+         one (e.g. comparing an unsigned field to [-1]) has no projection and is
+         rejected with a clear error. *)
+      Fmt.invalid_arg
+        "Wire: negative integer literal %d has no 3D projection (EverParse has \
+         no negative literals)"
+        n
   | Int n -> Fmt.int ppf n
   | Int64 n -> Fmt.pf ppf "%LduL" n
   | Bool true -> Fmt.string ppf "true"
@@ -1260,7 +1267,11 @@ let rec pp_expr : type a. a expr Fmt.t =
   | Param_ref p -> Fmt.string ppf (escape_3d p.ph_name)
   | Sizeof t -> Fmt.pf ppf "sizeof (%a)" pp_typ t
   | Sizeof_this -> Fmt.string ppf "sizeof (this)"
-  | Field_pos -> Fmt.string ppf "field_pos"
+  | Field_pos ->
+      (* EverParse has no [field_pos] keyword: the field position is not
+         available as a 3D expression, so it has no projection and is rejected
+         with a clear error. *)
+      invalid_arg "Wire: field_pos has no 3D projection"
   | Add (a, b) -> Fmt.pf ppf "(%a + %a)" pp_expr a pp_expr b
   | Sub (a, b) -> Fmt.pf ppf "(%a - %a)" pp_expr a pp_expr b
   | Mul (a, b) -> Fmt.pf ppf "(%a * %a)" pp_expr a pp_expr b

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -229,8 +229,8 @@ let test_3d_static_optional_transparent () =
 
 let test_3d_absent_optional_projects_to_unit () =
   (* A statically-absent optional contributes no bytes, so it projects as a
-     [unit] field, not as [<inner>[:byte-size 0]] (a zero-length list EverParse
-     refuses to name). *)
+     [unit] field and the schema carries no zero-length byte-size suffix (which
+     EverParse would refuse to name). *)
   let c inner =
     Codec.v "AbsentOpt"
       (fun v -> v)
@@ -289,6 +289,38 @@ let test_3d_on_success_conditional_return () =
   Alcotest.(check bool)
     "the field setter runs before the if" true
     (contains ~sub:"ActIfSetU8" out3d)
+
+let projects_or_raises codec =
+  match to_3d (Everparse.schema codec).module_ with
+  | (_ : string) -> false
+  | exception Invalid_argument _ -> true
+
+let test_3d_negative_literal_rejected () =
+  (* 3D has no negative integer literals, so a projected expression containing
+     one is rejected at projection with a clear error, not emitted as C
+     EverParse cannot parse. *)
+  let f = Field.v "a" uint8 in
+  let codec =
+    Codec.v "NegLit"
+      ~where:Expr.(Field.ref f <> int (-1))
+      (fun a -> a)
+      Codec.[ (f $ fun a -> a) ]
+  in
+  Alcotest.(check bool)
+    "negative literal rejected by projection" true (projects_or_raises codec)
+
+let test_3d_field_pos_rejected () =
+  (* EverParse has no [field_pos] keyword, so a projected expression using it is
+     rejected at projection, not emitted as an undefined identifier. *)
+  let f = Field.v "a" uint8 in
+  let codec =
+    Codec.v "FieldPos"
+      ~where:Expr.(field_pos = int 0)
+      (fun a -> a)
+      Codec.[ (f $ fun a -> a) ]
+  in
+  Alcotest.(check bool)
+    "field_pos rejected by projection" true (projects_or_raises codec)
 
 (* -- Codec definitions for 3D extraction tests --
    The shared codecs ([inner], [outer], [l0]/[l1]/[l2], [opt_record],
@@ -811,4 +843,8 @@ let suite =
         test_3d_on_act_drops_bool_return;
       Alcotest.test_case "3d: on_success conditional return to if/else" `Quick
         test_3d_on_success_conditional_return;
+      Alcotest.test_case "3d: negative literal rejected by projection" `Quick
+        test_3d_negative_literal_rejected;
+      Alcotest.test_case "3d: field_pos rejected by projection" `Quick
+        test_3d_field_pos_rejected;
     ] )


### PR DESCRIPTION
The last two shapes the exhaustive gate (#136) surfaced use constructs with no 3D form: a negative integer literal (`expr_ops`; 3D has no negative literals in any syntax) and `field_pos` (`sizeof`; EverParse has no such keyword). Every other operator they exercise (shifts, bitwise and/or/xor/not, casts, mod, div, comparisons, logic, `sizeof(this)`, `sizeof(<type>)`) projects and is covered by the rest of the registry.

Rather than emit C EverParse rejects with a cryptic error, projection now raises a clear `Invalid_argument` for those two constructs (the "reject with a clear error" half of the invariant). The projection fuzzer asserts they reject and no longer nests them into its compositions; the rest of the registry is swept through `3d.exe`. With this, the gate has no `known_gaps` left: every shape either projects to verified C or is cleanly rejected at projection.

Last of the six projection gaps from #136. Stacked on #139; retarget to main once it merges.