### PR TITLE
wire: zero-length byte_slice decodes to an empty slice

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -211,6 +211,10 @@
 
 ### Fixed
 
+- A zero-length `Wire.byte_slice` now decodes to an empty slice instead of
+  raising `Invalid_argument`. The slice constructor rejects a zero length, so a
+  `byte_slice` whose size resolved to 0 crashed the decoder rather than yielding
+  the empty slice (#180, @samoht)
 - `Wire.Codec.v` now rejects, at construction, a non-last field whose type is an
   embedded sub-codec ending in a greedy field (`all_bytes` / `all_zeros`). Such a
   tail consumes the rest of the buffer with no boundary, so it silently swallowed

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -247,7 +247,7 @@ let rec build_field_reader : type a. a typ -> int -> bytes -> int -> a =
   | Byte_array_where { size = Int n; _ } ->
       fun buf base -> Bytes.sub_string buf (base + field_off) n
   | Byte_slice { size = Int n } ->
-      fun buf base -> Slice.make buf ~first:(base + field_off) ~length:n
+      fun buf base -> Slice.make_or_eod buf ~first:(base + field_off) ~length:n
   | Where { inner; _ } -> build_field_reader inner field_off
   | Enum { base; cases; closed; _ } ->
       let read = build_field_reader base field_off in
@@ -1231,7 +1231,7 @@ let rec read_elem : type a. a typ -> bytes -> int -> a =
      chunks. The size is the element's own constant width. *)
   | Byte_array { size = Int n } -> Bytes.sub_string buf off n
   | Byte_array_where { size = Int n; _ } -> Bytes.sub_string buf off n
-  | Byte_slice { size = Int n } -> Slice.make buf ~first:off ~length:n
+  | Byte_slice { size = Int n } -> Slice.make_or_eod buf ~first:off ~length:n
   (* A lone bitfield occupies its base word; extract the value at its bit
      offset. *)
   | Bits { width; base; bit_order } ->

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -289,7 +289,7 @@ let rec parse_direct : type a. a typ -> bytes -> int -> int -> a * int =
   | Byte_slice { size } ->
       let n = Eval.expr Eval.empty size in
       check_eof len (off + n);
-      (Slice.make buf ~first:off ~length:n, off + n)
+      (Slice.make_or_eod buf ~first:off ~length:n, off + n)
   | Single_elem { size; elem; at_most = _ } ->
       let n = Eval.expr Eval.empty size in
       check_eof len (off + n);

--- a/test/test_wire.ml
+++ b/test/test_wire.ml
@@ -92,6 +92,26 @@ let test_parse_byte_array () =
   | Ok v -> Alcotest.(check string) "byte_array value" "hello" v
   | Error e -> Alcotest.failf "%a" pp_parse_error e
 
+(* A zero-length byte_slice decodes to an empty slice. The slice constructor
+   rejects a zero length, so the decoder used to raise [Invalid_argument]
+   ("invalid slice") instead of yielding the empty slice. *)
+let test_byte_slice_zero () =
+  let t = byte_slice ~size:(int 0) in
+  (match of_string t "" with
+  | Ok s ->
+      Alcotest.(check int)
+        "of_string zero slice length" 0
+        (Bytesrw.Bytes.Slice.length s)
+  | Error e ->
+      Alcotest.failf "of_string rejected zero slice: %a" pp_parse_error e);
+  let c = Codec.v "BS0" (fun s -> s) Codec.[ (Field.v "s" t $ fun s -> s) ] in
+  match Codec.decode c (Bytes.create 0) 0 with
+  | Ok s ->
+      Alcotest.(check int)
+        "codec zero slice length" 0
+        (Bytesrw.Bytes.Slice.length s)
+  | Error e -> Alcotest.failf "codec rejected zero slice: %a" pp_parse_error e
+
 let test_int8_negative () =
   let buf = Bytes.of_string "\xFE" in
   Alcotest.(check int) "-2" (-2) (of_bytes_exn int8 buf)
@@ -967,6 +987,7 @@ let suite =
       Alcotest.test_case "parse: uint64 le" `Quick test_parse_uint64_le;
       Alcotest.test_case "parse: array" `Quick test_parse_array;
       Alcotest.test_case "parse: byte_array" `Quick test_parse_byte_array;
+      Alcotest.test_case "parse: byte_slice size 0" `Quick test_byte_slice_zero;
       Alcotest.test_case "parse: int8 negative" `Quick test_int8_negative;
       Alcotest.test_case "parse: int8 full range" `Quick test_int8_full_range;
       Alcotest.test_case "parse: int16be negative" `Quick test_int16be_negative;


### PR DESCRIPTION
A zero-length `Wire.byte_slice` now decodes to an empty slice instead of raising `Invalid_argument`.

The underlying slice constructor rejects a zero length, so a `byte_slice` whose size resolved to 0 (a fixed `~size:(int 0)`, or a parameter/field that evaluated to 0) crashed the decoder with `Invalid_argument "invalid slice"` rather than yielding the empty slice. The three byte_slice decode sites now use the eod-tolerant slice constructor, matching the slice sites that already handled length 0. Found by the fuzz suite. Stacked on #179.
