### PR TITLE
3d: let the doc file base differ from the opam package

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ### Added
 
+- `Wire_3d`'s documentation helpers (`generate_doc`, `generate_dune_doc`, and
+  `main ~mode:`Doc`) take an optional `?name` that sets the generated
+  `<Name>.3d` / `<Name>.c` file base independently of the opam `~package`, so a
+  package like `ocaml-tcp` can emit a `Tcp.3d` spec while still installing under
+  its own name (#154, @samoht)
 - `Wire.Everparse.doc` and `Wire.Everparse.write_doc` project a codec, or a
   whole family of codecs, to a clean `.3d` with no FFI scaffolding: enums
   render as named 3D enum types, types shared across codecs are emitted once,

--- a/lib/3d/wire_3d.ml
+++ b/lib/3d/wire_3d.ml
@@ -621,25 +621,32 @@ let doc_module_name package =
   |> List.map String.capitalize_ascii
   |> String.concat ""
 
-let generate_3d_doc ~outdir ~package codecs =
+(* The 3D module / file base for the doc pipeline: [?name] when given, else the
+   opam [~package]. Lets the emitted [<Base>.3d] / [.c] be named independently of
+   the install package (whose name [~package] keeps for the install stanza). *)
+let doc_base ?name ~package () =
+  doc_module_name (match name with Some n -> n | None -> package)
+
+let generate_3d_doc ?name ~outdir ~package codecs =
   ensure_dir outdir;
-  write_doc ~outdir ~name:(doc_module_name package)
+  write_doc ~outdir
+    ~name:(doc_base ?name ~package ())
     (List.map (fun (Pack c) -> doc c) codecs)
 
-let generate_c_doc ?(quiet = true) ~outdir ~package _codecs =
+let generate_c_doc ?(quiet = true) ?name ~outdir ~package _codecs =
   ensure_dir outdir;
   if has_3d_exe () then
-    run_everparse_files ~quiet ~outdir [ doc_module_name package ^ ".3d" ]
+    run_everparse_files ~quiet ~outdir [ doc_base ?name ~package () ^ ".3d" ]
   else
     failwith
       "3d.exe not found in PATH. Install EverParse to regenerate C files."
 
-let generate_doc ?(quiet = true) ~outdir ~package codecs =
-  generate_3d_doc ~outdir ~package codecs;
-  generate_c_doc ~quiet ~outdir ~package codecs
+let generate_doc ?(quiet = true) ?name ~outdir ~package codecs =
+  generate_3d_doc ?name ~outdir ~package codecs;
+  generate_c_doc ~quiet ?name ~outdir ~package codecs
 
-let generate_dune_doc ~outdir ~package _codecs =
-  let base = doc_module_name package in
+let generate_dune_doc ?name ~outdir ~package _codecs =
+  let base = doc_base ?name ~package () in
   let three_d = base ^ ".3d" in
   let c_files =
     [ base ^ ".c"; base ^ ".h"; base ^ "Wrapper.c"; base ^ "Wrapper.h" ]
@@ -685,7 +692,7 @@ let generate_dune_doc ~outdir ~package _codecs =
   Format.pp_print_flush ppf ();
   close_out oc
 
-let main ~mode ~package codecs =
+let main ?name ~mode ~package codecs =
   let argv = Array.to_list Sys.argv in
   match mode with
   | `Ffi -> (
@@ -697,7 +704,7 @@ let main ~mode ~package codecs =
       | _ -> run ~outdir:"." schemas)
   | `Doc -> (
       match argv with
-      | [ _; "3d" ] -> generate_3d_doc ~outdir:"." ~package codecs
-      | [ _; "c" ] -> generate_c_doc ~outdir:"." ~package codecs
-      | [ _; "dune" ] -> generate_dune_doc ~outdir:"." ~package codecs
-      | _ -> generate_doc ~outdir:"." ~package codecs)
+      | [ _; "3d" ] -> generate_3d_doc ?name ~outdir:"." ~package codecs
+      | [ _; "c" ] -> generate_c_doc ?name ~outdir:"." ~package codecs
+      | [ _; "dune" ] -> generate_dune_doc ?name ~outdir:"." ~package codecs
+      | _ -> generate_doc ?name ~outdir:"." ~package codecs)

--- a/lib/3d/wire_3d.mli
+++ b/lib/3d/wire_3d.mli
@@ -116,22 +116,30 @@ val pack : 'a Wire.Codec.t -> packed
 (** [pack codec] erases [codec]'s type for a {!packed} list. *)
 
 val generate_doc :
-  ?quiet:bool -> outdir:string -> package:string -> packed list -> unit
-(** [generate_doc ?quiet ~outdir ~package codecs] runs the documentation
+  ?quiet:bool ->
+  ?name:string ->
+  outdir:string ->
+  package:string ->
+  packed list ->
+  unit
+(** [generate_doc ?quiet ?name ~outdir ~package codecs] runs the documentation
     pipeline: project each codec with {!Wire.Everparse.doc}, merge them into one
-    [<Package>.3d], and (when [3d.exe] is available) compile it to a single
-    validator-only [<Package>.c] (no [_Fields] plug, no FFI). The package name
-    becomes the 3D module name, normalised to a CamelCase identifier (["my-pkg"]
-    becomes [MyPkg]). *)
+    [<Name>.3d], and (when [3d.exe] is available) compile it to a single
+    validator-only [<Name>.c] (no [_Fields] plug, no FFI). The file base is
+    [name] when given, else [package], normalised to a CamelCase identifier
+    (["my-pkg"] becomes [MyPkg]); [package] always names the opam package. *)
 
-val generate_dune_doc : outdir:string -> package:string -> packed list -> unit
-(** [generate_dune_doc ~outdir ~package codecs] writes a [dune.inc] for the
-    single-file documentation build: rules that emit [<Package>.3d] and compile
-    it to [<Package>.c], a [runtest] rule that compiles the generated validator,
-    and an install stanza for that one spec and parser. *)
+val generate_dune_doc :
+  ?name:string -> outdir:string -> package:string -> packed list -> unit
+(** [generate_dune_doc ?name ~outdir ~package codecs] writes a [dune.inc] for
+    the single-file documentation build: rules that emit [<Name>.3d] and compile
+    it to [<Name>.c], a [runtest] rule that compiles the generated validator,
+    and an install stanza (under opam [package]) for that one spec and parser.
+    [name] defaults to [package]; see {!generate_doc}. *)
 
-val main : mode:[ `Ffi | `Doc ] -> package:string -> packed list -> unit
-(** [main ~mode ~package codecs] dispatches based on [Sys.argv]:
+val main :
+  ?name:string -> mode:[ `Ffi | `Doc ] -> package:string -> packed list -> unit
+(** [main ?name ~mode ~package codecs] dispatches based on [Sys.argv]:
     - [3d] writes the [.3d] file(s)
     - [c] produces the C parser(s)
     - [dune] generates [dune.inc] with build rules, test, and install stanzas
@@ -141,8 +149,11 @@ val main : mode:[ `Ffi | `Doc ] -> package:string -> packed list -> unit
     [~mode:`Ffi] it projects each codec with {!Wire.Everparse.schema} and drives
     the multi-file FFI pipeline, one set per codec. With [~mode:`Doc] it
     projects with {!Wire.Everparse.doc} and drives the single-file documentation
-    pipeline, one [<Package>.3d] and [<Package>.c] for the whole family. The
-    codecs are the same either way; only the mode changes. *)
+    pipeline, one [<Name>.3d] and [<Name>.c] for the whole family. The codecs
+    are the same either way; only the mode changes.
+
+    [name] overrides the doc file base (see {!generate_doc}); it has no effect
+    in [`Ffi] mode, whose file names come from the individual codecs. *)
 
 val has_3d_exe : unit -> bool
 (** [has_3d_exe ()] returns [true] if [3d.exe] is available in PATH or

--- a/test/3d/test_wire_3d.ml
+++ b/test/3d/test_wire_3d.ml
@@ -108,6 +108,20 @@ let test_generate_dune_doc () =
   Alcotest.(check bool) "no FFI plug" false (has "_Fields");
   Alcotest.(check bool) "no FFI test harness" false (has "test.c")
 
+let test_generate_dune_doc_name_override () =
+  (* [~name] sets the file base independently of the opam [~package]. *)
+  let tmpdir = Filename.temp_dir "wire_3d_dune_name" "" in
+  Wire_3d.generate_dune_doc ~name:"proto-spec" ~outdir:tmpdir ~package:"my-pkg"
+    [ Wire_3d.pack (doc_codec "Pkt") ];
+  let dune_inc = read_file (Filename.concat tmpdir "dune.inc") in
+  ignore (Fmt.kstr Sys.command "rm -rf %s" tmpdir);
+  let has sub = Re.execp (Re.compile (Re.str sub)) dune_inc in
+  Alcotest.(check bool) "file base from name" true (has "ProtoSpec.3d");
+  Alcotest.(check bool) "file base from name (c)" true (has "ProtoSpec.c");
+  Alcotest.(check bool) "package not used as file base" false (has "MyPkg.3d");
+  Alcotest.(check bool)
+    "install still uses the opam package" true (has "(package my-pkg)")
+
 let test_generate_doc () =
   (* generate_doc needs 3d.exe; skip when not available. *)
   if Wire_3d.has_3d_exe () then begin
@@ -530,7 +544,11 @@ let test_main_exists () =
      verify that the value exists and has the right type. *)
   let _ =
     (Wire_3d.main
-      : mode:[ `Ffi | `Doc ] -> package:string -> Wire_3d.packed list -> unit)
+      : ?name:string ->
+        mode:[ `Ffi | `Doc ] ->
+        package:string ->
+        Wire_3d.packed list ->
+        unit)
   in
   ()
 
@@ -926,6 +944,8 @@ let suite =
       Alcotest.test_case "ensure_dir" `Quick test_ensure_dir;
       Alcotest.test_case "generate_c (needs 3d.exe)" `Quick test_generate_c;
       Alcotest.test_case "generate_dune_doc" `Quick test_generate_dune_doc;
+      Alcotest.test_case "generate_dune_doc name override" `Quick
+        test_generate_dune_doc_name_override;
       Alcotest.test_case "generate_doc (needs 3d.exe)" `Quick test_generate_doc;
       Alcotest.test_case "uses_wire_ctx" `Quick test_uses_wire_ctx;
       Alcotest.test_case "has_3d_exe" `Quick test_has_3d_exe;


### PR DESCRIPTION
This PR adds an optional `?name` to `Wire_3d`'s doc helpers (`generate_doc`, `generate_dune_doc`, and `main`), setting the generated `<Name>.3d` / `<Name>.c` file base independently of the opam `~package`.

The doc pipeline (added in #152) derived the 3D module and file base from `~package`, which also names the install stanza, so a package like `ocaml-tcp` could only emit `OcamlTcp.3d`. Splitting codecs across packages and layers needs the module name chosen independently of where it installs. `?name` defaults to `~package` and is normalised the same way (`"proto-spec"` becomes `ProtoSpec`); `~package` keeps its only remaining job, the `(install (package …))` stanza. In `` `Ffi `` mode `name` is a no-op, since those file names come from the individual codecs.

Follow-up to #152.