### PR TITLE
3d: read validator name past a capital V in the codec name

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -100,6 +100,10 @@
 
 ### Fixed
 
+- A codec whose name contains a capital `V` (e.g. `VeritySuperblock`) now
+  generates its C parser. EverParse names the validator `<Name>Validate<Name>`,
+  and the name reader stopped at the first `V`, so C generation failed for any
+  such name (#143, @samoht)
 - A `Wire.enum` field now enforces its membership in the EverParse-generated C
   validator, rejecting values outside the named cases exactly as `Codec.decode`
   does (raising `Invalid_enum`), including for an enum nested inside a sub-codec

--- a/lib/3d/wire_3d.ml
+++ b/lib/3d/wire_3d.ml
@@ -80,19 +80,40 @@ let read_validate_name ~outdir s =
   let path = Filename.concat outdir (file_base s ^ ".h") in
   let ic = open_in path in
   let found = ref None in
+  let needle = "Validate" in
+  let nlen = String.length needle in
+  let is_ident c =
+    (c >= 'A' && c <= 'Z')
+    || (c >= 'a' && c <= 'z')
+    || (c >= '0' && c <= '9')
+    || c = '_'
+  in
+  (* EverParse declares the validator as [<Name>Validate<Name>(...)]. Find the
+     [Validate] keyword and return the C identifier immediately before it -- the
+     base [<Name>]. Scanning every position (not just the first 'V') lets the
+     name itself contain a 'V' (e.g. "VeritySuperblock"); anchoring on the
+     identifier before [Validate] also drops a leading return type should
+     EverParse ever emit it on the same line. *)
+  let base_before_validate line =
+    let len = String.length line in
+    let rec scan i =
+      if i + nlen > len then None
+      else if i > 0 && is_ident line.[i - 1] && String.sub line i nlen = needle
+      then begin
+        let j = ref i in
+        while !j > 0 && is_ident line.[!j - 1] do
+          decr j
+        done;
+        Some (String.sub line !j (i - !j))
+      end
+      else scan (i + 1)
+    in
+    scan 0
+  in
   (try
      while !found = None do
-       let line = input_line ic in
-       let line = String.trim line in
-       let needle = "Validate" in
-       match String.index_opt line 'V' with
-       | Some i
-         when i > 0
-              && String.length line >= i + String.length needle
-              && String.sub line i (String.length needle) = needle ->
-           (* the prefix before "Validate" is the base name *)
-           found := Some (String.sub line 0 i)
-       | _ -> ()
+       let line = String.trim (input_line ic) in
+       found := base_before_validate line
      done
    with End_of_file -> ());
   close_in ic;

--- a/test/3d/test_wire_3d.ml
+++ b/test/3d/test_wire_3d.ml
@@ -432,8 +432,20 @@ let e2e_repeat_byte_chunks_codec =
   let open Codec in
   v "RepChunks" (fun n chunks -> (n, chunks)) [ f_n $ fst; f_chunks $ snd ]
 
+(* A codec whose name carries a capital [V] before the [Validate] keyword
+   (e.g. [VeritySuperblockValidateVeritySuperblock] in the generated [.h]).
+   [read_validate_name] must find [Validate] past that leading [V] rather than
+   stopping at the first [V] it sees, or C generation fails outright. *)
+let e2e_vname_codec =
+  let open Wire in
+  let f_sig = Field.v "signature" (byte_array ~size:(int 8)) in
+  let f_version = Field.v "version" uint32 in
+  let open Codec in
+  v "VeritySuperblock" (fun s v -> (s, v)) [ f_sig $ fst; f_version $ snd ]
+
 let test_e2e_compile_run () =
   compile_and_run ~name:"Demo" e2e_simple_codec;
+  compile_and_run ~name:"VeritySuperblock" e2e_vname_codec;
   compile_and_run ~name:"ZtRep" e2e_repeat_zeroterm_codec;
   compile_and_run ~name:"RepChunks" e2e_repeat_byte_chunks_codec;
   compile_and_run ~name:"ArrChunks" e2e_array_byte_chunks_codec;


### PR DESCRIPTION
[read_validate_name](https://github.com/parsimoni-labs/ocaml-wire/blob/fix-validate-name-capital-v/lib/3d/wire_3d.ml#L79) reads the top-level validator name straight out of EverParse's generated `<Name>.h`, where it is declared as `<Name>Validate<Name>(...)`. It located the `Validate` keyword by jumping to the first `V` in the line, so a codec name that itself contains a capital `V` (for example `VeritySuperblock`) landed on the leading `V` of the name rather than the keyword, found no match, and aborted C generation for that codec. It now scans for `Validate` past any such `V` and returns the C identifier immediately before it, which also drops a leading return type should EverParse ever emit it on the same line.

The end-to-end generate-compile-run test gains a capital-`V` codec (`VeritySuperblock`) alongside the existing naming-convention cases; it fails on the previous commit (generation raises) and passes now.