### PR TITLE
test/diff: rename hand-rolled check to avoid EverParse collision

### DIFF
--- a/test/diff/gen_c.ml
+++ b/test/diff/gen_c.ml
@@ -170,7 +170,10 @@ let generate_c_stubs ~schema_dir outdir schemas =
         List.filter (fun p -> not (param_is_mutable p)) params
       in
       let output_params = List.filter (fun p -> param_is_mutable p) params in
-      pr "BOOLEAN %sCheck%s(uint8_t *base, uint32_t len) {\n" name name;
+      (* Distinct from EverParse's generated [<Name>Check<Name>], which for an
+         output-parameter codec takes an extra out-pointer and would otherwise
+         collide with this hand-rolled accept/reject wrapper. *)
+      pr "BOOLEAN %s_diff_check(uint8_t *base, uint32_t len) {\n" name;
       (* Declare locals for mutable params *)
       List.iter
         (fun p -> pr "  %s %s_val = 0;\n" (param_c_type p) (param_name p))
@@ -197,7 +200,7 @@ let generate_c_stubs ~schema_dir outdir schemas =
       pr "  CAMLparam1(v_bytes);\n";
       pr "  uint8_t *data = (uint8_t *)Bytes_val(v_bytes);\n";
       pr "  uint32_t len = caml_string_length(v_bytes);\n";
-      pr "  BOOLEAN result = %sCheck%s(data, len);\n" name name;
+      pr "  BOOLEAN result = %s_diff_check(data, len);\n" name;
       pr "  CAMLreturn(Val_bool(result));\n";
       pr "}\n\n")
     schemas;


### PR DESCRIPTION
The differential test generator (`gen_c.ml`) emitted a `BOOLEAN <Name>Check<Name>(base, len)` accept/reject wrapper. EverParse also generates `<Name>Check<Name>`, and for an output-parameter codec (the `ActionDemo` fixture, which assigns a `Param.output`) its version takes an extra out-pointer, so the two declarations collide when the generated wrapper header is included, breaking a full `BUILD_EVERPARSE=1` build. Rename the hand-rolled one to `<Name>_diff_check`. Not an EverParse bug (a clean output-param codec projects consistently); purely a naming clash in the test harness.