### PR TITLE
wire.3d: don't emit the agree param parser when no codec has params

### DIFF
--- a/lib/3d/wire_3d.ml
+++ b/lib/3d/wire_3d.ml
@@ -766,7 +766,7 @@ let read_checks ~outdir base =
   close_in ic;
   List.rev !acc
 
-let emit_agree_preamble ppf base =
+let emit_agree_preamble ppf base ~has_params =
   let pr fmt = Fmt.pf ppf (fmt ^^ "@\n") in
   pr "/* Differential check: the EverParse validator must accept exactly the";
   pr "   inputs the OCaml codec accepts. Reads `<codec> <params> <hex>";
@@ -784,17 +784,22 @@ let emit_agree_preamble ppf base =
   pr "void %sEverParseError(const char *s, const char *f, const char *r);" base;
   pr "void %sEverParseError(const char *s, const char *f, const char *r)" base;
   pr "{ (void) s; (void) f; (void) r; }";
-  pr "";
-  (* Parse the corpus's comma-separated parameter values (or [-] for none). *)
-  pr "static void parse_params(const char *s, unsigned long *out, int n) {";
-  pr "  const char *p = s;";
-  pr "  for (int i = 0; i < n; i++) {";
-  pr "    out[i] = strtoul(p, NULL, 10);";
-  pr "    const char *c = strchr(p, ',');";
-  pr "    if (c == NULL) break;";
-  pr "    p = c + 1;";
-  pr "  }";
-  pr "}"
+  (* Only emit the parameter parser when a codec actually has parameters: a
+     package of plain (non-parameterized) codecs never calls it, and an unused
+     static function is a -Werror under the strict flags. *)
+  if has_params then begin
+    pr "";
+    pr "/* Parse the corpus's comma-separated parameter values. */";
+    pr "static void parse_params(const char *s, unsigned long *out, int n) {";
+    pr "  const char *p = s;";
+    pr "  for (int i = 0; i < n; i++) {";
+    pr "    out[i] = strtoul(p, NULL, 10);";
+    pr "    const char *c = strchr(p, ',');";
+    pr "    if (c == NULL) break;";
+    pr "    p = c + 1;";
+    pr "  }";
+    pr "}"
+  end
 
 let emit_agree_run ppf triples =
   let pr fmt = Fmt.pf ppf (fmt ^^ "@\n") in
@@ -885,9 +890,10 @@ let generate_agree ?name ~outdir ~package codecs =
         (List.length names) (List.length checks) base
     else List.map2 (fun n (check, ptypes) -> (n, check, ptypes)) names checks
   in
+  let has_params = List.exists (fun (_, _, ptypes) -> ptypes <> []) triples in
   let oc = open_out (Filename.concat outdir "agree.c") in
   let ppf = Format.formatter_of_out_channel oc in
-  emit_agree_preamble ppf base;
+  emit_agree_preamble ppf base ~has_params;
   emit_agree_run ppf triples;
   emit_agree_main ppf;
   Format.pp_print_flush ppf ();

--- a/test/3d/test_wire_3d.ml
+++ b/test/3d/test_wire_3d.ml
@@ -188,42 +188,50 @@ let diff_param_codec =
     (fun len data -> (len, data))
     [ Codec.( $ ) f_length fst; Codec.( $ ) f_data snd ]
 
+let differential_ok ~name ~package ~count codecs =
+  let tmpdir = Filename.temp_dir ("wire_3d_diff_" ^ package) "" in
+  Wire_3d.generate_doc ~outdir:tmpdir ~name ~package codecs;
+  let oc = open_out (Filename.concat tmpdir "corpus") in
+  let ppf = Format.formatter_of_out_channel oc in
+  Wire_3d.generate_corpus ~count ppf codecs;
+  close_out oc;
+  let base = String.capitalize_ascii name in
+  let cmd =
+    Fmt.str
+      "cd %s && cc %s %s -c %s.c %sWrapper.c && ar rcs lib.a %s.o %sWrapper.o \
+       && cc %s %s agree.c lib.a -o agree && ./agree corpus 2>&1"
+      tmpdir Wire_3d.strict_cc_flags Wire_3d.everparse_type_defines base base
+      base base Wire_3d.strict_cc_flags Wire_3d.everparse_type_defines
+  in
+  let ic = Unix.open_process_in cmd in
+  let output = In_channel.input_all ic in
+  let status = Unix.close_process_in ic in
+  ignore (Fmt.kstr Sys.command "rm -rf %s" tmpdir);
+  match status with
+  | Unix.WEXITED 0 -> ()
+  | Unix.WEXITED n ->
+      Alcotest.failf "differential %s failed with exit %d:\n%s" name n output
+  | _ -> Alcotest.failf "differential %s terminated abnormally:\n%s" name output
+
 let test_doc_differential () =
   if not (Wire_3d.has_3d_exe ()) then ()
-  else begin
-    let tmpdir = Filename.temp_dir "wire_3d_doc_diff" "" in
-    let codecs =
+  else
+    differential_ok ~name:"protospec" ~package:"demo-doc" ~count:400
       [
         Wire_3d.pack diff_enum_codec;
         Wire_3d.pack diff_range_codec;
         Wire_3d.pack diff_bits_codec;
         Wire_3d.pack diff_param_codec;
       ]
-    in
-    Wire_3d.generate_doc ~outdir:tmpdir ~name:"protospec" ~package:"demo-doc"
-      codecs;
-    let oc = open_out (Filename.concat tmpdir "corpus") in
-    let ppf = Format.formatter_of_out_channel oc in
-    Wire_3d.generate_corpus ~count:400 ppf codecs;
-    close_out oc;
-    let cmd =
-      Fmt.str
-        "cd %s && cc %s %s -c Protospec.c ProtospecWrapper.c && ar rcs \
-         libprotospec.a Protospec.o ProtospecWrapper.o && cc %s %s agree.c \
-         libprotospec.a -o agree && ./agree corpus 2>&1"
-        tmpdir Wire_3d.strict_cc_flags Wire_3d.everparse_type_defines
-        Wire_3d.strict_cc_flags Wire_3d.everparse_type_defines
-    in
-    let ic = Unix.open_process_in cmd in
-    let output = In_channel.input_all ic in
-    let status = Unix.close_process_in ic in
-    ignore (Fmt.kstr Sys.command "rm -rf %s" tmpdir);
-    match status with
-    | Unix.WEXITED 0 -> ()
-    | Unix.WEXITED n ->
-        Alcotest.failf "doc differential failed with exit %d:\n%s" n output
-    | _ -> Alcotest.failf "doc differential terminated abnormally:\n%s" output
-  end
+
+let test_doc_differential_no_params () =
+  (* Regression: an all-non-parameterized package must still compile. The agree
+     harness must not emit an unused [parse_params] helper (a -Werror under the
+     strict flags) when no codec takes parameters. *)
+  if not (Wire_3d.has_3d_exe ()) then ()
+  else
+    differential_ok ~name:"plainspec" ~package:"plain-doc" ~count:100
+      [ Wire_3d.pack diff_enum_codec; Wire_3d.pack diff_range_codec ]
 
 (* End-to-end compile+run. Generates C for a schema, invokes the same
    cc command [generate_dune] emits, runs the resulting binary. This is
@@ -1036,6 +1044,8 @@ let suite =
       Alcotest.test_case "generate_doc (needs 3d.exe)" `Quick test_generate_doc;
       Alcotest.test_case "doc differential (needs 3d.exe)" `Quick
         test_doc_differential;
+      Alcotest.test_case "doc differential no params (needs 3d.exe)" `Quick
+        test_doc_differential_no_params;
       Alcotest.test_case "uses_wire_ctx" `Quick test_uses_wire_ctx;
       Alcotest.test_case "has_3d_exe" `Quick test_has_3d_exe;
       Alcotest.test_case "main exists" `Quick test_main_exists;


### PR DESCRIPTION
A regression from #163. The differential harness always wrote a `parse_params` helper into the generated `agree.c`, but a package whose codecs take no parameters never calls it, so under the strict `-Werror -Wunused-function` flags the unused static function failed to compile, breaking the differential `runtest` for every non-parameterized package.

`parse_params` is now emitted only when some codec has parameters. An all-non-parameterized package is added to the differential test so the case is compiled and run; the mixed package keeps covering the parameter path.