### PR TITLE
codec: validate fails cleanly on a too-short buffer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -211,6 +211,12 @@
 
 ### Fixed
 
+- `Wire.Codec.validate` on a buffer too short to hold the fields a check reads
+  now fails cleanly instead of raising `Invalid_argument`. A `where` or field
+  constraint may read a field whose offset depends on a length read from the
+  buffer; `decode` bounds-checks the buffer first, but `validate` ran the check
+  kernel directly, so a short buffer read out of bounds and crashed (#181,
+  @samoht)
 - A zero-length `Wire.byte_slice` now decodes to an empty slice instead of
   raising `Invalid_argument`. The slice constructor rejects a zero length, so a
   `byte_slice` whose size resolved to 0 crashed the decoder rather than yielding

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -2572,6 +2572,19 @@ let compile_where_clause param_slots field_readers where =
       let cc = mk_ctx ~param_slots idx in
       Some (compile_bool_arr cc cond)
 
+(* Run a validation pass, turning an out-of-bounds read into a clean eof. A
+   check may read a field whose offset depends on a length read from the buffer;
+   on a buffer too short to hold it that read is out of bounds. [decode] runs
+   [t.decode] first (which bounds-checks), but [Codec.validate] runs the check
+   kernel directly, so this keeps a short buffer a clean failure, not a crash. *)
+let validate_or_eof buf f =
+  try f ()
+  with Invalid_argument _ ->
+    raise
+      (Parse_error
+         (Unexpected_eof
+            { expected = Bytes.length buf + 1; got = Bytes.length buf }))
+
 let build_validators validators_rev checkers_rev compiled_where struct_fields
     n_total =
   let validator_fns = Array.of_list (List.map snd validators_rev) in
@@ -2613,7 +2626,7 @@ let build_validators validators_rev checkers_rev compiled_where struct_fields
         (* Validate through the same kernel decode uses ([validate_arr]), so
            [Codec.validate] and [decode] never disagree on field constraints,
            actions, or the [where] clause. *)
-        validate_arr arr buf off)
+        validate_or_eof buf (fun () -> validate_arr arr buf off))
     else fun ?env_slots:_ _buf _off -> ()
   in
   (validate_arr, populate, validate)

--- a/test/test_wire.ml
+++ b/test/test_wire.ml
@@ -967,11 +967,29 @@ let test_of_string_truncated_variable_codec () =
             (String.length s))
     [ ""; "\x05"; "\xff\x00" ]
 
+(* [Codec.validate] on a buffer too short to hold the fields a check reads must
+   fail cleanly, not crash. A check (here a [where]) reads a field at an offset
+   that depends on a length; [decode] bounds-checks before validating, but
+   [Codec.validate] runs the check kernel directly. *)
+let test_validate_short_buffer_no_crash () =
+  let len = Field.v "Len" (where Expr.true_ uint8) in
+  let data = Field.v "Data" (byte_array ~size:(Field.ref len)) in
+  let c =
+    Codec.v "VShort" (fun l d -> (l, d)) Codec.[ len $ fst; data $ snd ]
+  in
+  match Codec.validate c (Bytes.create 0) 0 with
+  | () -> Alcotest.fail "validate accepted an empty buffer"
+  | exception Wire.Validation_error _ -> ()
+  | exception Invalid_argument m ->
+      Alcotest.failf "validate crashed on a short buffer: %s" m
+
 (* -- Suite -- *)
 
 let suite =
   ( "wire",
     [
+      Alcotest.test_case "validate: short buffer does not crash" `Quick
+        test_validate_short_buffer_no_crash;
       Alcotest.test_case "enum_open: of_string accepts unlisted" `Quick
         test_enum_open_of_string_accepts_unlisted;
       Alcotest.test_case "of_string: truncated variable codec rejects" `Quick


### PR DESCRIPTION
`Wire.Codec.validate` on a buffer too short to hold the fields a check reads now fails cleanly instead of raising `Invalid_argument`.

A `where` clause or field constraint may read a field whose offset depends on a length read from the buffer. `decode` runs the field readers first (which bounds-check), so by the time it validates the buffer is known to be long enough; but `Codec.validate` runs the check kernel directly, so a buffer too short to hold those fields read out of bounds and escaped as `Invalid_argument` rather than a validation failure. The validation pass now converts the out-of-bounds read into an end-of-input error. Found by the fuzz suite's validate stream. Stacked on #180.
