### PR TITLE
codec: decode rejects unbound input params

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -211,6 +211,11 @@
 
 ### Fixed
 
+- `Wire.Codec.decode` now rejects a parametric codec whose env is missing or
+  leaves an input param unbound, raising `Invalid_argument` (naming the param)
+  the way `Codec.encode` already does. Decoding without binding a parameter used
+  to resolve a parameter-driven field size to 0 and silently truncate the field;
+  the binding precondition is now enforced up front on both sides (#176, @samoht)
 - `Wire.Param.bind_by_name` now drives a parameter-dependent field size on
   decode, not only `where` clauses and constraints. A field whose size comes from
   a parameter (a `byte_array`, `byte_slice`, or `uint_var` sized by

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -3085,32 +3085,33 @@ let unbound_params (t : 'r t) (env : Param.env) : string list =
     t.param_handles
   |> List.filter_map Fun.id
 
-(* Input params (read from the env) drive field sizes/offsets, so encoding
-   without their values would resolve those to 0. Output params are written
-   by decode-side actions and never consulted on encode, so a codec whose only
-   params are outputs needs no env. *)
+(* Input params (read from the env) drive field sizes/offsets, so encoding or
+   decoding without their values would resolve those to 0. Output params are
+   written by decode-side actions and never read on encode, and on decode an
+   absent env just means the caller does not want them back, so a codec whose
+   only params are outputs needs no env. *)
 let has_input_params (t : 'r t) =
   List.exists (fun (Param.Pack p) -> not p.Types.mutable_) t.param_handles
 
-let require_env t = function
+let require_env ~op t = function
   | None when not (has_input_params t) -> ()
   | None ->
       Fmt.invalid_arg
-        "Codec.encode: codec %s has input params; pass ?env (e.g. [Codec.env c \
-         |> Param.bind p N])."
-        t.name
+        "Codec.%s: codec %s has input params; pass ?env (e.g. [Codec.env c |> \
+         Param.bind p N])."
+        op t.name
   | Some env -> (
       match unbound_params t env with
       | [] -> ()
       | missing ->
           Fmt.invalid_arg
-            "Codec.encode: codec %s has unbound input params [%s]; bind every \
-             one before encoding."
-            t.name
+            "Codec.%s: codec %s has unbound input params [%s]; bind every one \
+             before use."
+            op t.name
             (String.concat ", " missing))
 
 let raw_encode ?env:e t v buf off =
-  require_env t e;
+  require_env ~op:"encode" t e;
   (match e with Some env -> load_env_into_cells t env | None -> ());
   t.encode v buf off
 
@@ -3149,13 +3150,20 @@ let env (t : _ t) : Param.env =
   }
 
 let decode_exn ?env:e t buf off =
+  (* Require an env that binds every input param, as encode does: an unbound
+     input param resolves a parametric size to 0, silently truncating the field
+     and misaligning the rest of the record. This is a usage error, not malformed
+     input, so it raises [Invalid_argument] rather than returning a parse error. *)
+  require_env ~op:"decode" t e;
   (* Seed the input cells from the env before reading fields: the field
      readers resolve [Param_ref p] via [!(p.cell)], so a parametric size
      (byte_array / byte_slice / uint_var) must see the env's value. Mirror of
      the seeding [encode] does. [Param.bind] also writes the cell directly, but
      [Param.bind_by_name] only has the name and writes [env.slots]; without
      this it would read as 0 and silently truncate the field. *)
-  (match e with Some env -> load_env_into_cells t env | None -> ());
+  (match e with
+  | Some env -> load_env_into_cells t env
+  | None -> ());
   let v = t.decode buf off in
   let arr = t.decode_scratch in
   clear_slots arr t.n_array_slots;
@@ -3181,7 +3189,7 @@ let decode ?env t buf off =
   try Ok (decode_exn ?env t buf off) with Types.Parse_error e -> Error e
 
 let encode ?env:e t v buf off =
-  require_env t e;
+  require_env ~op:"encode" t e;
   (match e with Some env -> load_env_into_cells t env | None -> ());
   let expected = t.size_of_value v in
   let actual = t.encode v buf off - off in

--- a/lib/codec.mli
+++ b/lib/codec.mli
@@ -70,7 +70,13 @@ val decode :
 (** [decode ?env c buf off] decodes a record from [buf] at offset [off].
 
     If [?env] is supplied, input params are read from it and output params are
-    written back to it after decoding. *)
+    written back to it after decoding.
+
+    Raises [Invalid_argument] when the codec has input params and no env is
+    supplied, or the env left any input param unbound (the error names the
+    offending param). An unbound input param would resolve a parametric field
+    size to 0 and silently truncate the field, so it is rejected up front the
+    same way {!encode} does. *)
 
 val decode_exn : ?env:Param.env -> 'r t -> bytes -> int -> 'r
 (** [decode_exn ?env c buf off] is like {!decode} but raises

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -917,7 +917,12 @@ module Codec : sig
     ?env:Param.env -> 'r t -> bytes -> int -> ('r, parse_error) result
   (** [decode ?env c buf off] decodes one record value at the given base offset.
       If [?env] is supplied, input params are read from it and output params are
-      written back to it on success. *)
+      written back to it on success.
+
+      Raises [Invalid_argument] when the codec has input params and the env is
+      missing or leaves one unbound, the same precondition {!encode} enforces:
+      an unbound input param would resolve a parametric field size to 0 and
+      silently truncate the field. *)
 
   val decode_exn : ?env:Param.env -> 'r t -> bytes -> int -> 'r
   (** Like {!decode} but raises {!exception:Parse_error} on failure. *)

--- a/test/test_param.ml
+++ b/test/test_param.ml
@@ -363,6 +363,28 @@ let test_param_size_bind_by_name () =
   Alcotest.(check string) "data 2" "XY" r2.data;
   Alcotest.(check int) "tag 2" 0xAA r2.tag
 
+let test_decode_rejects_unbound_param () =
+  (* An input param that drives a field size must be bound before decode, the
+     same precondition encode enforces. Decoding without an env, or with an env
+     that left the param unbound, would resolve the size to 0 and silently
+     truncate the field, so decode raises [Invalid_argument] up front. *)
+  let buf = Bytes.create 5 in
+  Bytes.blit_string "ABCD" 0 buf 0 4;
+  Bytes.set_uint8 buf 4 0xFF;
+  (* no env at all *)
+  Alcotest.check_raises "decode without env"
+    (Invalid_argument
+       "Codec.decode: codec ParamSize has input params; pass ?env (e.g. \
+        [Codec.env c |> Param.bind p N]).") (fun () ->
+      ignore (Codec.decode param_size_codec buf 0));
+  (* env present but the param left unbound *)
+  let env = Codec.env param_size_codec in
+  Alcotest.check_raises "decode with unbound param"
+    (Invalid_argument
+       "Codec.decode: codec ParamSize has unbound input params [data_size]; \
+        bind every one before use.") (fun () ->
+      ignore (Codec.decode ~env param_size_codec buf 0))
+
 let test_param_size_zero () =
   let env = Codec.env param_size_codec |> Param.bind ps_size_param 0 in
   let buf = Bytes.create 1 in
@@ -407,6 +429,8 @@ let suite =
       Alcotest.test_case "param: size decode" `Quick test_param_size_decode;
       Alcotest.test_case "param: size bind_by_name" `Quick
         test_param_size_bind_by_name;
+      Alcotest.test_case "param: decode rejects unbound" `Quick
+        test_decode_rejects_unbound_param;
       Alcotest.test_case "param: different sizes" `Quick
         test_param_size_different_sizes;
       Alcotest.test_case "param: size zero" `Quick test_param_size_zero;


### PR DESCRIPTION
`Wire.Codec.decode` now rejects a parametric codec whose env is missing or leaves an input param unbound, raising `Invalid_argument` (naming the param) the way `Codec.encode` already does.

An input param drives a field's size or offset. `encode` already calls `require_env` to reject a missing env or an unbound param up front, since either would resolve the size to 0 and corrupt the layout. `decode` did no such check: with no env, or an env that left a binding out, the size silently resolved to 0 and the field was truncated rather than erroring. `decode` now enforces the same precondition, so the two sides agree on what a valid call looks like. Stacked on #175.
