### PR TITLE
codec: reuse decode validation buffer across calls

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,6 +53,10 @@
 
 ### Changed
 
+- `Wire.Codec.decode` no longer allocates a fresh validation buffer on every
+  call: each codec reuses a single buffer across decodes, so decoding the same
+  codec in a loop allocates a constant amount instead of growing with the
+  number of decodes. Pure speedup, no API change (#149, @samoht)
 - Decoding a `Field.repeat` over a `Wire.casetype` (the DHCP / TCP
   option-list shape) no longer allocates a closure and a boxed length per
   element, so decode allocation no longer grows with the number of elements.

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -787,6 +787,11 @@ type 'r t = {
   validate_arr : int array -> bytes -> int -> unit;
   populate : int array -> bytes -> int -> unit;
   n_array_slots : int;
+  decode_scratch : int array;
+      (* Validation scratch, allocated once at [seal] and zeroed per decode
+         (see [decode_exn]), mirroring the [validate] closure, the struct
+         validator, and [Codec.get]'s staged reader. Same shared-buffer
+         contract: not safe for concurrent decode of one codec value. *)
   param_base : int;
   n_params : int;
   param_handles : Param.packed list;
@@ -2608,6 +2613,7 @@ let seal : type r. (r, r) record -> r t =
     validate_arr;
     populate;
     n_array_slots = n_total;
+    decode_scratch = Array.make n_total 0;
     param_base;
     n_params;
     param_handles;
@@ -2973,7 +2979,8 @@ let env (t : _ t) : Param.env =
 
 let decode_exn ?env:e t buf off =
   let v = t.decode buf off in
-  let arr = Array.make t.n_array_slots 0 in
+  let arr = t.decode_scratch in
+  Array.fill arr 0 t.n_array_slots 0;
   (match e with
   | Some (e : Param.env) when t.n_params > 0 ->
       Array.blit e.slots 0 arr t.param_base t.n_params


### PR DESCRIPTION
`Wire.Codec.decode` allocated a fresh int array on every call for its validation scratch, so decoding the same codec in a loop allocated a constant chunk per iteration, which shows up as a memtrace hotspot at the `decode_exn` call site. The buffer is now allocated once when the codec is sealed and zeroed on entry, matching what the validate closure, the struct validator, and `Codec.get`'s staged reader already do. The saving is `n_array_slots + 1` words per decode, and the same shared-buffer contract applies: decoding one codec value is not safe across concurrent threads.

Per-decode allocation on a small constrained codec:

    before  8.000 words/decode
    after   5.000 words/decode

The remaining 5 words are the decoded record and the result box; the 3 saved are the scratch array.