### PR TITLE
wire: bind expression equality explicitly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -158,6 +158,10 @@
 
 ### Fixed
 
+- `Wire.Expr.( = )` and `Wire.Expr.( <> )` are explicitly re-exported from the
+  expression language, so equality in a local `Expr.(...)` open builds `Eq` /
+  `Ne` constraints rather than depending on the surrounding equality binding
+  (@samoht)
 - A codec whose name contains a capital `V` (e.g. `VeritySuperblock`) now
   generates its C parser. EverParse names the validator `<Name>Validate<Name>`,
   and the name reader stopped at the first `V`, so C generation failed for any

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -119,7 +119,7 @@ let bits ?(bit_order = Types.Msb_first) ~width bf =
   Types.bits ~bit_order ~width base
 
 module Expr = struct
-  include Expr
+  include Types.Expr
 
   let true_ = Types.true_
   let false_ = Types.false_

--- a/test/test_wire.ml
+++ b/test/test_wire.ml
@@ -23,6 +23,23 @@ let encode_chunked ~chunk_size typ v =
   Bytesrw.Bytes.Writer.write_eod writer;
   Buffer.contents buf
 
+let test_expr_equality_operators () =
+  let module T = Wire.Private.Types in
+  let x = int 1 in
+  let y = int 2 in
+  let check_eq = function
+    | T.Eq (T.Int 1, T.Int 2) -> ()
+    | T.Bool b -> Alcotest.failf "Expr.(=) fell back to OCaml equality: %b" b
+    | _ -> Alcotest.fail "Expr.(=) did not build Eq"
+  in
+  let check_ne = function
+    | T.Ne (T.Int 1, T.Int 2) -> ()
+    | T.Bool b -> Alcotest.failf "Expr.(<>) fell back to OCaml inequality: %b" b
+    | _ -> Alcotest.fail "Expr.(<>) did not build Ne"
+  in
+  check_eq Expr.(x = y);
+  check_ne Expr.(x <> y)
+
 (* -- Parsing tests -- *)
 
 let test_parse_uint8 () =
@@ -878,6 +895,8 @@ let test_stream_encode_chunk3 () =
 let suite =
   ( "wire",
     [
+      Alcotest.test_case "expr: equality operators" `Quick
+        test_expr_equality_operators;
       (* parsing *)
       Alcotest.test_case "parse: uint8" `Quick test_parse_uint8;
       Alcotest.test_case "parse: uint16 le" `Quick test_parse_uint16_le;


### PR DESCRIPTION
This PR makes `Wire.Expr` include `Types.Expr` explicitly, so the public expression module binds `( = )` and `( <> )` from the Wire expression language instead of relying on the unqualified `Expr` name introduced earlier by `include Types`.

The expression AST already had `Eq` and `Ne`, and the private `Types.Expr` module already exposed the operators. The public `Wire.Expr` wrapper was less clear because it wrote `include Expr` while defining a new module with the same name. Spelling the source module as `Types.Expr` makes the re-export unambiguous and keeps local opens such as `Expr.(Field.ref f = int 42)` tied to Wire constraints rather than any surrounding equality binding.

The regression test builds equality and inequality through the public `Wire.Expr` module, then checks the resulting private AST nodes are `Eq` and `Ne` rather than plain boolean constants.
