### PR TITLE
wire: expose Expr.if_then_else for conditional value expressions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,12 @@
 
 ### Added
 
+- `Wire.Expr.if_then_else cond t e` builds a conditional value expression (the
+  3D `? :` ternary), so a size or constraint can depend on another field, e.g. a
+  16-bit length where 0 means 65536: `if_then_else Expr.(len = int 0) (int
+  65536) len`. The underlying constructor was previously reachable only through
+  the wrapped internal module (#164, @samoht)
+
 - The doc pipeline's differential harness now covers parameterized codecs: the
   corpus oracle binds each codec's `Param.input` values and the generated
   `agree.c` passes the same values to the EverParse validator, so a

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -268,6 +268,7 @@ module Expr = struct
   let ( && ) a b = And (a, b)
   let ( || ) a b = Or (a, b)
   let not a = Not a
+  let if_then_else c t e = If_then_else (c, t, e)
   let to_uint8 e = Cast (`U8, e)
   let to_uint16 e = Cast (`U16, e)
   let to_uint32 e = Cast (`U32, e)

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -352,6 +352,11 @@ module Expr : sig
   val not : bool expr -> bool expr
   (** Logical NOT. *)
 
+  val if_then_else : bool expr -> int expr -> int expr -> int expr
+  (** [if_then_else c t e] is [t] when [c] holds, else [e]. Use it for a value
+      that depends on another field, e.g. a size where [0] means a maximum:
+      [if_then_else Expr.(field = int 0) (int 65536) field]. *)
+
   (** {2 Integer casts} *)
 
   val to_uint8 : int expr -> int expr

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -293,6 +293,11 @@ module Expr : sig
   val not : bool expr -> bool expr
   (** Boolean negation. *)
 
+  val if_then_else : bool expr -> int expr -> int expr -> int expr
+  (** [if_then_else c t e] is [t] when [c] holds, else [e]. Use it for a value
+      that depends on another field, e.g. a size where [0] means a maximum:
+      [if_then_else Expr.(field = int 0) (int 65536) field]. *)
+
   val true_ : bool expr
   (** Constant [true]. *)
 

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -443,6 +443,27 @@ let test_3d_negative_literal_rejected () =
   Alcotest.(check bool)
     "negative literal rejected by projection" true (projects_or_raises codec)
 
+let test_if_then_else_projects () =
+  (* Expr.if_then_else projects to a 3D conditional, e.g. a size where a 0 field
+     means a maximum: [byte-size (... ? 65536 : N)]. *)
+  let f_n = Field.v "N" uint16be in
+  let size =
+    Expr.if_then_else Expr.(Field.ref f_n = int 0) (int 65536) (Field.ref f_n)
+  in
+  let c =
+    Codec.v "Pg"
+      (fun n d -> (n, d))
+      Codec.
+        [
+          (f_n $ fun (n, _) -> n);
+          (Field.v "Data" (byte_array ~size) $ fun (_, d) -> d);
+        ]
+  in
+  let out = to_3d (Everparse.schema c).module_ in
+  Alcotest.(check bool)
+    "renders the conditional" true
+    (contains ~sub:"? 65536 : N" out)
+
 let test_3d_int64_literal_uses_unsigned_decimal () =
   let f =
     Field.v "a" uint64be ~self_int64:(fun self ->
@@ -946,6 +967,8 @@ let suite =
       Alcotest.test_case "generation: casetype" `Quick test_casetype;
       Alcotest.test_case "generation: casetype enum-tag labels" `Quick
         test_casetype_enum_tag_labels;
+      Alcotest.test_case "generation: if_then_else projects" `Quick
+        test_if_then_else_projects;
       Alcotest.test_case "generation: pretty print" `Quick test_pretty_print;
       Alcotest.test_case "3d: codec embed" `Quick test_3d_codec_embed;
       Alcotest.test_case "3d: codec nested" `Quick test_3d_codec_nested;


### PR DESCRIPTION
`If_then_else` already exists in the expression GADT and projects to the 3D `? :` ternary, but it had no public smart constructor, so downstream code had to reach into the wrapped internal module (`Wire__Types.If_then_else`) to build a value that depends on another field.

`Expr.if_then_else cond t e` exposes it: `if_then_else Expr.(len = int 0) (int 65536) len` projects to `byte-size (... ? 65536 : len)`, which EverParse accepts. This is the canonical "0 means a maximum" length idiom (e.g. an ocaml-btree page size).