### PR TITLE
field: reject repeat over a zero-width element

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -220,6 +220,12 @@
 
 ### Fixed
 
+- `Field.repeat` over a zero-width element (`Wire.empty`) is now rejected at
+  construction, like `Wire.array` already was. A byte-budget list of a 0-width
+  element does not extract through EverParse, so the codec had no verified C
+  validator; the error now fires when the schema is built rather than producing
+  an unverifiable spec (#198, @samoht)
+
 - A closed `enum` (or `variants`) used as an `array` element, a `repeat`
   element, or an `optional` inner now enforces its value set in the
   EverParse-generated C validator, matching `Codec.decode`. Previously only a

--- a/lib/field.ml
+++ b/lib/field.ml
@@ -108,8 +108,10 @@ let rec is_repeat_element : type a. a Types.typ -> bool =
   let open Types in
   match typ with
   | Uint8 | Uint16 _ | Uint32 _ | Uint63 _ | Uint64 _ | Int8 | Int16 _ | Int32 _
-  | Int64 _ | Float32 _ | Float64 _ | Uint_var _ | Unit | Zeroterm ->
+  | Int64 _ | Float32 _ | Float64 _ | Uint_var _ | Zeroterm ->
       true
+  (* [Unit] is 0-width: a byte-budget list of it carries no bytes and projects to
+     a zero-size element EverParse refuses to extract, like the [array] case. *)
   | Byte_array { size = Int _ } | Byte_slice { size = Int _ } -> true
   | Codec { codec_struct; _ } ->
       (not (codec_ends_greedy codec_struct)) && Types.struct_nz codec_struct

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -585,13 +585,18 @@ let test_repeat_array_reject_bitfield () =
 (* A zero-width element ([empty] / unit) carries no bytes, so an array of it is
    degenerate and projects to a zero-size 3D array EverParse rejects. It is
    refused at construction. *)
-let test_array_reject_zero_width_element () =
+let test_reject_zero_width_element () =
   Alcotest.(check bool)
     "array over empty rejected" true
     (raises_invalid (fun () -> array ~len:(int 3) empty));
   Alcotest.(check bool)
     "array_seq over empty rejected" true
-    (raises_invalid (fun () -> array_seq seq_list ~len:(int 3) empty))
+    (raises_invalid (fun () -> array_seq seq_list ~len:(int 3) empty));
+  (* A byte-budget list of a 0-width element does not extract either, so
+     [Field.repeat] over [empty] is rejected like [array], not silently built. *)
+  Alcotest.(check bool)
+    "repeat over empty rejected" true
+    (raises_invalid (fun () -> Field.repeat "r" ~size:(int 3) empty))
 
 (* Wire.array over a fixed sub-record (Codec element): a fixed-count list of
    structs. Decoding raised Failure "build_field_reader: unsupported type"
@@ -5103,8 +5108,8 @@ let suite =
         test_repeat_oversized_length_rejected;
       Alcotest.test_case "repeat/array reject bitfield element" `Quick
         test_repeat_array_reject_bitfield;
-      Alcotest.test_case "array rejects zero-width element" `Quick
-        test_array_reject_zero_width_element;
+      Alcotest.test_case "array/repeat reject zero-width element" `Quick
+        test_reject_zero_width_element;
       Alcotest.test_case "array: record element roundtrip" `Quick
         test_array_record_element;
       Alcotest.test_case "array: record element projection" `Quick


### PR DESCRIPTION
`Field.repeat` over `Wire.empty` (a 0-width element) used to build, but a byte-budget list of a zero-width element does not extract through EverParse, so the resulting codec had no verified C validator. `Wire.array` already rejected a zero-width element at construction; `Field.repeat` admitted `Unit` and produced an unverifiable spec instead.

`is_repeat_element` no longer accepts `Unit`, so `Field.repeat` and `repeat_seq` refuse it at construction with the same error `array` gives.