### PR TITLE
3d: add a doc-mode pipeline to Wire_3d.main

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -59,6 +59,14 @@
 
 ### Changed
 
+- `Wire_3d.main` now takes packed codecs (`Wire_3d.pack codec`) and a
+  mandatory `~mode:[`Ffi | `Doc]`, so every `gen.ml` states what it emits.
+  `` `Ffi `` keeps the per-codec FFI parsers; `` `Doc `` emits one FFI-free
+  `<Package>.3d` specification and a single validator-only `<Package>.c` for
+  the whole package, through the new `Wire_3d.generate_doc` and
+  `Wire_3d.generate_dune_doc`. Migrate a `gen.ml` by replacing
+  `[schema c; ...]` with `~mode:`Ffi [pack c; ...]`, or `~mode:`Doc` for the
+  single-file output (#152, @samoht)
 - Reading or writing a `uint32` or `uint63` field now stays in the native
   `int` instead of round-tripping through a boxed `Int32` or `Int64`. The
   boxing surfaced as per-field allocation in tight decode and encode loops;

--- a/lib/3d/wire_3d.ml
+++ b/lib/3d/wire_3d.ml
@@ -318,21 +318,23 @@ let fields_c_files schemas =
       else None)
     schemas
 
-let run_everparse ?(quiet = true) ~outdir schemas =
+let run_everparse_files ?(quiet = true) ~outdir files =
   let exe =
     match locate_3d_exe () with
     | Some e -> e
     | None -> failwith "3d.exe not found in PATH or ~/.local/everparse/bin/"
   in
   List.iter
-    (fun s ->
-      let f = Wire.Everparse.filename s in
+    (fun f ->
       let redirect = if quiet then " > /dev/null 2>&1" else "" in
       let cmd = Fmt.str "cd %s && %s --batch %s%s" outdir exe f redirect in
       let ret = Sys.command cmd in
       if ret <> 0 then Fmt.failwith "EverParse failed on %s with code %d" f ret)
-    schemas;
+    files;
   copy_everparse_endianness ~outdir
+
+let run_everparse ?(quiet = true) ~outdir schemas =
+  run_everparse_files ~quiet ~outdir (List.map Wire.Everparse.filename schemas)
 
 let parse_3d ?(batch = false) ~outdir file =
   let exe =
@@ -594,9 +596,108 @@ let generate_dune ~outdir ~package schemas =
   Format.pp_print_flush ppf ();
   close_out oc
 
-let main ~package schemas =
-  match Array.to_list Sys.argv with
-  | [ _; "3d" ] -> generate_3d ~outdir:"." schemas
-  | [ _; "c" ] -> generate_c ~outdir:"." schemas
-  | [ _; "dune" ] -> generate_dune ~outdir:"." ~package schemas
-  | _ -> run ~outdir:"." schemas
+(* A codec awaiting projection. [main] and the doc helpers take these rather
+   than already-projected [Wire.Everparse.t] so the caller never has to choose
+   between [doc] and [schema]: the projection is picked here from the mode, not
+   at the call site, which removes the [~mode:`Doc] + [schema ...] mismatch. *)
+type packed = Pack : 'a Wire.Codec.t -> packed
+
+let pack c = Pack c
+
+(* -- Documentation / single-file pipeline. [main ~mode:`Doc] drives these:
+   project each codec with [Wire.Everparse.doc] (FFI-free), merge the family
+   into one [<Package>.3d] with [write_doc], and compile that single spec to a
+   validator-only [<Package>.c] -- no per-codec files, no [_Fields] plug, no FFI
+   stubs. The package name becomes the 3D module name, so turn it into a valid
+   EverParse identifier (CamelCase, no hyphens): "my-pkg" -> "MyPkg". -- *)
+let doc_module_name package =
+  let alnum c =
+    (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+  in
+  package
+  |> String.map (fun c -> if alnum c then c else '_')
+  |> String.split_on_char '_'
+  |> List.filter (fun s -> s <> "")
+  |> List.map String.capitalize_ascii
+  |> String.concat ""
+
+let generate_3d_doc ~outdir ~package codecs =
+  ensure_dir outdir;
+  write_doc ~outdir ~name:(doc_module_name package)
+    (List.map (fun (Pack c) -> doc c) codecs)
+
+let generate_c_doc ?(quiet = true) ~outdir ~package _codecs =
+  ensure_dir outdir;
+  if has_3d_exe () then
+    run_everparse_files ~quiet ~outdir [ doc_module_name package ^ ".3d" ]
+  else
+    failwith
+      "3d.exe not found in PATH. Install EverParse to regenerate C files."
+
+let generate_doc ?(quiet = true) ~outdir ~package codecs =
+  generate_3d_doc ~outdir ~package codecs;
+  generate_c_doc ~quiet ~outdir ~package codecs
+
+let generate_dune_doc ~outdir ~package _codecs =
+  let base = doc_module_name package in
+  let three_d = base ^ ".3d" in
+  let c_files =
+    [ base ^ ".c"; base ^ ".h"; base ^ "Wrapper.c"; base ^ "Wrapper.h" ]
+  in
+  let oc = open_out (Filename.concat outdir "dune.inc") in
+  let ppf = Format.formatter_of_out_channel oc in
+  let pr fmt = Fmt.pf ppf fmt in
+  pr
+    "(rule\n\
+    \ (alias 3d)\n\
+    \ (mode promote)\n\
+    \ (targets %s)\n\
+    \ (deps gen.exe)\n\
+    \ (action\n\
+    \  (run ./gen.exe 3d)))\n\n"
+    three_d;
+  pr
+    "(rule\n\
+    \ (alias 3d)\n\
+    \ (mode fallback)\n\
+    \ (targets EverParse.h EverParseEndianness.h %s)\n\
+    \ (deps gen.exe %s)\n\
+    \ (action\n\
+    \  (run ./gen.exe c)))\n\n"
+    (String.concat " " c_files)
+    three_d;
+  (* Compile the generated validator (no link: the wrapper's error callback is
+     the consumer's to define), so a downstream build fails loudly if the spec
+     stops projecting to compilable C. *)
+  pr
+    "(rule\n\
+    \ (alias runtest)\n\
+    \ (deps EverParse.h EverParseEndianness.h %s)\n\
+    \ (action\n\
+    \  (system\n\
+    \   \"cc %s -c %s.c %sWrapper.c\")))\n\n"
+    (String.concat " " c_files)
+    strict_cc_flags base base;
+  pr "(install\n (package %s)\n (section lib)\n (files\n" package;
+  List.iter (fun f -> pr "  (%s as c/%s)\n" f f) (three_d :: c_files);
+  pr "  (EverParse.h as c/EverParse.h)\n";
+  pr "  (EverParseEndianness.h as c/EverParseEndianness.h)))\n";
+  Format.pp_print_flush ppf ();
+  close_out oc
+
+let main ~mode ~package codecs =
+  let argv = Array.to_list Sys.argv in
+  match mode with
+  | `Ffi -> (
+      let schemas = List.map (fun (Pack c) -> schema c) codecs in
+      match argv with
+      | [ _; "3d" ] -> generate_3d ~outdir:"." schemas
+      | [ _; "c" ] -> generate_c ~outdir:"." schemas
+      | [ _; "dune" ] -> generate_dune ~outdir:"." ~package schemas
+      | _ -> run ~outdir:"." schemas)
+  | `Doc -> (
+      match argv with
+      | [ _; "3d" ] -> generate_3d_doc ~outdir:"." ~package codecs
+      | [ _; "c" ] -> generate_c_doc ~outdir:"." ~package codecs
+      | [ _; "dune" ] -> generate_dune_doc ~outdir:"." ~package codecs
+      | _ -> generate_doc ~outdir:"." ~package codecs)

--- a/lib/3d/wire_3d.mli
+++ b/lib/3d/wire_3d.mli
@@ -22,8 +22,12 @@
             (Field.v "Length" uint16be $ fun h -> h.length);
           ]
 
-    let main () = Wire_3d.main ~package:"hdr" [ Everparse.schema codec ]
+    let main () = Wire_3d.main ~mode:`Ffi ~package:"hdr" [ Wire_3d.pack codec ]
     ]}
+
+    [mode] is mandatory: [`Ffi] emits the per-codec FFI artifacts above, [`Doc]
+    a single FFI-free [<Package>.3d] spec and validator for the whole package.
+    The codecs are the same either way.
 
     With a minimal [dune] that includes the generated rules:
     {v
@@ -102,12 +106,43 @@ val run : ?quiet:bool -> outdir:string -> Wire.Everparse.t list -> unit
     invokes EverParse, and produces C validators. The [quiet] flag is passed
     through to EverParse execution. *)
 
-val main : package:string -> Wire.Everparse.t list -> unit
-(** [main ~package schemas] dispatches based on [Sys.argv]:
-    - [3d] runs {!generate_3d}
-    - [c] runs {!generate_c}
+type packed
+(** A codec with its type erased, so codecs of different record types share one
+    list. Build with {!pack}. {!main} and the doc helpers take these rather than
+    already-projected {!Wire.Everparse.t}, so the [doc]-vs-[schema] projection
+    is chosen from the mode, not at the call site. *)
+
+val pack : 'a Wire.Codec.t -> packed
+(** [pack codec] erases [codec]'s type for a {!packed} list. *)
+
+val generate_doc :
+  ?quiet:bool -> outdir:string -> package:string -> packed list -> unit
+(** [generate_doc ?quiet ~outdir ~package codecs] runs the documentation
+    pipeline: project each codec with {!Wire.Everparse.doc}, merge them into one
+    [<Package>.3d], and (when [3d.exe] is available) compile it to a single
+    validator-only [<Package>.c] (no [_Fields] plug, no FFI). The package name
+    becomes the 3D module name, normalised to a CamelCase identifier (["my-pkg"]
+    becomes [MyPkg]). *)
+
+val generate_dune_doc : outdir:string -> package:string -> packed list -> unit
+(** [generate_dune_doc ~outdir ~package codecs] writes a [dune.inc] for the
+    single-file documentation build: rules that emit [<Package>.3d] and compile
+    it to [<Package>.c], a [runtest] rule that compiles the generated validator,
+    and an install stanza for that one spec and parser. *)
+
+val main : mode:[ `Ffi | `Doc ] -> package:string -> packed list -> unit
+(** [main ~mode ~package codecs] dispatches based on [Sys.argv]:
+    - [3d] writes the [.3d] file(s)
+    - [c] produces the C parser(s)
     - [dune] generates [dune.inc] with build rules, test, and install stanzas
-    - otherwise runs {!run}. *)
+    - otherwise runs the full pipeline.
+
+    [mode] is mandatory, so every [gen.ml] states what it emits. With
+    [~mode:`Ffi] it projects each codec with {!Wire.Everparse.schema} and drives
+    the multi-file FFI pipeline, one set per codec. With [~mode:`Doc] it
+    projects with {!Wire.Everparse.doc} and drives the single-file documentation
+    pipeline, one [<Package>.3d] and [<Package>.c] for the whole family. The
+    codecs are the same either way; only the mode changes. *)
 
 val has_3d_exe : unit -> bool
 (** [has_3d_exe ()] returns [true] if [3d.exe] is available in PATH or

--- a/test/3d/test_wire_3d.ml
+++ b/test/3d/test_wire_3d.ml
@@ -80,6 +80,50 @@ let test_generate_c () =
       "ExternalTypedefs.h generated" true (Sys.file_exists ext_path)
   end
 
+let read_file path =
+  let ic = open_in path in
+  let n = in_channel_length ic in
+  let buf = Bytes.create n in
+  really_input ic buf 0 n;
+  close_in ic;
+  Bytes.unsafe_to_string buf
+
+let doc_codec name =
+  Codec.v name (fun v -> v) Codec.[ (Field.v "v" uint8 $ fun v -> v) ]
+
+let test_generate_dune_doc () =
+  (* The doc pipeline emits a single-file [dune.inc]: the package name becomes a
+     CamelCase module name and there is no FFI plug or test harness. *)
+  let tmpdir = Filename.temp_dir "wire_3d_dune_doc" "" in
+  Wire_3d.generate_dune_doc ~outdir:tmpdir ~package:"my-pkg"
+    [ Wire_3d.pack (doc_codec "Pkt") ];
+  let dune_inc = read_file (Filename.concat tmpdir "dune.inc") in
+  ignore (Fmt.kstr Sys.command "rm -rf %s" tmpdir);
+  let has sub = Re.execp (Re.compile (Re.str sub)) dune_inc in
+  Alcotest.(check bool) "single .3d target" true (has "MyPkg.3d");
+  Alcotest.(check bool) "single .c target" true (has "MyPkg.c");
+  Alcotest.(check bool) "wrapper target" true (has "MyPkgWrapper.c");
+  Alcotest.(check bool)
+    "installs under the package" true (has "(package my-pkg)");
+  Alcotest.(check bool) "no FFI plug" false (has "_Fields");
+  Alcotest.(check bool) "no FFI test harness" false (has "test.c")
+
+let test_generate_doc () =
+  (* generate_doc needs 3d.exe; skip when not available. *)
+  if Wire_3d.has_3d_exe () then begin
+    let tmpdir = Filename.temp_dir "wire_3d_gen_doc" "" in
+    Wire_3d.generate_doc ~outdir:tmpdir ~package:"my-pkg"
+      [ Wire_3d.pack (doc_codec "Pkt"); Wire_3d.pack (doc_codec "Pkt2") ];
+    let exists f = Sys.file_exists (Filename.concat tmpdir f) in
+    Alcotest.(check bool) "single merged .3d" true (exists "MyPkg.3d");
+    Alcotest.(check bool) "single validator .c" true (exists "MyPkg.c");
+    let c_src = read_file (Filename.concat tmpdir "MyPkg.c") in
+    Alcotest.(check bool)
+      "validator is FFI-free" false
+      (Re.execp (Re.compile (Re.str "WireSet")) c_src);
+    ignore (Fmt.kstr Sys.command "rm -rf %s" tmpdir)
+  end
+
 (* End-to-end compile+run. Generates C for a schema, invokes the same
    cc command [generate_dune] emits, runs the resulting binary. This is
    the one test that catches every kind of name mismatch between what
@@ -484,7 +528,10 @@ let test_has_3d_exe () =
 let test_main_exists () =
   (* main dispatches on Sys.argv; calling it in tests would exit, so we only
      verify that the value exists and has the right type. *)
-  let _ = (Wire_3d.main : package:string -> Wire.Everparse.t list -> unit) in
+  let _ =
+    (Wire_3d.main
+      : mode:[ `Ffi | `Doc ] -> package:string -> Wire_3d.packed list -> unit)
+  in
   ()
 
 (* Adversarial: [schema.wire_size] must agree with [Codec.wire_size] AND with
@@ -878,6 +925,8 @@ let suite =
       Alcotest.test_case "schema_of_struct" `Quick test_schema_of_struct;
       Alcotest.test_case "ensure_dir" `Quick test_ensure_dir;
       Alcotest.test_case "generate_c (needs 3d.exe)" `Quick test_generate_c;
+      Alcotest.test_case "generate_dune_doc" `Quick test_generate_dune_doc;
+      Alcotest.test_case "generate_doc (needs 3d.exe)" `Quick test_generate_doc;
       Alcotest.test_case "uses_wire_ctx" `Quick test_uses_wire_ctx;
       Alcotest.test_case "has_3d_exe" `Quick test_has_3d_exe;
       Alcotest.test_case "main exists" `Quick test_main_exists;


### PR DESCRIPTION
This PR adds a mandatory `~mode:[`Ffi | `Doc]` to `Wire_3d.main`, plus a codec wrapper `Wire_3d.pack`, so one `gen.ml` emits either the per-codec FFI parsers or a single FFI-free `<Package>.3d` specification and validator for the whole package.

`Wire_3d.main` already drove the multi-file FFI pipeline (one `.3d` and `.c` per codec plus the `_Fields` plug). The doc projection that produces the FFI-free spec landed in #151 (`Wire.Everparse.doc` / `write_doc`), but `Wire_3d` had no path driving it, so each downstream `gen.ml` would have had to hand-roll `write_doc`, the `3d.exe` call, and the `dune.inc` rules. The new `` `Doc `` mode merges the family into one `<Package>.3d` and compiles it to a single validator-only `<Package>.c`, through the new `Wire_3d.generate_doc` and `Wire_3d.generate_dune_doc`; `` `Ffi `` is the existing behaviour.

`main` now takes packed codecs rather than pre-projected schemas, and `mode` is mandatory rather than defaulted, so the mode picks the projection (`doc` vs `schema`) and every `gen.ml` states what it emits instead of relying on a silent default. This is a breaking change: migrate a `gen.ml` by replacing `[schema c; ...]` with `~mode:`Ffi [pack c; ...]`, or `~mode:`Doc` for the single-file output.

Follow-up to #151.