### PR TITLE
wire: of_string returns Error on truncated variable codec

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -211,6 +211,12 @@
 
 ### Fixed
 
+- `Wire.of_string` (and the other typ-level entry points) now return a clean
+  `Error` on a truncated input to a variable-size codec, instead of raising
+  `Invalid_argument`. Computing the codec's span reads its length and gate fields
+  up front; on a buffer too short to hold them, that read ran off the end and
+  escaped as an out-of-bounds exception rather than a parse error. `Codec.decode`
+  already guarded this; the typ-level path now does too (#178, @samoht)
 - `Wire.of_string` (and the other typ-level entry points) now accept an unlisted
   code in a `Wire.enum_open` field, matching `Wire.Codec.decode`. The typ-level
   decoder kept the closed-enum membership check regardless of the `enum_open`

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -155,7 +155,20 @@ let parse_all_zeros buf off len =
   (check 0, len)
 
 let parse_codec_typ codec_decode fixed_size size_of buf off len =
-  let sz = match fixed_size with Some n -> n | None -> size_of buf off in
+  let sz =
+    match fixed_size with
+    | Some n -> n
+    | None -> (
+        (* A variable-size codec computes its span by reading length / gate
+           fields from the buffer; on a buffer too short to hold them, that read
+           is out of bounds. Convert the [Invalid_argument] into a clean eof, the
+           same guard [Codec.decode]'s checked path applies, so [of_string] on a
+           truncated input returns [Error _] instead of crashing. *)
+        try size_of buf off
+        with Invalid_argument _ ->
+          raise (Parse_error (Unexpected_eof { expected = len + 1; got = len }))
+        )
+  in
   check_eof len (off + sz);
   (codec_decode buf off, off + sz)
 

--- a/test/test_wire.ml
+++ b/test/test_wire.ml
@@ -907,6 +907,25 @@ let test_enum_open_of_string_accepts_unlisted () =
   | Ok v -> Alcotest.(check int) "of_string accepts unlisted" 50 v
   | Error e -> Alcotest.failf "of_string rejected unlisted: %a" pp_parse_error e
 
+(* A variable-size codec computes its span by reading length fields; on a
+   truncated buffer that read runs off the end. [of_string] must return a clean
+   [Error] (eof), not raise [Invalid_argument], the same way [Codec.decode]
+   already rejects truncated input. *)
+let test_of_string_truncated_variable_codec () =
+  let len = Field.v "len" uint8 in
+  let data = Field.v "data" (byte_array ~size:(Field.ref len)) in
+  let c = Codec.v "Sized" (fun l d -> (l, d)) Codec.[ len $ fst; data $ snd ] in
+  let typ = codec c in
+  List.iter
+    (fun s ->
+      match of_string typ s with
+      | Ok _ | Error _ -> ()
+      | exception Invalid_argument m ->
+          Alcotest.failf
+            "of_string raised Invalid_argument %S on a %d-byte input" m
+            (String.length s))
+    [ ""; "\x05"; "\xff\x00" ]
+
 (* -- Suite -- *)
 
 let suite =
@@ -914,6 +933,8 @@ let suite =
     [
       Alcotest.test_case "enum_open: of_string accepts unlisted" `Quick
         test_enum_open_of_string_accepts_unlisted;
+      Alcotest.test_case "of_string: truncated variable codec rejects" `Quick
+        test_of_string_truncated_variable_codec;
       Alcotest.test_case "expr: equality operators" `Quick
         test_expr_equality_operators;
       (* parsing *)


### PR DESCRIPTION
`Wire.of_string` and the other typ-level entry points now return a clean `Error` on a truncated input to a variable-size codec, instead of raising `Invalid_argument`.

Decoding a codec embedded as a typ computes its byte span up front by reading the length and gate fields that determine the size, then advances past it. On a buffer too short to even hold those fields, that read ran off the end and surfaced as an out-of-bounds `Invalid_argument` rather than a parse error, so `of_string` on a truncated frame crashed where `Codec.decode` rejects it cleanly (`Codec.decode`'s checked path already guards the same computation). The span computation is now wrapped to convert the out-of-bounds read into an end-of-input error. Found by the fuzz suite's adversarial stream. Stacked on #177.
