### PR TITLE
wire: of_reader rewinds the reader on decode error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,6 +53,10 @@
 
 ### Changed
 
+- `Wire.of_reader` now rewinds on failure: every byte consumed by a failed
+  decode is pushed back, restoring the reader to its position before the
+  call, so the caller can retry with another description or after more
+  input arrives (#145, @samoht)
 - `Wire.of_reader` now consumes only the bytes of the decoded value and
   leaves the rest on the reader, so several values can be decoded
   back-to-back from the same reader. Previously the first call drained the

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -422,8 +422,10 @@ let read_exact reader n =
     if off >= n then buf
     else
       let slice = Reader.read reader in
-      if Slice.is_eod slice then
+      if Slice.is_eod slice then begin
+        push_back_bytes reader buf 0 off;
         raise (Parse_error (Unexpected_eof { expected = n; got = off }))
+      end
       else
         let slice_len = Slice.length slice in
         let need = n - off in
@@ -436,6 +438,18 @@ let read_exact reader n =
         loop (off + take)
   in
   loop 0
+
+(* Parse [bytes] and keep the reader transactional: on success push back the
+   bytes past the decoded value, on parse error push back everything so the
+   reader is restored to its position before the failed decode. *)
+let parse_or_rewind typ reader bytes len =
+  match parse_direct typ bytes 0 len with
+  | v, off ->
+      push_back_bytes reader bytes off (len - off);
+      v
+  | exception Parse_error e ->
+      push_back_bytes reader bytes 0 len;
+      raise (Parse_error e)
 
 let missing_more_input = function
   | Unexpected_eof _ -> true
@@ -462,9 +476,15 @@ let of_reader_incremental typ reader =
         push_back_bytes reader bytes off (len - off);
         v
     | exception Parse_error e when missing_more_input e ->
-        read_more (fun () -> raise (Parse_error e))
+        read_more (fun () ->
+            push_back_bytes reader bytes 0 len;
+            raise (Parse_error e))
+    | exception Parse_error e ->
+        push_back_bytes reader bytes 0 len;
+        raise (Parse_error e)
     | exception Invalid_argument _ ->
         read_more (fun () ->
+            push_back_bytes reader bytes 0 len;
             raise
               (Parse_error (Unexpected_eof { expected = len + 1; got = len })))
   in
@@ -473,12 +493,12 @@ let of_reader_incremental typ reader =
 let of_reader_exn typ reader =
   if typ_consumes_rest typ then
     let bytes = drain_reader reader in
-    fst (parse_direct typ bytes 0 (Bytes.length bytes))
+    parse_or_rewind typ reader bytes (Bytes.length bytes)
   else
     match Types.field_wire_size typ with
     | Some n ->
         let bytes = read_exact reader n in
-        fst (parse_direct typ bytes 0 n)
+        parse_or_rewind typ reader bytes n
     | None -> of_reader_incremental typ reader
 
 let of_reader typ reader =

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -742,7 +742,15 @@ val of_reader : 'a typ -> Bytesrw.Bytes.Reader.t -> ('a, parse_error) result
     Decoding consumes only the bytes of the decoded value; anything past it
     stays on the reader, so successive values can be decoded back-to-back from
     the same reader. Types that extend to the end of input ({!all_bytes},
-    {!all_zeros}, and anything containing them) consume the whole stream. *)
+    {!all_zeros}, and anything containing them) consume the whole stream.
+
+    On [Error] the reader is rewound: every byte consumed by the failed decode
+    is pushed back, restoring the reader to its position before the call, so the
+    caller can retry with another description or after more input arrives. The
+    guarantee covers parse errors only; an exception escaping a user {!map}
+    function does not rewind, and output parameters written by actions during
+    the failed decode are not rolled back. Push back makes
+    [Bytesrw.Bytes.Reader.pos] non-monotonic across a failed decode. *)
 
 val of_reader_exn : 'a typ -> Bytesrw.Bytes.Reader.t -> 'a
 (** Like {!of_reader} but raises {!exception:Parse_error} on failure. *)

--- a/test/test_wire.ml
+++ b/test/test_wire.ml
@@ -808,6 +808,46 @@ let test_stream_reader_sequential_zeroterm () =
   Alcotest.(check string) "text" "abc" (reader_decode_ok zeroterm reader);
   Alcotest.(check int) "tail" 0x7f (reader_decode_ok uint8 reader)
 
+(* Rewind on error: a failed decode pushes back everything it consumed, so
+   the same bytes decode under another description (one test per of_reader
+   path: fixed-size, partial fixed-size at eof, incremental, consumes-rest). *)
+
+let test_stream_rewind_fixed () =
+  let bad = enum "Tag" [ ("A", 1); ("B", 2) ] uint8 in
+  let reader = Bytesrw.Bytes.Reader.of_string ~slice_length:8 "\xff\x01\x02" in
+  (match Wire.of_reader bad reader with
+  | Error (Invalid_enum _) -> ()
+  | Ok v -> Alcotest.failf "expected enum failure, got %d" v
+  | Error e -> Alcotest.failf "expected Invalid_enum: %a" pp_parse_error e);
+  Alcotest.(check int) "rewound first" 0xff (reader_decode_ok uint8 reader);
+  Alcotest.(check int) "rest intact" 0x0102 (reader_decode_ok uint16be reader)
+
+let test_stream_rewind_partial_fixed () =
+  let reader = Bytesrw.Bytes.Reader.of_string ~slice_length:1 "\x01\x02\x03" in
+  (match Wire.of_reader uint32be reader with
+  | Error (Unexpected_eof _) -> ()
+  | Ok v -> Alcotest.failf "expected eof, got %d" v
+  | Error e -> Alcotest.failf "expected Unexpected_eof: %a" pp_parse_error e);
+  Alcotest.(check int) "rewound" 0x0102 (reader_decode_ok uint16be reader);
+  Alcotest.(check int) "rest intact" 0x03 (reader_decode_ok uint8 reader)
+
+let test_stream_rewind_incremental () =
+  let reader = Bytesrw.Bytes.Reader.of_string ~slice_length:1 "abc" in
+  (match Wire.of_reader zeroterm reader with
+  | Error (Constraint_failed _) -> ()
+  | Ok s -> Alcotest.failf "expected missing NUL, got %S" s
+  | Error e -> Alcotest.failf "expected Constraint_failed: %a" pp_parse_error e);
+  Alcotest.(check int) "rewound" 0x61 (reader_decode_ok uint8 reader);
+  Alcotest.(check int) "rest intact" 0x6263 (reader_decode_ok uint16be reader)
+
+let test_stream_rewind_consumes_rest () =
+  let reader = Bytesrw.Bytes.Reader.of_string ~slice_length:1 "ab" in
+  (match Wire.of_reader all_zeros reader with
+  | Error (All_zeros_failed _) -> ()
+  | Ok s -> Alcotest.failf "expected all_zeros failure, got %S" s
+  | Error e -> Alcotest.failf "expected All_zeros_failed: %a" pp_parse_error e);
+  Alcotest.(check int) "rewound" 0x6162 (reader_decode_ok uint16be reader)
+
 let test_stream_bitfield_chunk1 () =
   (* Bitfield: 6+10+16 bits packed in a uint32 *)
   let bf = bits ~width:6 U32 in
@@ -964,6 +1004,14 @@ let suite =
         test_stream_reader_sequential_cross_slice;
       Alcotest.test_case "stream: sequential zeroterm value" `Quick
         test_stream_reader_sequential_zeroterm;
+      Alcotest.test_case "stream: rewind on fixed-size error" `Quick
+        test_stream_rewind_fixed;
+      Alcotest.test_case "stream: rewind on partial fixed-size eof" `Quick
+        test_stream_rewind_partial_fixed;
+      Alcotest.test_case "stream: rewind on incremental error" `Quick
+        test_stream_rewind_incremental;
+      Alcotest.test_case "stream: rewind on consumes-rest error" `Quick
+        test_stream_rewind_consumes_rest;
       Alcotest.test_case "stream: bitfield chunk=1" `Quick
         test_stream_bitfield_chunk1;
       Alcotest.test_case "stream: encode chunk=1" `Quick


### PR DESCRIPTION
[`Wire.of_reader`](https://github.com/parsimoni-labs/ocaml-wire/blob/of-reader-rewind/lib/wire.mli#L732) used to leave the reader at an unspecified position after a failed decode, losing the consumed prefix. A failed decode now pushes back every byte it consumed, restoring the reader to its pre-call position, so the caller can retry with another description or wait for more input before trying again. The guarantee covers parse errors; an exception escaping a user `map` function does not rewind, and output parameters written by actions during the failed decode are not rolled back.

Completes the transactional contract from #144: consume exactly the decoded value, or consume nothing.