### PR TITLE
wire: widen narrow unsigned addition in field constraints

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -211,6 +211,12 @@
 
 ### Fixed
 
+- A field constraint that adds narrow unsigned fields (such as `a + b <= 10`
+  over two `uint8` fields) now projects to a `.3d` EverParse verifies. The sum
+  was emitted at the field's own width, which EverParse refuses to verify because
+  it can overflow, while `Wire.Codec.decode` computes the same sum in OCaml's
+  wide native int. The addition's operands are now widened to 64-bit so the
+  generated C validator and the decoder agree (#188, @samoht)
 - An `array` of an open `enum` (`Wire.enum_open`) now validates identically in
   the OCaml decoder and the EverParse-generated C validator: both accept any
   element value. The C validator used to reject element values outside the named

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -1957,7 +1957,60 @@ let project_refinement ~name ~kind (cond : bool expr) : bool expr =
          to 3D"
   | `Signed width -> translate_signed_ordering ~name ~width cond
 
-let pp_field ppf (Field f) =
+(* A field whose value is an unsigned scalar at most 32 bits wide, seen through
+   the transparent [Map] / [Enum] / [Where] wrappers. The sum of two such fields
+   fits in both OCaml's native int and a 64-bit unsigned, so an [Add] over them
+   can be projected without overflow by widening the operands. *)
+let rec widenable_unsigned : type a. a typ -> bool = function
+  | Uint8 | Uint16 _ | Uint32 _ -> true
+  | Map { inner; _ } -> widenable_unsigned inner
+  | Enum { base; _ } -> widenable_unsigned base
+  | Where { inner; _ } -> widenable_unsigned inner
+  | _ -> false
+
+(* EverParse computes a refinement at the field's own (narrow) width, so a plain
+   [a + b] over [UINT8] fields can overflow and F* refuses to verify it, while
+   the OCaml decoder computes the same sum in its wide native int. Widen each
+   [Add] operand that names a <=32-bit unsigned field to [UINT64] so the 3D sum
+   matches the decoder's. Only [Add] is rewritten: [Sub] can underflow (an
+   unsigned wrap the decoder does not do), and a wider or signed operand has no
+   sound widening, so those are left untouched and keep their current behaviour. *)
+let rec widen_add : type a. string list -> a expr -> a expr =
+ fun ws e ->
+  let r e = widen_add ws e in
+  let operand e =
+    match r e with
+    | Ref (I, n) as e when List.mem n ws -> Cast (`U64, e)
+    | e -> e
+  in
+  match e with
+  | Add (a, b) -> Add (operand a, operand b)
+  | Int _ | Int64 _ | Bool _ | Param_ref _ | Sizeof _ | Sizeof_this | Field_pos
+  | Ref _ ->
+      e
+  | Sub (a, b) -> Sub (r a, r b)
+  | Mul (a, b) -> Mul (r a, r b)
+  | Div (a, b) -> Div (r a, r b)
+  | Mod (a, b) -> Mod (r a, r b)
+  | Land (a, b) -> Land (r a, r b)
+  | Lor (a, b) -> Lor (r a, r b)
+  | Lxor (a, b) -> Lxor (r a, r b)
+  | Lnot a -> Lnot (r a)
+  | Lsl (a, b) -> Lsl (r a, r b)
+  | Lsr (a, b) -> Lsr (r a, r b)
+  | Eq (a, b) -> Eq (r a, r b)
+  | Ne (a, b) -> Ne (r a, r b)
+  | Lt (a, b) -> Lt (r a, r b)
+  | Le (a, b) -> Le (r a, r b)
+  | Gt (a, b) -> Gt (r a, r b)
+  | Ge (a, b) -> Ge (r a, r b)
+  | And (a, b) -> And (r a, r b)
+  | Or (a, b) -> Or (r a, r b)
+  | Not a -> Not (r a)
+  | Cast (w, x) -> Cast (w, r x)
+  | If_then_else (c, a, b) -> If_then_else (r c, r a, r b)
+
+let pp_field widenable ppf (Field f) =
   let raw_name, name =
     match f.field_name with
     | Some name -> (name, escape_3d name)
@@ -2009,6 +2062,9 @@ let pp_field ppf (Field f) =
       (project_refinement ~name:raw_name ~kind:(scalar_kind typ))
       constraint_
   in
+  (* Widen [a + b] over narrow unsigned fields so the 3D sum does not overflow
+     the field width, matching the OCaml decoder's wide-int computation. *)
+  let constraint_ = Option.map (widen_add widenable) constraint_ in
   let suffix, pp_base = field_suffix typ in
   let pp_base =
     match doc_enum with
@@ -2143,10 +2199,18 @@ let pp_struct ppf (s : struct_) =
   let name = escape_3d s.name in
   let where, fields = lower_where_to_field_constraint s.where s.fields in
   let fields = guard_subtraction_sizes fields in
+  let widenable =
+    List.filter_map
+      (fun (Field f) ->
+        match f.field_name with
+        | Some n when widenable_unsigned f.field_typ -> Some n
+        | _ -> None)
+      fields
+  in
   Fmt.pf ppf "typedef struct _%s%a" name pp_params s.params;
   Option.iter (Fmt.pf ppf "@,where (%a)" pp_expr) where;
   Fmt.pf ppf "@,{@[<v 2>";
-  List.iter (pp_field ppf) fields;
+  List.iter (pp_field widenable ppf) fields;
   Fmt.pf ppf "@]@,} %s" name
 
 let pp_enum_cases ppf cases =

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -185,6 +185,25 @@ let test_3d_signed_float_setters () =
     "no scalar falls through to SetBytes" false
     (contains ~sub:"SetBytes" output)
 
+let test_3d_arith_constraint_widens () =
+  (* A constraint adding two narrow unsigned fields overflows the field width in
+     3D, which EverParse refuses to verify, while the OCaml decoder computes the
+     sum in its wide native int. The projection widens each [Add] operand to
+     UINT64 so the 3D sum cannot overflow and matches the decoder. *)
+  let f_a = Field.v "a" uint8 in
+  let f_b =
+    Field.v "b" uint8 ~self_constraint:(fun b ->
+        Expr.(Field.int f_a + b <= int 10))
+  in
+  let c = Codec.v "Arith" (fun a b -> (a, b)) Codec.[ f_a $ fst; f_b $ snd ] in
+  let output = to_3d (Everparse.schema c).module_ in
+  Alcotest.(check bool)
+    "both Add operands widened to UINT64" true
+    (contains ~sub:"((UINT64) a) + ((UINT64) b)" output);
+  Alcotest.(check bool)
+    "no un-widened narrow sum" false
+    (contains ~sub:"(a + b)" output)
+
 let test_3d_array_enum_element_decl () =
   (* An enum used as an array element still needs its declaration emitted. The
      decl collection only looked through Map/Where wrappers, so an enum inside an
@@ -1097,6 +1116,8 @@ let suite =
         test_3d_uint63_projects_to_uint64;
       Alcotest.test_case "3d: signed and float setters" `Quick
         test_3d_signed_float_setters;
+      Alcotest.test_case "3d: arithmetic constraint widens operands" `Quick
+        test_3d_arith_constraint_widens;
       Alcotest.test_case "3d: array enum element decl" `Quick
         test_3d_array_enum_element_decl;
       Alcotest.test_case "3d: array open enum element renders base" `Quick


### PR DESCRIPTION
This PR fixes a projection failure for a field constraint that adds narrow unsigned fields, such as `a + b < 10` over two `uint8` fields.

EverParse verifies a refinement at the field`s own width, so the sum was emitted as a UINT8 addition that can overflow, which F* refuses to prove. The OCaml decoder computes the same sum in its wide native int, so the generated C validator rejected buffers the decoder accepts. Each addition operand that names an at-most-32-bit unsigned field is now widened to UINT64 before the projected sum is formed, so it cannot overflow and the two agree. Subtraction (which can underflow to an unsigned wrap the decoder never produces) and wider or signed operands have no sound widening and are left as they were.