### PR TITLE
feat: project codecs to FFI-free 3D protocol specs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,12 @@
 
 ### Added
 
+- `Wire.Everparse.doc` and `Wire.Everparse.write_doc` project a codec, or a
+  whole family of codecs, to a clean `.3d` with no FFI scaffolding: enums
+  render as named 3D enum types, types shared across codecs are emitted once,
+  and a protocol family lands in one readable `<Name>.3d`. The result doubles
+  as a protocol specification and as input to EverParse, which compiles it to a
+  standalone C validator with no FFI (#151, @samoht)
 - `Wire.Codec.rename` returns a codec with a new name, leaving its wire
   encoding and field constraints unchanged, so a generically built codec can
   be given a unique, meaningful name before code generation (@samoht)

--- a/examples/dune
+++ b/examples/dune
@@ -42,7 +42,10 @@
   Ethernet.3d
   IPv4.3d
   TCP.3d
-  UDP.3d)
+  UDP.3d
+  Net.3d
+  Space.3d
+  Demo.3d)
  (deps gen_3d.exe)
  (action
   (run ./gen_3d.exe)))
@@ -82,4 +85,7 @@
   Ethernet.3d
   IPv4.3d
   TCP.3d
-  UDP.3d))
+  UDP.3d
+  Net.3d
+  Space.3d
+  Demo.3d))

--- a/examples/gen_3d.ml
+++ b/examples/gen_3d.ml
@@ -50,4 +50,20 @@ let () =
       ("Message.3d", Demo.casetype_module);
       ("ExternDemo.3d", Demo.extern_module);
       ("Outer.3d", Demo.type_ref_module);
-    ]
+    ];
+  (* Documentation specs: a whole protocol family in one readable [.3d],
+     projected without the FFI scaffolding (see [Wire.Everparse.doc]). *)
+  List.iter
+    (fun (name, ts) -> Wire.Everparse.write_doc ~outdir:"." ~name ts)
+    Wire.Everparse.
+      [
+        ( "net",
+          [
+            doc Net.ethernet_codec;
+            doc Net.ipv4_codec;
+            doc Net.tcp_codec;
+            doc Net.udp_codec;
+          ] );
+        ("space", [ doc Space.clcw_codec; doc Space.packet_codec ]);
+        ("demo", [ doc Demo.enum_demo_codec; doc Demo.cases_demo_codec ]);
+      ]

--- a/examples/validate_3d.ml
+++ b/examples/validate_3d.ml
@@ -11,8 +11,11 @@ module Raw = Wire.Everparse.Raw
 type case =
   | Raw of string * Raw.module_
   | Codec : string * 'a Wire.Codec.t -> case
+  | Doc of string * Wire.Everparse.t list
+      (** A whole protocol family projected with {!Wire.Everparse.doc} and
+          merged into one [<Name>.3d] by {!Wire.Everparse.write_doc}. *)
 
-let case_name = function Raw (n, _) | Codec (n, _) -> n
+let case_name = function Raw (n, _) | Codec (n, _) | Doc (n, _) -> n
 
 let raw_struct ?(entrypoint = true) (s : Raw.struct_) =
   let module_ = Raw.module_ [ Raw.typedef ~entrypoint s ] in
@@ -58,6 +61,21 @@ let cases =
     Codec ("TMWithOCF", Space.tm_with_ocf_codec);
     Codec ("InnerCmd", Space.inner_cmd_codec);
     Codec ("OuterHdr", Space.outer_hdr_codec);
+    Doc
+      ( "Net",
+        Wire.Everparse.
+          [
+            doc Net.ethernet_codec;
+            doc Net.ipv4_codec;
+            doc Net.tcp_codec;
+            doc Net.udp_codec;
+          ] );
+    Doc
+      ("Space", Wire.Everparse.[ doc Space.clcw_codec; doc Space.packet_codec ]);
+    Doc
+      ( "Demo",
+        Wire.Everparse.[ doc Demo.enum_demo_codec; doc Demo.cases_demo_codec ]
+      );
   ]
 
 let emit ~outdir = function
@@ -69,6 +87,9 @@ let emit ~outdir = function
       let s = Wire.Everparse.schema codec in
       Wire_3d.generate_3d ~outdir [ s ];
       Wire.Everparse.filename s
+  | Doc (name, ts) ->
+      Wire.Everparse.write_doc ~outdir ~name ts;
+      String.capitalize_ascii name ^ ".3d"
 
 let validate_one case =
   let outdir = Filename.temp_dir "wire_validate_3d" "" in

--- a/lib/everparse.ml
+++ b/lib/everparse.ml
@@ -448,6 +448,21 @@ let with_output (s : Types.struct_) : Types.decl list =
   let refined_decls = refined_byte_typedefs s in
   [ ctx_decl ] @ extern_decls @ refined_decls @ [ parse_decl ]
 
+(* Documentation / pure-validator projection: the same structural 3D as
+   [with_output] but without the FFI scaffolding. No [WireCtx] extern, no
+   [WireSet*] setters, no extraction action injected on each field. Keeps the
+   struct, bitfields, [where] clause, refined-byte typedefs, enums, and
+   casetypes -- everything that describes the wire format. Reads as a protocol
+   spec, and 3d.exe still compiles it to a real (validator-only) C parser with
+   no FFI. *)
+let doc_decls (s : Types.struct_) : Types.decl list =
+  let s = { s with fields = List.map rewrite_absent_optional s.fields } in
+  let parse_fields = reorder_bit_groups_for_3d s.fields in
+  let parse_struct =
+    Types.param_struct s.name s.params ?where:s.where parse_fields
+  in
+  refined_byte_typedefs s @ [ Types.typedef ~entrypoint:true parse_struct ]
+
 (* Byte size of a struct after bitfield coalescing, mirroring Codec.compile_bits'
    logic: consecutive same-base, same-bit_order bitfields pack into one base
    word if their widths sum within the word; they roll over to a new base word
@@ -498,6 +513,13 @@ let schema_of_struct (s : Types.struct_) : t =
 let schema (type r) (codec : r Codec.t) : t =
   schema_of_struct (Codec.to_struct codec)
 
+let doc_of_struct (s : Types.struct_) : t =
+  let s = Types.split_string_casetype_fields s in
+  let name = Types.struct_name s in
+  let wire_size = coalesced_wire_size s.fields in
+  { name; module_ = Types.module_ (doc_decls s); wire_size; source = Some s }
+
+let doc (type r) (codec : r Codec.t) : t = doc_of_struct (Codec.to_struct codec)
 let filename (s : t) = String.capitalize_ascii s.name ^ ".3d"
 
 let uses_wire_ctx s =
@@ -586,6 +608,43 @@ let write_3d ~outdir schemas =
   List.iter
     (fun s -> Types.to_3d_file (Filename.concat outdir (filename s)) s.module_)
     schemas
+
+(* Merge several clean (doc) schemas into one module: union their decls, keeping
+   the first definition of each named typedef / enum / casetype so a type shared
+   across codecs (a common enum, a refined-byte element) is emitted once.
+   Dependency order survives because each input module already lists a type
+   before the typedef that uses it, and the shared type keeps its first slot. *)
+let merge ~name (ts : t list) : t =
+  let decl_name = function
+    | Types.Typedef { struct_ = { name; _ }; _ } -> Some name
+    | Types.Enum_decl { name; _ } | Types.Casetype_decl { name; _ } -> Some name
+    | Types.Define { name; _ } | Types.Extern_fn { name; _ } -> Some name
+    | _ -> None
+  in
+  let seen = Hashtbl.create 16 in
+  let keep d =
+    match decl_name d with
+    | None -> true
+    | Some n when Hashtbl.mem seen n -> false
+    | Some n ->
+        Hashtbl.add seen n ();
+        true
+  in
+  let decls =
+    List.fold_left
+      (fun acc t ->
+        List.fold_left
+          (fun acc d -> if keep d then d :: acc else acc)
+          acc t.module_.decls)
+      [] ts
+    |> List.rev
+  in
+  { name; module_ = Types.module_ decls; wire_size = None; source = None }
+
+let write_doc ~outdir ~name (ts : t list) =
+  Types.to_3d_file ~enum_as_type:true
+    (Filename.concat outdir (String.capitalize_ascii name ^ ".3d"))
+    (merge ~name ts).module_
 
 (* Public C-facing types *)
 

--- a/lib/everparse.mli
+++ b/lib/everparse.mli
@@ -143,6 +143,20 @@ val field_action_forms :
 val write_3d : outdir:string -> t list -> unit
 (** [write_3d ~outdir ts] writes one [.3d] file per schema in [outdir]. *)
 
+val doc : 'r Codec.t -> t
+(** [doc codec] projects [codec] to a clean schema for documentation and pure-C
+    parser generation. It carries the same structural 3D as {!schema} (struct,
+    bitfields, [where] clause, enums, casetypes, refined-byte typedefs) but
+    drops the FFI scaffolding: no [WireCtx] extern, no [WireSet*] extraction
+    callbacks. The result reads as a protocol specification, and 3d.exe compiles
+    it to a validator-only C parser with no FFI. *)
+
+val write_doc : outdir:string -> name:string -> t list -> unit
+(** [write_doc ~outdir ~name ts] merges the (doc) schemas [ts] into a single
+    module -- a type shared across several codecs is emitted once -- and writes
+    one [<Name>.3d] in [outdir], so a whole protocol family reads as one
+    document. Build each element with {!doc}. *)
+
 module Raw : sig
   type nonrec struct_ = struct_
   type field = Field.packed
@@ -186,11 +200,13 @@ module Raw : sig
   val module_ : ?doc:string -> decl list -> module_
   (** Build a 3D module from declarations. *)
 
-  val to_3d : module_ -> string
-  (** Render a 3D module to text. *)
+  val to_3d : ?enum_as_type:bool -> module_ -> string
+  (** Render a 3D module to text. With [~enum_as_type:true] an enum field
+      renders as its named 3D enum type rather than the base type plus a
+      membership refinement. *)
 
-  val to_3d_file : string -> module_ -> unit
-  (** Write a rendered 3D module to a file. *)
+  val to_3d_file : ?enum_as_type:bool -> string -> module_ -> unit
+  (** Write a rendered 3D module to a file. See {!to_3d} for [enum_as_type]. *)
 
   val field :
     string ->

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -1677,6 +1677,25 @@ and field_suffix : type a. a typ -> field_suffix * (Format.formatter -> unit) =
 
 let anon_counter = Stdlib.ref 0
 
+(* The documentation projection renders an enum field as its named 3D enum type
+   (e.g. [Status StatusCode;]), which makes EverParse enforce membership through
+   the type. The codegen projection keeps the base type plus an explicit
+   membership refinement, because its FFI plug reads the field as the base type.
+   Toggled around rendering by [to_3d]/[to_3d_file], mirroring [anon_counter]. *)
+let render_enum_as_type = Stdlib.ref false
+
+(* The named 3D enum type a field should render as under [render_enum_as_type],
+   seen through the transparent [Map] / [Where] / [Apply] wrappers. Only an enum
+   over a scalar base qualifies: an enum over a bitfield base maps to a plain
+   bitfield with no enum declaration to reference. *)
+let rec enum_type_name : type a. a typ -> string option = function
+  | Enum { base = Bits _; _ } -> None
+  | Enum { name; _ } -> Some name
+  | Map { inner; _ } -> enum_type_name inner
+  | Where { inner; _ } -> enum_type_name inner
+  | Apply { typ; _ } -> enum_type_name typ
+  | _ -> None
+
 let rec extract_where_constraint : type a. a typ -> bool expr option * a typ =
  fun typ ->
   match typ with
@@ -1728,17 +1747,22 @@ let pp_field ppf (Field f) =
     | Some len -> Some (Lt (Ref raw_name, Int len))
     | None -> None
   in
-  (* An [enum] field is valid only for one of its named values; emit that
-     membership as a refinement (the OCaml decoder enforces it on decode). *)
+  (* The documentation projection types the field as its named enum, so
+     EverParse enforces membership through the type. The codegen projection
+     instead emits membership as a refinement on the base type, which the OCaml
+     decoder mirrors on decode. *)
+  let doc_enum =
+    if !render_enum_as_type then enum_type_name f.field_typ else None
+  in
   let enum_cond =
-    match enum_cases_of f.field_typ with
-    | Some (v0 :: rest) ->
+    match (doc_enum, enum_cases_of f.field_typ) with
+    | None, Some (v0 :: rest) ->
         Some
           (List.fold_left
              (fun acc v -> Or (acc, Eq (Ref raw_name, Int v)))
              (Eq (Ref raw_name, Int v0))
              rest)
-    | Some [] | None -> None
+    | _ -> None
   in
   let constraint_ =
     combine_constraints
@@ -1748,6 +1772,11 @@ let pp_field ppf (Field f) =
       enum_cond
   in
   let suffix, pp_base = field_suffix typ in
+  let pp_base =
+    match doc_enum with
+    | Some n -> fun ppf -> Fmt.string ppf n
+    | None -> pp_base
+  in
   Fmt.pf ppf "@,%t %s%a" pp_base name pp_field_suffix suffix;
   Option.iter (Fmt.pf ppf " { %a }" pp_expr) constraint_;
   Option.iter (Fmt.pf ppf " %a" pp_action) f.action;
@@ -1947,13 +1976,17 @@ let pp_module ppf m =
   Option.iter (Fmt.pf ppf "/*++ %s --*/@,@,") m.doc;
   List.iter (pp_decl ppf) m.decls
 
-let to_3d m = Fmt.str "@[<v>%a@]" pp_module m
+let to_3d ?(enum_as_type = false) m =
+  render_enum_as_type := enum_as_type;
+  Fun.protect
+    ~finally:(fun () -> render_enum_as_type := false)
+    (fun () -> Fmt.str "@[<v>%a@]" pp_module m)
 
-let to_3d_file path m =
+let to_3d_file ?(enum_as_type = false) path m =
   let oc = open_out path in
-  let ppf = Format.formatter_of_out_channel oc in
-  Fmt.pf ppf "@[<v>%a@]@." pp_module m;
-  close_out oc
+  Fun.protect
+    ~finally:(fun () -> close_out oc)
+    (fun () -> output_string oc (to_3d ~enum_as_type m ^ "\n"))
 
 let raise_eof ~expected ~got =
   raise (Parse_error (Unexpected_eof { expected; got }))

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -731,11 +731,14 @@ val pp_action : Format.formatter -> action -> unit
 val pp_module : Format.formatter -> module_ -> unit
 (** Pretty-print a module as 3D source. *)
 
-val to_3d : module_ -> string
-(** Render a module as a 3D source string. *)
+val to_3d : ?enum_as_type:bool -> module_ -> string
+(** Render a module as a 3D source string. With [~enum_as_type:true] (the
+    documentation projection) an enum field renders as its named 3D enum type
+    rather than the base type plus a membership refinement. *)
 
-val to_3d_file : string -> module_ -> unit
-(** [to_3d_file path m] writes module [m] to a [.3d] file at [path]. *)
+val to_3d_file : ?enum_as_type:bool -> string -> module_ -> unit
+(** [to_3d_file path m] writes module [m] to a [.3d] file at [path]. See
+    {!to_3d} for [enum_as_type]. *)
 
 val escape_3d : string -> string
 (** [escape_3d name] appends [_] if [name] is a 3D or C reserved word. *)

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -1103,6 +1103,20 @@ module Everparse : sig
   val write_3d : outdir:string -> t list -> unit
   (** Writes one [.3d] file per schema into [outdir]. *)
 
+  val doc : 'r Codec.t -> t
+  (** [doc codec] projects [codec] to a clean schema for documentation and
+      pure-C parser generation: the same structural 3D as {!schema} (struct,
+      bitfields, [where] clause, enums, casetypes, refined-byte typedefs) but
+      without the FFI scaffolding (no [WireCtx] extern, no [WireSet*]
+      callbacks). It reads as a protocol specification, and 3d.exe compiles it
+      to a validator-only C parser with no FFI. *)
+
+  val write_doc : outdir:string -> name:string -> t list -> unit
+  (** [write_doc ~outdir ~name ts] merges the (doc) schemas [ts] into one module
+      -- a type shared across codecs is emitted once -- and writes a single
+      [<Name>.3d] into [outdir], so a whole protocol family reads as one
+      document. *)
+
   module Raw : sig
     (** Escape hatch for manual 3D authoring.
 
@@ -1151,11 +1165,14 @@ module Everparse : sig
     val module_ : ?doc:string -> decl list -> module_
     (** Builds a 3D module from declarations. *)
 
-    val to_3d : module_ -> string
-    (** Renders a 3D module to text. *)
+    val to_3d : ?enum_as_type:bool -> module_ -> string
+    (** Renders a 3D module to text. With [~enum_as_type:true] an enum field
+        renders as its named 3D enum type rather than the base type plus a
+        membership refinement. *)
 
-    val to_3d_file : string -> module_ -> unit
-    (** Writes a rendered 3D module to a file. *)
+    val to_3d_file : ?enum_as_type:bool -> string -> module_ -> unit
+    (** Writes a rendered 3D module to a file. See {!to_3d} for [enum_as_type].
+    *)
 
     val field :
       string -> ?constraint_:bool expr -> ?action:Action.t -> 'a typ -> field

--- a/test/3d/dune
+++ b/test/3d/dune
@@ -26,7 +26,10 @@
   Ethernet.3d
   IPv4.3d
   TCP.3d
-  UDP.3d)
+  UDP.3d
+  Net.3d
+  Space.3d
+  Demo.3d)
  (deps gen_3d.exe)
  (action
   (run ./gen_3d.exe)))
@@ -35,7 +38,13 @@
 
 (rule
  (alias 3d)
- (deps Bitfields.3d Enumerations.3d FieldDependence.3d)
+ (deps
+  Bitfields.3d
+  Enumerations.3d
+  FieldDependence.3d
+  Net.3d
+  Space.3d
+  Demo.3d)
  (action
   (bash
    "~/.local/everparse/bin/3d.exe --version && for f in *.3d; do ~/.local/everparse/bin/3d.exe --batch \"$f\" > /dev/null 2>&1 || exit 1; done")))

--- a/test/3d/gen_3d.ml
+++ b/test/3d/gen_3d.ml
@@ -128,4 +128,22 @@ let () =
 
   (* Net schemas -- also exercises all_schemas and all_structs *)
   List.iter (fun s -> gen_struct (struct_name s) s) Net.all_structs;
-  assert (List.length Net.all_schemas = List.length Net.all_structs)
+  assert (List.length Net.all_schemas = List.length Net.all_structs);
+
+  (* Documentation specs: a protocol family in one FFI-free [.3d] (see
+     [Wire.Everparse.doc]). The [3d] alias batch-compiles these to pure C, so
+     the validator-only projection is verified end to end. *)
+  List.iter
+    (fun (name, ts) -> Wire.Everparse.write_doc ~outdir:"." ~name ts)
+    Wire.Everparse.
+      [
+        ( "net",
+          [
+            doc Net.ethernet_codec;
+            doc Net.ipv4_codec;
+            doc Net.tcp_codec;
+            doc Net.udp_codec;
+          ] );
+        ("space", [ doc Space.clcw_codec; doc Space.packet_codec ]);
+        ("demo", [ doc Demo.enum_demo_codec; doc Demo.cases_demo_codec ]);
+      ]

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -185,6 +185,59 @@ let test_3d_enum_membership () =
     "enum nested in a sub-codec bounds its value" true
     (contains ~sub:"(e == 1)" (to_3d (Everparse.schema arr).module_))
 
+let test_doc_drops_ffi_scaffolding () =
+  (* The doc projection keeps the structure but not the FFI callbacks the
+     codegen schema carries. *)
+  let c =
+    Codec.v "Pkt" (fun v -> v) Codec.[ (Field.v "v" uint8 $ fun v -> v) ]
+  in
+  let schema = to_3d (Everparse.schema c).module_ in
+  let doc = to_3d ~enum_as_type:true (Everparse.doc c).module_ in
+  Alcotest.(check bool)
+    "schema has WireCtx" true
+    (contains ~sub:"WireCtx" schema);
+  Alcotest.(check bool) "doc has no WireCtx" false (contains ~sub:"WireCtx" doc);
+  Alcotest.(check bool) "doc has no WireSet" false (contains ~sub:"WireSet" doc);
+  Alcotest.(check bool) "doc keeps the field" true (contains ~sub:"UINT8 v" doc)
+
+let test_doc_enum_as_type () =
+  (* An enum field renders as its named 3D enum type, so EverParse enforces
+     membership through the type rather than an explicit refinement. *)
+  let e = enum "Color" [ ("Red", 0); ("Green", 1); ("Blue", 2) ] uint8 in
+  let c = Codec.v "Pix" (fun v -> v) Codec.[ (Field.v "Hue" e $ fun v -> v) ] in
+  let doc = to_3d ~enum_as_type:true (Everparse.doc c).module_ in
+  Alcotest.(check bool)
+    "declares the enum" true
+    (contains ~sub:"enum Color" doc);
+  Alcotest.(check bool)
+    "types the field as the enum" true
+    (contains ~sub:"Color Hue" doc);
+  Alcotest.(check bool)
+    "drops the membership refinement" false (contains ~sub:"== 0" doc);
+  Alcotest.(check bool)
+    "codegen schema keeps membership" true
+    (contains ~sub:"== 0" (to_3d (Everparse.schema c).module_))
+
+let test_doc_merge_dedup () =
+  (* write_doc unions a family into one module, emitting a shared type once. *)
+  let e = enum "Shared" [ ("A", 0); ("B", 1) ] uint8 in
+  let c1 = Codec.v "One" (fun v -> v) Codec.[ (Field.v "x" e $ fun v -> v) ] in
+  let c2 = Codec.v "Two" (fun v -> v) Codec.[ (Field.v "y" e $ fun v -> v) ] in
+  let dir = Filename.get_temp_dir_name () in
+  let name = "wire_doc_merge_test" in
+  Everparse.write_doc ~outdir:dir ~name [ Everparse.doc c1; Everparse.doc c2 ];
+  let path = Filename.concat dir (String.capitalize_ascii name ^ ".3d") in
+  let content = In_channel.with_open_text path In_channel.input_all in
+  Sys.remove path;
+  let count sub = List.length (Re.all (Re.compile (Re.str sub)) content) in
+  Alcotest.(check int) "shared enum declared once" 1 (count "enum Shared");
+  Alcotest.(check bool)
+    "first struct present" true
+    (contains ~sub:"One" content);
+  Alcotest.(check bool)
+    "second struct present" true
+    (contains ~sub:"Two" content)
+
 let test_3d_nested_byte_array_where () =
   (* A byte_array_where inside a nested region needs its synthesised refined-byte
      typedef emitted, before the wrapper that references it, or the schema names
@@ -832,6 +885,12 @@ let suite =
         test_3d_array_enum_element_decl;
       Alcotest.test_case "3d: enum membership refinement" `Quick
         test_3d_enum_membership;
+      Alcotest.test_case "doc: drops FFI scaffolding" `Quick
+        test_doc_drops_ffi_scaffolding;
+      Alcotest.test_case "doc: enum renders as named type" `Quick
+        test_doc_enum_as_type;
+      Alcotest.test_case "doc: merge dedups shared types" `Quick
+        test_doc_merge_dedup;
       Alcotest.test_case "3d: nested byte_array_where refined typedef" `Quick
         test_3d_nested_byte_array_where;
       Alcotest.test_case "3d: static optional transparent projection" `Quick


### PR DESCRIPTION
This PR adds `Wire.Everparse.doc` and `Wire.Everparse.write_doc`, projecting a codec (or a whole family of codecs) to a clean `.3d` for use as a protocol specification.

Wire already projects codecs to 3D through the existing `schema` function, but that output carries the FFI scaffolding the generated C validator needs (a `WireCtx` extern and a `WireSet` callback on every field) and emits one file per codec, so it reads as codegen rather than as a spec. The new `doc` projection drops that scaffolding and renders an enum field as its named 3D enum type instead of a base type plus a membership refinement; `write_doc` merges a protocol family into one `<Name>.3d` with a type shared across codecs emitted once. Because the result is still valid 3D, EverParse compiles it to a standalone validator-only C parser with no FFI.

The existing `schema` projection is unchanged: enum-as-type rendering is gated behind a new `enum_as_type` flag on `to_3d`, which only `write_doc` sets. The `test/3d` batch gate now compiles the merged `Net` / `Space` / `Demo` specs to C and `validate_3d` parses them.

The new `Net.3d` carries all four headers in one file:

    entrypoint
    typedef struct _TCP {
       UINT16BE SrcPort;
       UINT16BE DstPort;
       UINT32BE SeqNum;
       UINT32BE AckNum;
       UINT16BE DataOffset : 4;
       ...
       UINT16BE UrgentPtr;
    } TCP;

and an enum field now types against its declaration:

    UINT8 enum Status { OK = 0, WARN = 1, ERR = 2, CRIT = 3 }
    typedef struct _EnumDemo { Status StatusCode; UINT8 Code; } EnumDemo;