### PR TITLE
wire: of_string accepts unlisted enum_open codes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -211,6 +211,11 @@
 
 ### Fixed
 
+- `Wire.of_string` (and the other typ-level entry points) now accept an unlisted
+  code in a `Wire.enum_open` field, matching `Wire.Codec.decode`. The typ-level
+  decoder kept the closed-enum membership check regardless of the `enum_open`
+  flag, so it raised `Invalid_enum` on a value the codec accepts, an open enum
+  that behaved as closed on that path (#177, @samoht)
 - `Wire.Codec.decode` now rejects a parametric codec whose env is missing or
   leaves an input param unbound, raising `Invalid_argument` (naming the param)
   the way `Codec.encode` already does. Decoding without binding a parameter used

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -159,6 +159,16 @@ let parse_codec_typ codec_decode fixed_size size_of buf off len =
   check_eof len (off + sz);
   (codec_decode buf off, off + sz)
 
+(* Only a closed enum enforces membership; an open enum names known codes but
+   accepts any value. [Codec.decode] gates on [closed] the same way, so the two
+   decode paths agree on an unlisted code. *)
+let check_enum_membership ~closed cases v =
+  if closed then begin
+    let valid = List.map snd cases in
+    if not (List.mem v valid) then
+      raise (Parse_error (Invalid_enum { value = v; valid }))
+  end
+
 let parse_struct_typ s buf off len =
   let v = Codec.validator_of_struct s in
   let sz = Codec.struct_size_of v buf off in
@@ -276,11 +286,10 @@ let rec parse_direct : type a. a typ -> bytes -> int -> int -> a * int =
       let v, off' = parse_direct inner buf off len in
       (decode v, off')
   | Where { cond; inner } -> parse_where inner cond buf off len
-  | Enum { base; cases; _ } ->
+  | Enum { base; cases; closed; _ } ->
       let v, off' = parse_direct base buf off len in
-      let valid = List.map snd cases in
-      if List.mem v valid then (v, off')
-      else raise (Parse_error (Invalid_enum { value = v; valid }))
+      check_enum_membership ~closed cases v;
+      (v, off')
   | Codec { codec_decode; codec_fixed_size; codec_size_of; _ } ->
       parse_codec_typ codec_decode codec_fixed_size codec_size_of buf off len
   | Struct s -> parse_struct_typ s buf off len

--- a/test/test_wire.ml
+++ b/test/test_wire.ml
@@ -890,11 +890,30 @@ let test_stream_encode_chunk3 () =
   | Ok decoded -> Alcotest.(check int) "encode chunk=3" v decoded
   | Error e -> Alcotest.failf "encode chunk=3: %a" pp_parse_error e
 
+(* An open enum accepts any value, named or not. The typ-level [of_string] path
+   must agree with [Codec.decode] on an unlisted code; it used to keep the closed
+   enum's membership check and reject what the codec accepted. *)
+let test_enum_open_of_string_accepts_unlisted () =
+  let typ = enum_open "Code" [ ("A", 1); ("B", 2); ("C", 3) ] uint8 in
+  let c = Codec.v "EO" (fun v -> v) Codec.[ (Field.v "v" typ $ fun v -> v) ] in
+  let unlisted =
+    "\x32"
+    (* 50, not a named code *)
+  in
+  (match Codec.decode c (Bytes.of_string unlisted) 0 with
+  | Ok v -> Alcotest.(check int) "codec decode accepts unlisted" 50 v
+  | Error e -> Alcotest.failf "codec rejected unlisted: %a" pp_parse_error e);
+  match of_string typ unlisted with
+  | Ok v -> Alcotest.(check int) "of_string accepts unlisted" 50 v
+  | Error e -> Alcotest.failf "of_string rejected unlisted: %a" pp_parse_error e
+
 (* -- Suite -- *)
 
 let suite =
   ( "wire",
     [
+      Alcotest.test_case "enum_open: of_string accepts unlisted" `Quick
+        test_enum_open_of_string_accepts_unlisted;
       Alcotest.test_case "expr: equality operators" `Quick
         test_expr_equality_operators;
       (* parsing *)


### PR DESCRIPTION
`Wire.of_string` and the other typ-level entry points now accept an unlisted code in a `Wire.enum_open` field, matching `Wire.Codec.decode`.

`enum_open` names known codes for documentation but accepts any value; only a closed `enum` enforces membership. `Codec.decode` already gated the membership check on the `closed` flag, but the typ-level decoder (`of_string` / `of_bytes` / `of_reader`) ignored it and always rejected an unlisted code with `Invalid_enum`. So the same bytes decoded one way and were rejected the other, an open enum behaving as closed on that path. The check is now gated on `closed` in both decoders. Found by the fuzz suite, which exercises both paths over the registry. Stacked on #176.
