### PR TITLE
field: per-field doc notes for RFC citations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ### Added
 
+- `Wire.Field.v` takes an optional `?doc` (read back with `Wire.Field.doc`):
+  a free-text note, such as an RFC section, that the documentation projection
+  renders as a `/* ... */` comment above the field in the generated 3D. A
+  protocol spec can now cite the standard each individual field comes from, not
+  just the struct as a whole, and EverParse accepts the comment (#TODO, @samoht)
 - `Wire.Codec.v` takes an optional `?doc` (read back with `Wire.Codec.doc`):
   a free-text note, such as an RFC citation, that the documentation projection
   renders as a `/*++ ... --*/` comment on the codec's 3D typedef. The generated

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
   a free-text note, such as an RFC section, that the documentation projection
   renders as a `/* ... */` comment above the field in the generated 3D. A
   protocol spec can now cite the standard each individual field comes from, not
-  just the struct as a whole, and EverParse accepts the comment (#TODO, @samoht)
+  just the struct as a whole, and EverParse accepts the comment (#157, @samoht)
 - `Wire.Codec.v` takes an optional `?doc` (read back with `Wire.Codec.doc`):
   a free-text note, such as an RFC citation, that the documentation projection
   renders as a `/*++ ... --*/` comment on the codec's 3D typedef. The generated

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -369,6 +369,7 @@ type ('a, 'r) field = {
   typ : 'a typ;
   constraint_ : bool expr option;
   action : action option;
+  doc : string option;
   get : 'r -> 'a;
 }
 
@@ -385,8 +386,10 @@ let struct_field : type a r. (a, r) field -> Types.field =
   | Where { cond; inner } ->
       field fld.name
         ?constraint_:(combine_constraint fld.constraint_ (Some cond))
-        ?action:fld.action inner
-  | _ -> field fld.name ?constraint_:fld.constraint_ ?action:fld.action fld.typ
+        ?action:fld.action ?doc:fld.doc inner
+  | _ ->
+      field fld.name ?constraint_:fld.constraint_ ?action:fld.action
+        ?doc:fld.doc fld.typ
 
 let struct' = struct_
 
@@ -832,6 +835,7 @@ let bind (f : 'a Field.t) get =
     typ = Field.typ f;
     constraint_ = Field.constraint_ f;
     action = Field.action f;
+    doc = Field.doc f;
     get;
   }
 
@@ -2035,6 +2039,7 @@ and compile_map : type a w r.
       typ = inner;
       constraint_ = fld.constraint_;
       action = fld.action;
+      doc = fld.doc;
       get = (fun v -> encode (outer_get v));
     }
   in
@@ -2115,6 +2120,7 @@ and compile_optional_variable : type a r.
       typ = inner;
       constraint_ = None;
       action = None;
+      doc = fld.doc;
       get =
         (fun v ->
           match get v with
@@ -2222,6 +2228,7 @@ and compile_optional_or_variable : type a r.
       typ = inner;
       constraint_ = None;
       action = None;
+      doc = fld.doc;
       get = fld.get;
     }
   in
@@ -2781,6 +2788,7 @@ and apply_field_to_validator_acc acc (Types.Field f) =
           typ = f.field_typ;
           constraint_ = f.constraint_;
           action = f.action;
+          doc = f.field_doc;
           get = (fun () -> assert false);
         }
       in

--- a/lib/everparse.ml
+++ b/lib/everparse.ml
@@ -208,6 +208,7 @@ let map_field_action schema_name idx byte_off (Types.Field f) =
             field_typ = f.field_typ;
             constraint_ = f.constraint_;
             action = new_action;
+            field_doc = f.field_doc;
           }
     | None -> Types.Field f
   in
@@ -299,6 +300,7 @@ let pad_reversed_group total used base native reversed =
         field_typ = pad_typ;
         constraint_ = None;
         action = None;
+        field_doc = None;
       }
     :: reversed
   else reversed

--- a/lib/field.ml
+++ b/lib/field.ml
@@ -3,20 +3,21 @@ type 'a t = {
   typ : 'a Types.typ;
   constraint_ : bool Types.expr option;
   action : Types.action option;
+  doc : string option;
 }
 
 type 'a anon = { anon_typ : 'a Types.typ }
 
 let pp ppf f = Fmt.pf ppf "%s" f.name
 
-let v name ?constraint_ ?self_constraint ?action typ =
+let v name ?constraint_ ?self_constraint ?action ?doc typ =
   let constraint_ =
     match (constraint_, self_constraint) with
     | c, None -> c
     | None, Some f -> Some (f (Types.Ref name))
     | Some c, Some f -> Some (Types.And (c, f (Types.Ref name)))
   in
-  { name; typ; constraint_; action }
+  { name; typ; constraint_; action; doc }
 
 (* Field decorations: produce a field directly from a typ + optional/
    repeat metadata. Exposing these only at the field level keeps
@@ -117,10 +118,12 @@ let name f = f.name
 let typ f = f.typ
 let constraint_ f = f.constraint_
 let action f = f.action
+let doc f = f.doc
 
 type packed = Named : 'a t -> packed | Anon : 'a anon -> packed
 
 let decl_of_packed = function
   | Named f ->
-      Types.field f.name ?constraint_:f.constraint_ ?action:f.action f.typ
+      Types.field f.name ?constraint_:f.constraint_ ?action:f.action ?doc:f.doc
+        f.typ
   | Anon a -> Types.anon_field a.anon_typ

--- a/lib/field.mli
+++ b/lib/field.mli
@@ -20,9 +20,12 @@ val v :
   ?constraint_:bool Types.expr ->
   ?self_constraint:(int Types.expr -> bool Types.expr) ->
   ?action:Types.action ->
+  ?doc:string ->
   'a Types.typ ->
   'a t
-(** [v name typ] creates a named field.
+(** [v name typ] creates a named field. [?doc] attaches a free-text note (e.g.
+    an RFC section) that the documentation projection renders as a [/* ... */]
+    comment on the field in the generated 3D.
 
     [?self_constraint] receives a reference to the field being declared and
     returns a constraint over it; the typical use is to prove a later
@@ -109,6 +112,9 @@ val constraint_ : 'a t -> bool Types.expr option
 
 val action : 'a t -> Types.action option
 (** Field action, if any. *)
+
+val doc : 'a t -> string option
+(** Field note attached via {!v}'s [?doc], if any. *)
 
 type packed =
   | Named : 'a t -> packed

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -202,6 +202,7 @@ and field =
       field_typ : 'a typ;
       constraint_ : bool expr option;
       action : action option;
+      field_doc : string option;
     }
       -> field
 
@@ -696,12 +697,25 @@ let casetype name tag defs =
   Casetype { name; tag; cases = List.map resolve defs }
 
 (* Struct fields *)
-let field name ?constraint_ ?action typ =
-  Field { field_name = Some name; field_typ = typ; constraint_; action }
+let field name ?constraint_ ?action ?doc typ =
+  Field
+    {
+      field_name = Some name;
+      field_typ = typ;
+      constraint_;
+      action;
+      field_doc = doc;
+    }
 
 let anon_field typ =
   Field
-    { field_name = None; field_typ = typ; constraint_ = None; action = None }
+    {
+      field_name = None;
+      field_typ = typ;
+      constraint_ = None;
+      action = None;
+      field_doc = None;
+    }
 
 (* Struct constructors *)
 let struct_ name fields = { name; params = []; where = None; fields }
@@ -1774,6 +1788,7 @@ let pp_field ppf (Field f) =
     | Some n -> fun ppf -> Fmt.string ppf n
     | None -> pp_base
   in
+  Option.iter (fun d -> Fmt.pf ppf "@,/* %s */" d) f.field_doc;
   Fmt.pf ppf "@,%t %s%a" pp_base name pp_field_suffix suffix;
   Option.iter (Fmt.pf ppf " { %a }" pp_expr) constraint_;
   Option.iter (Fmt.pf ppf " %a" pp_action) f.action;

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -225,6 +225,7 @@ and field =
       field_typ : 'a typ;
       constraint_ : bool expr option;
       action : action option;
+      field_doc : string option;
     }
       -> field  (** A single struct field. *)
 
@@ -581,8 +582,14 @@ val split_string_casetype_fields : struct_ -> struct_
 (** {1 Struct Constructors} *)
 
 val field :
-  string -> ?constraint_:bool expr -> ?action:action -> 'a typ -> field
-(** Declare a named field. *)
+  string ->
+  ?constraint_:bool expr ->
+  ?action:action ->
+  ?doc:string ->
+  'a typ ->
+  field
+(** Declare a named field. [?doc] is rendered as a [/* ... */] comment above the
+    field in the 3D projection. *)
 
 val anon_field : 'a typ -> field
 (** Declare an anonymous (padding) field. *)

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -344,9 +344,12 @@ module Field : sig
     ?constraint_:bool expr ->
     ?self_constraint:(int expr -> bool expr) ->
     ?action:Action.t ->
+    ?doc:string ->
     'a typ ->
     'a t
-  (** [v name typ] creates a named field. [?self_constraint] receives the
+  (** [v name typ] creates a named field. [?doc] attaches a free-text note (e.g.
+      an RFC section) that the documentation projection renders as a [/* ... */]
+      comment on the field in the generated 3D. [?self_constraint] receives the
       field's own ref and returns a constraint over it; useful for proving a
       later size-expression safe (e.g. [self >= int 7] when a later field uses
       [byte_slice ~size:(ref len - int 7)]).
@@ -424,6 +427,9 @@ module Field : sig
 
   val constraint_ : 'a t -> bool expr option
   (** Field constraint, if any. *)
+
+  val doc : 'a t -> string option
+  (** Field note attached via {!v}'s [?doc], if any. *)
 
   val decl_of_packed : packed -> Types.field
   (** The {!Types.field} declaration of a packed field. *)

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -253,6 +253,52 @@ let test_doc_merge_dedup () =
     "second struct present" true
     (contains ~sub:"Two" content)
 
+let test_doc_field_citation () =
+  (* [Field.v ~doc] renders as a plain [/* ... */] comment above the field --
+     3d.exe rejects [/*++ --*/] at field position, so the per-field note uses
+     the plain comment form. *)
+  let f = Field.v "Length" ~doc:"RFC 9999 section 4.2" uint16be in
+  Alcotest.(check (option string))
+    "field exposes its doc" (Some "RFC 9999 section 4.2") (Field.doc f);
+  let c = Codec.v "Pkt" (fun v -> v) Codec.[ (f $ fun v -> v) ] in
+  let out = to_3d ~enum_as_type:true (Everparse.doc c).module_ in
+  Alcotest.(check bool)
+    "field carries the citation comment" true
+    (contains ~sub:"/* RFC 9999 section 4.2 */" out)
+
+let test_doc_bit_order_matches_schema () =
+  (* Doc-mode emits a validator with no FFI, so its bitfield layout is never
+     run through the differential C tests that check the schema (FFI)
+     projection's bit order against [Codec.get]. Both projections must apply
+     the same bit reordering; assert their bitfield sequence is identical so
+     doc-mode's order stays pinned to the order those tests already cover.
+     A,B,C share one [U8] word whose native order is [Lsb_first], so the
+     default [Msb_first] declaration is reversed in the 3D -- a doc path that
+     skipped the reorder would diverge here. *)
+  let c =
+    Codec.v "BitOrd"
+      (fun a b c d -> (a, b, c, d))
+      Codec.
+        [
+          (Field.v "A" (bits ~width:3 U8) $ fun (a, _, _, _) -> a);
+          (Field.v "B" (bits ~width:1 U8) $ fun (_, b, _, _) -> b);
+          (Field.v "C" (bits ~width:4 U8) $ fun (_, _, c, _) -> c);
+          (Field.v "D" uint8 $ fun (_, _, _, d) -> d);
+        ]
+  in
+  let bit_order_of schema =
+    match Everparse.entrypoint_struct schema with
+    | None -> Alcotest.fail "schema has no entrypoint struct"
+    | Some s ->
+        List.map
+          (fun (name, is_bitfield, _) -> (name, is_bitfield))
+          (Everparse.field_action_forms s)
+  in
+  Alcotest.(check (list (pair (option string) bool)))
+    "doc reorders bitfields exactly as the schema projection does"
+    (bit_order_of (Everparse.schema c))
+    (bit_order_of (Everparse.doc c))
+
 let test_3d_nested_byte_array_where () =
   (* A byte_array_where inside a nested region needs its synthesised refined-byte
      typedef emitted, before the wrapper that references it, or the schema names
@@ -908,6 +954,10 @@ let suite =
         test_doc_enum_as_type;
       Alcotest.test_case "doc: merge dedups shared types" `Quick
         test_doc_merge_dedup;
+      Alcotest.test_case "doc: field ~doc renders as citation comment" `Quick
+        test_doc_field_citation;
+      Alcotest.test_case "doc: bit order matches schema projection" `Quick
+        test_doc_bit_order_matches_schema;
       Alcotest.test_case "3d: nested byte_array_where refined typedef" `Quick
         test_3d_nested_byte_array_where;
       Alcotest.test_case "3d: static optional transparent projection" `Quick


### PR DESCRIPTION
This PR adds an optional `?doc` to `Wire.Field.v` (read back with `Wire.Field.doc`), which the documentation projection renders as a plain `/* ... */` comment above the field in the generated 3D.

The existing `Wire.Codec.v ~doc` (#155) cites the standard a whole struct comes from. This carries the same idea down to the individual field, so a spec can note which RFC section each field is defined in. Field-position comments use the plain `/* ... */` form because 3d.exe rejects `/*++ --*/` there, unlike at the typedef level. The change threads `?doc` through `Field`, `Codec`, and `Types.field` and renders it in `pp_field`.

It also adds a cross-check that the doc projection reorders bitfields exactly as the schema (FFI) projection does. Doc-mode emits no FFI callbacks, so its bitfield layout is otherwise never exercised by the differential C tests that pin the schema projection's bit order against `Codec.get`; the test asserts the two projections agree.