### PR TITLE
wire: validate bitfield width against its base

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -220,6 +220,12 @@
 
 ### Fixed
 
+- `Wire.bits ~width` is now validated against its base word: a width above the
+  base size (e.g. `bits ~width:9 U8`) or below 1 is rejected at construction.
+  Such a field had no faithful wire meaning, and the OCaml shift and the
+  EverParse-generated validator read different values from the same bytes
+  (#199, @samoht)
+
 - `Field.repeat` over a zero-width element (`Wire.empty`) is now rejected at
   construction, like `Wire.array` already was. A byte-budget list of a 0-width
   element does not extract through EverParse, so the codec had no verified C

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -314,7 +314,23 @@ let bf_uint16 = U16 Little
 let bf_uint16be = U16 Big
 let bf_uint32 = U32 Little
 let bf_uint32be = U32 Big
-let bits ?(bit_order = Msb_first) ~width base = Bits { width; base; bit_order }
+
+let bitfield_base_bits : bitfield_base -> int = function
+  | U8 -> 8
+  | U16 _ -> 16
+  | U32 _ -> 32
+
+let bits ?(bit_order = Msb_first) ~width base =
+  (* A bitfield must fit its base word: a [width] above the base size, or below
+     1, has no faithful wire meaning and the OCaml shift and the 3D [base F :
+     width] field would read different values. Reject it at construction. *)
+  let total = bitfield_base_bits base in
+  if width < 1 || width > total then
+    Fmt.invalid_arg
+      "Wire.bits: width %d does not fit a %d-bit base (must be 1..%d)" width
+      total total;
+  Bits { width; base; bit_order }
+
 let bit b = Bool.to_int b
 let is_set n = n <> 0
 

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -1040,6 +1040,23 @@ let test_uint_size_bounds () =
     "uint 4 accepted" false
     (raises_invalid (fun () -> uint (int 4)))
 
+(* A bitfield wider than its base word, or narrower than one bit, has no faithful
+   wire meaning (the OCaml shift and the 3D field would read different values), so
+   it is refused at construction. *)
+let test_bits_width_bounds () =
+  Alcotest.(check bool)
+    "9-bit field over U8 rejected" true
+    (raises_invalid (fun () -> bits ~width:9 U8));
+  Alcotest.(check bool)
+    "0-bit field rejected" true
+    (raises_invalid (fun () -> bits ~width:0 U8));
+  Alcotest.(check bool)
+    "17-bit field over U16 rejected" true
+    (raises_invalid (fun () -> bits ~width:17 U16));
+  Alcotest.(check bool)
+    "8-bit field over U8 accepted" false
+    (raises_invalid (fun () -> bits ~width:8 U8))
+
 (* A [casetype] [case] carries an explicit discriminator; omitting [~index] is
    refused at construction (only [default] is index-free). *)
 let test_casetype_case_requires_index () =
@@ -5144,6 +5161,8 @@ let suite =
         test_casetype_wrapped_greedy_not_last_rejected;
       Alcotest.test_case "uint rejects out-of-range size" `Quick
         test_uint_size_bounds;
+      Alcotest.test_case "bits rejects out-of-range width" `Quick
+        test_bits_width_bounds;
       Alcotest.test_case "casetype case requires ~index" `Quick
         test_casetype_case_requires_index;
       (* codec bitfields *)


### PR DESCRIPTION
`Wire.bits ~width` accepted any integer, so `bits ~width:9 U8` (or `~width:0`) built a field whose width does not fit its base word. Such a field has no faithful wire meaning: the OCaml MSB shift and the EverParse-generated `base F : width` field read different values from the same bytes, an OCaml/C divergence on adversarial input.

The `bits` constructor now rejects a width below 1 or above the base size (8/16/32 for U8/U16/U32) at construction.