### PR TITLE
lib: make the core library merlint-clean

### DIFF
--- a/lib/bitfield.ml
+++ b/lib/bitfield.ml
@@ -2,14 +2,14 @@
 
 open Types
 
-let byte_size = function BF_U8 -> 1 | BF_U16 _ -> 2 | BF_U32 _ -> 4
-let total_bits = function BF_U8 -> 8 | BF_U16 _ -> 16 | BF_U32 _ -> 32
+let byte_size = function U8 -> 1 | U16 _ -> 2 | U32 _ -> 4
+let total_bits = function U8 -> 8 | U16 _ -> 16 | U32 _ -> 32
 
 let equal a b =
   match (a, b) with
-  | BF_U8, BF_U8 -> true
-  | BF_U16 e1, BF_U16 e2 -> e1 = e2
-  | BF_U32 e1, BF_U32 e2 -> e1 = e2
+  | U8, U8 -> true
+  | U16 e1, U16 e2 -> e1 = e2
+  | U32 e1, U32 e2 -> e1 = e2
   | _ -> false
 
 (* Fast word reads -- avoid Bytes.get_int32_be which goes through Int32
@@ -36,25 +36,25 @@ let[@inline always] u32_be buf off =
 
 let read_word base buf off =
   match base with
-  | BF_U8 -> Bytes.get_uint8 buf off
-  | BF_U16 Little -> u16_le buf off
-  | BF_U16 Big -> u16_be buf off
-  | BF_U32 Little -> u32_le buf off
-  | BF_U32 Big -> u32_be buf off
+  | U8 -> Bytes.get_uint8 buf off
+  | U16 Little -> u16_le buf off
+  | U16 Big -> u16_be buf off
+  | U32 Little -> u32_le buf off
+  | U32 Big -> u32_be buf off
 
 let write_word base buf off v =
   match base with
-  | BF_U8 -> Bytes.set_uint8 buf off v
-  | BF_U16 Little -> Bytes.set_uint16_le buf off v
-  | BF_U16 Big -> Bytes.set_uint16_be buf off v
-  | BF_U32 Little -> UInt32.set_le buf off v
-  | BF_U32 Big -> UInt32.set_be buf off v
+  | U8 -> Bytes.set_uint8 buf off v
+  | U16 Little -> Bytes.set_uint16_le buf off v
+  | U16 Big -> Bytes.set_uint16_be buf off v
+  | U32 Little -> UInt32.set_le buf off v
+  | U32 Big -> UInt32.set_be buf off v
 
 (** EverParse's native bit order for a base: LE bases default to LSB-first (MSVC
     C bit-field packing), BE bases to MSB-first (network byte order). *)
 let native_bit_order = function
-  | BF_U8 | BF_U16 Little | BF_U32 Little -> Lsb_first
-  | BF_U16 Big | BF_U32 Big -> Msb_first
+  | U8 | U16 Little | U32 Little -> Lsb_first
+  | U16 Big | U32 Big -> Msb_first
 
 let[@inline] shift ~bit_order ~total ~bits_used ~width =
   match bit_order with

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -595,7 +595,7 @@ let bytes_leaves ?(sizeof_this : bytes -> int -> int = fun _ _ -> 0)
         | None ->
             Fmt.invalid_arg "Codec: unbound field ref %S in size expression"
               name);
-    param_ref = (fun (Pack_param p) _ _ -> !(p.ph_cell));
+    param_ref = (fun (Pack_param p) _ _ -> !(p.cell));
     sizeof_typ =
       (fun (Pack_typ t) ->
         match field_wire_size t with
@@ -641,11 +641,11 @@ let array_leaves (cc : compile_ctx) : (int array, unit) leaves =
       (fun (Pack_param p) a () ->
         (* The per-codec slot map is filled at seal, after these leaves are
            built, so it must be consulted per call. A param not in this
-           codec's map (e.g. one only reachable via [ph_cell] forwarding from
+           codec's map (e.g. one only reachable via [cell] forwarding from
            an embedding) falls back to the shared cell. *)
-        match Hashtbl.find_opt cc.param_slots p.Types.ph_name with
+        match Hashtbl.find_opt cc.param_slots p.Types.name with
         | Some i -> a.(i)
-        | None -> !(p.ph_cell));
+        | None -> !(p.cell));
     sizeof_typ =
       (fun (Pack_typ t) ->
         let n = field_wire_size t |> Option.value ~default:0 in
@@ -665,9 +665,9 @@ let compile_bool_arr cc e =
   fun arr -> f arr ()
 
 (* Compile action statements to operate on an int array instead of Eval.ctx.
-   Assign writes to ph_cell (mutable param) and updates the array.
+   Assign writes to cell (mutable param) and updates the array.
    Var binds a local by extending the index -- but since we can't grow the
-   array, local vars in actions use ph_cell-style mutation or are inlined.
+   array, local vars in actions use cell-style mutation or are inlined.
 
    Return true short-circuits remaining statements (the action succeeds).
    Return false and Abort raise Parse_error to abort the parse. *)
@@ -682,9 +682,9 @@ let rec compile_stmt (cc : compile_ctx) (s : Types.action_stmt) :
       let fe = compile_int_arr cc e in
       fun arr ->
         let v = fe arr in
-        match Hashtbl.find_opt cc.param_slots p.Types.ph_name with
+        match Hashtbl.find_opt cc.param_slots p.Types.name with
         | Some slot -> arr.(slot) <- v
-        | None -> p.Types.ph_cell := v)
+        | None -> p.Types.cell := v)
   | Field_assign (_, _, _) | Extern_call (_, _) -> fun _ -> ()
   | Return e ->
       let fe = compile_bool_arr cc e in
@@ -726,7 +726,7 @@ let compile_action (cc : compile_ctx) (act : action option) :
     compiled_action option =
   match act with
   | None -> None
-  | Some (On_success stmts | On_act stmts) ->
+  | Some (Success stmts | Act stmts) ->
       let f = compile_stmts cc stmts in
       Some (fun arr -> try f arr with Return_true -> ())
 
@@ -845,17 +845,17 @@ let bf_write_base = Bitfield.write_word
 let build_bf_reader base byte_off shift width =
   let mask = (1 lsl width) - 1 in
   match base with
-  | BF_U8 ->
+  | U8 ->
       fun buf off -> (Bytes.get_uint8 buf (off + byte_off) lsr shift) land mask
-  | BF_U16 Little ->
+  | U16 Little ->
       fun buf off ->
         (Bytes.get_uint16_le buf (off + byte_off) lsr shift) land mask
-  | BF_U16 Big ->
+  | U16 Big ->
       fun buf off ->
         (Bytes.get_uint16_be buf (off + byte_off) lsr shift) land mask
-  | BF_U32 Little ->
+  | U32 Little ->
       fun buf off -> (UInt32.le buf (off + byte_off) lsr shift) land mask
-  | BF_U32 Big ->
+  | U32 Big ->
       fun buf off -> (UInt32.be buf (off + byte_off) lsr shift) land mask
 
 let err_bf_overflow width value =
@@ -868,31 +868,31 @@ let[@inline] check_bf_overflow width value =
 let build_bf_writer base byte_off shift width =
   let mask = (1 lsl width) - 1 in
   match base with
-  | BF_U8 ->
+  | U8 ->
       fun buf off value ->
         check_bf_overflow width value;
         let cur = Bytes.get_uint8 buf (off + byte_off) in
         Bytes.set_uint8 buf (off + byte_off)
           (cur lor ((value land mask) lsl shift))
-  | BF_U16 Little ->
+  | U16 Little ->
       fun buf off value ->
         check_bf_overflow width value;
         let cur = Bytes.get_uint16_le buf (off + byte_off) in
         Bytes.set_uint16_le buf (off + byte_off)
           (cur lor ((value land mask) lsl shift))
-  | BF_U16 Big ->
+  | U16 Big ->
       fun buf off value ->
         check_bf_overflow width value;
         let cur = Bytes.get_uint16_be buf (off + byte_off) in
         Bytes.set_uint16_be buf (off + byte_off)
           (cur lor ((value land mask) lsl shift))
-  | BF_U32 Little ->
+  | U32 Little ->
       fun buf off value ->
         check_bf_overflow width value;
         let cur = UInt32.le buf (off + byte_off) in
         UInt32.set_le buf (off + byte_off)
           (cur lor ((value land mask) lsl shift))
-  | BF_U32 Big ->
+  | U32 Big ->
       fun buf off value ->
         check_bf_overflow width value;
         let cur = UInt32.be buf (off + byte_off) in
@@ -903,27 +903,27 @@ let build_bf_accessor_writer base byte_off shift width =
   let mask = (1 lsl width) - 1 in
   let clear_mask = lnot (mask lsl shift) in
   match base with
-  | BF_U8 ->
+  | U8 ->
       fun buf off value ->
         let cur = Bytes.get_uint8 buf (off + byte_off) in
         Bytes.set_uint8 buf (off + byte_off)
           (cur land clear_mask lor ((value land mask) lsl shift))
-  | BF_U16 Little ->
+  | U16 Little ->
       fun buf off value ->
         let cur = Bytes.get_uint16_le buf (off + byte_off) in
         Bytes.set_uint16_le buf (off + byte_off)
           (cur land clear_mask lor ((value land mask) lsl shift))
-  | BF_U16 Big ->
+  | U16 Big ->
       fun buf off value ->
         let cur = Bytes.get_uint16_be buf (off + byte_off) in
         Bytes.set_uint16_be buf (off + byte_off)
           (cur land clear_mask lor ((value land mask) lsl shift))
-  | BF_U32 Little ->
+  | U32 Little ->
       fun buf off value ->
         let cur = UInt32.le buf (off + byte_off) in
         UInt32.set_le buf (off + byte_off)
           (cur land clear_mask lor ((value land mask) lsl shift))
-  | BF_U32 Big ->
+  | U32 Big ->
       fun buf off value ->
         let cur = UInt32.be buf (off + byte_off) in
         UInt32.set_be buf (off + byte_off)
@@ -1004,7 +1004,7 @@ let rec iter_param_refs_stmt f = function
   | Types.Var (_, e) -> iter_param_refs f e
 
 let iter_param_refs_action f = function
-  | Types.On_success stmts | Types.On_act stmts ->
+  | Types.Success stmts | Types.Act stmts ->
       List.iter (iter_param_refs_stmt f) stmts
 
 let rec iter_param_refs_typ : type a. (Param.packed -> unit) -> a typ -> unit =
@@ -2240,7 +2240,7 @@ let apply_compiled : type a f r.
   let action_vanames =
     match fld.action with
     | None -> []
-    | Some (Types.On_success stmts | Types.On_act stmts) ->
+    | Some (Types.Success stmts | Types.Act stmts) ->
         List.fold_left action_vars [] stmts
   in
   let n_extra_vars = List.length action_vanames in
@@ -2494,8 +2494,8 @@ let collect_param_handles struct_fields where =
   let seen = Hashtbl.create 4 in
   let handles = Stdlib.ref ([] : Param.packed list) in
   let visit (Param.Pack p as packed) =
-    if not (Hashtbl.mem seen p.ph_name) then begin
-      Hashtbl.add seen p.ph_name ();
+    if not (Hashtbl.mem seen p.name) then begin
+      Hashtbl.add seen p.name ();
       handles := packed :: !handles
     end
   in
@@ -2507,8 +2507,7 @@ let collect_param_handles struct_fields where =
 let fill_param_slots tbl param_base handles =
   Hashtbl.reset tbl;
   List.iteri
-    (fun i (Param.Pack p) ->
-      Hashtbl.replace tbl p.Types.ph_name (param_base + i))
+    (fun i (Param.Pack p) -> Hashtbl.replace tbl p.Types.name (param_base + i))
     handles
 
 let build_checked_decode raw_decode wire_size_info min_size =
@@ -2704,7 +2703,7 @@ let build_field_checks acc ~populate ~validator_off ~name ~action ~constraint_ =
   let action_vanames =
     match action with
     | None -> []
-    | Some (Types.On_success stmts | Types.On_act stmts) ->
+    | Some (Types.Success stmts | Types.Act stmts) ->
         List.fold_left action_vars [] stmts
   in
   let dummy_reader _buf _base = 0 in
@@ -2889,28 +2888,25 @@ let is_fixed (t : _ t) =
 
 let raw_decode (t : _ t) buf off = t.decode buf off
 
-(* Copy each input param's env value into its [ph_cell]. The encode
-   closures read [Param_ref p] via [!(p.ph_cell)] (see [bytes_leaves]
+(* Copy each input param's env value into its [cell]. The encode
+   closures read [Param_ref p] via [!(p.cell)] (see [bytes_leaves]
    in [compile_expr]), so the cells are the runtime backing for
    parametric field sizes. Mirror of the env -> array blit in
    [decode_exn]. *)
 let load_env_into_cells (t : 'r t) (env : Param.env) =
   (* The env slot of [param_handles.(i)] is [i] (the env is built in the same
      order, see [env] below). *)
-  List.iteri
-    (fun i (Param.Pack p) -> p.ph_cell := env.slots.(i))
-    t.param_handles
+  List.iteri (fun i (Param.Pack p) -> p.cell := env.slots.(i)) t.param_handles
 
 (* Reject [encode] on a parametric codec without an env, and reject envs
    that left an input param unbound. Either case would silently resolve
-   parametric sizes to 0 (the ph_cell init value), producing zero-byte
+   parametric sizes to 0 (the cell init value), producing zero-byte
    regions for byte_array / byte_slice / uint_var fields and writing the
    rest of the record at the wrong offsets. *)
 let unbound_params (t : 'r t) (env : Param.env) : string list =
   List.mapi
     (fun i (Param.Pack p) ->
-      if (not p.Types.ph_mutable) && not env.bound.(i) then Some p.ph_name
-      else None)
+      if (not p.Types.mutable_) && not env.bound.(i) then Some p.name else None)
     t.param_handles
   |> List.filter_map Fun.id
 
@@ -2919,7 +2915,7 @@ let unbound_params (t : 'r t) (env : Param.env) : string list =
    by decode-side actions and never consulted on encode, so a codec whose only
    params are outputs needs no env. *)
 let has_input_params (t : 'r t) =
-  List.exists (fun (Param.Pack p) -> not p.Types.ph_mutable) t.param_handles
+  List.exists (fun (Param.Pack p) -> not p.Types.mutable_) t.param_handles
 
 let require_env t = function
   | None when not (has_input_params t) -> ()
@@ -2944,20 +2940,20 @@ let raw_encode ?env:e t v buf off =
   t.encode v buf off
 
 (* Encode a sub-codec embedded as a field/element. The enclosing codec has
-   already seeded every input param's [ph_cell] from its own env (its
+   already seeded every input param's [cell] from its own env (its
    [param_handles] include the sub's, see [iter_param_refs_typ]), so the sub
    must not re-run [require_env] (it has no env of its own here). *)
 let embed_encode (t : 'r t) v buf off = t.encode v buf off
 
 (* Decode a sub-codec embedded as a field/element, enforcing its [where] and
    field constraints (the plain field-reader decode skips them). Param values
-   come from the [ph_cell]s the enclosing codec seeded; copy them into the
+   come from the [cell]s the enclosing codec seeded; copy them into the
    sub's per-decode slots so its constraints resolve correctly. *)
 let embed_decode (t : 'r t) buf off =
   let v = t.decode buf off in
   let env_slots =
     Array.of_list
-      (List.map (fun (Param.Pack p) -> !(p.Types.ph_cell)) t.param_handles)
+      (List.map (fun (Param.Pack p) -> !(p.Types.cell)) t.param_handles)
   in
   t.validate ~env_slots buf off;
   v
@@ -2972,7 +2968,7 @@ let env (t : _ t) : Param.env =
     Types.codec_id = t.id;
     names =
       Array.of_list
-        (List.map (fun (Param.Pack p) -> p.Types.ph_name) t.param_handles);
+        (List.map (fun (Param.Pack p) -> p.Types.name) t.param_handles);
     slots = Array.make t.n_params 0;
     bound = Array.make t.n_params false;
   }
@@ -2994,7 +2990,7 @@ let decode_exn ?env:e t buf off =
         (fun i (Param.Pack p) ->
           let v = arr.(t.param_base + i) in
           e.slots.(i) <- v;
-          p.ph_cell := v)
+          p.cell := v)
         t.param_handles
   | None -> ());
   v
@@ -3019,11 +3015,7 @@ let encode ?env:e t v buf off =
 let collect_params (fields : Types.field list) where =
   collect_param_handles fields where
   |> List.map (fun (Param.Pack p) ->
-      {
-        param_name = p.ph_name;
-        param_typ = p.ph_packed_typ;
-        mutable_ = p.ph_mutable;
-      })
+      { param_name = p.name; param_typ = p.packed_typ; mutable_ = p.mutable_ })
 
 let to_struct t =
   let formals = collect_params t.struct_fields t.where in
@@ -3179,7 +3171,7 @@ let[@inline] get (type a r) ?env (codec : r t) (f : (a, r) field) :
                   (fun i (Param.Pack p) ->
                     let v = arr.(param_base + i) in
                     e.slots.(i) <- v;
-                    p.ph_cell := v)
+                    p.cell := v)
                   param_handles),
               fun arr ->
                 if n_params > 0 then
@@ -3264,11 +3256,11 @@ let bitfield (type r) (codec : r t) (f : (int, r) field) : bitfield =
          [Bitfield.read_word base] would create. *)
       let word_reader =
         match base with
-        | BF_U8 -> fun buf off -> Bytes.get_uint8 buf (off + byte_off)
-        | BF_U16 Little -> fun buf off -> Bitfield.u16_le buf (off + byte_off)
-        | BF_U16 Big -> fun buf off -> Bitfield.u16_be buf (off + byte_off)
-        | BF_U32 Little -> fun buf off -> Bitfield.u32_le buf (off + byte_off)
-        | BF_U32 Big -> fun buf off -> Bitfield.u32_be buf (off + byte_off)
+        | U8 -> fun buf off -> Bytes.get_uint8 buf (off + byte_off)
+        | U16 Little -> fun buf off -> Bitfield.u16_le buf (off + byte_off)
+        | U16 Big -> fun buf off -> Bitfield.u16_be buf (off + byte_off)
+        | U32 Little -> fun buf off -> Bitfield.u32_le buf (off + byte_off)
+        | U32 Big -> fun buf off -> Bitfield.u32_be buf (off + byte_off)
       in
       let mask = (1 lsl width) - 1 in
       { word_reader; packed = shift lor (mask lsl 8) }

--- a/lib/eval.ml
+++ b/lib/eval.ml
@@ -102,7 +102,7 @@ let rec expr : type a. ctx -> a expr -> a =
           failwith
             ("Eval.expr: unbound field " ^ name
            ^ " (cross-field references are only valid inside a struct)"))
-  | Param_ref p -> !(p.ph_cell)
+  | Param_ref p -> !(p.cell)
   | Sizeof t -> field_wire_size t |> Option.value ~default:0
   | Sizeof_this -> 0
   | Field_pos -> 0

--- a/lib/everparse.ml
+++ b/lib/everparse.ml
@@ -88,11 +88,11 @@ let rec type_suffix : type a. a Types.typ -> string = function
   | Types.Float32 Types.Big -> "U32BE"
   | Types.Float64 Types.Little -> "U64"
   | Types.Float64 Types.Big -> "U64BE"
-  | Types.Bits { base = Types.BF_U8; _ } -> "U8"
-  | Types.Bits { base = Types.BF_U16 Types.Little; _ } -> "U16"
-  | Types.Bits { base = Types.BF_U16 Types.Big; _ } -> "U16BE"
-  | Types.Bits { base = Types.BF_U32 Types.Little; _ } -> "U32"
-  | Types.Bits { base = Types.BF_U32 Types.Big; _ } -> "U32BE"
+  | Types.Bits { base = Types.U8; _ } -> "U8"
+  | Types.Bits { base = Types.U16 Types.Little; _ } -> "U16"
+  | Types.Bits { base = Types.U16 Types.Big; _ } -> "U16BE"
+  | Types.Bits { base = Types.U32 Types.Little; _ } -> "U32"
+  | Types.Bits { base = Types.U32 Types.Big; _ } -> "U32BE"
   | Types.Map { inner; _ } -> type_suffix inner
   | Types.Enum { base; _ } -> type_suffix base
   | Types.Where { inner; _ } -> type_suffix inner
@@ -190,19 +190,17 @@ let map_field_action schema_name idx byte_off (Types.Field f) =
           if is_bitfield f.field_typ then
             (* Bitfields: :act fires per sub-field during coalesced parsing *)
             match f.action with
-            | None -> Some (Types.On_act [ call ])
-            | Some (Types.On_act stmts) ->
-                Some (Types.On_act (act_stmts stmts call))
-            | Some (Types.On_success stmts) ->
-                Some (Types.On_act (act_stmts stmts call))
+            | None -> Some (Types.Act [ call ])
+            | Some (Types.Act stmts) -> Some (Types.Act (act_stmts stmts call))
+            | Some (Types.Success stmts) ->
+                Some (Types.Act (act_stmts stmts call))
           else
             (* Scalars and byte-size fields: :on-success *)
             match f.action with
-            | None -> Some (Types.On_success [ call; Types.Return Types.true_ ])
-            | Some (Types.On_success stmts) ->
-                Some (Types.On_success (on_success_stmts stmts call))
-            | Some (Types.On_act stmts) ->
-                Some (Types.On_act (act_stmts stmts call))
+            | None -> Some (Types.Success [ call; Types.Return Types.true_ ])
+            | Some (Types.Success stmts) ->
+                Some (Types.Success (on_success_stmts stmts call))
+            | Some (Types.Act stmts) -> Some (Types.Act (act_stmts stmts call))
         in
         Types.Field
           {
@@ -598,8 +596,8 @@ let field_action_forms (st : Types.struct_) =
       let form =
         match f.action with
         | None -> No_action
-        | Some (Types.On_act _) -> On_act
-        | Some (Types.On_success _) -> On_success
+        | Some (Types.Act _) -> On_act
+        | Some (Types.Success _) -> On_success
       in
       (f.field_name, is_bitfield f.field_typ, form))
     st.fields

--- a/lib/param.ml
+++ b/lib/param.ml
@@ -2,7 +2,7 @@ type input = Types.param_input
 type output = Types.param_output
 type ('a, 'k) t = ('a, 'k) Types.param_handle
 
-let pp ppf p = Fmt.string ppf p.Types.ph_name
+let pp ppf (p : (_, _) t) = Fmt.string ppf p.Types.name
 
 (* Per-typ converter from the OCaml representation to [int] and back. One
    match dispatches both directions; [to_int] and [of_int] just project
@@ -65,31 +65,27 @@ let check_typ name typ =
 let input name typ =
   check_typ "input" typ;
   {
-    Types.ph_name = name;
-    ph_typ = typ;
-    ph_packed_typ = Types.Pack_typ typ;
-    ph_mutable = false;
-    ph_cell = ref 0;
+    Types.name;
+    typ;
+    packed_typ = Types.Pack_typ typ;
+    mutable_ = false;
+    cell = ref 0;
   }
 
 let output name typ =
   check_typ "output" typ;
   {
-    Types.ph_name = name;
-    ph_typ = typ;
-    ph_packed_typ = Types.Pack_typ typ;
-    ph_mutable = true;
-    ph_cell = ref 0;
+    Types.name;
+    typ;
+    packed_typ = Types.Pack_typ typ;
+    mutable_ = true;
+    cell = ref 0;
   }
 
 let decl (t : ('a, 'k) t) : Types.param =
-  {
-    param_name = t.ph_name;
-    param_typ = t.ph_packed_typ;
-    mutable_ = t.ph_mutable;
-  }
+  { param_name = t.name; param_typ = t.packed_typ; mutable_ = t.mutable_ }
 
-let name t = t.Types.ph_name
+let name (t : (_, _) t) = t.Types.name
 let expr t : int Types.expr = Types.Param_ref t
 
 (* -- Param.env -- *)
@@ -107,19 +103,19 @@ let env_idx (env : env) name =
   find 0
 
 let bind (p : ('a, input) t) (v : 'a) (env : env) : env =
-  let iv = to_int p.Types.ph_typ v in
+  let iv = to_int p.Types.typ v in
   let slots = Array.copy env.slots in
   let bound = Array.copy env.bound in
-  let i = env_idx env p.Types.ph_name in
+  let i = env_idx env p.Types.name in
   if i >= 0 then begin
     slots.(i) <- iv;
     bound.(i) <- true
   end;
-  p.ph_cell := iv;
+  p.cell := iv;
   { env with Types.slots; bound }
 
 let get (env : env) (p : ('a, 'k) t) : 'a =
-  let i = env_idx env p.Types.ph_name in
-  if i < 0 then of_int p.ph_typ !(p.ph_cell) else of_int p.ph_typ env.slots.(i)
+  let i = env_idx env p.Types.name in
+  if i < 0 then of_int p.typ !(p.cell) else of_int p.typ env.slots.(i)
 
 type packed = Pack : ('a, 'k) t -> packed

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -17,12 +17,12 @@ type param_input
 type param_output
 
 type ('a, 'k) param_handle = {
-  ph_name : string;
-  ph_typ : 'a typ;
-  ph_packed_typ : packed_typ;
-  ph_mutable : bool;
-  ph_cell : int ref;
-      (* [ph_cell] is the per-handle backing read by encode/size expressions and
+  name : string;
+  typ : 'a typ;
+  packed_typ : packed_typ;
+  mutable_ : bool;
+  cell : int ref;
+      (* [cell] is the per-handle backing read by encode/size expressions and
          the value-forwarding vehicle for embedded sub-codecs. Slot resolution
          (decode array index, env index) is NOT stored here: it is per-codec,
          since one handle may be referenced both standalone and from an
@@ -65,7 +65,7 @@ and _ expr =
   | If_then_else : bool expr * int expr * int expr -> int expr
 
 (* Bitfield base types - standalone, not mutually recursive *)
-and bitfield_base = BF_U8 | BF_U16 of endian | BF_U32 of endian
+and bitfield_base = U8 | U16 of endian | U32 of endian
 
 (* Types *)
 and _ typ =
@@ -208,7 +208,7 @@ and field =
 and param = { param_name : string; param_typ : packed_typ; mutable_ : bool }
 
 (* Actions *)
-and action = On_success of action_stmt list | On_act of action_stmt list
+and action = Success of action_stmt list | Act of action_stmt list
 
 and action_stmt =
   | Assign : ('a, param_output) param_handle * int expr -> action_stmt
@@ -300,11 +300,11 @@ let uint ?(endian = Big) size =
   Uint_var { size; endian }
 
 (* Bitfield bases *)
-let bf_uint8 = BF_U8
-let bf_uint16 = BF_U16 Little
-let bf_uint16be = BF_U16 Big
-let bf_uint32 = BF_U32 Little
-let bf_uint32be = BF_U32 Big
+let bf_uint8 = U8
+let bf_uint16 = U16 Little
+let bf_uint16be = U16 Big
+let bf_uint32 = U32 Little
+let bf_uint32be = U32 Big
 let bits ?(bit_order = Msb_first) ~width base = Bits { width; base; bit_order }
 let bit b = Bool.to_int b
 let is_set n = n <> 0
@@ -705,7 +705,7 @@ let anon_field typ =
 
 (* Struct constructors *)
 let struct_ name fields = { name; params = []; where = None; fields }
-let struct_name s = s.name
+let struct_name (s : struct_) = s.name
 let struct_typ s = Struct s
 let field_names s = List.filter_map (fun (Field f) -> f.field_name) s.fields
 
@@ -777,8 +777,8 @@ let type_ref name = Type_ref name
 let qualified_ref module_ name = Qualified_ref { module_; name }
 
 (* Actions *)
-let on_success stmts = On_success stmts
-let on_act stmts = On_act stmts
+let on_success stmts = Success stmts
+let on_act stmts = Act stmts
 let assign (p : ('a, param_output) param_handle) e = Assign (p, e)
 let return_bool e = Return e
 let abort = Abort
@@ -1238,9 +1238,9 @@ let escape_3d name =
 let pp_endian ppf = function Little -> () | Big -> Fmt.string ppf "BE"
 
 let pp_bitfield_base ppf = function
-  | BF_U8 -> Fmt.string ppf "UINT8"
-  | BF_U16 e -> Fmt.pf ppf "UINT16%a" pp_endian e
-  | BF_U32 e -> Fmt.pf ppf "UINT32%a" pp_endian e
+  | U8 -> Fmt.string ppf "UINT8"
+  | U16 e -> Fmt.pf ppf "UINT16%a" pp_endian e
+  | U32 e -> Fmt.pf ppf "UINT32%a" pp_endian e
 
 let pp_cast_type ppf = function
   | `U8 -> Fmt.string ppf "UINT8"
@@ -1264,7 +1264,7 @@ let rec pp_expr : type a. a expr Fmt.t =
   | Bool true -> Fmt.string ppf "true"
   | Bool false -> Fmt.string ppf "false"
   | Ref name -> Fmt.string ppf (escape_3d name)
-  | Param_ref p -> Fmt.string ppf (escape_3d p.ph_name)
+  | Param_ref p -> Fmt.string ppf (escape_3d p.name)
   | Sizeof t -> Fmt.pf ppf "sizeof (%a)" pp_typ t
   | Sizeof_this -> Fmt.string ppf "sizeof (this)"
   | Field_pos ->
@@ -1410,7 +1410,7 @@ let rec subst_expr : type a. (string * int expr) list -> a expr -> a expr =
 let pp_stmt env ppf stmt =
   let e a = subst_expr env a in
   match stmt with
-  | Assign (p, x) -> Fmt.pf ppf "*%s = %a;" (escape_3d p.ph_name) pp_expr (e x)
+  | Assign (p, x) -> Fmt.pf ppf "*%s = %a;" (escape_3d p.name) pp_expr (e x)
   | Field_assign (ptr, field_name, x) ->
       Fmt.pf ppf "%s->%s = %a;" ptr field_name pp_expr (e x)
   | Extern_call (fn, args) -> Fmt.pf ppf "%s(%s);" fn (String.concat ", " args)
@@ -1438,9 +1438,8 @@ let rec pp_stmts env ppf = function
       pp_stmts env ppf rest
 
 let pp_action ppf = function
-  | On_success stmts ->
-      Fmt.pf ppf "@[<h>{:on-success %a }@]" (pp_stmts []) stmts
-  | On_act stmts -> Fmt.pf ppf "@[<h>{:act %a }@]" (pp_stmts []) stmts
+  | Success stmts -> Fmt.pf ppf "@[<h>{:on-success %a }@]" (pp_stmts []) stmts
+  | Act stmts -> Fmt.pf ppf "@[<h>{:act %a }@]" (pp_stmts []) stmts
 
 (* Extract field suffix for arrays - the modifier goes after the field name *)
 type field_suffix =
@@ -1457,9 +1456,9 @@ let rec inner_wire_size : type a. a typ -> int option = function
   | Uint16 _ | Int16 _ -> Some 2
   | Uint32 _ | Int32 _ | Float32 _ -> Some 4
   | Uint63 _ | Uint64 _ | Int64 _ | Float64 _ -> Some 8
-  | Bits { base = BF_U8; _ } -> Some 1
-  | Bits { base = BF_U16 _; _ } -> Some 2
-  | Bits { base = BF_U32 _; _ } -> Some 4
+  | Bits { base = U8; _ } -> Some 1
+  | Bits { base = U16 _; _ } -> Some 2
+  | Bits { base = U32 _; _ } -> Some 4
   | Unit -> Some 0
   | Map { inner; _ } -> inner_wire_size inner
   | Enum { base; _ } -> inner_wire_size base
@@ -1506,7 +1505,7 @@ let rec renders_as_named_composite : type a. a typ -> bool = function
 
 (* 3d-model boundary for a byte-budget list ([T_nlist]) element's base type
    printer. [Nlist_elem.t] is abstract, so the only way to obtain one is
-   [Nlist_elem.make], which refuses a named-composite element that is not [nz] --
+   [Nlist_elem.v], which refuses a named-composite element that is not [nz] --
    EverParse rejects a list whose element parser may consume zero bytes. Routing
    both list emit sites ([array] / [repeat]) through here means the projection
    cannot hand {!pp_field} a base for an ill-kinded list. [is_array_element] /
@@ -1515,12 +1514,12 @@ let rec renders_as_named_composite : type a. a typ -> bool = function
 module Nlist_elem : sig
   type t
 
-  val make : 'a typ -> (Format.formatter -> unit) -> t
+  val v : 'a typ -> (Format.formatter -> unit) -> t
   val pp : t -> Format.formatter -> unit
 end = struct
   type t = Format.formatter -> unit
 
-  let make : type a. a typ -> (Format.formatter -> unit) -> t =
+  let v : type a. a typ -> (Format.formatter -> unit) -> t =
    fun elem pp ->
     if (not (renders_as_named_composite elem)) || nz elem then pp
     else
@@ -1633,7 +1632,7 @@ and field_suffix : type a. a typ -> field_suffix * (Format.formatter -> unit) =
              chunk) is dropped so it is not duplicated. A named-composite base
              must be [nz] (see {!nlist_base}). *)
           ( Byte_array (Mul (len, s)),
-            Nlist_elem.pp (Nlist_elem.make elem (snd (field_suffix elem))) )
+            Nlist_elem.pp (Nlist_elem.v elem (snd (field_suffix elem))) )
       | _ ->
           (* Unreachable: [array] rejects variable-size elem at construction. *)
           assert false)
@@ -1665,9 +1664,7 @@ and field_suffix : type a. a typ -> field_suffix * (Format.formatter -> unit) =
             match repeat_elem_struct elem with
             | Some name -> Fmt.string ppf name
             | None ->
-                Nlist_elem.pp
-                  (Nlist_elem.make elem (snd (field_suffix elem)))
-                  ppf)
+                Nlist_elem.pp (Nlist_elem.v elem (snd (field_suffix elem))) ppf)
       in
       (Byte_array size, pp_elem)
   | Zeroterm -> (Zeroterm, fun ppf -> Fmt.string ppf "UINT8")
@@ -2028,9 +2025,9 @@ let rec size_of_typ_value : type a. a typ -> a -> int =
   | Int64 _ -> 8
   | Float32 _ -> 4
   | Float64 _ -> 8
-  | Bits { base = BF_U8; _ } -> 1
-  | Bits { base = BF_U16 _; _ } -> 2
-  | Bits { base = BF_U32 _; _ } -> 4
+  | Bits { base = U8; _ } -> 1
+  | Bits { base = U16 _; _ } -> 2
+  | Bits { base = U32 _; _ } -> 4
   | Unit -> 0
   | All_bytes -> String.length v
   | All_zeros -> String.length v
@@ -2111,10 +2108,7 @@ let rec field_wire_size : type a. a typ -> int option = function
   | Uint_var { size = Int n; _ } -> Some n
   | Uint_var _ -> None
   | Bits { base; _ } -> (
-      match base with
-      | BF_U8 -> Some 1
-      | BF_U16 _ -> Some 2
-      | BF_U32 _ -> Some 4)
+      match base with U8 -> Some 1 | U16 _ -> Some 2 | U32 _ -> Some 4)
   | Unit -> Some 0
   | Byte_array { size = Int n }
   | Byte_array_where { size = Int n; _ }
@@ -2136,9 +2130,9 @@ let rec field_wire_size : type a. a typ -> int option = function
   | _ -> None
 
 let c_type_of : type a. a typ -> string = function
-  | Uint8 | Bits { base = BF_U8; _ } -> "uint8_t"
-  | Uint16 _ | Bits { base = BF_U16 _; _ } -> "uint16_t"
-  | Uint32 _ | Uint63 _ | Bits { base = BF_U32 _; _ } -> "uint32_t"
+  | Uint8 | Bits { base = U8; _ } -> "uint8_t"
+  | Uint16 _ | Bits { base = U16 _; _ } -> "uint16_t"
+  | Uint32 _ | Uint63 _ | Bits { base = U32 _; _ } -> "uint32_t"
   | Uint64 _ -> "uint64_t"
   (* Signed types project to UINT* in 3D so EverParse only sees unsigned
      widths; the same width drives the C field type. *)

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -40,11 +40,11 @@ type param_input
 type param_output
 
 type ('a, 'k) param_handle = {
-  ph_name : string;
-  ph_typ : 'a typ;
-  ph_packed_typ : packed_typ;
-  ph_mutable : bool;
-  ph_cell : int ref;
+  name : string;
+  typ : 'a typ;
+  packed_typ : packed_typ;
+  mutable_ : bool;
+  cell : int ref;
 }
 
 and packed_typ = Pack_typ : 'a typ -> packed_typ
@@ -90,9 +90,9 @@ and _ expr =
 (** {1 Types} *)
 
 and bitfield_base =
-  | BF_U8
-  | BF_U16 of endian
-  | BF_U32 of endian  (** Base storage for bitfield extractions. *)
+  | U8
+  | U16 of endian
+  | U32 of endian  (** Base storage for bitfield extractions. *)
 
 and _ typ =
   | Uint8 : int typ  (** 8-bit unsigned. *)
@@ -232,8 +232,8 @@ and param = { param_name : string; param_typ : packed_typ; mutable_ : bool }
 (** Formal parameter. *)
 
 and action =
-  | On_success of action_stmt list
-  | On_act of action_stmt list  (** Action attached to a field. *)
+  | Success of action_stmt list
+  | Act of action_stmt list  (** Action attached to a field. *)
 
 and action_stmt =
   | Assign : ('a, param_output) param_handle * int expr -> action_stmt

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -413,10 +413,10 @@ let rec typ_consumes_rest : type a. a typ -> bool = function
 and struct_consumes_rest (s : struct_) =
   List.exists (fun (Field f) -> typ_consumes_rest f.field_typ) s.fields
 
-let push_back_bytes reader bytes first length =
+let push_back_bytes reader bytes first (length : int) =
   if length > 0 then Reader.push_back reader (Slice.make bytes ~first ~length)
 
-let read_exact reader n =
+let read_exact reader (n : int) =
   let buf = Bytes.create n in
   let rec loop off =
     if off >= n then buf
@@ -658,11 +658,11 @@ let rec encode_into : type a. a typ -> a -> encoder -> unit =
       let shift = Bitfield.shift ~bit_order ~total ~bits_used:0 ~width in
       let masked = (v land mask) lsl shift in
       match base with
-      | BF_U8 -> write_byte enc masked
-      | BF_U16 Little -> write_uint16_le enc masked
-      | BF_U16 Big -> write_uint16_be enc masked
-      | BF_U32 Little -> write_int32_le enc (Int32.of_int masked)
-      | BF_U32 Big -> write_int32_be enc (Int32.of_int masked))
+      | U8 -> write_byte enc masked
+      | U16 Little -> write_uint16_le enc masked
+      | U16 Big -> write_uint16_be enc masked
+      | U32 Little -> write_int32_le enc (Int32.of_int masked)
+      | U32 Big -> write_int32_be enc (Int32.of_int masked))
   | Unit -> ()
   | All_bytes -> write_string enc v
   | All_zeros -> write_string enc v
@@ -756,19 +756,19 @@ let encode_bits buf off v width base bit_order =
   let shift = Bitfield.shift ~bit_order ~total ~bits_used:0 ~width in
   let masked = (v land mask) lsl shift in
   match base with
-  | BF_U8 ->
+  | U8 ->
       Bytes.set_uint8 buf off masked;
       off + 1
-  | BF_U16 Little ->
+  | U16 Little ->
       Bytes.set_uint16_le buf off masked;
       off + 2
-  | BF_U16 Big ->
+  | U16 Big ->
       Bytes.set_uint16_be buf off masked;
       off + 2
-  | BF_U32 Little ->
+  | U32 Little ->
       Bytes.set_int32_le buf off (Int32.of_int masked);
       off + 4
-  | BF_U32 Big ->
+  | U32 Big ->
       Bytes.set_int32_be buf off (Int32.of_int masked);
       off + 4
 

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -1106,8 +1106,8 @@ module Everparse : sig
   val doc : 'r Codec.t -> t
   (** [doc codec] projects [codec] to a clean schema for documentation and
       pure-C parser generation: the same structural 3D as {!schema} (struct,
-      bitfields, [where] clause, enums, casetypes, refined-byte typedefs) but
-      without the FFI scaffolding (no [WireCtx] extern, no [WireSet*]
+      bitfields, {!val-where} clause, enums, casetypes, refined-byte typedefs)
+      but without the FFI scaffolding (no [WireCtx] extern, no [WireSet*]
       callbacks). It reads as a protocol specification, and 3d.exe compiles it
       to a validator-only C parser with no FFI. *)
 

--- a/test/test_bitfield.ml
+++ b/test/test_bitfield.ml
@@ -1,11 +1,11 @@
 module Bitfield = Wire.Private.Bitfield
 module Types = Wire.Private.Types
 
-let bf_u8 = Types.BF_U8
-let bf_u16_le = Types.BF_U16 Little
-let bf_u16_be = Types.BF_U16 Big
-let bf_u32_le = Types.BF_U32 Little
-let bf_u32_be = Types.BF_U32 Big
+let bf_u8 = Types.U8
+let bf_u16_le = Types.U16 Little
+let bf_u16_be = Types.U16 Big
+let bf_u32_le = Types.U32 Little
+let bf_u32_be = Types.U32 Big
 
 let test_byte_size () =
   Alcotest.(check int) "BF_U8" 1 (Bitfield.byte_size bf_u8);

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -1456,7 +1456,7 @@ let test_action_unfired_by_validate () =
   (* validate does NOT fire actions *)
   Alcotest.(check int)
     "action not fired by validate" 0
-    !(action_out2.Wire.Private.Types.ph_cell)
+    !(action_out2.Wire.Private.Types.cell)
 
 let test_get_noaction_zero_overhead () =
   (* get on a field without an action should not allocate.


### PR DESCRIPTION
This PR makes the core `wire` library pass merlint with no findings.

merlint flags the library under several rules: redundant variant and field prefixes (E334) on `param_handle` (`ph_*`), `bitfield_base` (`BF_*`), and `action` (`On_*`); two comparisons it cannot prove scalar (E106); `Nlist_elem.make` that should be `v` (E332); and a bare `[where]` odoc reference (E420). Clearing them lets a later PR touch these files without bypassing the pre-commit hook, which was the reason #151 needed `--no-verify`.

Those prefixes turn out to be partly load-bearing: dropping `ph_name`/`ph_typ` collides with `struct_.name` and `param.mutable_`, so the handful of sites where inference becomes ambiguous carry an explicit type annotation rather than a warning suppression. The renames are semantics-preserving and the full suite is unchanged; the two test files only update their references to the renamed `Wire.Private.Types` constructors.

Scope is the shipped library only. The test and example fixtures carry the bulk of the repo's E334 debt (~270 issues) and are left for a separate cleanup.