### PR TITLE
3d: capitalize every segment in everparse_name

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -220,6 +220,14 @@
 
 ### Fixed
 
+- A codec whose name has a lower-case segment after an underscore (such as
+  `Grpc_message`) now generates C identifiers that match the ones EverParse
+  emits. `Wire_3d.everparse_name` capitalized only the first segment, yielding
+  `Grpcmessage` where EverParse produces `GrpcMessage`, so the generated FFI
+  stubs and the documentation differential harness referenced a name that did
+  not exist and failed to link. Every underscore-separated segment is now
+  capitalized (@samoht)
+
 - A field constraint that adds narrow unsigned fields (such as `a + b <= 10`
   over two `uint8` fields) now projects to a `.3d` EverParse verifies. The sum
   was emitted at the field's own width, which EverParse refuses to verify because

--- a/lib/3d/wire_3d.ml
+++ b/lib/3d/wire_3d.ml
@@ -33,12 +33,18 @@ let normalize_segment seg =
   done;
   Buffer.contents b
 
-(* EverParse strips underscores when generating C identifiers and
-   CamelCases each segment. [EP_Header -> EpHeader],
-   [MC_Status_Reply -> McStatusReply], [SSID -> Ssid]. *)
+(* EverParse strips underscores when generating a C identifier from a name and
+   joins the [_]-separated segments into CamelCase: each segment is capitalized
+   and any internal run of two or more uppercase letters collapses to one.
+   [Grpc_message -> GrpcMessage], [EP_Header -> EpHeader],
+   [MC_Status_Reply -> McStatusReply], [SSID -> Ssid]. wire writes the .3d file
+   and type with a capitalized name, so the leading segment is normally already
+   capitalized; capitalizing it here keeps the identifier matching EverParse even
+   for an otherwise lower-case name. *)
 let everparse_name name =
   String.split_on_char '_' name
-  |> List.map normalize_segment |> String.concat ""
+  |> List.map (fun seg -> String.capitalize_ascii (normalize_segment seg))
+  |> String.concat ""
 
 (* EverParse derives the C output filename from the [.3d] filename, which
    [Wire.Everparse.filename] already writes with [String.capitalize_ascii].

--- a/lib/3d/wire_3d.mli
+++ b/lib/3d/wire_3d.mli
@@ -41,11 +41,12 @@
     the resulting {!type:Wire.Everparse.Raw.struct_} values. *)
 
 val everparse_name : string -> string
-(** [everparse_name name] returns the EverParse-normalized identifier for a
-    struct name. EverParse 3D normalizes names that start with two or more
-    consecutive uppercase letters by lowercasing the whole name and capitalizing
-    only the first letter (e.g., [CLCW] becomes [Clcw], [TMFrame] becomes
-    [Tmframe]). Names with standard camelCase are preserved. *)
+(** [everparse_name name] returns the C identifier EverParse derives from a
+    struct name: underscores are stripped and the [_]-separated segments are
+    joined in CamelCase. Each segment is capitalized and any internal run of two
+    or more consecutive uppercase letters collapses to a single one. E.g.
+    [Grpc_message] becomes [GrpcMessage], [EP_Header] becomes [EpHeader], [CLCW]
+    becomes [Clcw], and [TMFrame] becomes [Tmframe]. *)
 
 val generate_3d : outdir:string -> Wire.Everparse.t list -> unit
 (** [generate_3d ~outdir schemas] generates [.3d] files from Wire modules. *)

--- a/test/3d/test_wire_3d.ml
+++ b/test/3d/test_wire_3d.ml
@@ -19,10 +19,11 @@ let test_everparse_name () =
   Alcotest.(check string)
     "SpaceOSFrame -> SpaceOsframe" "SpaceOsframe"
     (Wire_3d.everparse_name "SpaceOSFrame");
-  (* Standard camelCase is preserved *)
+  (* Each segment is capitalized: wire writes the .3d type with a capitalized
+     name, so [myField] reaches EverParse as [MyField]. *)
   Alcotest.(check string) "Foo -> Foo" "Foo" (Wire_3d.everparse_name "Foo");
   Alcotest.(check string)
-    "myField -> myField" "myField"
+    "myField -> MyField" "MyField"
     (Wire_3d.everparse_name "myField");
   (* Single uppercase letter at start is not >=2 consecutive uppercase *)
   Alcotest.(check string)
@@ -38,6 +39,14 @@ let test_everparse_name () =
   Alcotest.(check string)
     "Foo_Bar -> FooBar" "FooBar"
     (Wire_3d.everparse_name "Foo_Bar");
+  (* A lowercase segment after an underscore is capitalized, so the identifier
+     matches the [GrpcMessage] EverParse generates for a [Grpc_message] type. *)
+  Alcotest.(check string)
+    "Grpc_message -> GrpcMessage" "GrpcMessage"
+    (Wire_3d.everparse_name "Grpc_message");
+  Alcotest.(check string)
+    "rpmsg_endpoint_info -> RpmsgEndpointInfo" "RpmsgEndpointInfo"
+    (Wire_3d.everparse_name "rpmsg_endpoint_info");
   (* Empty string *)
   Alcotest.(check string) "empty" "" (Wire_3d.everparse_name "")
 


### PR DESCRIPTION
`Wire_3d.everparse_name` used to capitalize only the first underscore-separated segment of a struct name; it now capitalizes every segment.

`everparse_name` predicts the C identifier EverParse derives from a name, used both to name the generated `<Name>Fields` plug struct and to reference the validator from the FFI stubs and the documentation differential harness. For a name like `Grpc_message` it produced `Grpcmessage`, but EverParse emits `GrpcMessage`, so the generated stubs and the agree harness referenced a symbol that did not exist and failed to link. Names without a lower-case segment after an underscore (every codec shipped today) are unaffected.