### PR TITLE
codec: carry a doc note for RFC citations in the .3d

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ### Added
 
+- `Wire.Codec.v` takes an optional `?doc` (read back with `Wire.Codec.doc`):
+  a free-text note, such as an RFC citation, that the documentation projection
+  renders as a `/*++ ... --*/` comment on the codec's 3D typedef. The generated
+  spec then documents which standard each protocol struct comes from, and
+  EverParse accepts the comment (#155, @samoht)
 - `Wire_3d`'s documentation helpers (`generate_doc`, `generate_dune_doc`, and
   `main ~mode:`Doc`) take an optional `?name` that sets the generated
   `<Name>.3d` / `<Name>.c` file base independently of the opam `~package`, so a

--- a/examples/net/net.ml
+++ b/examples/net/net.ml
@@ -30,7 +30,7 @@ let bf_eth_ethertype = Codec.(f_eth_ethertype $ fun e -> e.eth_ethertype)
 let bf_eth_payload = Codec.(f_eth_payload $ fun e -> e.eth_payload)
 
 let ethernet_codec =
-  Codec.v "Ethernet"
+  Codec.v "Ethernet" ~doc:"Ethernet II (DIX) frame header; IEEE 802.3"
     (fun dst src etype payload ->
       {
         eth_dst = dst;
@@ -80,7 +80,7 @@ let bf_ip_dst = Codec.(f_ip_dst $ fun p -> p.ip_dst)
 let bf_ip_payload = Codec.(f_ip_payload $ fun p -> p.ip_payload)
 
 let ipv4_codec =
-  Codec.v "IPv4"
+  Codec.v "IPv4" ~doc:"IPv4 header, RFC 791 section 3.1"
     (fun version ihl dscp ecn total_length identification flags fragment_offset
          ttl protocol checksum src dst payload ->
       {
@@ -178,7 +178,7 @@ let bf_tcp_syn = Codec.(f_tcp_syn $ fun t -> t.tcp_syn)
 let bf_tcp_ack = Codec.(f_tcp_ack $ fun t -> t.tcp_ack)
 
 let tcp_codec =
-  Codec.v "TCP" tcp_of_fields
+  Codec.v "TCP" ~doc:"TCP header, RFC 9293 section 3.1" tcp_of_fields
     Codec.
       [
         bf_tcp_src_port;
@@ -219,7 +219,7 @@ let f_udp_length = Field.v "Length" uint16be
 let f_udp_checksum = Field.v "Checksum" uint16be
 
 let udp_codec =
-  Codec.v "UDP"
+  Codec.v "UDP" ~doc:"UDP header, RFC 768"
     (fun src_port dst_port length checksum ->
       {
         udp_src_port = src_port;

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -756,8 +756,9 @@ type ('f, 'r) record =
           (* fields + action-local vars (for array allocation) *)
       r_bf : bf_codec_state option;
       field_access_rev : (string * field_access) list;
-      field_readers : field_reader list;
       where : bool expr option;
+      doc : string option;
+      field_readers : field_reader list;
       param_slots : (string, int) Hashtbl.t;
           (* Per-codec param name to decode-array slot, filled at seal. *)
     }
@@ -796,13 +797,17 @@ type 'r t = {
   n_params : int;
   param_handles : Param.packed list;
   where : bool expr option;
+  doc : string option;
+      (** Free-text note (e.g. an RFC citation) projected as a [/*++ ... --*/]
+          comment on the codec's 3D typedef. *)
 }
 
-let record_start ?where name make =
+let record_start ?where ?doc name make =
   Record
     {
       name;
       make;
+      doc;
       readers = Nil;
       writers_rev = [];
       size_of_value_rev = [];
@@ -2318,6 +2323,7 @@ let apply_compiled : type a f r.
       field_access_rev = (fld.name, cf.field_access) :: r.field_access_rev;
       field_readers = new_field_readers;
       where = r.where;
+      doc = r.doc;
       param_slots = r.param_slots;
     }
 
@@ -2617,6 +2623,7 @@ let seal : type r. (r, r) record -> r t =
     n_params;
     param_handles;
     where = r.where;
+    doc = r.doc;
   }
 
 (* -- Validator-only path: build a struct validator from [Types.struct_]
@@ -2855,13 +2862,14 @@ type ('f, 'r) fields =
   | [] : ('r, 'r) fields
   | ( :: ) : ('a, 'r) field * ('f, 'r) fields -> ('a -> 'f, 'r) fields
 
-let view : type f r. string -> ?where:bool expr -> f -> (f, r) fields -> r t =
- fun name ?where constructor flds ->
+let view : type f r.
+    string -> ?where:bool expr -> ?doc:string -> f -> (f, r) fields -> r t =
+ fun name ?where ?doc constructor flds ->
   let rec add : type g. (g, r) record -> (g, r) fields -> r t =
    fun r flds ->
     match flds with [] -> seal r | f :: rest -> add (add_field r f) rest
   in
-  add (record_start ?where name constructor) flds
+  add (record_start ?where ?doc name constructor) flds
 
 let v = view
 
@@ -3193,6 +3201,7 @@ let[@inline] set (type a r) (codec : r t) (f : (a, r) field) :
 
 let name (t : _ t) = t.name
 let rename new_name (t : _ t) = { t with name = new_name }
+let doc (t : _ t) = t.doc
 let field_readers (t : _ t) = t.field_readers
 let pp ppf (t : _ t) = Fmt.string ppf t.name
 let field_ref (type a r) (f : (a, r) field) : int expr = Ref f.name

--- a/lib/codec.mli
+++ b/lib/codec.mli
@@ -30,8 +30,17 @@ type ('f, 'r) fields =
 val ( $ ) : 'a Field.t -> ('r -> 'a) -> ('a, 'r) field
 (** [f $ proj] binds a field to a record projection. *)
 
-val v : string -> ?where:bool Types.expr -> 'f -> ('f, 'r) fields -> 'r t
-(** [v name constructor fields] seals a codec from a field list. *)
+val v :
+  string ->
+  ?where:bool Types.expr ->
+  ?doc:string ->
+  'f ->
+  ('f, 'r) fields ->
+  'r t
+(** [v name constructor fields] seals a codec from a field list. [?doc] attaches
+    a free-text note (e.g. an RFC citation) that the documentation projection
+    renders as a [/*++ ... --*/] comment on the codec's 3D typedef; see {!doc}.
+*)
 
 val wire_size : 'r t -> int
 (** Fixed wire size in bytes. Raises if variable-length. *)
@@ -163,6 +172,9 @@ val rename : string -> 'r t -> 'r t
     not the wire encoding, so renaming leaves encode/decode and all field
     constraints unchanged. Use it to give a generically built codec a unique,
     meaningful name for projection or code generation. *)
+
+val doc : 'r t -> string option
+(** [doc c] is the note attached via {!v}'s [?doc], if any. *)
 
 val field_readers : 'r t -> (string * (bytes -> int -> int)) list
 (** [field_readers c] returns the int-valued field readers of [c], indexed by

--- a/lib/everparse.ml
+++ b/lib/everparse.ml
@@ -453,13 +453,13 @@ let with_output (s : Types.struct_) : Types.decl list =
    casetypes -- everything that describes the wire format. Reads as a protocol
    spec, and 3d.exe still compiles it to a real (validator-only) C parser with
    no FFI. *)
-let doc_decls (s : Types.struct_) : Types.decl list =
+let doc_decls ?doc (s : Types.struct_) : Types.decl list =
   let s = { s with fields = List.map rewrite_absent_optional s.fields } in
   let parse_fields = reorder_bit_groups_for_3d s.fields in
   let parse_struct =
     Types.param_struct s.name s.params ?where:s.where parse_fields
   in
-  refined_byte_typedefs s @ [ Types.typedef ~entrypoint:true parse_struct ]
+  refined_byte_typedefs s @ [ Types.typedef ?doc ~entrypoint:true parse_struct ]
 
 (* Byte size of a struct after bitfield coalescing, mirroring Codec.compile_bits'
    logic: consecutive same-base, same-bit_order bitfields pack into one base
@@ -511,13 +511,20 @@ let schema_of_struct (s : Types.struct_) : t =
 let schema (type r) (codec : r Codec.t) : t =
   schema_of_struct (Codec.to_struct codec)
 
-let doc_of_struct (s : Types.struct_) : t =
+let doc_of_struct ?doc (s : Types.struct_) : t =
   let s = Types.split_string_casetype_fields s in
   let name = Types.struct_name s in
   let wire_size = coalesced_wire_size s.fields in
-  { name; module_ = Types.module_ (doc_decls s); wire_size; source = Some s }
+  {
+    name;
+    module_ = Types.module_ (doc_decls ?doc s);
+    wire_size;
+    source = Some s;
+  }
 
-let doc (type r) (codec : r Codec.t) : t = doc_of_struct (Codec.to_struct codec)
+let doc (type r) (codec : r Codec.t) : t =
+  doc_of_struct ?doc:(Codec.doc codec) (Codec.to_struct codec)
+
 let filename (s : t) = String.capitalize_ascii s.name ^ ".3d"
 
 let uses_wire_ctx s =

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -826,8 +826,11 @@ module Codec : sig
   val ( $ ) : 'a Field.t -> ('r -> 'a) -> ('a, 'r) field
   (** [f $ proj] binds a {!Field.t} to a record projection. *)
 
-  val v : string -> ?where:bool expr -> 'f -> ('f, 'r) fields -> 'r t
-  (** [v name constructor fields] seals a codec.
+  val v :
+    string -> ?where:bool expr -> ?doc:string -> 'f -> ('f, 'r) fields -> 'r t
+  (** [v name constructor fields] seals a codec. [?doc] attaches a free-text
+      note (e.g. an RFC citation) that the documentation projection renders as a
+      [/*++ ... --*/] comment on the codec's 3D typedef; see {!doc}.
 
       {[
       let codec =
@@ -843,6 +846,9 @@ module Codec : sig
       encode/decode and all field constraints unchanged. Use it to give a
       generically built codec a unique, meaningful name for projection or code
       generation. *)
+
+  val doc : 'r t -> string option
+  (** [doc c] is the note attached via {!v}'s [?doc], if any. *)
 
   val wire_size : 'r t -> int
   (** Fixed wire size of the codec.

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -218,6 +218,21 @@ let test_doc_enum_as_type () =
     "codegen schema keeps membership" true
     (contains ~sub:"== 0" (to_3d (Everparse.schema c).module_))
 
+let test_doc_codec_citation () =
+  (* [Codec.v ~doc] renders as a [/*++ ... --*/] comment on the typedef, so a
+     spec can cite the RFC (or other source) it comes from. *)
+  let c =
+    Codec.v "Pkt" ~doc:"RFC 9999 section 1"
+      (fun v -> v)
+      Codec.[ (Field.v "v" uint8 $ fun v -> v) ]
+  in
+  Alcotest.(check (option string))
+    "codec exposes its doc" (Some "RFC 9999 section 1") (Codec.doc c);
+  let out = to_3d ~enum_as_type:true (Everparse.doc c).module_ in
+  Alcotest.(check bool)
+    "typedef carries the citation comment" true
+    (contains ~sub:"/*++ RFC 9999 section 1 --*/" out)
+
 let test_doc_merge_dedup () =
   (* write_doc unions a family into one module, emitting a shared type once. *)
   let e = enum "Shared" [ ("A", 0); ("B", 1) ] uint8 in
@@ -887,6 +902,8 @@ let suite =
         test_3d_enum_membership;
       Alcotest.test_case "doc: drops FFI scaffolding" `Quick
         test_doc_drops_ffi_scaffolding;
+      Alcotest.test_case "doc: codec ~doc renders as citation comment" `Quick
+        test_doc_codec_citation;
       Alcotest.test_case "doc: enum renders as named type" `Quick
         test_doc_enum_as_type;
       Alcotest.test_case "doc: merge dedups shared types" `Quick


### PR DESCRIPTION
This PR adds an optional `?doc` to `Wire.Codec.v` (read back with `Wire.Codec.doc`) that the documentation projection renders as a `/*++ ... --*/` comment on the codec's 3D typedef, so a generated spec cites the standard each protocol struct comes from.

The doc projection added in #151 emits `.3d` files meant to read as protocol specs, and the renderer already turns a typedef's `doc` into an EverParse `/*++ ... --*/` comment, but only the low-level `Raw.typedef ~doc` could supply that text. `Codec.v ~doc` threads it through the high-level codec API, so `Everparse.doc` carries the note onto the typedef. The net example codecs now cite their RFCs (IPv4 RFC 791, TCP RFC 9293, UDP RFC 768), so the generated `Net.3d` documents each header's source, and EverParse accepts the comment (the `test/3d` batch gate compiles it).

Follow-up to #151.