### PR TITLE
codec: reject greedy-tailed embedded sub-codec as non-last field

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -211,6 +211,12 @@
 
 ### Fixed
 
+- `Wire.Codec.v` now rejects, at construction, a non-last field whose type is an
+  embedded sub-codec ending in a greedy field (`all_bytes` / `all_zeros`). Such a
+  tail consumes the rest of the buffer with no boundary, so it silently swallowed
+  the following field's bytes and the record failed to decode. The greedy-must-be-
+  last check already rejected a bare greedy field that is not last; it now looks
+  through an embedded sub-codec too (#179, @samoht)
 - `Wire.of_string` (and the other typ-level entry points) now return a clean
   `Error` on a truncated input to a variable-size codec, instead of raising
   `Invalid_argument`. Computing the codec's span reads its length and gate fields

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -926,6 +926,11 @@ let bf_base_total_bits = Bitfield.total_bits
 let bf_base_equal = Bitfield.equal
 let bf_write_base = Bitfield.write_word
 
+let equal_bit_order (a : Types.bit_order) (b : Types.bit_order) =
+  match (a, b) with
+  | Msb_first, Msb_first | Lsb_first, Lsb_first -> true
+  | Msb_first, Lsb_first | Lsb_first, Msb_first -> false
+
 (* Build-time dispatch: pattern match on base happens once at codec
    construction, not on every read/write call. *)
 let build_bf_reader base byte_off shift width =
@@ -1512,7 +1517,8 @@ let compile_bits : type r.
   let is_continuation =
     match ctx.bf with
     | Some bf ->
-        bf_base_equal bf.base base && bf.bit_order = bit_order
+        bf_base_equal bf.base base
+        && equal_bit_order bf.bit_order bit_order
         && bf.bits_used + width <= bf.total_bits
     | None -> false
   in
@@ -2650,17 +2656,38 @@ let build_checked_decode raw_decode wire_size_info min_size =
         raise_eof ~expected:(end_off - off) ~got:(Bytes.length buf - off));
   raw_decode buf off
 
-(* A greedy field ([all_bytes] / [all_zeros]) consumes the rest of the buffer,
-   so it is only meaningful as the last field: an earlier one starves every
-   field after it (and 3D's [:consume-all] must be last too). Reject it at
-   construction rather than silently truncating later fields at decode. *)
+(* Whether a field consumes the rest of the buffer: a greedy leaf ([all_bytes] /
+   [all_zeros]), or an embedded sub-codec whose own last field does. A greedy
+   tail has no boundary once another field follows it, so an embedded codec
+   ending in one is just as unbounded as a bare greedy field. *)
+let rec field_consumes_rest : type a. a Types.typ -> bool =
+ fun t ->
+  is_greedy t
+  ||
+  match t with
+  | Types.Codec { codec_struct; _ } -> (
+      match List.rev codec_struct.fields with
+      | Types.Field f :: _ -> field_consumes_rest f.field_typ
+      | [] -> false)
+  | Types.Map { inner; _ } -> field_consumes_rest inner
+  | Types.Where { inner; _ } -> field_consumes_rest inner
+  | Types.Enum { base; _ } -> field_consumes_rest base
+  | _ -> false
+
+(* A greedy field consumes the rest of the buffer, so it is only meaningful as
+   the last field: an earlier one starves every field after it (and 3D's
+   [:consume-all] must be last too). This also covers an embedded sub-codec
+   ending in a greedy field, whose tail would otherwise swallow the following
+   field's bytes. Reject it at construction rather than silently truncating
+   later fields at decode. *)
 let reject_greedy_not_last name fields =
   let rec check = function
     | [] | [ _ ] -> ()
     | Types.Field f :: rest ->
-        if is_greedy f.field_typ then
+        if field_consumes_rest f.field_typ then
           Fmt.invalid_arg
-            "Codec.v %s: a greedy field (all_bytes / all_zeros) must be the \
+            "Codec.v %s: a field that consumes the rest of the buffer \
+             (all_bytes / all_zeros, or a sub-codec ending in one) must be the \
              last field, but %s is followed by more fields"
             name
             (Option.value ~default:"<anon>" f.field_name);

--- a/test/test_wire.ml
+++ b/test/test_wire.ml
@@ -238,6 +238,27 @@ let test_all_zeros_in_codec () =
   | Ok (Ok _) -> Alcotest.fail "all_zeros must reject non-zero pad byte"
   | _ -> ()
 
+(* An embedded sub-codec ending in a greedy field has no boundary once another
+   field follows it, so its tail would swallow the next field's bytes. The lib
+   rejects this at construction the same way it rejects a bare greedy field that
+   is not last. *)
+let test_reject_greedy_embedded_not_last () =
+  let inner =
+    Codec.v "Inner"
+      (fun f z -> (f, z))
+      Codec.[ Field.v "f" float64be $ fst; Field.v "z" all_zeros $ snd ]
+  in
+  Alcotest.check_raises "greedy embedded sub-codec not last"
+    (Invalid_argument
+       "Codec.v Outer: a field that consumes the rest of the buffer (all_bytes \
+        / all_zeros, or a sub-codec ending in one) must be the last field, but \
+        n is followed by more fields") (fun () ->
+      ignore
+        (Codec.v "Outer"
+           (fun n b -> (n, b))
+           Codec.
+             [ Field.v "n" (codec inner) $ fst; Field.v "b" (bit uint8) $ snd ]))
+
 let printable_byte b = Expr.(b >= int 0x20 && b <= int 0x7e)
 
 let test_bawhere_accepts () =
@@ -968,6 +989,8 @@ let suite =
         test_codec_all_bytes_tail;
       Alcotest.test_case "codec: all_zeros as field" `Quick
         test_all_zeros_in_codec;
+      Alcotest.test_case "codec: reject greedy embedded sub-codec not last"
+        `Quick test_reject_greedy_embedded_not_last;
       Alcotest.test_case "parse: byte_array_where accepts" `Quick
         test_bawhere_accepts;
       Alcotest.test_case "parse: byte_array_where rejects" `Quick


### PR DESCRIPTION
`Wire.Codec.v` now rejects, at construction, a non-last field whose type is an embedded sub-codec ending in a greedy field (`all_bytes` / `all_zeros`).

A greedy field consumes the rest of the buffer, so it is only meaningful as the last field. The construction check already rejected a bare greedy field that is not last, but it did not look through a `Wire.codec` embedding: a sub-codec ending in `all_bytes` / `all_zeros`, used as a non-last field, was accepted, and its tail then swallowed the following field's bytes so the record failed to decode. The check now recurses through an embedded sub-codec (and `map` / `where` / `enum` wrappers), so the unroundtrippable shape is rejected up front with a clear error. A greedy field or greedy-tailed sub-codec as the last field is unaffected.

Found by the fuzz suite's nested-composition stream. The commit also swaps one pre-existing polymorphic `bit_order` comparison in the touched file for a typed equality, which the touched-file lint required. Stacked on #178.
