### PR TITLE
perf: keep uint32/uint63 field access in unboxed int

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,6 +53,11 @@
 
 ### Changed
 
+- Reading or writing a `uint32` or `uint63` field now stays in the native
+  `int` instead of round-tripping through a boxed `Int32` or `Int64`. The
+  boxing surfaced as per-field allocation in tight decode and encode loops;
+  field access is now allocation-free regardless of how the compiler optimises
+  the surrounding code. Pure speedup, no API change (#150, @samoht)
 - `Wire.Codec.decode` no longer allocates a fresh validation buffer on every
   call: each codec reuses a single buffer across decodes, so decoding the same
   codec in a loop allocates a constant amount instead of growing with the

--- a/lib/uInt32.ml
+++ b/lib/uInt32.ml
@@ -2,13 +2,27 @@ type t = int
 
 let pp = Fmt.int
 
+(* Compose two unboxed 16-bit reads/writes rather than going through
+   [Int32.to_int] / [Int32.of_int], which box an [int32] per call. The
+   result stays in the native [int]. *)
+
 let le buf off =
-  Bytes.get_int32_le buf off |> Int32.to_int |> ( land ) 0xFFFF_FFFF
+  let lo = Bytes.get_uint16_le buf off in
+  let hi = Bytes.get_uint16_le buf (off + 2) in
+  lo lor (hi lsl 16)
 
 let be buf off =
-  Bytes.get_int32_be buf off |> Int32.to_int |> ( land ) 0xFFFF_FFFF
+  let hi = Bytes.get_uint16_be buf off in
+  let lo = Bytes.get_uint16_be buf (off + 2) in
+  (hi lsl 16) lor lo
 
-let set_le buf off v = Bytes.set_int32_le buf off (Int32.of_int v)
-let set_be buf off v = Bytes.set_int32_be buf off (Int32.of_int v)
+let set_le buf off v =
+  Bytes.set_uint16_le buf off (v land 0xFFFF);
+  Bytes.set_uint16_le buf (off + 2) ((v lsr 16) land 0xFFFF)
+
+let set_be buf off v =
+  Bytes.set_uint16_be buf off ((v lsr 16) land 0xFFFF);
+  Bytes.set_uint16_be buf (off + 2) (v land 0xFFFF)
+
 let to_int t = t
 let of_int t = t land 0xFFFF_FFFF

--- a/lib/uInt63.ml
+++ b/lib/uInt63.ml
@@ -3,9 +3,41 @@
 type t = int
 
 let pp = Fmt.int
-let le buf off = Bytes.get_int64_le buf off |> Int64.to_int |> ( land ) max_int
-let be buf off = Bytes.get_int64_be buf off |> Int64.to_int |> ( land ) max_int
-let set_le buf off v = Bytes.set_int64_le buf off (Int64.of_int v)
-let set_be buf off v = Bytes.set_int64_be buf off (Int64.of_int v)
+
+(* Compose four unboxed 16-bit reads/writes rather than going through
+   [Int64.to_int] / [Int64.of_int], which box an [int64] per call. The
+   result stays in the native [int]; reads still mask to [max_int] (the
+   top bit does not fit a 63-bit [int]), and the most-significant write
+   chunk uses [asr] so it carries the same sign extension [Int64.of_int]
+   produced. *)
+
+let le buf off =
+  let w0 = Bytes.get_uint16_le buf off in
+  let w1 = Bytes.get_uint16_le buf (off + 2) in
+  let w2 = Bytes.get_uint16_le buf (off + 4) in
+  let w3 = Bytes.get_uint16_le buf (off + 6) in
+  let v = w0 lor (w1 lsl 16) lor (w2 lsl 32) lor (w3 lsl 48) in
+  v land max_int
+
+let be buf off =
+  let w0 = Bytes.get_uint16_be buf off in
+  let w1 = Bytes.get_uint16_be buf (off + 2) in
+  let w2 = Bytes.get_uint16_be buf (off + 4) in
+  let w3 = Bytes.get_uint16_be buf (off + 6) in
+  let v = (w0 lsl 48) lor (w1 lsl 32) lor (w2 lsl 16) lor w3 in
+  v land max_int
+
+let set_le buf off v =
+  Bytes.set_uint16_le buf off (v land 0xFFFF);
+  Bytes.set_uint16_le buf (off + 2) ((v lsr 16) land 0xFFFF);
+  Bytes.set_uint16_le buf (off + 4) ((v lsr 32) land 0xFFFF);
+  Bytes.set_uint16_le buf (off + 6) ((v asr 48) land 0xFFFF)
+
+let set_be buf off v =
+  Bytes.set_uint16_be buf off ((v asr 48) land 0xFFFF);
+  Bytes.set_uint16_be buf (off + 2) ((v lsr 32) land 0xFFFF);
+  Bytes.set_uint16_be buf (off + 4) ((v lsr 16) land 0xFFFF);
+  Bytes.set_uint16_be buf (off + 6) (v land 0xFFFF)
+
 let to_int t = t
 let of_int t = t

--- a/test/test_uint32.ml
+++ b/test/test_uint32.ml
@@ -17,10 +17,30 @@ let test_of_int_masks () =
   Alcotest.(check int) "mask" 0xFF (UInt32.of_int 0xFF);
   Alcotest.(check int) "identity" 42 (UInt32.to_int (UInt32.of_int 42))
 
+(* Pin the wire byte order so the read/write paths cannot drift. *)
+let test_byte_layout () =
+  let buf = Bytes.of_string "\x01\x02\x03\x04" in
+  Alcotest.(check int) "le read" 0x04030201 (UInt32.le buf 0);
+  Alcotest.(check int) "be read" 0x01020304 (UInt32.be buf 0);
+  let out = Bytes.create 4 in
+  UInt32.set_le out 0 0x04030201;
+  Alcotest.(check string) "le write" "\x01\x02\x03\x04" (Bytes.to_string out);
+  UInt32.set_be out 0 0x01020304;
+  Alcotest.(check string) "be write" "\x01\x02\x03\x04" (Bytes.to_string out)
+
+let test_boundaries () =
+  List.iter
+    (fun v ->
+      check_roundtrip "le" ~set:UInt32.set_le ~get:UInt32.le v;
+      check_roundtrip "be" ~set:UInt32.set_be ~get:UInt32.be v)
+    [ 0x0; 0x1; 0xFFFF; 0x1_0000; 0x7FFF_FFFF; 0x8000_0000; 0xFFFF_FFFF ]
+
 let suite =
   ( "uint32",
     [
       Alcotest.test_case "roundtrip le" `Quick test_roundtrip_le;
       Alcotest.test_case "roundtrip be" `Quick test_roundtrip_be;
       Alcotest.test_case "of_int masks" `Quick test_of_int_masks;
+      Alcotest.test_case "byte layout" `Quick test_byte_layout;
+      Alcotest.test_case "boundaries" `Quick test_boundaries;
     ] )

--- a/test/test_uint63.ml
+++ b/test/test_uint63.ml
@@ -18,10 +18,33 @@ let test_roundtrip_be () =
 let test_of_int_identity () =
   Alcotest.(check int) "identity" 42 (UInt63.to_int (UInt63.of_int 42))
 
+(* Pin the wire byte order across all eight bytes so the read/write paths
+   cannot drift. *)
+let test_byte_layout () =
+  let buf = Bytes.of_string "\x01\x02\x03\x04\x05\x06\x07\x08" in
+  Alcotest.(check int) "le read" 0x0807_0605_0403_0201 (UInt63.le buf 0);
+  Alcotest.(check int) "be read" 0x0102_0304_0506_0708 (UInt63.be buf 0);
+  let out = Bytes.create 8 in
+  UInt63.set_le out 0 0x0807_0605_0403_0201;
+  Alcotest.(check string)
+    "le write" "\x01\x02\x03\x04\x05\x06\x07\x08" (Bytes.to_string out);
+  UInt63.set_be out 0 0x0102_0304_0506_0708;
+  Alcotest.(check string)
+    "be write" "\x01\x02\x03\x04\x05\x06\x07\x08" (Bytes.to_string out)
+
+let test_boundaries () =
+  List.iter
+    (fun v ->
+      check_roundtrip "le" ~set:UInt63.set_le ~get:UInt63.le v;
+      check_roundtrip "be" ~set:UInt63.set_be ~get:UInt63.be v)
+    [ 0x0; 0x1; 0xFFFF; 0x1_0000_0000; 0x0102_0304_0506_0708; max_int ]
+
 let suite =
   ( "uint63",
     [
       Alcotest.test_case "roundtrip le" `Quick test_roundtrip_le;
       Alcotest.test_case "roundtrip be" `Quick test_roundtrip_be;
       Alcotest.test_case "of_int identity" `Quick test_of_int_identity;
+      Alcotest.test_case "byte layout" `Quick test_byte_layout;
+      Alcotest.test_case "boundaries" `Quick test_boundaries;
     ] )


### PR DESCRIPTION
`UInt32.le`/`be`/`set_le`/`set_be` and the `UInt63` equivalents round-tripped each value through a boxed `Int32` or `Int64`. ocamlopt elides that box when the bytes primitive and the conversion stay adjacent, but it reappears wherever the value escapes the access site, so a decode or encode loop over these fields allocates per access. Composing two (uint32) or four (uint63) unboxed 16-bit reads or writes keeps the value in the native `int`, so field access is allocation-free regardless of how the surrounding code is compiled.

A read or write measured where the value escapes the access site, so the box is not elided:

    before  3.000 words/op
    after   0.000 words/op

The most-significant `uint63` write chunk uses `asr` to reproduce `Int64.of_int`'s sign extension byte for byte, and reads still mask to `max_int`, so the wire layout is unchanged.