### PR TITLE
wire: add enum_open for open (non-validating) enumerations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,15 @@
 
 ### Added
 
+- `Wire.enum_open name cases base` is an open enumeration: it names the known
+  values for documentation but accepts any value. Unlike `Wire.enum` /
+  `Wire.variants`, it does not reject an unlisted value (no decode
+  `Invalid_enum`, and the field projects as its base scalar with no membership
+  refinement), which is what an open value set (a protocol field that may carry
+  unknown or future codes) needs. The known codes are still emitted as a 3D
+  enum declaration, so they stay documented in the generated `.3d` (#166,
+  @samoht)
+
 - The doc pipeline's differential `agree.c` is now derived from the codecs
   alone: it computes each validator's name and parameter types from the Wire
   definitions instead of reading the EverParse-generated `<Name>Wrapper.h`. The

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -201,6 +201,10 @@ let enum_checker cases =
     if List.mem v valid then v
     else raise (Parse_error (Invalid_enum { value = v; valid }))
 
+(* An open enum ([closed = false]) accepts any base value: the names only
+   document known members, so decode does not reject the rest. *)
+let enum_check cases closed = if closed then enum_checker cases else fun v -> v
+
 (** Build a direct field reader that reads at a fixed offset. No tuples, no refs
     \- just pure value read. Caller must ensure the buffer is large enough. *)
 let rec build_field_reader : type a. a typ -> int -> bytes -> int -> a =
@@ -245,9 +249,9 @@ let rec build_field_reader : type a. a typ -> int -> bytes -> int -> a =
   | Byte_slice { size = Int n } ->
       fun buf base -> Slice.make buf ~first:(base + field_off) ~length:n
   | Where { inner; _ } -> build_field_reader inner field_off
-  | Enum { base; cases; _ } ->
+  | Enum { base; cases; closed; _ } ->
       let read = build_field_reader base field_off in
-      let check = enum_checker cases in
+      let check = enum_check cases closed in
       fun buf base -> check (read buf base)
   | Map { inner; decode; _ } ->
       let read = build_field_reader inner field_off in
@@ -337,8 +341,8 @@ let rec build_populate : type a.
       fun slots buf base ->
         set_int_slot slots idx (Bytes.get_int64_be buf base |> Int64.to_int)
   | Where { inner; _ } -> build_populate inner idx reader
-  | Enum { base; cases; _ } ->
-      let check = enum_checker cases in
+  | Enum { base; cases; closed; _ } ->
+      let check = enum_check cases closed in
       build_populate base idx (fun buf b -> check (reader buf b))
   | Map { inner; encode; _ } ->
       build_populate inner idx (fun buf base -> encode (reader buf base))
@@ -1203,7 +1207,8 @@ let rec read_elem : type a. a typ -> bytes -> int -> a =
   | Codec { codec_decode; _ } -> codec_decode buf off
   | Map { inner; decode; _ } -> decode (read_elem inner buf off)
   | Where { inner; _ } -> read_elem inner buf off
-  | Enum { base; cases; _ } -> enum_checker cases (read_elem base buf off)
+  | Enum { base; cases; closed; _ } ->
+      enum_check cases closed (read_elem base buf off)
   | Casetype { tag; cases; _ } ->
       let tag_val = read_elem tag buf off in
       read_case_body cases tag_val buf (off + tag_byte_size tag)
@@ -2072,12 +2077,12 @@ let rec compile_field : type a r.
  fun ctx fld ->
   match fld.typ with
   | Map { inner; decode; encode; _ } -> compile_map ctx fld inner decode encode
-  | Enum { base; cases; _ } ->
+  | Enum { base; cases; closed; _ } ->
       (* Compile as the base integer, then validate the decoded value is one of
          the named cases. [compile_field] would otherwise strip the cases and
          accept any base value, unlike the EverParse validator. *)
       let cf = compile_field ctx { fld with typ = base } in
-      let check = enum_checker cases in
+      let check = enum_check cases closed in
       {
         cf with
         raw_reader = (fun buf off -> check (cf.raw_reader buf off));
@@ -3168,9 +3173,9 @@ let rec build_staged_reader : type a. a typ -> field_access -> bytes -> int -> a
         let sz = size_fn buf base in
         Bytes.sub_string buf (base + fo) sz
   | Where { inner; _ }, _ -> build_staged_reader inner access
-  | Enum { base; cases; _ }, _ ->
+  | Enum { base; cases; closed; _ }, _ ->
       let read = build_staged_reader base access in
-      let check = enum_checker cases in
+      let check = enum_check cases closed in
       fun buf base -> check (read buf base)
   | Map { inner; decode; _ }, _ ->
       let read = build_staged_reader inner access in

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -116,6 +116,10 @@ and _ typ =
       name : string;
       cases : (string * int) list;
       base : int typ;
+      closed : bool;
+          (* [true]: only the listed values are valid (decode rejects others, the
+             3D projection emits a membership refinement). [false]: an open set,
+             the names document known values but any value is accepted. *)
     }
       -> int typ
   | Casetype : {
@@ -616,7 +620,8 @@ let nested_at_most ~size elem =
   reject_bitfield_element ~combinator:"nested_at_most" elem;
   Single_elem { size; elem; at_most = true }
 
-let enum name cases base = Enum { name; cases; base }
+let enum name cases base = Enum { name; cases; base; closed = true }
+let enum_open name cases base = Enum { name; cases; base; closed = false }
 
 let fail_parse_error fmt =
   Fmt.kstr (fun s -> raise (Parse_error (Constraint_failed s))) fmt
@@ -863,8 +868,13 @@ let enum_decls (s : struct_) : decl list =
   List.iter
     (fun (Field f) ->
       let rec extract : type a. a typ -> unit = function
-        | Enum { name; cases; base }
+        | Enum { name; cases; base; _ }
           when (not (Hashtbl.mem seen name)) && not (is_bits base) ->
+            (* Both open and closed enums declare a 3D enum type so the named
+               codes survive in the generated .3d. A closed enum additionally
+               constrains its field with a membership refinement; an open enum
+               leaves the field as its base scalar (any value accepted) while
+               still documenting the known codes through the declaration. *)
             Hashtbl.add seen name ();
             decls := Enum_decl { name; cases; base = Pack_typ base } :: !decls
         | Map { inner; _ } -> extract inner
@@ -1578,7 +1588,10 @@ let rec index_bound_of : type a. a typ -> int option = function
    named cases, exactly as the OCaml decoder does (a bare base value otherwise
    slips through C while [Codec.decode] raises [Invalid_enum]). *)
 let rec enum_cases_of : type a. a typ -> int list option = function
-  | Enum { cases; _ } -> Some (List.map snd cases)
+  (* Only a closed enum bounds its value set; an open enum accepts any value, so
+     it emits no membership refinement. *)
+  | Enum { cases; closed = true; _ } -> Some (List.map snd cases)
+  | Enum { closed = false; _ } -> None
   | Map { inner; _ } -> enum_cases_of inner
   | Where { inner; _ } -> enum_cases_of inner
   | Apply { typ; _ } -> enum_cases_of typ
@@ -1716,6 +1729,9 @@ let render_enum_as_type = Stdlib.ref false
    bitfield with no enum declaration to reference. *)
 let rec enum_type_name : type a. a typ -> string option = function
   | Enum { base = Bits _; _ } -> None
+  (* An open enum has no 3D enum type to name (it projects as its base), so the
+     doc projection types the field as the base scalar, not the enum. *)
+  | Enum { closed = false; _ } -> None
   | Enum { name; _ } -> Some name
   | Map { inner; _ } -> enum_type_name inner
   | Where { inner; _ } -> enum_type_name inner

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -148,6 +148,9 @@ and _ typ =
       name : string;
       cases : (string * int) list;
       base : int typ;
+      closed : bool;
+          (** [true]: only the listed values are valid. [false]: open set, the
+              names document known values but any value is accepted. *)
     }
       -> int typ  (** Named enumeration. *)
   | Casetype : {
@@ -549,6 +552,11 @@ val nested_at_most : size:int expr -> 'a typ -> 'a typ
 
 val enum : string -> (string * int) list -> int typ -> int typ
 (** Named enumeration over an integer base. *)
+
+val enum_open : string -> (string * int) list -> int typ -> int typ
+(** Open enumeration: the named codes are declared in the 3D projection for
+    documentation, but any value is accepted (no membership refinement, no
+    decode rejection). *)
 
 val variants : string -> (string * 'a) list -> int typ -> 'a typ
 (** Named variant mapping over an integer base. *)

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -689,6 +689,14 @@ val enum : string -> (string * int) list -> int typ -> int typ
     useful for 3D projection where the name and cases appear in the generated
     [.3d] file. *)
 
+val enum_open : string -> (string * int) list -> int typ -> int typ
+(** [enum_open name cases base] is like {!enum} but for an open value set: the
+    named cases document the known values, but any value is accepted. Decode
+    does not reject unlisted values, and the field projects as its base scalar
+    with no membership refinement, so a protocol field that may carry unknown or
+    future codes is not wrongly rejected. The known codes are still emitted as a
+    3D enum declaration, so they remain documented in the generated [.3d]. *)
+
 val variants : string -> (string * 'a) list -> int typ -> 'a typ
 (** [variants name cases base] maps integer values to OCaml values via a named
     enumeration. Unlike {!enum}, this converts to proper OCaml values. *)

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -206,6 +206,27 @@ let test_3d_enum_membership () =
     "enum nested in a sub-codec bounds its value" true
     (contains ~sub:"(e == 1)" (to_3d (Everparse.schema arr).module_))
 
+let test_enum_open_accepts_and_no_refinement () =
+  (* An open enum names known values but accepts any: decode does not reject an
+     unlisted value, and the projection emits no membership refinement (the
+     field is its base scalar) yet still declares the named codes, so an open
+     value set is documented without being wrongly rejected. *)
+  let e = enum_open "Kind" [ ("A", 0); ("B", 2) ] uint8 in
+  let c = Codec.v "OpenK" (fun v -> v) Codec.[ (Field.v "k" e $ fun v -> v) ] in
+  let buf = Bytes.make 1 '\x05' in
+  (match Codec.decode c buf 0 with
+  | Ok v -> Alcotest.(check int) "open accepts unlisted value" 5 v
+  | Error _ -> Alcotest.fail "open enum wrongly rejected an unlisted value");
+  let out = to_3d (Everparse.schema c).module_ in
+  Alcotest.(check bool)
+    "no membership refinement" false (contains ~sub:"== 0" out);
+  Alcotest.(check bool)
+    "projects as base scalar" true
+    (contains ~sub:"UINT8 k" out);
+  Alcotest.(check bool)
+    "names survive as a 3D enum declaration" true
+    (contains ~sub:"enum Kind" out)
+
 let test_doc_drops_ffi_scaffolding () =
   (* The doc projection keeps the structure but not the FFI callbacks the
      codegen schema carries. *)
@@ -1001,6 +1022,8 @@ let suite =
         test_3d_signed_float_setters;
       Alcotest.test_case "3d: array enum element decl" `Quick
         test_3d_array_enum_element_decl;
+      Alcotest.test_case "generation: open enum accepts and has no refinement"
+        `Quick test_enum_open_accepts_and_no_refinement;
       Alcotest.test_case "3d: enum membership refinement" `Quick
         test_3d_enum_membership;
       Alcotest.test_case "doc: drops FFI scaffolding" `Quick


### PR DESCRIPTION
`enum` and `variants` are strictly closed: decode raises `Invalid_enum` on any unlisted value, and the 3D projection emits a membership refinement (`(v == 0) || ...`) so the generated validator rejects it too. That is correct for a fixed value set, but wrong for an open field whose unknown or future codes are valid and should pass through.

`enum_open name cases base` keeps the named values for documentation but accepts any value: decode does not reject, the field projects as its base scalar with no membership refinement (so EverParse also accepts the full range), and the known codes are still declared as a 3D enum type so they stay documented in the generated `.3d`. Closed `enum`/`variants` are unchanged.

An open mapping to OCaml values needs no new combinator: composing `enum_open` with the existing `map` round-trips unknown codes through a fallback constructor, and `casetype`'s `default` branch already covers open tagged unions.
