### PR TITLE
wire: project an open enum array element as its base type

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -211,6 +211,12 @@
 
 ### Fixed
 
+- An `array` of an open `enum` (`Wire.enum_open`) now validates identically in
+  the OCaml decoder and the EverParse-generated C validator: both accept any
+  element value. The C validator used to reject element values outside the named
+  codes (it constrained each element to the enum's named set), while
+  `Wire.Codec.decode` accepted them, so the two disagreed on which buffers are
+  valid (#187, @samoht)
 - An `enum` / `variants` over a big-endian base (e.g. `enum ... uint16be`) now
   projects to a `.3d` EverParse accepts. It was emitted as a `UINT16BE enum`
   declaration, which EverParse rejects (it types the integer constants as the

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -1625,6 +1625,21 @@ let index_bound_elt : type a. a typ -> (string * bool expr) option =
       Some (elt_var, Lt (Ref (I, elt_var), Int bound))
   | _ -> None
 
+(* The bare base an open enum renders as when it is a fixed-size array element.
+   A closed enum admits only its named codes, so it projects to a 3D enum type
+   that EverParse enforces per element, mirroring the OCaml decoder. An open enum
+   admits any value and carries no membership, so it must render as its base
+   scalar, not the enum type, or the generated C validator would reject codes the
+   OCaml decoder accepts. Returns [None] for a closed enum or a non-enum, which
+   keep their existing rendering. *)
+let rec open_enum_elem_base : type a. a typ -> (Format.formatter -> unit) option
+    = function
+  | Enum { closed = false; base; _ } -> Some (fun ppf -> pp_typ ppf base)
+  | Map { inner; _ } -> open_enum_elem_base inner
+  | Where { inner; _ } -> open_enum_elem_base inner
+  | Apply { typ; _ } -> open_enum_elem_base typ
+  | _ -> None
+
 let rec optional_suffix : type a.
     bool expr -> a typ -> field_suffix * (Format.formatter -> unit) =
  fun present inner ->
@@ -1682,7 +1697,13 @@ and field_suffix : type a. a typ -> field_suffix * (Format.formatter -> unit) =
                  the OCaml decoder enforces. *)
               ( Byte_array len,
                 fun ppf -> Fmt.string ppf (synth_name_of_elt_var elt_var) )
-          | None -> (Array len, fun ppf -> pp_typ ppf elem))
+          | None ->
+              let pp_elem ppf =
+                match open_enum_elem_base elem with
+                | Some pp -> pp ppf
+                | None -> pp_typ ppf elem
+              in
+              (Array len, pp_elem))
       | _, Some s ->
           (* A wider element is emitted as its bare base under a byte budget of
              [len * width]; its own [:byte-size] suffix (e.g. for a [byte_array]

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -204,6 +204,27 @@ let test_3d_array_enum_element_decl () =
     "array element references the enum" true
     (contains ~sub:"Color v[" output)
 
+let test_3d_array_open_enum_element () =
+  (* An open enum admits any value, so as an array element it must project as its
+     bare base, not the named enum type. Rendering it as the enum type makes the
+     generated C validator reject codes outside the named set, while the OCaml
+     decoder (an open enum checks no membership) accepts them: a soundness
+     divergence the differential fuzzer flagged. *)
+  let e = enum_open "Code" [ ("A", 1); ("B", 2); ("C", 3) ] uint8 in
+  let c =
+    Codec.v "ArrOpenE"
+      (fun v -> v)
+      Codec.[ (Field.v "v" (array ~len:(int 4) e) $ fun v -> v) ]
+  in
+  let output = to_3d (Everparse.schema c).module_ in
+  Alcotest.(check bool)
+    "open-enum array element renders as its base scalar" true
+    (contains ~sub:"UINT8 v[" output);
+  Alcotest.(check bool)
+    "open-enum array element does not enforce membership via the enum type"
+    false
+    (contains ~sub:"Code v[" output)
+
 let test_3d_enum_membership () =
   (* An enum field must enforce membership in the verified C, on a scalar field
      and inside a sub-codec, or the validator accepts values that Codec.decode
@@ -1078,6 +1099,8 @@ let suite =
         test_3d_signed_float_setters;
       Alcotest.test_case "3d: array enum element decl" `Quick
         test_3d_array_enum_element_decl;
+      Alcotest.test_case "3d: array open enum element renders base" `Quick
+        test_3d_array_open_enum_element;
       Alcotest.test_case "generation: open enum accepts and has no refinement"
         `Quick test_enum_open_accepts_and_no_refinement;
       Alcotest.test_case "3d: enum membership refinement" `Quick


### PR DESCRIPTION
This PR fixes an accept/reject divergence between the OCaml decoder and the EverParse-generated C validator for an `array` of an open `enum` (`Wire.enum_open`).

An open enum admits any value, so `Wire.Codec.decode` runs no membership check on it. The array element printer, though, rendered any enum element as its named 3D enum type, which EverParse constrains to the named codes per element. So the generated C validator rejected element values outside the named set while the decoder accepted them, and the two disagreed on which buffers are valid. The differential fuzzer flagged it. An open enum array element now projects as its bare base scalar with no membership; a closed enum still projects to the enum type, so its membership stays enforced on both sides (the existing closed-enum array test is unchanged).