### PR TITLE
codec: enforce Wire.where and field actions on decode and validate

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -211,6 +211,13 @@
 
 ### Fixed
 
+- `Wire.Codec.decode` and `Wire.Codec.validate` now enforce a constraint written
+  as `Wire.where cond t` on a field, and any field `~action`. Such a `where` was
+  projected into the generated `.3d` (so the EverParse C validator rejected
+  violating input) but was silently dropped on the OCaml side, so OCaml accepted
+  what the verified C rejects; and `Codec.validate` skipped field actions that
+  `decode` ran, so the two disagreed. Decode and validate now share a single
+  validation path and enforce identical semantics (#169, @samoht)
 - A `Wire.casetype` that switches on a `Wire.enum` tag now projects to a 3D
   schema EverParse accepts: each case label is emitted as the enum constant name
   (`case InteriorIndex:`) instead of the raw integer (`case 2:`), which EverParse

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -2328,6 +2328,18 @@ and compile_optional_or_variable : type a r.
 
 (* -- Apply a compiled plan to the record state -- *)
 
+(* A [Wire.where] constraint lives inside the field's [typ] ([Where {cond; _}]),
+   which the field reader passes through transparently. Left there it reaches the
+   3D refinement (via [struct_field]) but never the OCaml validators. Collect the
+   conds so [apply_compiled] can fold them into the field's check, the same path
+   a [~constraint_] takes -- so decode and validate enforce exactly what the 3D
+   projection does. *)
+let rec typ_where_conds : type a. a Types.typ -> bool Types.expr list = function
+  | Types.Where { cond; inner } -> cond :: typ_where_conds inner
+  | Types.Map { inner; _ } -> typ_where_conds inner
+  | Types.Enum { base; _ } -> typ_where_conds base
+  | _ -> []
+
 (* The single place that mutates the record accumulator: assemble constraint
    and action checkers, then fold the [compiled_field] into a new record
    state. *)
@@ -2354,26 +2366,34 @@ let apply_compiled : type a f r.
       ~param_slots:r.param_slots idx
   in
   let check =
-    match fld.constraint_ with
-    | None -> None
-    | Some c -> Some (compile_bool_arr cc c)
+    (* Fold the field's [~constraint_] together with any [Wire.where] cond
+       carried in its typ, so a [where] is enforced on decode/validate and not
+       only in the 3D projection. *)
+    let conds =
+      (match fld.constraint_ with Some c -> [ c ] | None -> [])
+      @ typ_where_conds fld.typ
+    in
+    match conds with
+    | [] -> None
+    | first :: rest ->
+        Some
+          (compile_bool_arr cc
+             (List.fold_left (fun a c -> And (a, c)) first rest))
   in
   let act = compile_action cc fld.action in
   let populate = cf.populate in
-  let full arr buf base =
-    populate arr buf base;
-    (match check with
-    | Some f when not (f arr) ->
-        raise (Parse_error (Constraint_failed "field constraint"))
-    | _ -> ());
-    match act with Some f -> f arr | None -> ()
-  in
   let check_only arr buf base =
     populate arr buf base;
     match check with
     | Some f when not (f arr) ->
         raise (Parse_error (Constraint_failed "field constraint"))
     | _ -> ()
+  in
+  (* The full validator is the read-and-check plus the field action. Decode and
+     [Codec.validate] both run it, so an action never fires on one path only. *)
+  let full arr buf base =
+    check_only arr buf base;
+    match act with Some f -> f arr | None -> ()
   in
   let faction =
     match act with None -> None | Some act_fn -> Some (fld.name, act_fn)
@@ -2566,7 +2586,9 @@ let build_validators validators_rev checkers_rev compiled_where struct_fields
   in
   let has_checks =
     compiled_where <> None
-    || List.exists (fun (Types.Field f) -> f.constraint_ <> None) struct_fields
+    || List.exists
+         (fun (Types.Field f) -> f.constraint_ <> None || f.action <> None)
+         struct_fields
   in
   let validate =
     if has_checks then (
@@ -2580,11 +2602,10 @@ let build_validators validators_rev checkers_rev compiled_where struct_fields
             let n = Array.length slots in
             Array.blit slots 0 arr.ints (n_total - n) n
         | None -> ());
-        populate arr buf off;
-        match compiled_where with
-        | Some f when not (f arr) ->
-            raise (Parse_error (Constraint_failed "where clause"))
-        | _ -> ())
+        (* Validate through the same kernel decode uses ([validate_arr]), so
+           [Codec.validate] and [decode] never disagree on field constraints,
+           actions, or the [where] clause. *)
+        validate_arr arr buf off)
     else fun ?env_slots:_ _buf _off -> ()
   in
   (validate_arr, populate, validate)

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -198,6 +198,55 @@ let test_validate_then_get () =
   let get_x = Staged.unstage (Codec.get validate_codec validate_cf_x) in
   Alcotest.(check int) "validate then get" 8 (get_x buf 0)
 
+(* A [Wire.where] cond carried in a field's typ ([where (len < 2) uint8]) must be
+   enforced by both decode and validate, not only projected to 3D. The cond
+   reaches the EverParse refinement, so leaving it unchecked on the OCaml side
+   would accept inputs the verified C validator rejects. *)
+let typ_where_codec =
+  let open Codec in
+  let f_len = Field.v "len" uint8 in
+  let f_d = Field.v "d" (where Expr.(Field.ref f_len < int 2) uint8) in
+  v "TypWhere" (fun len d -> (len, d)) [ f_len $ fst; f_d $ snd ]
+
+let test_decode_enforces_typ_where () =
+  (match Codec.decode typ_where_codec (Bytes.of_string "\006\000") 0 with
+  | Error (Constraint_failed _) -> ()
+  | Ok _ -> Alcotest.fail "decode accepted a Wire.where violation"
+  | Error _ -> Alcotest.fail "decode failed with the wrong error");
+  match Codec.decode typ_where_codec (Bytes.of_string "\001\000") 0 with
+  | Ok _ -> ()
+  | Error _ -> Alcotest.fail "decode rejected a valid input"
+
+let test_validate_enforces_typ_where () =
+  (match Codec.validate typ_where_codec (Bytes.of_string "\006\000") 0 with
+  | () -> Alcotest.fail "validate accepted a Wire.where violation"
+  | exception Validation_error (Constraint_failed _) -> ());
+  Codec.validate typ_where_codec (Bytes.of_string "\001\000") 0
+
+(* decode runs field actions; validate must run the same ones, or the two paths
+   disagree on a codec whose action can fail (here [return_bool (x < 128)]). *)
+let action_validate_codec =
+  let open Codec in
+  let f_x = Field.v "x" uint8 in
+  let f_y =
+    Field.v "y" uint8
+      ~action:
+        (Action.on_success
+           [ Action.return_bool Expr.(Field.ref f_x < int 128) ])
+  in
+  v "ActValidate" (fun x y -> (x, y)) [ f_x $ fst; f_y $ snd ]
+
+let test_validate_runs_field_action () =
+  (match Codec.decode action_validate_codec (Bytes.of_string "\200\000") 0 with
+  | Error (Constraint_failed _) -> ()
+  | _ -> Alcotest.fail "decode did not reject the action violation");
+  (match
+     Codec.validate action_validate_codec (Bytes.of_string "\200\000") 0
+   with
+  | () -> Alcotest.fail "validate skipped the field action decode enforces"
+  | exception Validation_error (Constraint_failed _) -> ());
+  Codec.validate action_validate_codec (Bytes.of_string "\100\000") 0
+
 let test_struct_of_codec_metadata () =
   let output = render_3d projection_codec in
   (* The struct-level [where] referencing the field [x] is lowered onto the
@@ -4900,6 +4949,12 @@ let suite =
       Alcotest.test_case "validate: rejects bad constraint" `Quick
         test_validate_rejects_bad_constraint;
       Alcotest.test_case "validate: then get" `Quick test_validate_then_get;
+      Alcotest.test_case "decode: enforces typ-level where" `Quick
+        test_decode_enforces_typ_where;
+      Alcotest.test_case "validate: enforces typ-level where" `Quick
+        test_validate_enforces_typ_where;
+      Alcotest.test_case "validate: runs field action" `Quick
+        test_validate_runs_field_action;
       Alcotest.test_case "record: with_multi" `Quick test_record_with_multi;
       Alcotest.test_case "record: byte_array roundtrip" `Quick
         test_record_byte_array_roundtrip;


### PR DESCRIPTION
`Wire.Codec.decode` and `Wire.Codec.validate` used to drop a constraint written as `Wire.where cond t` on a field, and `validate` additionally skipped field `~action`s that `decode` ran. Both now enforce them, through a single validation path.

A field `where` is lowered into a 3D refinement, so the EverParse C validator rejects violating input, but the OCaml side passed it straight through: decode and validate accepted what the verified C rejects. Separately, `validate` ran a populate path that skipped the field actions decode runs, so the two disagreed on a codec whose action can fail. The fix folds the typ-level `where` cond into the field check (the path a `~constraint_` already takes) and routes `validate` through the same `validate_arr` kernel `decode` uses, so decode, validate, and the 3D projection enforce identical semantics.

The fuzz suite never caught this because its `where` combinator builds `Wire.where Expr.true_ inner`, a cond that can never be violated; making the typ-level `where` adversarial is a follow-up.
