### PR TITLE
codec: project a big-endian-based enum as a refinement

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -211,6 +211,12 @@
 
 ### Fixed
 
+- An `enum` / `variants` over a big-endian base (e.g. `enum ... uint16be`) now
+  projects to a `.3d` EverParse accepts. It was emitted as a `UINT16BE enum`
+  declaration, which EverParse rejects (it types the integer constants as the
+  native width: "Expected UINT16BE, got UINT16"). A big-endian-based enum now
+  projects as its base scalar with a membership refinement (closed) or bare base
+  (open), with no enum declaration (#185, @samoht)
 - `Wire.array` / `Wire.array_seq` now reject a zero-width element (`empty` /
   unit) at construction. Such an array carries no bytes and projected to a
   zero-size 3D array EverParse rejects; it is a degenerate shape and is refused

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -854,11 +854,23 @@ let casetype_decl name params tag cases =
 (* Module *)
 type module_ = { doc : string option; decls : decl list }
 
+(* An enum over a big-endian multi-byte base cannot be a 3D [enum] type:
+   EverParse types the integer constants as the native (little-endian) width and
+   rejects the declaration ("Expected UINT16BE, got UINT16"). Such an enum is
+   projected as its base scalar with a membership refinement (closed) or bare
+   base (open) instead, the same shape used outside the doc projection. *)
+let enum_base_is_be : type a. a typ -> bool = function
+  | Uint16 Big | Uint32 Big | Uint63 Big | Uint64 Big -> true
+  | Int16 Big | Int32 Big | Int64 Big -> true
+  | Uint_var { endian = Big; _ } -> true
+  | _ -> false
+
 (* Extract enum declarations needed by struct fields. Scans field types for
    Enum constructors (including under Map/Where wrappers) and returns the
    corresponding enum_decl entries, deduplicated by name. Enums over bitfield
    bases are skipped: they map to plain bitfields in 3D (the enum/variant
-   mapping is OCaml-only). *)
+   mapping is OCaml-only). An enum over a big-endian base is skipped too (no 3D
+   enum type for it; the field carries a membership refinement instead). *)
 let enum_decls (s : struct_) : decl list =
   let seen = Hashtbl.create 4 in
   let decls = Stdlib.ref [] in
@@ -870,7 +882,9 @@ let enum_decls (s : struct_) : decl list =
     (fun (Field f) ->
       let rec extract : type a. a typ -> unit = function
         | Enum { name; cases; base; _ }
-          when (not (Hashtbl.mem seen name)) && not (is_bits base) ->
+          when (not (Hashtbl.mem seen name))
+               && (not (is_bits base))
+               && not (enum_base_is_be base) ->
             (* Both open and closed enums declare a 3D enum type so the named
                codes survive in the generated .3d. A closed enum additionally
                constrains its field with a membership refinement; an open enum
@@ -1733,6 +1747,9 @@ let rec enum_type_name : type a. a typ -> string option = function
   (* An open enum has no 3D enum type to name (it projects as its base), so the
      doc projection types the field as the base scalar, not the enum. *)
   | Enum { closed = false; _ } -> None
+  (* A big-endian base has no valid 3D enum type either; project as base plus a
+     membership refinement. *)
+  | Enum { base; _ } when enum_base_is_be base -> None
   | Enum { name; _ } -> Some name
   | Map { inner; _ } -> enum_type_name inner
   | Where { inner; _ } -> enum_type_name inner

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -41,6 +41,33 @@ let test_enumerations () =
   Alcotest.(check bool) "contains enum" true (contains ~sub:"enum" output);
   Alcotest.(check bool) "contains Enum8_1" true (contains ~sub:"Enum8_1" output)
 
+(* An enum over a big-endian base has no valid 3D enum type (EverParse types the
+   constants as the native width and rejects the declaration), so it projects as
+   the base scalar with a membership refinement instead of an enum decl. A native
+   uint8 enum still projects as a named enum type. *)
+let test_enum_big_endian_projection () =
+  let be =
+    enum "WideCode" [ ("Zero", 0); ("One", 1); ("High", 0xBEEF) ] uint16be
+  in
+  let out =
+    to_3d ~enum_as_type:true
+      (module_ [ typedef (struct_ "BeEnum" [ field "v" be ]) ])
+  in
+  Alcotest.(check bool)
+    "no enum decl for BE base" false
+    (contains ~sub:"enum WideCode" out);
+  Alcotest.(check bool)
+    "BE enum field carries membership refinement" true
+    (contains ~sub:"48879" out);
+  let le = enum "Color" [ ("Red", 1); ("Green", 2) ] uint8 in
+  let out_le =
+    to_3d ~enum_as_type:true
+      (module_ [ typedef (struct_ "LeEnum" [ field "v" le ]) ])
+  in
+  Alcotest.(check bool)
+    "uint8 enum keeps enum decl" true
+    (contains ~sub:"enum Color" out_le)
+
 let test_field_dependence () =
   let t_struct = param_struct "t" [ param "a" uint32 ] [ field "x" uint32 ] in
   let f_a = field "a" uint32 in
@@ -1010,6 +1037,8 @@ let suite =
         test_array_lookup_element_bound;
       Alcotest.test_case "generation: bitfields" `Quick test_bitfields;
       Alcotest.test_case "generation: enumerations" `Quick test_enumerations;
+      Alcotest.test_case "generation: big-endian enum projection" `Quick
+        test_enum_big_endian_projection;
       Alcotest.test_case "generation: field dependence" `Quick
         test_field_dependence;
       Alcotest.test_case "generation: casetype" `Quick test_casetype;


### PR DESCRIPTION
An `enum` / `variants` over a big-endian base (e.g. `enum ... uint16be`) now projects to a `.3d` EverParse accepts.

It was emitted as a `UINT16BE enum WideCode { ... }` declaration, which EverParse rejects because it types the integer constants as the native width (`Expected UINT16BE, got UINT16`) -- 3D has no big-endian integer literals. A big-endian-based enum now projects as its base scalar with a membership refinement (closed) or bare base (open), with no enum declaration; native (uint8 etc.) enums still project as named 3D enum types. Surfaced by the fuzz harness's `enum_u16be` / `enum_open_u16be` / `variants_u16be` generators. Stacked on #184.
