### PR TITLE
codec: reject a where used as a casetype case body

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -220,6 +220,11 @@
 
 ### Fixed
 
+- A non-trivial `Wire.where` used as a `Wire.casetype` case body is now rejected
+  at construction. Such a refinement projects to `case k: T { cond } v;`, which
+  is not valid 3D (a case body takes no refinement), unlike a top-level field
+  `where`, so the codec had no verified validator (#200, @samoht)
+
 - `Wire.bits ~width` is now validated against its base word: a width above the
   base size (e.g. `bits ~width:9 U8`) or below 1 is rejected at construction.
   Such a field had no faithful wire meaning, and the OCaml shift and the

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -2756,6 +2756,14 @@ let reject_nested_where name fields =
     | Types.Single_elem { elem; _ } -> if any_real_where elem then fail fname
     | Types.Optional { inner; _ } -> if any_real_where inner then fail fname
     | Types.Optional_or { inner; _ } -> if any_real_where inner then fail fname
+    | Types.Casetype { cases; _ } ->
+        (* A [where] as a casetype case body projects to [case k: T { cond } v;],
+           which is not valid 3D (a refinement is not allowed on a case body),
+           unlike a top-level field refinement. Reject a non-trivial one. *)
+        List.iter
+          (fun (Types.Case_branch { cb_inner; _ }) ->
+            if any_real_where cb_inner then fail fname)
+          cases
     | _ -> ()
   in
   List.iter

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -281,6 +281,22 @@ let test_reject_nested_where () =
               (where Expr.(Field.ref limit < int 9) uint8)
             $ snd);
         ]);
+  reject "casetype case body" (fun () ->
+      Codec.v "CtW"
+        (fun t v -> (t, v))
+        [
+          Codec.(Field.v "tag" uint8 $ fst);
+          Codec.(
+            Field.v "body"
+              (casetype "BodyW" uint8
+                 [
+                   case ~index:1
+                     (where Expr.(int 1 = int 1) uint8)
+                     ~inject:(fun s -> s)
+                     ~project:Option.some;
+                 ])
+            $ snd);
+        ]);
   (* A top-level field where is still accepted (it projects and is enforced). *)
   ignore
     (Codec.v "TopW"


### PR DESCRIPTION
A non-trivial `Wire.where` used as a `Wire.casetype` case body used to build, but it projects to `case k: T { cond } v;`, which is not valid 3D grammar: a case body takes no refinement, unlike a top-level field `where`. The codec then sealed with no verified C validator.

`reject_nested_where` already walked `array`, `repeat`, `optional`, and single-element containers; it now also walks casetype case bodies and rejects a non-trivial `where` in one at construction. A `where true` stays a harmless no-op, as elsewhere.