### PR TITLE
examples: RFC-document the net protocol spec and commit it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ c_stubs.ml
 prof.txt
 prof.trace/
 *.3d
+# Except the committed RFC-documented protocol spec (kept in sync by a runtest
+# diff against examples/net/gen_spec).
+!examples/net/Net.3d
 schemas/
 AGENTS.md
 .agents/

--- a/examples/net/Net.3d
+++ b/examples/net/Net.3d
@@ -1,0 +1,82 @@
+/*++ Ethernet II (DIX) frame header; IEEE 802.3 --*/
+entrypoint
+typedef struct _Ethernet
+{
+   UINT8 DstMAC[:byte-size 6];
+   UINT8 SrcMAC[:byte-size 6];
+   UINT16BE EtherType;
+   UINT8 Payload[:byte-size 40];
+} Ethernet;
+
+/*++ IPv4 header, RFC 791 section 3.1 --*/
+entrypoint
+typedef struct _IPv4
+{
+   /* RFC 791 3.1: header length in 32-bit words */
+   UINT8 IHL : 4;
+   /* RFC 791 3.1: version, 4 for IPv4 */
+   UINT8 Version : 4;
+   /* RFC 3168: explicit congestion notification */
+   UINT8 ECN : 2;
+   /* RFC 2474: differentiated services codepoint */
+   UINT8 DSCP : 6;
+   /* RFC 791 3.1: total length in octets */
+   UINT16BE TotalLength;
+   /* RFC 791 3.1: fragment reassembly identifier */
+   UINT16BE Identification;
+   /* RFC 791 3.1: control flags (DF, MF) */
+   UINT16BE Flags : 3;
+   /* RFC 791 3.1: fragment offset in 8-octet units */
+   UINT16BE FragmentOffset : 13;
+   /* RFC 791 3.1: time to live */
+   UINT8 TTL;
+   /* RFC 791 3.1: next-level protocol (6 TCP, 17 UDP) */
+   UINT8 Protocol;
+   /* RFC 791 3.1: header checksum */
+   UINT16BE HeaderChecksum;
+   /* RFC 791 3.1: source address */
+   UINT32BE SrcAddr;
+   /* RFC 791 3.1: destination address */
+   UINT32BE DstAddr;
+   UINT8 Payload[:byte-size 20];
+} IPv4;
+
+/*++ TCP header, RFC 9293 section 3.1 --*/
+entrypoint
+typedef struct _TCP
+{
+   UINT16BE SrcPort;
+   UINT16BE DstPort;
+   UINT32BE SeqNum;
+   UINT32BE AckNum;
+   UINT16BE DataOffset : 4;
+   UINT16BE Reserved : 3;
+   UINT16BE NS : 1;
+   UINT16BE CWR : 1;
+   UINT16BE ECE : 1;
+   UINT16BE URG : 1;
+   UINT16BE ACK : 1;
+   UINT16BE PSH : 1;
+   UINT16BE RST : 1;
+   UINT16BE SYN : 1;
+   UINT16BE FIN : 1;
+   UINT16BE Window;
+   UINT16BE Checksum;
+   UINT16BE UrgentPtr;
+} TCP;
+
+/*++ UDP header, RFC 768 --*/
+entrypoint
+typedef struct _UDP
+{
+   /* RFC 768: source port */
+   UINT16BE SrcPort;
+   /* RFC 768: destination port */
+   UINT16BE DstPort;
+   /* RFC 768: octet length of header and data */
+   UINT16BE Length;
+   /* RFC 768: checksum over pseudo-header, header, and data */
+   UINT16BE Checksum;
+} UDP;
+
+

--- a/examples/net/dune
+++ b/examples/net/dune
@@ -8,3 +8,25 @@
  (name example)
  (modules example)
  (libraries net wire))
+
+; The committed Net.3d is the RFC-documented projection of the net codecs.
+; gen_spec renders it; the runtest diff fails if it drifts from net.ml, and
+; [dune promote] refreshes it. No 3d.exe needed (the .3d is pure projection).
+
+(executable
+ (name gen_spec)
+ (modules gen_spec)
+ (libraries net wire))
+
+(rule
+ (target net.actual.3d)
+ (deps gen_spec.exe)
+ (action
+  (with-stdout-to
+   net.actual.3d
+   (run ./gen_spec.exe))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff Net.3d net.actual.3d)))

--- a/examples/net/gen_spec.ml
+++ b/examples/net/gen_spec.ml
@@ -1,0 +1,15 @@
+(* Render the net protocol family to its documentation [.3d] and print it.
+   The committed [Net.3d] is this output; a runtest diff keeps the two in sync,
+   so the checked-in spec never drifts from the codecs in [net.ml]. *)
+let () =
+  let dir = Filename.temp_dir "net_spec" "" in
+  Wire.Everparse.write_doc ~outdir:dir ~name:"net"
+    Wire.Everparse.
+      [
+        doc Net.ethernet_codec;
+        doc Net.ipv4_codec;
+        doc Net.tcp_codec;
+        doc Net.udp_codec;
+      ];
+  let path = Filename.concat dir "Net.3d" in
+  print_string (In_channel.with_open_text path In_channel.input_all)

--- a/examples/net/net.ml
+++ b/examples/net/net.ml
@@ -64,9 +64,70 @@ type ipv4 = {
   payload : Slice.t;
 }
 
-let f_ip_protocol = Field.v "Protocol" uint8
-let f_ip_src = Field.v "SrcAddr" uint32be
-let f_ip_dst = Field.v "DstAddr" uint32be
+let bf_ip_version =
+  Codec.(
+    Field.v "Version" ~doc:"RFC 791 3.1: version, 4 for IPv4" (bits ~width:4 U8)
+    $ fun p -> p.version)
+
+let bf_ip_ihl =
+  Codec.(
+    Field.v "IHL" ~doc:"RFC 791 3.1: header length in 32-bit words"
+      (bits ~width:4 U8)
+    $ fun p -> p.ihl)
+
+let bf_ip_dscp =
+  Codec.(
+    Field.v "DSCP" ~doc:"RFC 2474: differentiated services codepoint"
+      (bits ~width:6 U8)
+    $ fun p -> p.dscp)
+
+let bf_ip_ecn =
+  Codec.(
+    Field.v "ECN" ~doc:"RFC 3168: explicit congestion notification"
+      (bits ~width:2 U8)
+    $ fun p -> p.ecn)
+
+let bf_ip_total_length =
+  Codec.(
+    Field.v "TotalLength" ~doc:"RFC 791 3.1: total length in octets" uint16be
+    $ fun p -> p.total_length)
+
+let bf_ip_identification =
+  Codec.(
+    Field.v "Identification" ~doc:"RFC 791 3.1: fragment reassembly identifier"
+      uint16be
+    $ fun p -> p.identification)
+
+let bf_ip_flags =
+  Codec.(
+    Field.v "Flags" ~doc:"RFC 791 3.1: control flags (DF, MF)"
+      (bits ~width:3 U16be)
+    $ fun p -> p.flags)
+
+let bf_ip_fragment_offset =
+  Codec.(
+    Field.v "FragmentOffset"
+      ~doc:"RFC 791 3.1: fragment offset in 8-octet units"
+      (bits ~width:13 U16be)
+    $ fun p -> p.fragment_offset)
+
+let bf_ip_ttl =
+  Codec.(Field.v "TTL" ~doc:"RFC 791 3.1: time to live" uint8 $ fun p -> p.ttl)
+
+let bf_ip_checksum =
+  Codec.(
+    Field.v "HeaderChecksum" ~doc:"RFC 791 3.1: header checksum" uint16be
+    $ fun p -> p.checksum)
+
+let f_ip_protocol =
+  Field.v "Protocol" ~doc:"RFC 791 3.1: next-level protocol (6 TCP, 17 UDP)"
+    uint8
+
+let f_ip_src = Field.v "SrcAddr" ~doc:"RFC 791 3.1: source address" uint32be
+
+let f_ip_dst =
+  Field.v "DstAddr" ~doc:"RFC 791 3.1: destination address" uint32be
+
 let f_ip_payload = Field.v "Payload" (byte_slice ~size:(int ipv4_payload_size))
 let bf_ip_protocol = Codec.(f_ip_protocol $ fun p -> p.protocol)
 let bf_ip_src = Codec.(f_ip_src $ fun p -> p.src)
@@ -95,18 +156,17 @@ let ipv4_codec =
       })
     Codec.
       [
-        (Field.v "Version" (bits ~width:4 U8) $ fun p -> p.version);
-        (Field.v "IHL" (bits ~width:4 U8) $ fun p -> p.ihl);
-        (Field.v "DSCP" (bits ~width:6 U8) $ fun p -> p.dscp);
-        (Field.v "ECN" (bits ~width:2 U8) $ fun p -> p.ecn);
-        (Field.v "TotalLength" uint16be $ fun p -> p.total_length);
-        (Field.v "Identification" uint16be $ fun p -> p.identification);
-        (Field.v "Flags" (bits ~width:3 U16be) $ fun p -> p.flags);
-        ( Field.v "FragmentOffset" (bits ~width:13 U16be) $ fun p ->
-          p.fragment_offset );
-        (Field.v "TTL" uint8 $ fun p -> p.ttl);
+        bf_ip_version;
+        bf_ip_ihl;
+        bf_ip_dscp;
+        bf_ip_ecn;
+        bf_ip_total_length;
+        bf_ip_identification;
+        bf_ip_flags;
+        bf_ip_fragment_offset;
+        bf_ip_ttl;
         bf_ip_protocol;
-        (Field.v "HeaderChecksum" uint16be $ fun p -> p.checksum);
+        bf_ip_checksum;
         bf_ip_src;
         bf_ip_dst;
         bf_ip_payload;
@@ -202,10 +262,15 @@ let tcp_size = Codec.wire_size tcp_codec
 
 type udp = { src_port : int; dst_port : int; length : int; checksum : int }
 
-let f_udp_src_port = Field.v "SrcPort" uint16be
-let f_udp_dst_port = Field.v "DstPort" uint16be
-let f_udp_length = Field.v "Length" uint16be
-let f_udp_checksum = Field.v "Checksum" uint16be
+let f_udp_src_port = Field.v "SrcPort" ~doc:"RFC 768: source port" uint16be
+let f_udp_dst_port = Field.v "DstPort" ~doc:"RFC 768: destination port" uint16be
+
+let f_udp_length =
+  Field.v "Length" ~doc:"RFC 768: octet length of header and data" uint16be
+
+let f_udp_checksum =
+  Field.v "Checksum"
+    ~doc:"RFC 768: checksum over pseudo-header, header, and data" uint16be
 
 let udp_codec =
   Codec.v "UDP" ~doc:"UDP header, RFC 768"


### PR DESCRIPTION
The net codecs already carried struct-level RFC citations (`Codec.v ~doc`); now each IPv4 and UDP header field also carries its defining RFC section via `Field.v ~doc`, and the rendered spec is committed as `examples/net/Net.3d`.

That file is the documentation projection of the four net codecs, so it reads as an RFC-annotated protocol specification rather than living only in the OCaml source. A `runtest` diff regenerates it from the codecs and fails if it ever drifts from `net.ml`, so it is never a stale snapshot, and since the `.3d` projection is pure OCaml the check needs no 3d.exe. The IPv4 header fields are lifted to top-level bindings so the codec definition stays under the length limit.