### PR TITLE
wire: int64 field constraints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ocaml-compiler: ['5.3', '5.2', '5.1']
+        ocaml-compiler: ['5.3', '5.2']
         include:
           - os: macos-latest
             ocaml-compiler: '5.3'

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ### Added
 
+- `Wire.Field.v` takes an optional `?self_int64`, and `Wire.Field.int64` /
+  `Wire.Expr.int64` build full-width 64-bit field constraints. This lets
+  schemas constrain domains such as signed-magnitude `uint64` values without
+  truncating the field through OCaml's native `int` (@samoht)
 - `Wire.Field.v` takes an optional `?doc` (read back with `Wire.Field.doc`):
   a free-text note, such as an RFC section, that the documentation projection
   renders as a `/* ... */` comment above the field in the generated 3D. A

--- a/dune-project
+++ b/dune-project
@@ -22,7 +22,7 @@
    Define your wire format once, then use it for OCaml parsing via bytesrw or \
    emit .3d files for verified C parser generation via EverParse.")
  (depends
-  (ocaml (>= 5.1))
+  (ocaml (>= 5.2))
   (bytesrw (>= 0.1))
   (eio (>= 1.0))
   (fmt (>= 0.9))

--- a/lib/ascii.ml
+++ b/lib/ascii.ml
@@ -19,7 +19,7 @@ let rec pp_expr : type a. Buffer.t -> a Types.expr -> unit =
   | Int n -> Buffer.add_string buf (string_of_int n)
   | Int64 n -> Buffer.add_string buf (Int64.to_string n)
   | Bool b -> Buffer.add_string buf (string_of_bool b)
-  | Ref name -> Buffer.add_string buf name
+  | Ref (_, name) -> Buffer.add_string buf name
   | Add (a, b) ->
       pp_expr buf a;
       Buffer.add_string buf " + ";

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -275,44 +275,67 @@ let rec build_field_reader : type a. a typ -> int -> bytes -> int -> a =
 
 let int_of_typ_value = Eval.int_of_exn
 
+type slots = { ints : int array; int64s : int64 array }
+
+let alloc_slots n = { ints = Array.make n 0; int64s = Array.make n 0L }
+
+let clear_slots s n =
+  Array.fill s.ints 0 n 0;
+  Array.fill s.int64s 0 n 0L
+
+let set_int_slot s idx v = s.ints.(idx) <- v
+let set_int64_slot s idx v = s.int64s.(idx) <- v
+
 (* Build a populate function that writes a field value into the validator
    array without allocating. Resolves the type at seal time so the hot
    path is a direct arr.(idx) <- reader buf base. *)
 let rec build_populate : type a.
-    a typ -> int -> (bytes -> int -> a) -> int array -> bytes -> int -> unit =
+    a typ -> int -> (bytes -> int -> a) -> slots -> bytes -> int -> unit =
  fun typ idx reader ->
   match typ with
-  | Uint8 -> fun arr buf base -> arr.(idx) <- reader buf base
-  | Uint16 _ -> fun arr buf base -> arr.(idx) <- reader buf base
-  | Uint_var _ -> fun arr buf base -> arr.(idx) <- reader buf base
-  | Uint32 _ -> fun arr buf base -> arr.(idx) <- UInt32.to_int (reader buf base)
-  | Uint63 _ -> fun arr buf base -> arr.(idx) <- UInt63.to_int (reader buf base)
-  | Int8 -> fun arr buf base -> arr.(idx) <- reader buf base
-  | Int16 _ -> fun arr buf base -> arr.(idx) <- reader buf base
-  | Int32 _ -> fun arr buf base -> arr.(idx) <- reader buf base
-  | Bits _ -> fun arr buf base -> arr.(idx) <- reader buf base
-  | Uint64 _ -> (
-      fun arr buf base ->
-        match Int64.unsigned_to_int (reader buf base) with
-        | Some v -> arr.(idx) <- v
-        | None -> ())
-  | Int64 _ -> fun arr buf base -> arr.(idx) <- Int64.to_int (reader buf base)
-  (* Floats store their IEEE 754 bit pattern in [int_array] so [Ref name]
-     in a constraint sees the same value the 3D-side sees. The user-facing
-     reader still returns the [float], reinterpreted via [Int*.float_of_bits]
-     elsewhere. *)
+  | Uint8 -> fun slots buf base -> set_int_slot slots idx (reader buf base)
+  | Uint16 _ -> fun slots buf base -> set_int_slot slots idx (reader buf base)
+  | Uint_var _ -> fun slots buf base -> set_int_slot slots idx (reader buf base)
+  | Uint32 _ ->
+      fun slots buf base ->
+        set_int_slot slots idx (UInt32.to_int (reader buf base))
+  | Uint63 _ ->
+      fun slots buf base ->
+        set_int_slot slots idx (UInt63.to_int (reader buf base))
+  | Int8 -> fun slots buf base -> set_int_slot slots idx (reader buf base)
+  | Int16 _ -> fun slots buf base -> set_int_slot slots idx (reader buf base)
+  | Int32 _ -> fun slots buf base -> set_int_slot slots idx (reader buf base)
+  | Bits _ -> fun slots buf base -> set_int_slot slots idx (reader buf base)
+  (* [Uint64] / [Int64] populate both slots: the full value in [int64s] for
+     full-width [Field.int64] refs, and the truncated value in [ints] so legacy
+     int-kind [Field.ref] / [Field.int] constraints keep their pre-int64
+     behavior instead of silently reading an unpopulated zero. ([has_int64_slot]
+     gates the int64 ref API to exactly these types.) *)
+  | Uint64 _ ->
+      fun slots buf base ->
+        let v = reader buf base in
+        set_int64_slot slots idx v;
+        Option.iter (set_int_slot slots idx) (Int64.unsigned_to_int v)
+  | Int64 _ ->
+      fun slots buf base ->
+        let v = reader buf base in
+        set_int64_slot slots idx v;
+        set_int_slot slots idx (Int64.to_int v)
+  (* Floats store their IEEE 754 bit pattern in the int slot so [Ref name] in a
+     constraint sees the value the 3D side sees. The user-facing reader still
+     returns the [float], reinterpreted via [Int*.float_of_bits] elsewhere. *)
   | Float32 Little ->
-      fun arr buf base ->
-        arr.(idx) <- Bytes.get_int32_le buf base |> Int32.to_int
+      fun slots buf base ->
+        set_int_slot slots idx (Bytes.get_int32_le buf base |> Int32.to_int)
   | Float32 Big ->
-      fun arr buf base ->
-        arr.(idx) <- Bytes.get_int32_be buf base |> Int32.to_int
+      fun slots buf base ->
+        set_int_slot slots idx (Bytes.get_int32_be buf base |> Int32.to_int)
   | Float64 Little ->
-      fun arr buf base ->
-        arr.(idx) <- Bytes.get_int64_le buf base |> Int64.to_int
+      fun slots buf base ->
+        set_int_slot slots idx (Bytes.get_int64_le buf base |> Int64.to_int)
   | Float64 Big ->
-      fun arr buf base ->
-        arr.(idx) <- Bytes.get_int64_be buf base |> Int64.to_int
+      fun slots buf base ->
+        set_int_slot slots idx (Bytes.get_int64_be buf base |> Int64.to_int)
   | Where { inner; _ } -> build_populate inner idx reader
   | Enum { base; cases; _ } ->
       let check = enum_checker cases in
@@ -330,9 +353,9 @@ let rec build_populate : type a.
         build_populate inner idx (fun buf base ->
             match reader buf base with Some v -> v | None -> assert false)
       in
-      fun arr buf base ->
+      fun slots buf base ->
         match reader buf base with
-        | Some _ -> inner_populate arr buf base
+        | Some _ -> inner_populate slots buf base
         | None -> ())
   | _ ->
       (* Aggregate / string-valued types have no scalar int projection.
@@ -439,11 +462,23 @@ type packed_param = Pack_param : ('a, 'k) param_handle -> packed_param
    int-array layer passes [arr ()] with an immediate unit. *)
 type ('c1, 'c2) leaves = {
   ref_ : string -> 'c1 -> 'c2 -> int;
+  i64 : string -> 'c1 -> 'c2 -> int64;
   param_ref : packed_param -> 'c1 -> 'c2 -> int;
   sizeof_typ : packed_typ -> 'c1 -> 'c2 -> int;
   sizeof_this : 'c1 -> 'c2 -> int;
   field_pos : 'c1 -> 'c2 -> int;
 }
+
+let compile_int64 : type c1 c2.
+    (c1, c2) leaves -> int64 expr -> c1 -> c2 -> int64 =
+ fun l e ->
+  match e with Int64 n -> fun _ _ -> n | Ref (I64, name) -> l.i64 name
+
+let try_int64 : type a c1 c2.
+    (c1, c2) leaves -> a expr -> (c1 -> c2 -> int64) option =
+ fun l e ->
+  let go e = Some (compile_int64 l e) in
+  match e with Int64 _ as e -> go e | Ref (I64, _) as e -> go e | _ -> None
 
 let rec compile_int : type c1 c2. (c1, c2) leaves -> int expr -> c1 -> c2 -> int
     =
@@ -451,7 +486,7 @@ let rec compile_int : type c1 c2. (c1, c2) leaves -> int expr -> c1 -> c2 -> int
   let rec_ = compile_int l in
   match e with
   | Int n -> fun _ _ -> n
-  | Ref name -> l.ref_ name
+  | Ref (I, name) -> l.ref_ name
   | Param_ref p -> l.param_ref (Pack_param p)
   | Sizeof t -> l.sizeof_typ (Pack_typ t)
   | Sizeof_this -> l.sizeof_this
@@ -509,7 +544,7 @@ and try_int : type a c1 c2.
   let go e = Some (compile_int l e) in
   match e with
   | Int _ as e -> go e
-  | Ref _ as e -> go e
+  | Ref (I, _) as e -> go e
   | Param_ref _ as e -> go e
   | Sizeof _ as e -> go e
   | Sizeof_this as e -> go e
@@ -549,32 +584,59 @@ and try_bool : type a c1 c2.
 and compile_bool : type c1 c2. (c1, c2) leaves -> bool expr -> c1 -> c2 -> bool
     =
  fun l e ->
-  let int_rec = compile_int l in
   let bool_rec = compile_bool l in
   match e with
   | Bool b -> fun _ _ -> b
   | Eq (a, b) -> (
-      match (try_int l a, try_int l b, try_bool l a, try_bool l b) with
-      | Some fa, Some fb, _, _ -> fun c d -> fa c d = fb c d
-      | _, _, Some fa, Some fb -> fun c d -> fa c d = fb c d
+      match
+        ( try_int l a,
+          try_int l b,
+          try_int64 l a,
+          try_int64 l b,
+          try_bool l a,
+          try_bool l b )
+      with
+      | Some fa, Some fb, _, _, _, _ -> fun c d -> fa c d = fb c d
+      | _, _, Some fa, Some fb, _, _ -> fun c d -> fa c d = fb c d
+      | _, _, _, _, Some fa, Some fb -> fun c d -> fa c d = fb c d
       | _ -> assert false)
   | Ne (a, b) -> (
-      match (try_int l a, try_int l b, try_bool l a, try_bool l b) with
-      | Some fa, Some fb, _, _ -> fun c d -> fa c d <> fb c d
-      | _, _, Some fa, Some fb -> fun c d -> fa c d <> fb c d
+      match
+        ( try_int l a,
+          try_int l b,
+          try_int64 l a,
+          try_int64 l b,
+          try_bool l a,
+          try_bool l b )
+      with
+      | Some fa, Some fb, _, _, _, _ -> fun c d -> fa c d <> fb c d
+      | _, _, Some fa, Some fb, _, _ -> fun c d -> fa c d <> fb c d
+      | _, _, _, _, Some fa, Some fb -> fun c d -> fa c d <> fb c d
       | _ -> assert false)
-  | Lt (a, b) ->
-      let fa = int_rec a and fb = int_rec b in
-      fun c d -> fa c d < fb c d
-  | Le (a, b) ->
-      let fa = int_rec a and fb = int_rec b in
-      fun c d -> fa c d <= fb c d
-  | Gt (a, b) ->
-      let fa = int_rec a and fb = int_rec b in
-      fun c d -> fa c d > fb c d
-  | Ge (a, b) ->
-      let fa = int_rec a and fb = int_rec b in
-      fun c d -> fa c d >= fb c d
+  | Lt (a, b) -> (
+      match (try_int l a, try_int l b, try_int64 l a, try_int64 l b) with
+      | Some fa, Some fb, _, _ -> fun c d -> fa c d < fb c d
+      | _, _, Some fa, Some fb ->
+          fun c d -> Int64.unsigned_compare (fa c d) (fb c d) < 0
+      | _ -> assert false)
+  | Le (a, b) -> (
+      match (try_int l a, try_int l b, try_int64 l a, try_int64 l b) with
+      | Some fa, Some fb, _, _ -> fun c d -> fa c d <= fb c d
+      | _, _, Some fa, Some fb ->
+          fun c d -> Int64.unsigned_compare (fa c d) (fb c d) <= 0
+      | _ -> assert false)
+  | Gt (a, b) -> (
+      match (try_int l a, try_int l b, try_int64 l a, try_int64 l b) with
+      | Some fa, Some fb, _, _ -> fun c d -> fa c d > fb c d
+      | _, _, Some fa, Some fb ->
+          fun c d -> Int64.unsigned_compare (fa c d) (fb c d) > 0
+      | _ -> assert false)
+  | Ge (a, b) -> (
+      match (try_int l a, try_int l b, try_int64 l a, try_int64 l b) with
+      | Some fa, Some fb, _, _ -> fun c d -> fa c d >= fb c d
+      | _, _, Some fa, Some fb ->
+          fun c d -> Int64.unsigned_compare (fa c d) (fb c d) >= 0
+      | _ -> assert false)
   | And (a, b) ->
       let fa = bool_rec a and fb = bool_rec b in
       fun c d -> fa c d && fb c d
@@ -584,6 +646,7 @@ and compile_bool : type c1 c2. (c1, c2) leaves -> bool expr -> c1 -> c2 -> bool
   | Not e ->
       let fe = bool_rec e in
       fun c d -> not (fe c d)
+  | Ref _ -> .
 
 (* Closure-based access layer: the context is [buf] and [base], passed as two
    curried arguments. The compiled offset/size functions are [bytes -> int ->
@@ -598,6 +661,12 @@ let bytes_leaves ?(sizeof_this : bytes -> int -> int = fun _ _ -> 0)
         | None ->
             Fmt.invalid_arg "Codec: unbound field ref %S in size expression"
               name);
+    i64 =
+      (fun name _ _ ->
+        Fmt.invalid_arg
+          "Codec: full-width field ref %S is only available in field \
+           constraints"
+          name);
     param_ref = (fun (Pack_param p) _ _ -> !(p.cell));
     sizeof_typ =
       (fun (Pack_typ t) ->
@@ -634,12 +703,16 @@ type compile_ctx = {
 let mk_ctx ?(sizeof_this = 0) ?(field_pos = 0) ~param_slots idx =
   { idx; sizeof_this; field_pos; param_slots }
 
-let array_leaves (cc : compile_ctx) : (int array, unit) leaves =
+let array_leaves (cc : compile_ctx) : (slots, unit) leaves =
   {
     ref_ =
       (fun name ->
         let i = cc.idx name in
-        fun a () -> a.(i));
+        fun a () -> a.ints.(i));
+    i64 =
+      (fun name ->
+        let i = cc.idx name in
+        fun a () -> a.int64s.(i));
     param_ref =
       (fun (Pack_param p) a () ->
         (* The per-codec slot map is filled at seal, after these leaves are
@@ -647,7 +720,7 @@ let array_leaves (cc : compile_ctx) : (int array, unit) leaves =
            codec's map (e.g. one only reachable via [cell] forwarding from
            an embedding) falls back to the shared cell. *)
         match Hashtbl.find_opt cc.param_slots p.Types.name with
-        | Some i -> a.(i)
+        | Some i -> a.ints.(i)
         | None -> !(p.cell));
     sizeof_typ =
       (fun (Pack_typ t) ->
@@ -674,7 +747,7 @@ let compile_bool_arr cc e =
 
    Return true short-circuits remaining statements (the action succeeds).
    Return false and Abort raise Parse_error to abort the parse. *)
-type compiled_action = int array -> unit
+type compiled_action = slots -> unit
 
 exception Return_true
 
@@ -686,7 +759,7 @@ let rec compile_stmt (cc : compile_ctx) (s : Types.action_stmt) :
       fun arr ->
         let v = fe arr in
         match Hashtbl.find_opt cc.param_slots p.Types.name with
-        | Some slot -> arr.(slot) <- v
+        | Some slot -> set_int_slot arr slot v
         | None -> p.Types.cell := v)
   | Field_assign (_, _, _) | Extern_call (_, _) -> fun _ -> ()
   | Return e ->
@@ -714,7 +787,7 @@ let rec compile_stmt (cc : compile_ctx) (s : Types.action_stmt) :
          silently write to nowhere. *)
       let i = cc.idx name in
       let fe = compile_int_arr cc e in
-      fun arr -> arr.(i) <- fe arr
+      fun arr -> set_int_slot arr i (fe arr)
 
 and compile_stmts (cc : compile_ctx) (stmts : Types.action_stmt list) :
     compiled_action =
@@ -750,9 +823,9 @@ type ('f, 'r) record =
       next_off : next_off; (* where the next field starts *)
       fields_rev : Types.field list;
       validators_rev :
-        (int (* byte offset *) * (int array -> bytes -> int -> unit)) list;
+        (int (* byte offset *) * (slots -> bytes -> int -> unit)) list;
       checkers_rev :
-        (int (* byte offset *) * (int array -> bytes -> int -> unit)) list;
+        (int (* byte offset *) * (slots -> bytes -> int -> unit)) list;
       field_actions_rev : (string * compiled_action) list;
       n_fields : int; (* count of named fields (for field indexing) *)
       n_array_slots : int;
@@ -788,10 +861,10 @@ type 'r t = {
   wire_size : wire_size_info;
   struct_fields : Types.field list;
   validate : ?env_slots:int array -> bytes -> int -> unit;
-  validate_arr : int array -> bytes -> int -> unit;
-  populate : int array -> bytes -> int -> unit;
+  validate_arr : slots -> bytes -> int -> unit;
+  populate : slots -> bytes -> int -> unit;
   n_array_slots : int;
-  decode_scratch : int array;
+  decode_scratch : slots;
       (* Validation scratch, allocated once at [seal] and zeroed per decode
          (see [decode_exn]), mirroring the [validate] closure, the struct
          validator, and [Codec.get]'s staged reader. Same shared-buffer
@@ -973,10 +1046,18 @@ let rec iter_param_refs : type a. (Param.packed -> unit) -> a expr -> unit =
   | Lor (a, b)
   | Lxor (a, b)
   | Lsl (a, b)
-  | Lsr (a, b)
-  | Lt (a, b)
-  | Le (a, b)
-  | Gt (a, b)
+  | Lsr (a, b) ->
+      iter_param_refs f a;
+      iter_param_refs f b
+  | Lt (a, b) ->
+      iter_param_refs f a;
+      iter_param_refs f b
+  | Le (a, b) ->
+      iter_param_refs f a;
+      iter_param_refs f b
+  | Gt (a, b) ->
+      iter_param_refs f a;
+      iter_param_refs f b
   | Ge (a, b) ->
       iter_param_refs f a;
       iter_param_refs f b
@@ -1293,7 +1374,7 @@ type ('a, 'r) compiled_field = {
   nested_readers : field_reader list;
       (* Embedded sub-codec field readers, shifted into the parent frame. *)
   validator_off : int; (* [-1] when the byte offset is dynamic *)
-  populate : int array -> bytes -> int -> unit;
+  populate : slots -> bytes -> int -> unit;
       (* Pre-built populate function for the int-array validator path; the
          slot index (n_fields at the time the field is compiled) is baked
          in. Composite types use a no-op. *)
@@ -1353,7 +1434,7 @@ let advance_next_off (no : next_off) (n : int) : next_off =
   | Dynamic f -> Dynamic (fun buf base -> f buf base + n)
 
 let null_int_reader : bytes -> int -> int = fun _buf _base -> 0
-let no_populate : int array -> bytes -> int -> unit = fun _arr _buf _base -> ()
+let no_populate : slots -> bytes -> int -> unit = fun _arr _buf _base -> ()
 
 (* Reader+writer pair for a Codec-or-scalar inner type placed at the current
    frame offset. Extracted so [compile_optional] and [compile_optional_or]
@@ -1583,7 +1664,7 @@ let optional_compiled : type a r.
     raw_writer:(r -> bytes -> int -> int -> int) ->
     size_delta:int ->
     next_off:next_off ->
-    populate:(int array -> bytes -> int -> unit) ->
+    populate:(slots -> bytes -> int -> unit) ->
     unit ->
     (a, r) compiled_field =
  fun ctx ?(int_reader = null_int_reader) ~raw_reader ~raw_writer ~size_delta
@@ -2484,15 +2565,15 @@ let build_validators validators_rev checkers_rev compiled_where struct_fields
   in
   let validate =
     if has_checks then (
-      let arr = Array.make n_total 0 in
+      let arr = alloc_slots n_total in
       fun ?env_slots buf off ->
-        Array.fill arr 0 n_total 0;
+        clear_slots arr n_total;
         (match env_slots with
         | Some slots ->
             (* Seed param slots from the supplied env so [where] clauses
                that reference [Param.input] evaluate correctly. *)
             let n = Array.length slots in
-            Array.blit slots 0 arr (n_total - n) n
+            Array.blit slots 0 arr.ints (n_total - n) n
         | None -> ());
         populate arr buf off;
         match compiled_where with
@@ -2625,7 +2706,7 @@ let seal : type r. (r, r) record -> r t =
     validate_arr;
     populate;
     n_array_slots = n_total;
-    decode_scratch = Array.make n_total 0;
+    decode_scratch = alloc_slots n_total;
     param_base;
     n_params;
     param_handles;
@@ -2648,8 +2729,8 @@ type validator = {
 
 (* Internal accumulator -- the validator-relevant subset of [record]. *)
 type validator_acc = {
-  validators_rev : (int * (int array -> bytes -> int -> unit)) list;
-  checkers_rev : (int * (int array -> bytes -> int -> unit)) list;
+  validators_rev : (int * (slots -> bytes -> int -> unit)) list;
+  checkers_rev : (int * (slots -> bytes -> int -> unit)) list;
   field_readers : field_reader list;
   n_fields : int;
   n_array_slots : int;
@@ -2841,10 +2922,10 @@ and validator_of_struct (s : Types.struct_) : validator =
   (* Full validation: fire field actions and check the where clause.
      [build_validators]'s third return [validate] is checkers-only (no
      actions). [validate_arr] runs full validators -- pre-allocate one
-     scratch [int array], zero it on entry. *)
-  let arr = Array.make n_total 0 in
+     scratch slots, zeroed on entry. *)
+  let arr = alloc_slots n_total in
   let validate buf off =
-    if n_total > 0 then Array.fill arr 0 n_total 0;
+    if n_total > 0 then clear_slots arr n_total;
     validate_arr arr buf off
   in
   { min_size = acc.min_size; wire_size = wire_size_info; validate }
@@ -2992,10 +3073,10 @@ let env (t : _ t) : Param.env =
 let decode_exn ?env:e t buf off =
   let v = t.decode buf off in
   let arr = t.decode_scratch in
-  Array.fill arr 0 t.n_array_slots 0;
+  clear_slots arr t.n_array_slots;
   (match e with
   | Some (e : Param.env) when t.n_params > 0 ->
-      Array.blit e.slots 0 arr t.param_base t.n_params
+      Array.blit e.slots 0 arr.ints t.param_base t.n_params
   | _ -> ());
   t.validate_arr arr buf off;
   (match e with
@@ -3004,7 +3085,7 @@ let decode_exn ?env:e t buf off =
          [i]. Write decoded output params back into the env (and the cell). *)
       List.iteri
         (fun i (Param.Pack p) ->
-          let v = arr.(t.param_base + i) in
+          let v = arr.ints.(t.param_base + i) in
           e.slots.(i) <- v;
           p.cell := v)
         t.param_handles
@@ -3169,8 +3250,8 @@ let[@inline] get (type a r) ?env (codec : r t) (f : (a, r) field) :
   match List.assoc_opt f.name codec.field_actions with
   | None -> Staged.stage read
   | Some act ->
-      let arr = Array.make codec.n_array_slots 0 in
-      let n = Array.length arr in
+      let arr = alloc_slots codec.n_array_slots in
+      let n = codec.n_array_slots in
       let populate = codec.populate in
       let n_params = codec.n_params in
       let sync, blit_input =
@@ -3185,17 +3266,17 @@ let[@inline] get (type a r) ?env (codec : r t) (f : (a, r) field) :
             ( (fun arr ->
                 List.iteri
                   (fun i (Param.Pack p) ->
-                    let v = arr.(param_base + i) in
+                    let v = arr.ints.(param_base + i) in
                     e.slots.(i) <- v;
                     p.cell := v)
                   param_handles),
               fun arr ->
                 if n_params > 0 then
-                  Array.blit e.slots 0 arr param_base n_params )
+                  Array.blit e.slots 0 arr.ints param_base n_params )
       in
       Staged.stage (fun buf off ->
           let v = read buf off in
-          Array.fill arr 0 n 0;
+          clear_slots arr n;
           blit_input arr;
           populate arr buf off;
           act arr;
@@ -3212,7 +3293,7 @@ let rename new_name (t : _ t) = { t with name = new_name }
 let doc (t : _ t) = t.doc
 let field_readers (t : _ t) = t.field_readers
 let pp ppf (t : _ t) = Fmt.string ppf t.name
-let field_ref (type a r) (f : (a, r) field) : int expr = Ref f.name
+let field_ref (type a r) (f : (a, r) field) : int expr = Ref (I, f.name)
 
 (* -- Slice navigation: zero-copy access to the offset/length of a
       [Byte_slice] field. Used to descend into a nested codec without

--- a/lib/eval.ml
+++ b/lib/eval.ml
@@ -95,13 +95,17 @@ let rec expr : type a. ctx -> a expr -> a =
   | Int n -> n
   | Int64 n -> n
   | Bool b -> b
-  | Ref name -> (
+  | Ref (I, name) -> (
       match List.assoc_opt name ctx with
       | Some v -> v
       | None ->
           failwith
             ("Eval.expr: unbound field " ^ name
            ^ " (cross-field references are only valid inside a struct)"))
+  | Ref (I64, name) ->
+      failwith
+        ("Eval.expr: unbound int64 field " ^ name
+       ^ " (cross-field references are only valid inside a struct)")
   | Param_ref p -> !(p.cell)
   | Sizeof t -> field_wire_size t |> Option.value ~default:0
   | Sizeof_this -> 0
@@ -119,10 +123,10 @@ let rec expr : type a. ctx -> a expr -> a =
   | Lsr (a, b) -> expr ctx a lsr expr ctx b
   | Eq (a, b) -> expr ctx a = expr ctx b
   | Ne (a, b) -> expr ctx a <> expr ctx b
-  | Lt (a, b) -> expr ctx a < expr ctx b
-  | Le (a, b) -> expr ctx a <= expr ctx b
-  | Gt (a, b) -> expr ctx a > expr ctx b
-  | Ge (a, b) -> expr ctx a >= expr ctx b
+  | Lt (a, b) -> compare_expr ctx a b < 0
+  | Le (a, b) -> compare_expr ctx a b <= 0
+  | Gt (a, b) -> compare_expr ctx a b > 0
+  | Ge (a, b) -> compare_expr ctx a b >= 0
   | And (a, b) -> expr ctx a && expr ctx b
   | Or (a, b) -> expr ctx a || expr ctx b
   | Not a -> not (expr ctx a)
@@ -134,3 +138,13 @@ let rec expr : type a. ctx -> a expr -> a =
       | `U32 -> v land 0xFFFF_FFFF
       | `U64 -> v)
   | If_then_else (c, t, e) -> if expr ctx c then expr ctx t else expr ctx e
+
+and compare_expr : type a. ctx -> a expr -> a expr -> int =
+ fun ctx a b ->
+  match a with
+  | Int64 _ -> compare_int64_expr ctx a b
+  | Ref (I64, _) -> compare_int64_expr ctx a b
+  | _ -> Stdlib.compare (expr ctx a) (expr ctx b)
+
+and compare_int64_expr ctx (a : int64 expr) (b : int64 expr) =
+  Int64.unsigned_compare (expr ctx a) (expr ctx b)

--- a/lib/everparse.ml
+++ b/lib/everparse.ml
@@ -688,7 +688,7 @@ module Raw = struct
   let anon_field typ = Field.Anon (Field.anon typ)
 
   let field_ref = function
-    | Field.Named f -> Types.Ref (Field.name f)
+    | Field.Named f -> Types.ref (Field.name f)
     | Field.Anon _ -> invalid_arg "Everparse.Raw.field_ref: anonymous field"
 
   let unpack_fields fields = List.map Field.decl_of_packed fields

--- a/lib/field.ml
+++ b/lib/field.ml
@@ -10,12 +10,36 @@ type 'a anon = { anon_typ : 'a Types.typ }
 
 let pp ppf f = Fmt.pf ppf "%s" f.name
 
-let v name ?constraint_ ?self_constraint ?action ?doc typ =
+let combine a b =
+  match (a, b) with
+  | None, c | c, None -> c
+  | Some a, Some b -> Some (Types.And (a, b))
+
+let rec has_int64_slot : type a. a Types.typ -> bool =
+ fun typ ->
+  let open Types in
+  match typ with
+  | Uint64 _ | Int64 _ -> true
+  | Where { inner; _ } -> has_int64_slot inner
+  | Optional { inner; _ } -> has_int64_slot inner
+  | Optional_or { inner; _ } -> has_int64_slot inner
+  | _ -> false
+
+let reject_no_int64_slot ~combinator name typ =
+  if not (has_int64_slot typ) then
+    Fmt.invalid_arg
+      "Wire.Field.%s: field %S does not have a full-width int64 validation slot"
+      combinator name
+
+let v name ?constraint_ ?self_constraint ?self_int64 ?action ?doc typ =
+  if Option.is_some self_int64 then
+    reject_no_int64_slot ~combinator:"v ?self_int64" name typ;
   let constraint_ =
-    match (constraint_, self_constraint) with
-    | c, None -> c
-    | None, Some f -> Some (f (Types.Ref name))
-    | Some c, Some f -> Some (Types.And (c, f (Types.Ref name)))
+    constraint_
+    |> combine
+         (Option.map (fun f -> f (Types.Ref (Types.I, name))) self_constraint)
+    |> combine
+         (Option.map (fun f -> f (Types.Ref (Types.I64, name))) self_int64)
   in
   { name; typ; constraint_; action; doc }
 
@@ -24,12 +48,14 @@ let v name ?constraint_ ?self_constraint ?action ?doc typ =
    [Wire.optional]/[Wire.repeat] off the typ-level surface so the
    resulting decoration cannot be nested inside [array]/[where]/etc.
    where 3D has no projection for it. *)
-let optional name ?constraint_ ?self_constraint ?action ~present typ =
-  v name ?constraint_ ?self_constraint ?action (Types.optional present typ)
-
-let optional_or name ?constraint_ ?self_constraint ?action ~present ~default typ
+let optional name ?constraint_ ?self_constraint ?self_int64 ?action ~present typ
     =
-  v name ?constraint_ ?self_constraint ?action
+  v name ?constraint_ ?self_constraint ?self_int64 ?action
+    (Types.optional present typ)
+
+let optional_or name ?constraint_ ?self_constraint ?self_int64 ?action ~present
+    ~default typ =
+  v name ?constraint_ ?self_constraint ?self_int64 ?action
     (Types.optional_or present ~default typ)
 
 (* A sub-codec ending in a greedy field ([all_bytes] / [all_zeros]) reads "the
@@ -104,16 +130,25 @@ let reject_unprojectable_repeat ~combinator typ =
        NUL-terminated strings, sub-codecs, and casetypes."
       combinator
 
-let repeat name ?constraint_ ?self_constraint ?action ~size typ =
+let repeat name ?constraint_ ?self_constraint ?self_int64 ?action ~size typ =
   reject_unprojectable_repeat ~combinator:"repeat" typ;
-  v name ?constraint_ ?self_constraint ?action (Types.repeat ~size typ)
+  v name ?constraint_ ?self_constraint ?self_int64 ?action
+    (Types.repeat ~size typ)
 
-let repeat_seq name ?constraint_ ?self_constraint ?action ~seq ~size typ =
+let repeat_seq name ?constraint_ ?self_constraint ?self_int64 ?action ~seq ~size
+    typ =
   reject_unprojectable_repeat ~combinator:"repeat_seq" typ;
-  v name ?constraint_ ?self_constraint ?action (Types.repeat_seq seq ~size typ)
+  v name ?constraint_ ?self_constraint ?self_int64 ?action
+    (Types.repeat_seq seq ~size typ)
 
 let anon typ = { anon_typ = typ }
-let ref f = Types.Ref f.name
+let ref f = Types.Ref (Types.I, f.name)
+let int f = Types.Ref (Types.I, f.name)
+
+let int64 f =
+  reject_no_int64_slot ~combinator:"int64" f.name f.typ;
+  Types.Ref (Types.I64, f.name)
+
 let name f = f.name
 let typ f = f.typ
 let constraint_ f = f.constraint_

--- a/lib/field.mli
+++ b/lib/field.mli
@@ -19,6 +19,7 @@ val v :
   string ->
   ?constraint_:bool Types.expr ->
   ?self_constraint:(int Types.expr -> bool Types.expr) ->
+  ?self_int64:(int64 Types.expr -> bool Types.expr) ->
   ?action:Types.action ->
   ?doc:string ->
   'a Types.typ ->
@@ -40,9 +41,11 @@ val v :
     ]}
 
     projects to [UINT16BE Length {{ Length >= 7 }}], which EverParse's SMT can
-    then use to discharge [byte-size (Length - 7)] on a later field. If both
-    [?constraint_] and [?self_constraint] are given, the two are combined with
-    [And].
+    then use to discharge [byte-size (Length - 7)] on a later field.
+    [?self_int64] is the same convenience for full-width 64-bit field
+    constraints, using {!Expr.int64} literals and {!int64} references. If
+    [?constraint_] and a self constraint are both given, the constraints are
+    combined with [And].
 
     For optional / repeating payloads use {!optional} / {!optional_or} /
     {!repeat} -- those decorations only have a 3D projection at the top of a
@@ -52,6 +55,7 @@ val optional :
   string ->
   ?constraint_:bool Types.expr ->
   ?self_constraint:(int Types.expr -> bool Types.expr) ->
+  ?self_int64:(int64 Types.expr -> bool Types.expr) ->
   ?action:Types.action ->
   present:bool Types.expr ->
   'a Types.typ ->
@@ -63,6 +67,7 @@ val optional_or :
   string ->
   ?constraint_:bool Types.expr ->
   ?self_constraint:(int Types.expr -> bool Types.expr) ->
+  ?self_int64:(int64 Types.expr -> bool Types.expr) ->
   ?action:Types.action ->
   present:bool Types.expr ->
   default:'a ->
@@ -75,6 +80,7 @@ val repeat :
   string ->
   ?constraint_:bool Types.expr ->
   ?self_constraint:(int Types.expr -> bool Types.expr) ->
+  ?self_int64:(int64 Types.expr -> bool Types.expr) ->
   ?action:Types.action ->
   size:int Types.expr ->
   'a Types.typ ->
@@ -86,6 +92,7 @@ val repeat_seq :
   string ->
   ?constraint_:bool Types.expr ->
   ?self_constraint:(int Types.expr -> bool Types.expr) ->
+  ?self_int64:(int64 Types.expr -> bool Types.expr) ->
   ?action:Types.action ->
   seq:('a, 'seq) Types.seq_map ->
   size:int Types.expr ->
@@ -100,6 +107,13 @@ val ref : 'a t -> int Types.expr
 (** [ref f] returns the expression referencing this field's underlying integer
     value. Works on any field whose wire type is or wraps an integer, including
     [bool] fields created with {!Wire.bit}. *)
+
+val int : 'a t -> int Types.expr
+(** [int f] returns this field as a native-integer expression. *)
+
+val int64 : int64 t -> int64 Types.expr
+(** [int64 f] returns the expression referencing this field's full 64-bit value,
+    without truncating to OCaml's native integer range. *)
 
 val name : 'a t -> string
 (** Field name. *)

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -32,11 +32,13 @@ type ('a, 'k) param_handle = {
 and packed_typ = Pack_typ : 'a typ -> packed_typ
 
 (* Expressions *)
+and _ ref_kind = I : int ref_kind | I64 : int64 ref_kind
+
 and _ expr =
   | Int : int -> int expr
   | Int64 : int64 -> int64 expr
   | Bool : bool -> bool expr
-  | Ref : string -> int expr
+  | Ref : 'a ref_kind * string -> 'a expr
   | Param_ref : ('a, 'k) param_handle -> int expr
   | Sizeof : 'a typ -> int expr
   | Sizeof_this : int expr
@@ -54,10 +56,10 @@ and _ expr =
   | Lsr : int expr * int expr -> int expr
   | Eq : 'a expr * 'a expr -> bool expr
   | Ne : 'a expr * 'a expr -> bool expr
-  | Lt : int expr * int expr -> bool expr
-  | Le : int expr * int expr -> bool expr
-  | Gt : int expr * int expr -> bool expr
-  | Ge : int expr * int expr -> bool expr
+  | Lt : 'a expr * 'a expr -> bool expr
+  | Le : 'a expr * 'a expr -> bool expr
+  | Gt : 'a expr * 'a expr -> bool expr
+  | Ge : 'a expr * 'a expr -> bool expr
   | And : bool expr * bool expr -> bool expr
   | Or : bool expr * bool expr -> bool expr
   | Not : bool expr -> bool expr
@@ -239,12 +241,13 @@ type param_env = {
 let int n = Int n
 let true_ = Bool true
 let false_ = Bool false
-let ref name = Ref name
+let ref name = Ref (I, name)
 let sizeof t = Sizeof t
 let sizeof_this = Sizeof_this
 let field_pos = Field_pos
 
 module Expr = struct
+  let int64 n = Int64 n
   let ( + ) a b = Add (a, b)
   let ( - ) a b = Sub (a, b)
   let ( * ) a b = Mul (a, b)
@@ -564,7 +567,7 @@ let byte_array_where ~size ~per_byte =
   let n = !byte_array_where_counter in
   Stdlib.incr byte_array_where_counter;
   let elt_var = elt_var_prefix ^ string_of_int n in
-  let cond = per_byte (Ref elt_var) in
+  let cond = per_byte (Ref (I, elt_var)) in
   Byte_array_where { size; elt_var; cond }
 
 (* The 3D synthesized typedef name derived from an elt_var. The element
@@ -945,7 +948,7 @@ let casetype_pair : type a k.
   let tag_field = field "tag" tag in
   let body_field =
     field "body"
-      (Apply { typ = Type_ref body_name; args = [ Pack_expr (Ref "tag") ] })
+      (Apply { typ = Type_ref body_name; args = [ Pack_expr (Ref (I, "tag")) ] })
   in
   let wrapper = typedef (struct_ name [ tag_field; body_field ]) in
   (dispatch, wrapper)
@@ -1262,6 +1265,16 @@ let pp_cast_type ppf = function
   | `U32 -> Fmt.string ppf "UINT32"
   | `U64 -> Fmt.string ppf "UINT64"
 
+let string_of_uint64 n =
+  let ten = 10L in
+  let rec loop n acc =
+    let q = Int64.unsigned_div n ten in
+    let r = Int64.unsigned_rem n ten |> Int64.to_int in
+    let acc = Char.chr (Char.code '0' + r) :: acc in
+    if q = 0L then acc else loop q acc
+  in
+  String.of_seq (List.to_seq (loop n []))
+
 let rec pp_expr : type a. a expr Fmt.t =
  fun ppf expr ->
   match expr with
@@ -1274,10 +1287,10 @@ let rec pp_expr : type a. a expr Fmt.t =
          no negative literals)"
         n
   | Int n -> Fmt.int ppf n
-  | Int64 n -> Fmt.pf ppf "%LduL" n
+  | Int64 n -> Fmt.pf ppf "%suL" (string_of_uint64 n)
   | Bool true -> Fmt.string ppf "true"
   | Bool false -> Fmt.string ppf "false"
-  | Ref name -> Fmt.string ppf (escape_3d name)
+  | Ref (_, name) -> Fmt.string ppf (escape_3d name)
   | Param_ref p -> Fmt.string ppf (escape_3d p.name)
   | Sizeof t -> Fmt.pf ppf "sizeof (%a)" pp_typ t
   | Sizeof_this -> Fmt.string ppf "sizeof (this)"
@@ -1397,7 +1410,8 @@ let rec subst_expr : type a. (string * int expr) list -> a expr -> a expr =
   | Int _ | Int64 _ | Bool _ | Param_ref _ | Sizeof _ | Sizeof_this | Field_pos
     ->
       e
-  | Ref name -> ( try List.assoc name env with Not_found -> e)
+  | Ref (I, name) -> ( try List.assoc name env with Not_found -> e)
+  | Ref (I64, _) -> e
   | Add (a, b) -> Add (r a, r b)
   | Sub (a, b) -> Sub (r a, r b)
   | Mul (a, b) -> Mul (r a, r b)
@@ -1579,7 +1593,7 @@ let index_bound_elt : type a. a typ -> (string * bool expr) option =
   match (inner_wire_size elem, index_bound_of elem) with
   | Some 1, Some bound ->
       let elt_var = Fmt.str "%slk%d" elt_var_prefix bound in
-      Some (elt_var, Lt (Ref elt_var, Int bound))
+      Some (elt_var, Lt (Ref (I, elt_var), Int bound))
   | _ -> None
 
 let rec optional_suffix : type a.
@@ -1755,7 +1769,7 @@ let pp_field ppf (Field f) =
      as a refinement (the OCaml decoder enforces it via the [Map] decode). *)
   let bound_cond =
     match index_bound_of f.field_typ with
-    | Some len -> Some (Lt (Ref raw_name, Int len))
+    | Some len -> Some (Lt (Ref (I, raw_name), Int len))
     | None -> None
   in
   (* The documentation projection types the field as its named enum, so
@@ -1770,8 +1784,8 @@ let pp_field ppf (Field f) =
     | None, Some (v0 :: rest) ->
         Some
           (List.fold_left
-             (fun acc v -> Or (acc, Eq (Ref raw_name, Int v)))
-             (Eq (Ref raw_name, Int v0))
+             (fun acc v -> Or (acc, Eq (Ref (I, raw_name), Int v)))
+             (Eq (Ref (I, raw_name), Int v0))
              rest)
     | _ -> None
   in
@@ -1811,7 +1825,7 @@ let rec collect_refs : type a. a expr -> string list = function
   | Int _ | Int64 _ | Bool _ | Param_ref _ | Sizeof _ | Sizeof_this | Field_pos
     ->
       []
-  | Ref name -> [ name ]
+  | Ref (_, name) -> [ name ]
   | Add (a, b)
   | Sub (a, b)
   | Mul (a, b)
@@ -1824,8 +1838,10 @@ let rec collect_refs : type a. a expr -> string list = function
   | Lsr (a, b) ->
       collect_refs a @ collect_refs b
   | Lnot a -> collect_refs a
-  | Lt (a, b) | Le (a, b) | Gt (a, b) | Ge (a, b) ->
-      collect_refs a @ collect_refs b
+  | Lt (a, b) -> collect_refs_packed a @ collect_refs_packed b
+  | Le (a, b) -> collect_refs_packed a @ collect_refs_packed b
+  | Gt (a, b) -> collect_refs_packed a @ collect_refs_packed b
+  | Ge (a, b) -> collect_refs_packed a @ collect_refs_packed b
   | And (a, b) | Or (a, b) -> collect_refs a @ collect_refs b
   | Not a -> collect_refs a
   | Cast (_, a) -> collect_refs a

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -54,11 +54,13 @@ and packed_typ = Pack_typ : 'a typ -> packed_typ
     Typed expression language used in constraints, actions and size
     computations. Arithmetic and bitwise operators mirror OCaml conventions. *)
 
+and _ ref_kind = I : int ref_kind | I64 : int64 ref_kind
+
 and _ expr =
   | Int : int -> int expr
   | Int64 : int64 -> int64 expr
   | Bool : bool -> bool expr
-  | Ref : string -> int expr
+  | Ref : 'a ref_kind * string -> 'a expr
   | Param_ref : ('a, 'k) param_handle -> int expr
   | Sizeof : 'a typ -> int expr
   | Sizeof_this : int expr
@@ -76,10 +78,10 @@ and _ expr =
   | Lsr : int expr * int expr -> int expr
   | Eq : 'a expr * 'a expr -> bool expr
   | Ne : 'a expr * 'a expr -> bool expr
-  | Lt : int expr * int expr -> bool expr
-  | Le : int expr * int expr -> bool expr
-  | Gt : int expr * int expr -> bool expr
-  | Ge : int expr * int expr -> bool expr
+  | Lt : 'a expr * 'a expr -> bool expr
+  | Le : 'a expr * 'a expr -> bool expr
+  | Gt : 'a expr * 'a expr -> bool expr
+  | Ge : 'a expr * 'a expr -> bool expr
   | And : bool expr * bool expr -> bool expr
   | Or : bool expr * bool expr -> bool expr
   | Not : bool expr -> bool expr
@@ -283,6 +285,9 @@ val field_pos : int expr
 module Expr : sig
   (** {2 Arithmetic and bitwise operators} *)
 
+  val int64 : int64 -> int64 expr
+  (** 64-bit integer literal. *)
+
   val ( + ) : int expr -> int expr -> int expr
   (** Addition. *)
 
@@ -324,17 +329,17 @@ module Expr : sig
   val ( <> ) : 'a expr -> 'a expr -> bool expr
   (** Inequality. *)
 
-  val ( < ) : int expr -> int expr -> bool expr
-  (** Strictly less than. *)
+  val ( < ) : 'a expr -> 'a expr -> bool expr
+  (** Strictly less than, on native-integer or 64-bit expressions. *)
 
-  val ( <= ) : int expr -> int expr -> bool expr
-  (** Less than or equal. *)
+  val ( <= ) : 'a expr -> 'a expr -> bool expr
+  (** Less than or equal, on native-integer or 64-bit expressions. *)
 
-  val ( > ) : int expr -> int expr -> bool expr
-  (** Strictly greater than. *)
+  val ( > ) : 'a expr -> 'a expr -> bool expr
+  (** Strictly greater than, on native-integer or 64-bit expressions. *)
 
-  val ( >= ) : int expr -> int expr -> bool expr
-  (** Greater than or equal. *)
+  val ( >= ) : 'a expr -> 'a expr -> bool expr
+  (** Greater than or equal, on native-integer or 64-bit expressions. *)
 
   (** {2 Boolean operators} *)
 

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -225,6 +225,9 @@ module Expr : sig
       Open this module locally to build constraint and size expressions:
       [Expr.(Field.ref f + int 1)]. *)
 
+  val int64 : int64 -> int64 expr
+  (** Constant 64-bit integer expression. *)
+
   val ( + ) : int expr -> int expr -> int expr
   (** Addition. *)
 
@@ -264,17 +267,17 @@ module Expr : sig
   val ( <> ) : 'a expr -> 'a expr -> bool expr
   (** Inequality. *)
 
-  val ( < ) : int expr -> int expr -> bool expr
-  (** Less than. *)
+  val ( < ) : 'a expr -> 'a expr -> bool expr
+  (** Less than, on native-integer or 64-bit expressions. *)
 
-  val ( <= ) : int expr -> int expr -> bool expr
-  (** Less than or equal. *)
+  val ( <= ) : 'a expr -> 'a expr -> bool expr
+  (** Less than or equal, on native-integer or 64-bit expressions. *)
 
-  val ( > ) : int expr -> int expr -> bool expr
-  (** Greater than. *)
+  val ( > ) : 'a expr -> 'a expr -> bool expr
+  (** Greater than, on native-integer or 64-bit expressions. *)
 
-  val ( >= ) : int expr -> int expr -> bool expr
-  (** Greater than or equal. *)
+  val ( >= ) : 'a expr -> 'a expr -> bool expr
+  (** Greater than or equal, on native-integer or 64-bit expressions. *)
 
   val ( && ) : bool expr -> bool expr -> bool expr
   (** Boolean conjunction. *)
@@ -343,6 +346,7 @@ module Field : sig
     string ->
     ?constraint_:bool expr ->
     ?self_constraint:(int expr -> bool expr) ->
+    ?self_int64:(int64 expr -> bool expr) ->
     ?action:Action.t ->
     ?doc:string ->
     'a typ ->
@@ -352,7 +356,9 @@ module Field : sig
       comment on the field in the generated 3D. [?self_constraint] receives the
       field's own ref and returns a constraint over it; useful for proving a
       later size-expression safe (e.g. [self >= int 7] when a later field uses
-      [byte_slice ~size:(ref len - int 7)]).
+      [byte_slice ~size:(ref len - int 7)]). [?self_int64] is the same
+      convenience for full-width 64-bit constraints using {!Expr.int64} literals
+      and {!int64} field references.
 
       Use {!optional} / {!optional_or} / {!repeat} for optional and repeating
       payloads -- they only project to 3D as the top of a struct field, never as
@@ -362,6 +368,7 @@ module Field : sig
     string ->
     ?constraint_:bool expr ->
     ?self_constraint:(int expr -> bool expr) ->
+    ?self_int64:(int64 expr -> bool expr) ->
     ?action:Action.t ->
     present:bool expr ->
     'a typ ->
@@ -373,6 +380,7 @@ module Field : sig
     string ->
     ?constraint_:bool expr ->
     ?self_constraint:(int expr -> bool expr) ->
+    ?self_int64:(int64 expr -> bool expr) ->
     ?action:Action.t ->
     present:bool expr ->
     default:'a ->
@@ -385,6 +393,7 @@ module Field : sig
     string ->
     ?constraint_:bool expr ->
     ?self_constraint:(int expr -> bool expr) ->
+    ?self_int64:(int64 expr -> bool expr) ->
     ?action:Action.t ->
     size:int expr ->
     'a typ ->
@@ -401,6 +410,7 @@ module Field : sig
     string ->
     ?constraint_:bool expr ->
     ?self_constraint:(int expr -> bool expr) ->
+    ?self_int64:(int64 expr -> bool expr) ->
     ?action:Action.t ->
     seq:('a, 'seq) Types.seq_map ->
     size:int expr ->
@@ -415,6 +425,13 @@ module Field : sig
   (** [ref f] returns the expression referencing this field's underlying integer
       value. Works on any field whose wire type is or wraps an integer,
       including boolean fields created with {!bit}. *)
+
+  val int : 'a t -> int expr
+  (** [int f] returns this field as a native-integer expression. *)
+
+  val int64 : int64 t -> int64 expr
+  (** [int64 f] returns the expression referencing this field's full 64-bit
+      value, without truncating to OCaml's native integer range. *)
 
   val name : 'a t -> string
   (** Field name. *)

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -2677,6 +2677,56 @@ let test_dep_ref_size_eval () =
   Bytes.set_uint8 buf 0 0;
   Alcotest.(check int) "compute size 0" 1 (Codec.wire_size_at codec buf 0)
 
+let signed_magnitude_seek_codec =
+  let f_seek =
+    Field.v "Seek" uint64be ~self_int64:(fun self ->
+        Expr.(self <= int64 Int64.max_int || self > int64 Int64.min_int))
+  in
+  Codec.v "SignedMagnitudeSeek" Fun.id Codec.[ f_seek $ Fun.id ]
+
+let seek_buf v =
+  let b = Bytes.create 8 in
+  Bytes.set_int64_be b 0 v;
+  b
+
+let test_int64_field_constraint_accepts_signed_magnitude_domain () =
+  List.iter
+    (fun v ->
+      let decoded =
+        decode_ok (Codec.decode signed_magnitude_seek_codec (seek_buf v) 0)
+      in
+      Alcotest.(check int64) "seek" v decoded)
+    [ 0L; Int64.max_int; Int64.succ Int64.min_int; -1L ]
+
+let test_int64_field_constraint_rejects_negative_zero () =
+  match Codec.decode signed_magnitude_seek_codec (seek_buf Int64.min_int) 0 with
+  | Ok _ -> Alcotest.fail "expected signed-magnitude negative zero to fail"
+  | Error (Constraint_failed _) -> ()
+  | Error e ->
+      Alcotest.failf "expected Constraint_failed, got %a" pp_parse_error e
+
+(* A plain int-kind [self_constraint] on a uint64 field must still read the
+   field value, not an unpopulated zero slot: an out-of-range value has to be
+   rejected, or the bound is silently vacuous. *)
+let test_uint64_int_ref_constraint_enforced () =
+  let f =
+    Field.v "Len" uint64be ~self_constraint:(fun self -> Expr.(self <= int 10))
+  in
+  let codec = Codec.v "U64IntRef" Fun.id Codec.[ f $ Fun.id ] in
+  let buf v =
+    let b = Bytes.create 8 in
+    Bytes.set_int64_be b 0 v;
+    b
+  in
+  Alcotest.(check int64)
+    "in-range accepts" 3L
+    (decode_ok (Codec.decode codec (buf 3L) 0));
+  match Codec.decode codec (buf 20L) 0 with
+  | Ok _ -> Alcotest.fail "20 exceeds the bound and must be rejected"
+  | Error (Constraint_failed _) -> ()
+  | Error e ->
+      Alcotest.failf "expected Constraint_failed, got %a" pp_parse_error e
+
 (* -- struct_of_codec for variable-size codecs -- *)
 
 let test_struct_of_dep () =
@@ -3577,7 +3627,7 @@ let test_field_ref_through_optional () =
   Alcotest.(check (option int)) "x" (Some 0x80) r.x;
   Alcotest.(check int) "check" 0x7F r.check
 
-let test_uint64_ref_in_size () =
+let test_uint64_in_size_expr () =
   let f_len = Field.v "Len" uint64be in
   let codec =
     let open Codec in
@@ -5191,8 +5241,13 @@ let suite =
         test_optional_lor_predicate;
       Alcotest.test_case "optional: Field.ref reads inner value" `Quick
         test_field_ref_through_optional;
-      Alcotest.test_case "ref: uint64 in size expr" `Quick
-        test_uint64_ref_in_size;
+      Alcotest.test_case "uint64 in size expr" `Quick test_uint64_in_size_expr;
+      Alcotest.test_case "constraint: int64 signed-magnitude domain" `Quick
+        test_int64_field_constraint_accepts_signed_magnitude_domain;
+      Alcotest.test_case "constraint: int64 rejects negative zero" `Quick
+        test_int64_field_constraint_rejects_negative_zero;
+      Alcotest.test_case "constraint: int-ref bound on uint64 enforced" `Quick
+        test_uint64_int_ref_constraint_enforced;
       (* repeat *)
       Alcotest.test_case "repeat: decode empty" `Quick test_repeat_decode_empty;
       Alcotest.test_case "repeat: decode one" `Quick test_repeat_decode_one;

--- a/test/test_eval.ml
+++ b/test/test_eval.ml
@@ -79,7 +79,7 @@ let test_expr_ref_fails () =
     (Failure
        "Eval.expr: unbound field x (cross-field references are only valid \
         inside a struct)") (fun () ->
-      ignore (Eval.expr Eval.empty (Types.Ref "x")))
+      ignore (Eval.expr Eval.empty (Types.ref "x")))
 
 let test_cast_u8 () =
   let v = Eval.expr Eval.empty (Types.Cast (`U8, Types.Int 0x1234)) in

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -422,6 +422,17 @@ let test_3d_negative_literal_rejected () =
   Alcotest.(check bool)
     "negative literal rejected by projection" true (projects_or_raises codec)
 
+let test_3d_int64_literal_uses_unsigned_decimal () =
+  let f =
+    Field.v "a" uint64be ~self_int64:(fun self ->
+        Expr.(self > int64 Int64.min_int))
+  in
+  let codec = Codec.v "I64Lit" Fun.id Codec.[ f $ Fun.id ] in
+  let out3d = to_3d (Everparse.schema codec).module_ in
+  Alcotest.(check bool)
+    "high-bit int64 literal prints unsigned" true
+    (contains ~sub:"9223372036854775808uL" out3d)
+
 let test_3d_field_pos_rejected () =
   (* EverParse has no [field_pos] keyword, so a projected expression using it is
      rejected at projection, not emitted as an undefined identifier. *)
@@ -970,6 +981,8 @@ let suite =
         test_3d_on_success_conditional_return;
       Alcotest.test_case "3d: negative literal rejected by projection" `Quick
         test_3d_negative_literal_rejected;
+      Alcotest.test_case "3d: int64 literal unsigned decimal" `Quick
+        test_3d_int64_literal_uses_unsigned_decimal;
       Alcotest.test_case "3d: field_pos rejected by projection" `Quick
         test_3d_field_pos_rejected;
     ] )

--- a/test/test_field.ml
+++ b/test/test_field.ml
@@ -16,7 +16,7 @@ let test_anon () =
 let test_ref_returns_ref_expr () =
   let f = Field.v "Tag" Types.uint8 in
   match Field.ref f with
-  | Types.Ref name -> Alcotest.(check string) "ref name" "Tag" name
+  | Types.Ref (Types.I, name) -> Alcotest.(check string) "ref name" "Tag" name
   | _ -> Alcotest.fail "expected Ref expression"
 
 let test_pp_prints_name () =
@@ -57,12 +57,13 @@ let test_no_constraint () =
   | Some _ -> Alcotest.fail "expected no constraint"
 
 (* ref on non-int fields: bool, mapped, uint64. The expression is always
-   Ref name -- the type system no longer restricts the field's OCaml type. *)
+   Ref (I, name) -- the type system no longer restricts the field's OCaml
+   type. *)
 
 let test_ref_bool_field () =
   let f = Field.v "Flag" (Types.bool Types.uint8) in
   match Field.ref f with
-  | Types.Ref name -> Alcotest.(check string) "ref name" "Flag" name
+  | Types.Ref (Types.I, name) -> Alcotest.(check string) "ref name" "Flag" name
   | _ -> Alcotest.fail "expected Ref"
 
 let test_ref_mapped_field () =
@@ -74,14 +75,39 @@ let test_ref_mapped_field () =
          Types.uint8)
   in
   match Field.ref f with
-  | Types.Ref name -> Alcotest.(check string) "ref name" "Code" name
+  | Types.Ref (Types.I, name) -> Alcotest.(check string) "ref name" "Code" name
   | _ -> Alcotest.fail "expected Ref"
 
 let test_ref_uint64_field () =
   let f = Field.v "Timestamp" (Types.Uint64 Types.Big) in
   match Field.ref f with
-  | Types.Ref name -> Alcotest.(check string) "ref name" "Timestamp" name
+  | Types.Ref (Types.I, name) ->
+      Alcotest.(check string) "ref name" "Timestamp" name
   | _ -> Alcotest.fail "expected Ref"
+
+let test_int64_uint64_field () =
+  let f = Field.v "Timestamp" (Types.Uint64 Types.Big) in
+  match Field.int64 f with
+  | Types.Ref (Types.I64, name) ->
+      Alcotest.(check string) "ref name" "Timestamp" name
+  | _ -> Alcotest.fail "expected int64 Ref"
+
+let test_int64_rejects_field_without_int64_slot () =
+  let check_invalid label f =
+    match f () with
+    | () -> Alcotest.failf "%s: expected Invalid_argument" label
+    | exception Invalid_argument _ -> ()
+  in
+  let mapped =
+    Field.v "Mapped" (Types.map Int64.of_int Int64.to_int Types.uint8)
+  in
+  check_invalid "mapped field" (fun () ->
+      ignore (Field.int64 mapped : int64 Types.expr));
+  check_invalid "self_int64 on uint8" (fun () ->
+      ignore
+        (Field.v "Tiny" Types.uint8 ~self_int64:(fun self ->
+             Types.Expr.(self = int64 0L))
+          : int Field.t))
 
 let suite =
   ( "field",
@@ -94,6 +120,9 @@ let suite =
       Alcotest.test_case "ref on bool field" `Quick test_ref_bool_field;
       Alcotest.test_case "ref on mapped field" `Quick test_ref_mapped_field;
       Alcotest.test_case "ref on uint64 field" `Quick test_ref_uint64_field;
+      Alcotest.test_case "int64 on uint64 field" `Quick test_int64_uint64_field;
+      Alcotest.test_case "int64 rejects missing slot" `Quick
+        test_int64_rejects_field_without_int64_slot;
       Alcotest.test_case "pp prints name" `Quick test_pp_prints_name;
       Alcotest.test_case "to_decl named" `Quick test_to_decl_named;
       Alcotest.test_case "to_decl anon" `Quick test_to_decl_anon;

--- a/wire.opam
+++ b/wire.opam
@@ -11,7 +11,7 @@ homepage: "https://github.com/parsimoni-labs/ocaml-wire"
 bug-reports: "https://github.com/parsimoni-labs/ocaml-wire/issues"
 depends: [
   "dune" {>= "3.21"}
-  "ocaml" {>= "5.1"}
+  "ocaml" {>= "5.2"}
   "bytesrw" {>= "0.1"}
   "eio" {>= "1.0"}
   "fmt" {>= "0.9"}


### PR DESCRIPTION
This PR adds `Wire.Field.int64`, `Wire.Expr.int64`, and a `?self_int64` parameter on `Field.v` (and `optional` / `optional_or` / `repeat` / `repeat_seq`), for full-width 64-bit field constraints.

A `where`/constraint over a `uint64` field used to go through OCaml's native `int` slot, so a value that did not fit (>= 2^62) was silently dropped and the constraint then compared against a wrong value. The field value is now carried losslessly in a dedicated 64-bit slot and compared with unsigned semantics, matching the EverParse `UINT64` projection, which prints `uL` literals and compares unsigned. The comparison operators generalise from `int expr` to any `int` or `int64` expression. Legacy int-kind `Field.ref` constraints on a 64-bit field still read the truncated value, so existing schemas are unaffected; `Field.int64` is the new full-width accessor and is rejected at construction on fields without a 64-bit slot.