### PR TITLE
wire.3d: size the agree corpus buffer to the input width

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -211,6 +211,11 @@
 
 ### Fixed
 
+- The doc pipeline's differential self-check (`agree.c`) no longer false-reports
+  a mismatch for a codec with a large payload. The generated reader held each
+  corpus line in a buffer one char short of two hex digits per input byte, so an
+  8 KB payload (16384 hex chars) truncated the line and misparsed the verdict.
+  The buffer is now sized to the input width (#172, @samoht)
 - `Wire.Codec.decode` and `Wire.Codec.validate` now enforce a constraint written
   as `Wire.where cond t` on a field, and any field `~action`. Such a `where` was
   projected into the generated `.3d` (so the EverParse C validator rejected

--- a/lib/3d/wire_3d.ml
+++ b/lib/3d/wire_3d.ml
@@ -801,11 +801,13 @@ let emit_agree_main ppf =
   pr "  if (!fp) { perror(\"fopen\"); return 2; }";
   pr "  char name[256];";
   pr "  char params[4096];";
-  pr "  char hex[16384];";
-  pr "  uint8_t buf[8192];";
+  (* [hex] needs two chars per [buf] byte plus the NUL; one char short truncates
+     the corpus line and misparses the verdict as a false mismatch. *)
+  pr "  uint8_t buf[65536];";
+  pr "  char hex[2 * sizeof(buf) + 1];";
   pr "  long verdict, total = 0, mismatch = 0;";
   pr
-    "  while (fscanf(fp, \"%%255s %%4095s %%16383s %%ld\", name, params, hex, \
+    "  while (fscanf(fp, \"%%255s %%4095s %%131072s %%ld\", name, params, hex, \
      &verdict) == 4) {";
   pr "    uint32_t len = 0;";
   pr "    if (strcmp(hex, \"-\") != 0) {";

--- a/test/3d/test_wire_3d.ml
+++ b/test/3d/test_wire_3d.ml
@@ -238,6 +238,21 @@ let test_doc_differential_no_params () =
     differential_ok ~name:"plainspec" ~package:"plain-doc" ~count:100
       [ Wire_3d.pack diff_enum_codec; Wire_3d.pack diff_range_codec ]
 
+(* An 8192-byte payload makes each corpus line 16384 hex chars; the agree
+   reader's hex buffer must hold the line, or it truncates and the verdict
+   misparses into a false mismatch. *)
+let diff_large_payload_codec =
+  let open Wire in
+  Codec.v "SharedMem"
+    (fun d -> d)
+    [ Codec.( $ ) (Field.v "data" (byte_array ~size:(int 8192))) (fun d -> d) ]
+
+let test_doc_differential_large_payload () =
+  if not (Wire_3d.has_3d_exe ()) then ()
+  else
+    differential_ok ~name:"sharedspec" ~package:"shared-doc" ~count:40
+      [ Wire_3d.pack diff_large_payload_codec ]
+
 (* End-to-end compile+run. Generates C for a schema, invokes the same
    cc command [generate_dune] emits, runs the resulting binary. This is
    the one test that catches every kind of name mismatch between what
@@ -1057,6 +1072,8 @@ let suite =
         test_doc_differential;
       Alcotest.test_case "doc differential no params (needs 3d.exe)" `Quick
         test_doc_differential_no_params;
+      Alcotest.test_case "doc differential large payload (needs 3d.exe)" `Quick
+        test_doc_differential_large_payload;
       Alcotest.test_case "uses_wire_ctx" `Quick test_uses_wire_ctx;
       Alcotest.test_case "has_3d_exe" `Quick test_has_3d_exe;
       Alcotest.test_case "main exists" `Quick test_main_exists;


### PR DESCRIPTION
The doc pipeline's differential self-check (`agree.c`) false-reported a mismatch for a codec with a large payload. The generated reader held each corpus line in a buffer one char short of two hex digits per input byte, so an 8 KB payload (16384 hex chars) truncated the line; the leftover character plus the verdict field then misparsed into a bogus oracle value and a spurious mismatch.

The hex buffer is now sized to `2 * sizeof(buf) + 1` and `buf` grown so larger schemas fit. This surfaces only in Doc mode on a schema near the 8 KB boundary (space-wire's `SharedMem`).
