### PR TITLE
codec: reject an array of a zero-width element

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -211,6 +211,10 @@
 
 ### Fixed
 
+- `Wire.array` / `Wire.array_seq` now reject a zero-width element (`empty` /
+  unit) at construction. Such an array carries no bytes and projected to a
+  zero-size 3D array EverParse rejects; it is a degenerate shape and is refused
+  up front (#184, @samoht)
 - `Wire.Codec.v` now rejects, at construction, a non-last field that is a
   `Wire.casetype` with a case body ending in a greedy field (`all_bytes` /
   `all_zeros`). If that case is selected the greedy tail consumes the rest of the

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -475,7 +475,8 @@ let rec is_array_element : type a. a typ -> bool = function
   | Uint8 | Uint16 _ | Uint32 _ | Uint63 _ | Uint64 _ -> true
   | Int8 | Int16 _ | Int32 _ | Int64 _ -> true
   | Float32 _ | Float64 _ -> true
-  | Unit -> true
+  (* [Unit] is 0-width: an array of it carries no bytes and projects to a
+     zero-size 3D array EverParse rejects, so it is not a valid element. *)
   | Uint_var { size = Int _; _ } -> true
   | Byte_array { size = Int _ } | Byte_slice { size = Int _ } -> true
   | Codec { codec_fixed_size; codec_struct; _ } ->
@@ -1824,19 +1825,20 @@ let rec mentions_field : type a. string -> a expr -> bool =
    outside the signed range folds to a literal, and anything that is not a plain
    comparison of the field with an integer literal is rejected (it cannot be
    projected faithfully). *)
+let rebuild_ordering op (l : int expr) (r : int expr) : bool expr =
+  match op with
+  | `Lt -> Lt (l, r)
+  | `Le -> Le (l, r)
+  | `Gt -> Gt (l, r)
+  | `Ge -> Ge (l, r)
+
 let translate_signed_ordering ~name ~width (cond : bool expr) : bool expr =
   let signbit = 1 lsl (width - 1) in
   let mask = (1 lsl width) - 1 in
   let smax = signbit - 1 and smin = -signbit in
   let flip_const k : int expr = Int (k land mask lxor signbit) in
   let flip_self : int expr = Lxor (Ref (I, name), Int signbit) in
-  let rebuild op l r : bool expr =
-    match op with
-    | `Lt -> Lt (l, r)
-    | `Le -> Le (l, r)
-    | `Gt -> Gt (l, r)
-    | `Ge -> Ge (l, r)
-  in
+  let rebuild = rebuild_ordering in
   let self_op_const op k : bool expr =
     if k > smax then match op with `Lt | `Le -> Bool true | _ -> Bool false
     else if k < smin then

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -582,6 +582,17 @@ let test_repeat_array_reject_bitfield () =
     (raises_invalid (fun () ->
          Field.repeat "x" ~size:(int 4) (bit (bits ~width:1 U8))))
 
+(* A zero-width element ([empty] / unit) carries no bytes, so an array of it is
+   degenerate and projects to a zero-size 3D array EverParse rejects. It is
+   refused at construction. *)
+let test_array_reject_zero_width_element () =
+  Alcotest.(check bool)
+    "array over empty rejected" true
+    (raises_invalid (fun () -> array ~len:(int 3) empty));
+  Alcotest.(check bool)
+    "array_seq over empty rejected" true
+    (raises_invalid (fun () -> array_seq seq_list ~len:(int 3) empty))
+
 (* Wire.array over a fixed sub-record (Codec element): a fixed-count list of
    structs. Decoding raised Failure "build_field_reader: unsupported type"
    because the array element reader had no Codec case. The schema projects the
@@ -5058,6 +5069,8 @@ let suite =
         test_repeat_oversized_length_rejected;
       Alcotest.test_case "repeat/array reject bitfield element" `Quick
         test_repeat_array_reject_bitfield;
+      Alcotest.test_case "array rejects zero-width element" `Quick
+        test_array_reject_zero_width_element;
       Alcotest.test_case "array: record element roundtrip" `Quick
         test_array_record_element;
       Alcotest.test_case "array: record element projection" `Quick


### PR DESCRIPTION
`Wire.array` / `Wire.array_seq` now reject a zero-width element (`empty` / unit) at construction.

An array of a zero-width element carries no bytes and projects to `unit v[:byte-size 0]`, which EverParse rejects; the shape is degenerate (its length is meaningless), so it is refused up front via `is_array_element` no longer admitting `Unit`. The commit also extracts the pure `rebuild` helper out of `translate_signed_ordering` into a top-level `rebuild_ordering` (no behaviour change), which the whole-file lint flagged as over the length threshold once this file was touched.

Surfaced by the fuzz harness's `array(3,empty)` generator. Stacked on #183.
