### PR TITLE
wire: of_reader consumes only the decoded value

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,9 +53,14 @@
 
 ### Changed
 
+- `Wire.of_reader` now consumes only the bytes of the decoded value and
+  leaves the rest on the reader, so several values can be decoded
+  back-to-back from the same reader. Previously the first call drained the
+  whole reader. Types that extend to the end of input (`all_bytes`,
+  `all_zeros`) still consume the whole stream (#144, @samoht)
 - The `Wire.Everparse.plug_field` record fields lose their `pf_` prefix
   (`pf_name` is now `name`, `pf_idx` is `idx`, and so on). Update custom
-  plug generators accordingly (@samoht)
+  plug generators accordingly (#144, @samoht)
 - Codecs that share a synthesised type (an `enum`, or a refined-byte or
   element-wrapper struct) can now be linked into one binary, so full protocol
   stacks built from per-codec parsers (Ethernet, IPv4, TCP, ...) link cleanly.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,6 +53,9 @@
 
 ### Changed
 
+- The `Wire.Everparse.plug_field` record fields lose their `pf_` prefix
+  (`pf_name` is now `name`, `pf_idx` is `idx`, and so on). Update custom
+  plug generators accordingly (@samoht)
 - Codecs that share a synthesised type (an `enum`, or a refined-byte or
   element-wrapper struct) can now be linked into one binary, so full protocol
   stacks built from per-codec parsers (Ethernet, IPv4, TCP, ...) link cleanly.

--- a/bench/clcw/clcw_bench.ml
+++ b/bench/clcw/clcw_bench.ml
@@ -101,7 +101,9 @@ let check ~n_words =
 
 let main () =
   Memtrace.trace_if_requested ~context:"clcw" ();
-  let n_words = 1_000_000 in
+  let n_words =
+    if Array.length Sys.argv > 1 then int_of_string Sys.argv.(1) else 1_000_000
+  in
   let t, st = benchmark ~n_words in
   Fmt.pr "CLCW polling loop (%d words, %dB each, contiguous buffer)\n\n" n_words
     word_size;

--- a/bench/gateway/gateway_bench.ml
+++ b/bench/gateway/gateway_bench.ml
@@ -156,7 +156,9 @@ let check ~n_frames =
 
 let main () =
   Memtrace.trace_if_requested ~context:"gateway" ();
-  let n_frames = 1_000_000 in
+  let n_frames =
+    if Array.length Sys.argv > 1 then int_of_string Sys.argv.(1) else 1_000_000
+  in
   let t, st = benchmark ~n_frames in
   Fmt.pr
     "TM frame reassembly (%d frames, %d-byte CADUs, %d embedded packets)\n\n"

--- a/bench/routing/routing_bench.ml
+++ b/bench/routing/routing_bench.ml
@@ -131,7 +131,9 @@ let check ~n_pkts =
 
 let main () =
   Memtrace.trace_if_requested ~context:"routing" ();
-  let n_pkts = 10_000_000 in
+  let n_pkts =
+    if Array.length Sys.argv > 1 then int_of_string Sys.argv.(1) else 10_000_000
+  in
   let t, payload_bytes, st, buf = benchmark ~n_pkts in
   Fmt.pr "APID demux (%d packets, %d MB stream, %d MB payload)\n\n" n_pkts
     (Bytes.length buf / 1_000_000)

--- a/lib/3d/wire_3d.ml
+++ b/lib/3d/wire_3d.ml
@@ -35,8 +35,8 @@ let everparse_name name =
    and CamelCases segments ([rpmsg_endpoint_info] -> [RpmsgEndpointInfo]).
    Keep the two concerns separate: [file_base] for filenames, [c_ident] for
    C identifiers. *)
-let file_base s = String.capitalize_ascii s.name
-let c_ident s = everparse_name s.name
+let file_base (s : t) = String.capitalize_ascii s.name
+let c_ident (s : t) = everparse_name s.name
 
 (* EverParse normalizes extern callback names in ways that are awkward to
    mirror exactly (runs of uppercase after a digit get lowercased, trailing
@@ -212,17 +212,15 @@ let write_fields_header ~outdir s =
   List.iter
     (fun f ->
       pr "#define %s_IDX_%s %d@\n" prefix
-        (String.uppercase_ascii f.Wire.Everparse.pf_name)
-        f.pf_idx)
+        (String.uppercase_ascii f.Wire.Everparse.name)
+        f.idx)
     fields;
   if fields <> [] then pr "@\n";
   pr "/* Default plug: one typed member per named field. Pass a pointer to@\n";
   pr "   [%sFields] as [WIRECTX *] when you want every field populated. */@\n"
     ident;
   pr "typedef struct %sFields {@\n" ident;
-  List.iter
-    (fun f -> pr "  %s %s;@\n" f.Wire.Everparse.pf_c_type f.pf_name)
-    fields;
+  List.iter (fun f -> pr "  %s %s;@\n" f.Wire.Everparse.c_type f.name) fields;
   if fields = [] then pr "  int _unused;@\n";
   pr "} %sFields;@\n" ident;
   pr "#endif@\n";
@@ -234,16 +232,16 @@ let write_fields_header ~outdir s =
    underlying [UINT32] / [UINT64] but the plug struct stores the typed
    float; everyone else takes a value cast. *)
 let emit_setter_case ppf logical f =
-  if String.equal f.Wire.Everparse.pf_setter logical then
-    match f.pf_c_type with
+  if String.equal f.Wire.Everparse.setter logical then
+    match f.c_type with
     | "float" | "double" ->
         Fmt.pf ppf
           "    case %d: { %s _x; memcpy(&_x, &v, sizeof _x); f->%s = _x; \
            break; }@\n"
-          f.pf_idx f.pf_c_type f.pf_name
+          f.idx f.c_type f.name
     | _ ->
-        Fmt.pf ppf "    case %d: f->%s = (%s) v; break;@\n" f.pf_idx f.pf_name
-          f.pf_c_type
+        Fmt.pf ppf "    case %d: f->%s = (%s) v; break;@\n" f.idx f.name
+          f.c_type
 
 let write_fields_impl ~outdir s =
   let fields = Wire.Everparse.plug_fields s in

--- a/lib/everparse.ml
+++ b/lib/everparse.ml
@@ -60,7 +60,7 @@ let rec is_byte_field : type a. a Types.typ -> bool = function
   | Types.Single_elem _ -> true
   | _ -> false
 
-type setter_info = { setter_name : string; setter_val_typ : Types.packed_typ }
+type setter_info = { name : string; val_typ : Types.packed_typ }
 
 (* 3D type suffix for unique extern function names *)
 let rec type_suffix : type a. a Types.typ -> string = function
@@ -108,8 +108,8 @@ let rec setter_of : type a. string -> a Types.typ -> setter_info =
   | Types.Byte_array _ | Types.Byte_array_where _ | Types.Byte_slice _
   | Types.Uint_var _ ->
       {
-        setter_name = schema_name ^ "SetBytes";
-        setter_val_typ = Types.Pack_typ (Types.Uint32 Types.Little);
+        name = schema_name ^ "SetBytes";
+        val_typ = Types.Pack_typ (Types.Uint32 Types.Little);
       }
   | Types.Optional { inner; _ } -> setter_of schema_name inner
   | Types.Optional_or { inner; _ } -> setter_of schema_name inner
@@ -118,10 +118,7 @@ let rec setter_of : type a. string -> a Types.typ -> setter_info =
   | Types.Where { inner; _ } -> setter_of schema_name inner
   | _ ->
       let suffix = type_suffix t in
-      {
-        setter_name = schema_name ^ "Set" ^ suffix;
-        setter_val_typ = Types.Pack_typ t;
-      }
+      { name = schema_name ^ "Set" ^ suffix; val_typ = Types.Pack_typ t }
 
 let setter_call : type a.
     string -> a Types.typ -> string -> int -> int option -> Types.action_stmt =
@@ -135,7 +132,7 @@ let setter_call : type a.
       in
       (schema_name ^ "SetBytes", off)
     else
-      let { setter_name; _ } = setter_of schema_name typ in
+      let { name = setter_name; _ } = setter_of schema_name typ in
       (setter_name, Types.escape_3d name)
   in
   Types.Extern_call (setter, [ "ctx"; Fmt.str "(UINT32) %d" field_idx; value ])
@@ -335,10 +332,10 @@ let reorder_bit_groups_for_3d fields =
   in
   go [] fields
 
-let bytes_setter schema_name =
+let bytes_setter schema_name : setter_info =
   {
-    setter_name = schema_name ^ "SetBytes";
-    setter_val_typ = Types.Pack_typ (Types.Uint32 Types.Little);
+    name = schema_name ^ "SetBytes";
+    val_typ = Types.Pack_typ (Types.Uint32 Types.Little);
   }
 
 let collect_extern_setters schema_name ctx_struct u32 fields =
@@ -352,12 +349,12 @@ let collect_extern_setters schema_name ctx_struct u32 fields =
             if is_byte_field f.field_typ then bytes_setter schema_name
             else setter_of schema_name f.field_typ
           in
-          if Hashtbl.mem seen si.setter_name then None
+          if Hashtbl.mem seen si.name then None
           else begin
-            Hashtbl.add seen si.setter_name ();
-            let (Types.Pack_typ val_typ) = si.setter_val_typ in
+            Hashtbl.add seen si.name ();
+            let (Types.Pack_typ val_typ) = si.val_typ in
             Some
-              (Types.extern_fn si.setter_name
+              (Types.extern_fn si.name
                  [
                    Types.mutable_param "ctx" (Types.struct_typ ctx_struct);
                    Types.param "idx" u32;
@@ -501,7 +498,7 @@ let schema_of_struct (s : Types.struct_) : t =
 let schema (type r) (codec : r Codec.t) : t =
   schema_of_struct (Codec.to_struct codec)
 
-let filename s = String.capitalize_ascii s.name ^ ".3d"
+let filename (s : t) = String.capitalize_ascii s.name ^ ".3d"
 
 let uses_wire_ctx s =
   List.exists
@@ -513,14 +510,14 @@ let uses_wire_ctx s =
     s.module_.decls
 
 type plug_field = {
-  pf_name : string;
-  pf_idx : int;
-  pf_c_type : string;
-  pf_setter : string;
-  pf_val_c_type : string;
+  name : string;
+  idx : int;
+  c_type : string;
+  setter : string;
+  val_c_type : string;
 }
 
-let plug_field s idx (Types.Field f) =
+let plug_field (s : t) idx (Types.Field f) =
   match f.field_name with
   | None -> None
   | Some name ->
@@ -530,14 +527,14 @@ let plug_field s idx (Types.Field f) =
         if is_byte_field f.field_typ then bytes_setter s.name
         else setter_of s.name f.field_typ
       in
-      let (Types.Pack_typ val_typ) = setter.setter_val_typ in
+      let (Types.Pack_typ val_typ) = setter.val_typ in
       Some
         {
-          pf_name = name;
-          pf_idx = i;
-          pf_c_type = Types.c_type_of f.field_typ;
-          pf_setter = setter.setter_name;
-          pf_val_c_type = Types.c_type_of val_typ;
+          name;
+          idx = i;
+          c_type = Types.c_type_of f.field_typ;
+          setter = setter.name;
+          val_c_type = Types.c_type_of val_typ;
         }
 
 let plug_fields s =
@@ -551,10 +548,10 @@ let plug_setters s =
   let seen = Hashtbl.create 8 in
   List.filter_map
     (fun f ->
-      if Hashtbl.mem seen f.pf_setter then None
+      if Hashtbl.mem seen f.setter then None
       else begin
-        Hashtbl.add seen f.pf_setter ();
-        Some (f.pf_setter, f.pf_val_c_type)
+        Hashtbl.add seen f.setter ();
+        Some (f.setter, f.val_c_type)
       end)
     (plug_fields s)
 

--- a/lib/everparse.mli
+++ b/lib/everparse.mli
@@ -78,11 +78,11 @@ val uses_wire_ctx : t -> bool
 *)
 
 type plug_field = {
-  pf_name : string;  (** Field name as declared in the codec. *)
-  pf_idx : int;  (** Index passed to the [WireSet*] callback. *)
-  pf_c_type : string;  (** C type for the generated struct member. *)
-  pf_setter : string;  (** [WireSet*] name that extracts this field. *)
-  pf_val_c_type : string;  (** C type of the value argument to the setter. *)
+  name : string;  (** Field name as declared in the codec. *)
+  idx : int;  (** Index passed to the [WireSet*] callback. *)
+  c_type : string;  (** C type for the generated struct member. *)
+  setter : string;  (** [WireSet*] name that extracts this field. *)
+  val_c_type : string;  (** C type of the value argument to the setter. *)
 }
 (** Plug info: the data needed by a concrete [WIRECTX] implementation (e.g.
     {!Wire_3d}'s [<Name>_Fields] default plug) to materialise a typed struct
@@ -95,8 +95,8 @@ val plug_fields : t -> plug_field list
 
 val plug_setters : t -> (string * string) list
 (** [plug_setters s] lists the unique [WireSet*] setters referenced by [s] as
-    [(setter_name, val_c_type)] pairs. Each one needs an implementation in the
-    plug. *)
+    [(setter, val_c_type)] pairs. Each one needs an implementation in the plug.
+*)
 
 val extern_fn_names : t -> string list
 (** [extern_fn_names s] lists the names of every extern function declared in the

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -390,9 +390,96 @@ let drain_reader reader =
   in
   loop ()
 
+let rec typ_consumes_rest : type a. a typ -> bool = function
+  | All_bytes | All_zeros -> true
+  | Map { inner; _ } -> typ_consumes_rest inner
+  | Where { inner; _ } -> typ_consumes_rest inner
+  | Enum { base; _ } -> typ_consumes_rest base
+  | Optional { inner; _ } -> typ_consumes_rest inner
+  | Optional_or { inner; _ } -> typ_consumes_rest inner
+  | Array { elem; _ } -> typ_consumes_rest elem
+  | Repeat { elem; _ } -> typ_consumes_rest elem
+  | Codec { codec_struct; _ } | Struct codec_struct ->
+      struct_consumes_rest codec_struct
+  | Casetype { tag; cases; _ } ->
+      typ_consumes_rest tag
+      || List.exists
+           (fun (Case_branch { cb_inner; _ }) -> typ_consumes_rest cb_inner)
+           cases
+  | Apply { typ; _ } -> typ_consumes_rest typ
+  | Single_elem _ -> false
+  | _ -> false
+
+and struct_consumes_rest (s : struct_) =
+  List.exists (fun (Field f) -> typ_consumes_rest f.field_typ) s.fields
+
+let push_back_bytes reader bytes first length =
+  if length > 0 then Reader.push_back reader (Slice.make bytes ~first ~length)
+
+let read_exact reader n =
+  let buf = Bytes.create n in
+  let rec loop off =
+    if off >= n then buf
+    else
+      let slice = Reader.read reader in
+      if Slice.is_eod slice then
+        raise (Parse_error (Unexpected_eof { expected = n; got = off }))
+      else
+        let slice_len = Slice.length slice in
+        let need = n - off in
+        let take = Int.min need slice_len in
+        Bytes.blit (Slice.bytes slice) (Slice.first slice) buf off take;
+        (if slice_len > take then
+           match Slice.drop take slice with
+           | None -> assert false
+           | Some rest -> Reader.push_back reader rest);
+        loop (off + take)
+  in
+  loop 0
+
+let missing_more_input = function
+  | Unexpected_eof _ -> true
+  (* must match the message raised by [Codec.zeroterm_nul_pos] *)
+  | Constraint_failed "zeroterm: missing NUL terminator" -> true
+  | _ -> false
+
+let of_reader_incremental typ reader =
+  let buf = Buffer.create 256 in
+  let rec loop () =
+    let bytes = Buffer.to_bytes buf in
+    let len = Bytes.length bytes in
+    let read_more on_eod =
+      let slice = Reader.read reader in
+      if Slice.is_eod slice then on_eod ()
+      else begin
+        Buffer.add_subbytes buf (Slice.bytes slice) (Slice.first slice)
+          (Slice.length slice);
+        loop ()
+      end
+    in
+    match parse_direct typ bytes 0 len with
+    | v, off ->
+        push_back_bytes reader bytes off (len - off);
+        v
+    | exception Parse_error e when missing_more_input e ->
+        read_more (fun () -> raise (Parse_error e))
+    | exception Invalid_argument _ ->
+        read_more (fun () ->
+            raise
+              (Parse_error (Unexpected_eof { expected = len + 1; got = len })))
+  in
+  loop ()
+
 let of_reader_exn typ reader =
-  let bytes = drain_reader reader in
-  fst (parse_direct typ bytes 0 (Bytes.length bytes))
+  if typ_consumes_rest typ then
+    let bytes = drain_reader reader in
+    fst (parse_direct typ bytes 0 (Bytes.length bytes))
+  else
+    match Types.field_wire_size typ with
+    | Some n ->
+        let bytes = read_exact reader n in
+        fst (parse_direct typ bytes 0 n)
+    | None -> of_reader_incremental typ reader
 
 let of_reader typ reader =
   match of_reader_exn typ reader with

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -1058,11 +1058,11 @@ module Everparse : sig
       Schemas built via {!schema} always satisfy this. *)
 
   type plug_field = {
-    pf_name : string;
-    pf_idx : int;
-    pf_c_type : string;
-    pf_setter : string;
-    pf_val_c_type : string;
+    name : string;
+    idx : int;
+    c_type : string;
+    setter : string;
+    val_c_type : string;
   }
   (** Plug info: the data needed to materialise a typed struct and [<Name>Set*]
       dispatchers for a schema. See {!Everparse.plug_field}. *)
@@ -1073,7 +1073,7 @@ module Everparse : sig
 
   val plug_setters : t -> (string * string) list
   (** [plug_setters s] lists the unique [WireSet*] setters referenced by [s] as
-      [(setter_name, val_c_type)] pairs. *)
+      [(setter, val_c_type)] pairs. *)
 
   val entrypoint_struct : t -> struct_ option
   (** Entrypoint typedef struct in the schema's module, if any. *)

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -739,8 +739,10 @@ val of_reader : 'a typ -> Bytesrw.Bytes.Reader.t -> ('a, parse_error) result
     For the zero-copy codec path, prefer {!Codec.decode} which takes an explicit
     {!Param.env}.
 
-    Decoding is prefix-based: success does not imply that the reader is
-    exhausted afterwards. *)
+    Decoding consumes only the bytes of the decoded value; anything past it
+    stays on the reader, so successive values can be decoded back-to-back from
+    the same reader. Types that extend to the end of input ({!all_bytes},
+    {!all_zeros}, and anything containing them) consume the whole stream. *)
 
 val of_reader_exn : 'a typ -> Bytesrw.Bytes.Reader.t -> 'a
 (** Like {!of_reader} but raises {!exception:Parse_error} on failure. *)

--- a/test/stubs/test_wire_stubs.ml
+++ b/test/stubs/test_wire_stubs.ml
@@ -425,7 +425,7 @@ let check_action_forms codec =
     (Wire.Everparse.field_action_forms ep)
 
 let plug_field_names s =
-  List.map (fun f -> f.Wire.Everparse.pf_name) (Wire.Everparse.plug_fields s)
+  List.map (fun f -> f.Wire.Everparse.name) (Wire.Everparse.plug_fields s)
 
 (* Invariant 2: [plug_fields] enumerates exactly the named fields of the
    source struct in declaration order, with consecutive indices starting at
@@ -439,9 +439,7 @@ let check_plug_completeness codec =
   Alcotest.(check (list string))
     "plug_fields matches named source fields" expected got;
   let idxs =
-    List.map
-      (fun f -> f.Wire.Everparse.pf_idx)
-      (Wire.Everparse.plug_fields schema)
+    List.map (fun f -> f.Wire.Everparse.idx) (Wire.Everparse.plug_fields schema)
   in
   let expected_idxs = List.init (List.length idxs) Fun.id in
   Alcotest.(check (list int)) "indices consecutive from 0" expected_idxs idxs
@@ -465,7 +463,7 @@ let check_setter_scoping codec_a codec_b =
         Alcotest.failf "setter %s missing schema prefix %s" n sa.name)
     na
 
-(* Invariant 4: every pf_setter appears in plug_setters, and every setter in
+(* Invariant 4: every setter appears in plug_setters, and every setter in
    plug_setters is actually declared in the module as an extern_fn. Catches
    drift between what plug_fields claims and what the 3D module declares. *)
 let check_setter_declarations codec =
@@ -479,10 +477,10 @@ let check_setter_declarations codec =
     (Wire.Everparse.plug_setters schema);
   List.iter
     (fun f ->
-      let setter = f.Wire.Everparse.pf_setter in
+      let setter = f.Wire.Everparse.setter in
       if not (List.mem_assoc setter (Wire.Everparse.plug_setters schema)) then
         Alcotest.failf "field %s references setter %s not in plug_setters"
-          f.Wire.Everparse.pf_name setter)
+          f.Wire.Everparse.name setter)
     (Wire.Everparse.plug_fields schema)
 
 (* Test fixtures. Each codec exercises a specific combination so invariants

--- a/test/test_wire.ml
+++ b/test/test_wire.ml
@@ -10,6 +10,11 @@ let parse_chunked ~chunk_size typ s =
   let reader = Bytesrw.Bytes.Reader.of_string ~slice_length:chunk_size s in
   Wire.of_reader typ reader
 
+let reader_decode_ok typ reader =
+  match Wire.of_reader typ reader with
+  | Ok v -> v
+  | Error e -> Alcotest.failf "%a" pp_parse_error e
+
 (* Helper: encode to string via streaming writer with [chunk_size] buffer *)
 let encode_chunked ~chunk_size typ v =
   let buf = Buffer.create 64 in
@@ -780,6 +785,29 @@ let test_stream_uint64_chunk5 () =
   | Ok v -> Alcotest.(check int64) "uint64 chunk=5" 0xAAAABBBBCCCCDDDDL v
   | Error e -> Alcotest.failf "uint64 chunk=5: %a" pp_parse_error e
 
+let test_stream_reader_sequential_fixed () =
+  let reader =
+    Bytesrw.Bytes.Reader.of_string ~slice_length:8 "\x01\x02\x03\x04\x05"
+  in
+  Alcotest.(check int) "first" 0x01 (reader_decode_ok uint8 reader);
+  Alcotest.(check int) "second" 0x0203 (reader_decode_ok uint16be reader);
+  Alcotest.(check int) "third" 0x0405 (reader_decode_ok uint16be reader);
+  Alcotest.(check bool)
+    "reader exhausted" true
+    (Bytesrw.Bytes.Slice.is_eod (Bytesrw.Bytes.Reader.read reader))
+
+let test_stream_reader_sequential_cross_slice () =
+  let reader =
+    Bytesrw.Bytes.Reader.of_string ~slice_length:1 "\x01\x02\x03\x04"
+  in
+  Alcotest.(check int) "first" 0x0102 (reader_decode_ok uint16be reader);
+  Alcotest.(check int) "second" 0x0304 (reader_decode_ok uint16be reader)
+
+let test_stream_reader_sequential_zeroterm () =
+  let reader = Bytesrw.Bytes.Reader.of_string ~slice_length:2 "abc\000\x7f" in
+  Alcotest.(check string) "text" "abc" (reader_decode_ok zeroterm reader);
+  Alcotest.(check int) "tail" 0x7f (reader_decode_ok uint8 reader)
+
 let test_stream_bitfield_chunk1 () =
   (* Bitfield: 6+10+16 bits packed in a uint32 *)
   let bf = bits ~width:6 U32 in
@@ -930,6 +958,12 @@ let suite =
         test_stream_uint64_chunk3;
       Alcotest.test_case "stream: uint64 chunk=5" `Quick
         test_stream_uint64_chunk5;
+      Alcotest.test_case "stream: sequential fixed values" `Quick
+        test_stream_reader_sequential_fixed;
+      Alcotest.test_case "stream: sequential cross-slice values" `Quick
+        test_stream_reader_sequential_cross_slice;
+      Alcotest.test_case "stream: sequential zeroterm value" `Quick
+        test_stream_reader_sequential_zeroterm;
       Alcotest.test_case "stream: bitfield chunk=1" `Quick
         test_stream_bitfield_chunk1;
       Alcotest.test_case "stream: encode chunk=1" `Quick


### PR DESCRIPTION
[`Wire.of_reader`](https://github.com/parsimoni-labs/ocaml-wire/blob/of-reader-sequential/lib/wire.mli#L732) used to drain the whole reader on the first call, so a second value could never be decoded from the same stream. It now consumes only the bytes of the decoded value: fixed-size types read exactly their width, variable-size types accumulate slices until a parse succeeds, and leftover bytes are pushed back on the reader. Types that extend to the end of input (`all_bytes`, `all_zeros`) keep the draining behaviour.

Commit c9c0dfde drops the redundant pf_ and setter_ field prefixes in `Wire.Everparse` (pure rename) and commit f2f28b57 lets the bench executables take an iteration count on the command line.