### PR TITLE
codec: bind_by_name drives parametric field sizes on decode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -211,6 +211,13 @@
 
 ### Fixed
 
+- `Wire.Param.bind_by_name` now drives a parameter-dependent field size on
+  decode, not only `where` clauses and constraints. A field whose size comes from
+  a parameter (a `byte_array`, `byte_slice`, or `uint_var` sized by
+  `Param.expr`) read as zero bytes when its parameter was bound by name, silently
+  truncating the field and misaligning everything after it; only the typed
+  `Param.bind` worked. Both binders now resolve parametric sizes identically
+  (#175, @samoht)
 - A signed integer field's ordering constraint (e.g. `int8 x` with `x < 100`) now
   projects soundly. A signed field becomes an unsigned `UINT*` in 3D, so the
   refinement was emitted as an unsigned comparison and the verified C validator

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -3149,6 +3149,13 @@ let env (t : _ t) : Param.env =
   }
 
 let decode_exn ?env:e t buf off =
+  (* Seed the input cells from the env before reading fields: the field
+     readers resolve [Param_ref p] via [!(p.cell)], so a parametric size
+     (byte_array / byte_slice / uint_var) must see the env's value. Mirror of
+     the seeding [encode] does. [Param.bind] also writes the cell directly, but
+     [Param.bind_by_name] only has the name and writes [env.slots]; without
+     this it would read as 0 and silently truncate the field. *)
+  (match e with Some env -> load_env_into_cells t env | None -> ());
   let v = t.decode buf off in
   let arr = t.decode_scratch in
   clear_slots arr t.n_array_slots;

--- a/test/test_param.ml
+++ b/test/test_param.ml
@@ -343,6 +343,26 @@ let test_param_size_different_sizes () =
   Alcotest.(check string) "data 8" "12345678" r8.data;
   Alcotest.(check int) "tag 8" 0xBB r8.tag
 
+let test_param_size_bind_by_name () =
+  (* A param-driven size resolves through the field reader (the cell), not the
+     [where]/constraint path. [bind_by_name] must drive it exactly as the typed
+     [bind] does, otherwise the size reads as 0 and the field is truncated. *)
+  let env = Codec.env param_size_codec |> Param.bind_by_name "data_size" 4 in
+  let buf = Bytes.create 5 in
+  Bytes.blit_string "ABCD" 0 buf 0 4;
+  Bytes.set_uint8 buf 4 0xFF;
+  let r = decode_ok (Codec.decode ~env param_size_codec buf 0) in
+  Alcotest.(check string) "data" "ABCD" r.data;
+  Alcotest.(check int) "tag" 0xFF r.tag;
+  (* same codec, a different bound size *)
+  let env2 = Codec.env param_size_codec |> Param.bind_by_name "data_size" 2 in
+  let buf2 = Bytes.create 3 in
+  Bytes.blit_string "XY" 0 buf2 0 2;
+  Bytes.set_uint8 buf2 2 0xAA;
+  let r2 = decode_ok (Codec.decode ~env:env2 param_size_codec buf2 0) in
+  Alcotest.(check string) "data 2" "XY" r2.data;
+  Alcotest.(check int) "tag 2" 0xAA r2.tag
+
 let test_param_size_zero () =
   let env = Codec.env param_size_codec |> Param.bind ps_size_param 0 in
   let buf = Bytes.create 1 in
@@ -385,6 +405,8 @@ let suite =
       Alcotest.test_case "no params" `Quick test_no_params;
       (* param-driven size *)
       Alcotest.test_case "param: size decode" `Quick test_param_size_decode;
+      Alcotest.test_case "param: size bind_by_name" `Quick
+        test_param_size_bind_by_name;
       Alcotest.test_case "param: different sizes" `Quick
         test_param_size_different_sizes;
       Alcotest.test_case "param: size zero" `Quick test_param_size_zero;


### PR DESCRIPTION
`Wire.Param.bind_by_name` now drives a parameter-dependent field size on decode, not only `where` clauses and constraints.

A field sized by a parameter (a `byte_array`, `byte_slice`, or `uint_var` sized by `Param.expr`) resolves its size through the field reader, which reads the value from the parameter's handle cell. `decode` never seeded those cells from its env and relied on the typed `Param.bind` having written the cell as a side effect; `bind_by_name` has only the name, writes `env.slots`, and leaves the cell at 0, so the size read as zero bytes and the field was silently truncated, misaligning everything after it. `decode` now seeds the cells from the env before reading fields, as `encode` already does, so both binders behave identically. The existing `bind_by_name` test only exercised a `where` clause, which goes through the slots-based validation path, so the gap went unnoticed.
