### PR TITLE
3d: name the generated dune.inc alias 3d, not gen

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,6 +53,10 @@
 
 ### Changed
 
+- The build rules `wire.3d` generates (the `dune.inc` and the wrapper in its
+  setup example) now use a `3d` alias instead of the generic `gen`, so
+  `dune build @3d` regenerates the `.3d` files and EverParse C parsers.
+  Update any `dune build @gen` invocation accordingly (#146, @samoht)
 - `Wire.of_reader` now rewinds on failure: every byte consumed by a failed
   decode is pushed back, restoring the reader to its position before the
   call, so the caller can retry with another description or after more

--- a/lib/3d/wire_3d.ml
+++ b/lib/3d/wire_3d.ml
@@ -536,14 +536,14 @@ let strict_cc_flags =
 let emit_gen_rules ppf three_d_files c_files ctx_files =
   Fmt.pf ppf
     "(rule\n\
-    \ (alias gen)\n\
+    \ (alias 3d)\n\
     \ (mode promote)\n\
     \ (targets %s)\n\
     \ (deps gen.exe)\n\
     \ (action\n\
     \  (run ./gen.exe 3d)))\n\n\
      (rule\n\
-    \ (alias gen)\n\
+    \ (alias 3d)\n\
     \ (mode fallback)\n\
     \ (targets EverParse.h EverParseEndianness.h %s test.c)\n\
     \ (deps gen.exe %s)\n\

--- a/lib/3d/wire_3d.mli
+++ b/lib/3d/wire_3d.mli
@@ -28,7 +28,7 @@
     With a minimal [dune] that includes the generated rules:
     {v
       (executable (name gen) (modules gen) (libraries clcw wire.3d))
-      (rule (mode promote) (alias gen)
+      (rule (mode promote) (alias 3d)
        (targets dune.inc) (deps gen.exe) (action (run ./gen.exe dune)))
       (include dune.inc)
     v}


### PR DESCRIPTION
The `dune.inc` that `Wire_3d.generate_dune` emits grouped its regeneration rules under a generic `gen` alias, which says nothing about what it rebuilds and reads as just another generic codegen alias to a downstream package. The rules now live under a `3d` alias, matching the one the EverParse pipeline already uses in the repo's own tests, so `dune build @3d` regenerates the `.3d` files and the EverParse C parsers in one place. Downstream setups that wired `dune build @gen` need to switch to `@3d`.