### PR TITLE
codec: reject greedy casetype case body as non-last field

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -211,6 +211,13 @@
 
 ### Fixed
 
+- `Wire.Codec.v` now rejects, at construction, a non-last field that is a
+  `Wire.casetype` with a case body ending in a greedy field (`all_bytes` /
+  `all_zeros`). If that case is selected the greedy tail consumes the rest of the
+  buffer, starving the following field, so the record failed to round-trip while
+  construction silently accepted it. The greedy-must-be-last check now looks
+  through casetype case bodies, as it already does through an embedded sub-codec
+  (#182, @samoht)
 - `Wire.Codec.validate` on a buffer too short to hold the fields a check reads
   now fails cleanly instead of raising `Invalid_argument`. A `where` or field
   constraint may read a field whose offset depends on a length read from the

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -2670,9 +2670,10 @@ let build_checked_decode raw_decode wire_size_info min_size =
   raw_decode buf off
 
 (* Whether a field consumes the rest of the buffer: a greedy leaf ([all_bytes] /
-   [all_zeros]), or an embedded sub-codec whose own last field does. A greedy
-   tail has no boundary once another field follows it, so an embedded codec
-   ending in one is just as unbounded as a bare greedy field. *)
+   [all_zeros]), an embedded sub-codec whose own last field does, or a casetype
+   any of whose case bodies does (if that case is selected its greedy tail has no
+   boundary). A greedy tail has no boundary once another field follows it, so
+   each of these is just as unbounded as a bare greedy field. *)
 let rec field_consumes_rest : type a. a Types.typ -> bool =
  fun t ->
   is_greedy t
@@ -2682,6 +2683,11 @@ let rec field_consumes_rest : type a. a Types.typ -> bool =
       match List.rev codec_struct.fields with
       | Types.Field f :: _ -> field_consumes_rest f.field_typ
       | [] -> false)
+  | Types.Casetype { cases; _ } ->
+      List.exists
+        (fun (Types.Case_branch { cb_inner; _ }) ->
+          field_consumes_rest cb_inner)
+        cases
   | Types.Map { inner; _ } -> field_consumes_rest inner
   | Types.Where { inner; _ } -> field_consumes_rest inner
   | Types.Enum { base; _ } -> field_consumes_rest base

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -947,6 +947,36 @@ let test_greedy_not_last_rejected () =
     "greedy last roundtrip" true
     (decode_ok (Codec.decode c buf 0) = v)
 
+(* A casetype whose case body is a sub-codec ending in a greedy field consumes
+   the rest of the buffer when that case is selected; placed before another
+   field it would starve it, so it is refused at construction. As the last field
+   it is fine. *)
+let test_casetype_greedy_case_not_last_rejected () =
+  let greedy =
+    Codec.v "G" (fun z -> z) Codec.[ Field.v "z" all_zeros $ Fun.id ]
+  in
+  let ct =
+    casetype "CtG" uint8
+      [
+        case ~index:1 uint8
+          ~inject:(fun v -> `U v)
+          ~project:(function `U v -> Some v | _ -> None);
+        case ~index:2 (codec greedy)
+          ~inject:(fun v -> `G v)
+          ~project:(function `G v -> Some v | _ -> None);
+      ]
+  in
+  Alcotest.(check bool)
+    "casetype with greedy case body before another field rejected" true
+    (raises_invalid (fun () ->
+         Codec.v "Outer"
+           (fun c t -> (c, t))
+           Codec.[ Field.v "ct" ct $ fst; Field.v "tail" uint8 $ snd ]));
+  Alcotest.(check bool)
+    "casetype with greedy case body as last field accepted" false
+    (raises_invalid (fun () ->
+         Codec.v "OuterOk" Fun.id Codec.[ Field.v "ct" ct $ Fun.id ]))
+
 (* [uint] is a 1-to-7-byte unsigned integer; a literal size outside that range
    is refused at construction. *)
 let test_uint_size_bounds () =
@@ -5056,6 +5086,8 @@ let suite =
         test_casetype_reject_greedy_case_body;
       Alcotest.test_case "greedy field must be last" `Quick
         test_greedy_not_last_rejected;
+      Alcotest.test_case "casetype greedy case body must be last" `Quick
+        test_casetype_greedy_case_not_last_rejected;
       Alcotest.test_case "uint rejects out-of-range size" `Quick
         test_uint_size_bounds;
       Alcotest.test_case "casetype case requires ~index" `Quick


### PR DESCRIPTION
`Wire.Codec.v` now rejects, at construction, a non-last field that is a `Wire.casetype` with a case body ending in a greedy field (`all_bytes` / `all_zeros`).

A casetype case body may be a sub-codec ending in a greedy field (this is supported, #50). If such a case is selected at decode, its greedy tail consumes the rest of the buffer, so when the casetype is not the last field it starves everything after it and the record fails to round-trip, while construction silently accepted it. The greedy-must-be-last check (which already looks through an embedded sub-codec, #179) now also looks through casetype case bodies. A casetype with a greedy case body as the last field is unaffected. Found by the fuzz suite. Stacked on #181.
