### PR TITLE
3d: name enum-tagged casetype switch cases by constant

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -167,6 +167,10 @@
 
 ### Fixed
 
+- A `Wire.casetype` that switches on a `Wire.enum` tag now projects to a 3D
+  schema EverParse accepts: each case label is emitted as the enum constant name
+  (`case InteriorIndex:`) instead of the raw integer (`case 2:`), which EverParse
+  rejected as not a member of the enumerated type (#TODO, @samoht)
 - `Wire.Expr.( = )` and `Wire.Expr.( <> )` are explicitly re-exported from the
   expression language, so equality in a local `Expr.(...)` open builds `Eq` /
   `Ne` constraints rather than depending on the surrounding equality binding

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -170,7 +170,7 @@
 - A `Wire.casetype` that switches on a `Wire.enum` tag now projects to a 3D
   schema EverParse accepts: each case label is emitted as the enum constant name
   (`case InteriorIndex:`) instead of the raw integer (`case 2:`), which EverParse
-  rejected as not a member of the enumerated type (#TODO, @samoht)
+  rejected as not a member of the enumerated type (#162, @samoht)
 - `Wire.Expr.( = )` and `Wire.Expr.( <> )` are explicitly re-exported from the
   expression language, so equality in a local `Expr.(...)` open builds `Eq` /
   `Ne` constraints rather than depending on the surrounding equality binding

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -1927,7 +1927,19 @@ let pp_enum_cases ppf cases =
       Fmt.pf ppf "@,%s = %d" cname value)
     cases
 
-let pp_casetype_cases ppf cases =
+let pp_casetype_cases : type k.
+    Format.formatter -> k typ -> decl_case list -> unit =
+ fun ppf tag cases ->
+  (* When the switch tag is an enum, EverParse requires each case label to be the
+     enum constant name, not the raw integer it stands for. *)
+  let enum_label k =
+    match tag with
+    | Enum { cases = ecases; _ } ->
+        List.find_map
+          (fun (n, v) -> if Int.equal v k then Some n else None)
+          ecases
+    | _ -> None
+  in
   List.iteri
     (fun i (tag_opt, Pack_typ typ) ->
       let field_name = Fmt.str "v%d" i in
@@ -1936,8 +1948,14 @@ let pp_casetype_cases ppf cases =
         Fmt.pf ppf "%t %s%a" pp_base field_name pp_field_suffix suffix
       in
       match tag_opt with
-      | Some e -> Fmt.pf ppf "@,case %a: %a;" pp_packed_expr e pp_body ()
-      | None -> Fmt.pf ppf "@,default: %a;" pp_body ())
+      | None -> Fmt.pf ppf "@,default: %a;" pp_body ()
+      | Some e -> (
+          let label =
+            match e with Pack_expr (Int k) -> enum_label k | _ -> None
+          in
+          match label with
+          | Some name -> Fmt.pf ppf "@,case %s: %a;" (escape_3d name) pp_body ()
+          | None -> Fmt.pf ppf "@,case %a: %a;" pp_packed_expr e pp_body ()))
     cases
 
 let pp_decl ppf = function
@@ -1968,7 +1986,7 @@ let pp_decl ppf = function
       Fmt.pf ppf "%a enum %s {@[<v 2>" pp_typ base name;
       pp_enum_cases ppf cases;
       Fmt.pf ppf "@]@,}@,@,"
-  | Casetype_decl { name; params; tag = Pack_typ _; cases } ->
+  | Casetype_decl { name; params; tag = Pack_typ tag; cases } ->
       (* First param is the switch discriminant *)
       let disc_name =
         match params with p :: _ -> p.param_name | [] -> "tag"
@@ -1981,7 +1999,7 @@ let pp_decl ppf = function
       in
       Fmt.pf ppf "casetype %s%a {@[<v 2>@,switch (%s) {" internal_name pp_params
         params disc_name;
-      pp_casetype_cases ppf cases;
+      pp_casetype_cases ppf tag cases;
       Fmt.pf ppf "@,}@]@,} %s;@,@," public_name
 
 let pp_module ppf m =

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -71,6 +71,27 @@ let test_casetype () =
     (contains ~sub:"switch (key)" output);
   Alcotest.(check bool) "public name is D" true (contains ~sub:"} D;" output)
 
+let test_casetype_enum_tag_labels () =
+  (* Switching on an enum tag, EverParse requires each case label to be the enum
+     constant name, not the raw integer: [case InteriorIndex:], not [case 2:]. *)
+  let kind = enum "PageKind" [ ("LeafIndex", 0); ("InteriorIndex", 2) ] uint8 in
+  let d =
+    casetype_decl "_PageBody"
+      [ param "tag" kind ]
+      kind
+      [ decl_case 0 uint32; decl_case 2 uint16 ]
+  in
+  let output = to_3d (module_ [ d ]) in
+  Alcotest.(check bool)
+    "low case uses the enum constant name" true
+    (contains ~sub:"case LeafIndex:" output);
+  Alcotest.(check bool)
+    "high case uses the enum constant name" true
+    (contains ~sub:"case InteriorIndex:" output);
+  Alcotest.(check bool)
+    "no raw-integer case label" false
+    (contains ~sub:"case 2:" output)
+
 let test_pretty_print () =
   let simple =
     struct_ "Simple" [ field "a" uint8; field "b" uint16be; field "c" uint32 ]
@@ -912,6 +933,8 @@ let suite =
       Alcotest.test_case "generation: field dependence" `Quick
         test_field_dependence;
       Alcotest.test_case "generation: casetype" `Quick test_casetype;
+      Alcotest.test_case "generation: casetype enum-tag labels" `Quick
+        test_casetype_enum_tag_labels;
       Alcotest.test_case "generation: pretty print" `Quick test_pretty_print;
       Alcotest.test_case "3d: codec embed" `Quick test_3d_codec_embed;
       Alcotest.test_case "3d: codec nested" `Quick test_3d_codec_nested;


### PR DESCRIPTION
A `Wire.casetype` switching on a `Wire.enum` tag used to emit each switch case label as the raw integer (`case 2:`). EverParse requires the enum constant name (`case InteriorIndex:`) when the discriminant is an enum, and rejected the projected schema with `Case (2uy) is not in the enumerated type`.

The case-label printer (`pp_casetype_cases`) had no access to the tag type, so it could only print the integer. It now takes the tag type and, for an enum tag, looks the value up in the enum's cases and prints the constant name; integer-tagged casetypes are unchanged. The generated `.3d` for an enum-discriminated union now F*-verifies. This unblocks self-dispatching enum-tagged page/frame layouts (e.g. a B-tree `PageKind` switch).