### PR TITLE
wire.3d: normalize the agree check name like EverParse

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -218,6 +218,13 @@
   `.3d` did not compile while OCaml decode silently ignored the constraint. A
   `where` is supported as a top-level field refinement; move the constraint onto
   the field itself or a codec `~where` (#173, @samoht)
+- The doc pipeline's differential self-check (`agree.c`) now links for a codec
+  whose name has interior consecutive capitals. EverParse normalizes such a name
+  in the validator symbol (`SpaceOSFrame -> SpaceOsframe`), but the harness built
+  the symbol from the raw name, so the generated check called an undeclared
+  function. The name now goes through the same normalization, which also collapses
+  a consecutive-capital run anywhere in a name, not only at the start (#171,
+  @samoht)
 - The doc pipeline's differential self-check (`agree.c`) no longer false-reports
   a mismatch for a codec with a large payload. The generated reader held each
   corpus line in a buffer one char short of two hex digits per input byte, so an

--- a/lib/3d/wire_3d.ml
+++ b/lib/3d/wire_3d.ml
@@ -5,19 +5,33 @@ open Wire.Everparse
 let is_upper c = Char.uppercase_ascii c = c && Char.lowercase_ascii c <> c
 
 (* Apply EverParse's normalization to a single identifier segment (no
-   underscores): if the segment begins with two or more uppercase letters,
-   lowercase the whole segment and capitalize the first letter ([SSID ->
-   Ssid], [TMFrame -> Tmframe]); otherwise leave it alone. *)
+   underscores): every run of two or more consecutive uppercase letters keeps
+   its first letter and lowercases the rest, wherever it occurs in the segment
+   ([SSID -> Ssid], [TMFrame -> Tmframe], [SpaceOSFrame -> SpaceOsframe]); a lone
+   uppercase letter (a camelCase word boundary) is left alone. *)
 let normalize_segment seg =
   let len = String.length seg in
-  let rec count_upper i =
-    if i < len && is_upper seg.[i] then count_upper (i + 1) else i
-  in
-  if len > 0 && count_upper 0 >= 2 then
-    String.init len (fun i ->
-        let c = Char.lowercase_ascii seg.[i] in
-        if i = 0 then Char.uppercase_ascii c else c)
-  else seg
+  let b = Buffer.create len in
+  let i = ref 0 in
+  while !i < len do
+    if is_upper seg.[!i] then begin
+      let j = ref !i in
+      while !j < len && is_upper seg.[!j] do
+        incr j
+      done;
+      Buffer.add_char b seg.[!i];
+      if !j - !i >= 2 then
+        for k = !i + 1 to !j - 1 do
+          Buffer.add_char b (Char.lowercase_ascii seg.[k])
+        done;
+      i := !j
+    end
+    else begin
+      Buffer.add_char b seg.[!i];
+      incr i
+    end
+  done;
+  Buffer.contents b
 
 (* EverParse strips underscores when generating C identifiers and
    CamelCases each segment. [EP_Header -> EpHeader],
@@ -858,7 +872,11 @@ let generate_agree ?name ~outdir ~package codecs =
           | Some st -> Raw.input_param_c_types st
           | None -> []
         in
-        (s.name, base ^ "Check" ^ s.name, ptypes))
+        (* EverParse normalizes the codec name in the wrapper symbol (a run of
+           consecutive caps keeps only its first letter: [SpaceOSFrame ->
+           SpaceOsframe]), so run it through [everparse_name] or the call links to
+           an undeclared function. *)
+        (s.name, base ^ "Check" ^ everparse_name s.name, ptypes))
       codecs
   in
   let has_params = List.exists (fun (_, _, ptypes) -> ptypes <> []) triples in

--- a/test/3d/test_wire_3d.ml
+++ b/test/3d/test_wire_3d.ml
@@ -14,6 +14,11 @@ let test_everparse_name () =
   Alcotest.(check string)
     "TMFrame -> Tmframe" "Tmframe"
     (Wire_3d.everparse_name "TMFrame");
+  (* A consecutive-capital run is collapsed wherever it occurs, not only at the
+     start: the [OSF] run in the middle lowercases to [osf]. *)
+  Alcotest.(check string)
+    "SpaceOSFrame -> SpaceOsframe" "SpaceOsframe"
+    (Wire_3d.everparse_name "SpaceOSFrame");
   (* Standard camelCase is preserved *)
   Alcotest.(check string) "Foo -> Foo" "Foo" (Wire_3d.everparse_name "Foo");
   Alcotest.(check string)
@@ -252,6 +257,21 @@ let test_doc_differential_large_payload () =
   else
     differential_ok ~name:"sharedspec" ~package:"shared-doc" ~count:40
       [ Wire_3d.pack diff_large_payload_codec ]
+
+(* Interior consecutive caps: EverParse normalizes the validator symbol to
+   [SpacewireCheckSpaceOsframe], so agree.c must build the same name through
+   [everparse_name] or its call links to an undeclared function. *)
+let diff_caps_name_codec =
+  let open Wire in
+  Codec.v "SpaceOSFrame"
+    (fun v -> v)
+    [ Codec.( $ ) (Field.v "v" uint8) (fun v -> v) ]
+
+let test_doc_differential_caps_name () =
+  if not (Wire_3d.has_3d_exe ()) then ()
+  else
+    differential_ok ~name:"spacewire" ~package:"space-wire" ~count:40
+      [ Wire_3d.pack diff_caps_name_codec ]
 
 (* End-to-end compile+run. Generates C for a schema, invokes the same
    cc command [generate_dune] emits, runs the resulting binary. This is
@@ -1074,6 +1094,8 @@ let suite =
         test_doc_differential_no_params;
       Alcotest.test_case "doc differential large payload (needs 3d.exe)" `Quick
         test_doc_differential_large_payload;
+      Alcotest.test_case "doc differential caps name (needs 3d.exe)" `Quick
+        test_doc_differential_caps_name;
       Alcotest.test_case "uses_wire_ctx" `Quick test_uses_wire_ctx;
       Alcotest.test_case "has_3d_exe" `Quick test_has_3d_exe;
       Alcotest.test_case "main exists" `Quick test_main_exists;


### PR DESCRIPTION
The doc pipeline's differential self-check (`agree.c`) failed to link for a codec whose name has interior consecutive capitals. EverParse normalizes such a name in the validator symbol (`SpaceOSFrame` becomes `SpaceOsframe`), but `generate_agree` built the symbol `<Base>Check<Codec>` from the raw codec name, so the generated check called an undeclared function.

The check name now goes through the existing `everparse_name`, and `normalize_segment` collapses a consecutive-capital run wherever it occurs, not only at the start of a segment. This surfaces only in Doc mode on a codec name with interior consecutive caps (space-wire's `SpaceOSFrame`); the small canonical schemas never hit it.
