### PR TITLE
wire: reject a casetype tag with no 3D projection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -220,6 +220,12 @@
 
 ### Fixed
 
+- A `Wire.casetype` whose tag is a `uint ~size` value, or an enum over a
+  big-endian base, is now rejected at construction. Neither projects to a 3D
+  type the dispatch can name, so the codec built without a verified validator.
+  A fixed-width integer, bitfield, or little-endian / 1-byte enum tag is
+  unaffected (#201, @samoht)
+
 - A non-trivial `Wire.where` used as a `Wire.casetype` case body is now rejected
   at construction. Such a refinement projects to `case k: T { cond } v;`, which
   is not valid 3D (a case body takes no refinement), unlike a top-level field

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -686,7 +686,37 @@ let case ?index inner ~inject ~project =
 let default inner ~inject ~project =
   Default_def { dd_inner = inner; dd_inject = inject; dd_project = project }
 
+(* An enum over a big-endian multi-byte base cannot be a 3D [enum] type:
+   EverParse types the integer constants as the native (little-endian) width and
+   rejects the declaration ("Expected UINT16BE, got UINT16"). Such an enum is
+   projected as its base scalar with a membership refinement (closed) or bare
+   base (open) instead, the same shape used outside the doc projection. *)
+let enum_base_is_be : type a. a typ -> bool = function
+  | Uint16 Big | Uint32 Big | Uint63 Big | Uint64 Big -> true
+  | Int16 Big | Int32 Big | Int64 Big -> true
+  | Uint_var { endian = Big; _ } -> true
+  | _ -> false
+
+(* A casetype tag must project to a 3D type the generated [switch] dispatches on.
+   A [uint ~size] (Uint_var) tag renders as [UINTBE(n)], which is not a 3D type;
+   an enum over a big-endian base has no 3D enum type to name in the case labels.
+   Neither projects, so reject it at construction (seen through the transparent
+   [Map] / [Where] wrappers a [variants] tag carries). *)
+let rec reject_unprojectable_casetype_tag : type k. k typ -> unit = function
+  | Uint_var _ ->
+      invalid_arg
+        "Wire.casetype: a [uint ~size] tag has no 3D projection; use a \
+         fixed-width integer, bitfield, or enum tag."
+  | Enum { base; _ } when enum_base_is_be base ->
+      invalid_arg
+        "Wire.casetype: an enum over a big-endian base has no 3D casetype-tag \
+         projection; use a little-endian or 1-byte enum base."
+  | Map { inner; _ } -> reject_unprojectable_casetype_tag inner
+  | Where { inner; _ } -> reject_unprojectable_casetype_tag inner
+  | _ -> ()
+
 let casetype name tag defs =
+  reject_unprojectable_casetype_tag tag;
   let resolve = function
     | Case_def { cd_index; cd_inner; cd_inject; cd_project } ->
         reject_decoration ~combinator:"casetype" cd_inner;
@@ -869,17 +899,6 @@ let casetype_decl name params tag cases =
 
 (* Module *)
 type module_ = { doc : string option; decls : decl list }
-
-(* An enum over a big-endian multi-byte base cannot be a 3D [enum] type:
-   EverParse types the integer constants as the native (little-endian) width and
-   rejects the declaration ("Expected UINT16BE, got UINT16"). Such an enum is
-   projected as its base scalar with a membership refinement (closed) or bare
-   base (open) instead, the same shape used outside the doc projection. *)
-let enum_base_is_be : type a. a typ -> bool = function
-  | Uint16 Big | Uint32 Big | Uint63 Big | Uint64 Big -> true
-  | Int16 Big | Int32 Big | Int64 Big -> true
-  | Uint_var { endian = Big; _ } -> true
-  | _ -> false
 
 (* Extract enum declarations needed by struct fields. Scans field types for
    Enum constructors (including under Map/Where wrappers) and returns the

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -1082,6 +1082,27 @@ let test_casetype_case_requires_index () =
          casetype "NoIndex" uint8
            [ case uint8 ~inject:Fun.id ~project:Option.some ]))
 
+(* A casetype tag must project to a 3D type the [switch] dispatches on. A
+   [uint ~size] tag renders as a non-3D [UINTBE(n)], and an enum over a
+   big-endian base has no 3D enum type for its case labels, so both are refused
+   at construction; a little-endian / 1-byte enum tag is fine. *)
+let test_casetype_reject_unprojectable_tag () =
+  let one_case tag =
+    casetype "CtTag" tag
+      [ case ~index:1 uint8 ~inject:(fun s -> s) ~project:Option.some ]
+  in
+  Alcotest.(check bool)
+    "uint ~size tag rejected" true
+    (raises_invalid (fun () -> one_case (uint (int 2))));
+  Alcotest.(check bool)
+    "big-endian enum tag rejected" true
+    (raises_invalid (fun () ->
+         one_case (enum "TagBe" [ ("A", 0); ("B", 1) ] uint16be)));
+  Alcotest.(check bool)
+    "little-endian enum tag accepted" false
+    (raises_invalid (fun () ->
+         one_case (enum "TagLe" [ ("A", 0); ("B", 1) ] uint8)))
+
 (* -- Codec bitfield tests -- *)
 
 type bf32_record = { a : int; b : int; c : int; d : int }
@@ -5181,6 +5202,8 @@ let suite =
         test_bits_width_bounds;
       Alcotest.test_case "casetype case requires ~index" `Quick
         test_casetype_case_requires_index;
+      Alcotest.test_case "casetype rejects unprojectable tag" `Quick
+        test_casetype_reject_unprojectable_tag;
       (* codec bitfields *)
       Alcotest.test_case "codec bitfield: wire_size" `Quick
         test_codec_bitfield_wire_size;


### PR DESCRIPTION
A `Wire.casetype` dispatches on its tag through a 3D `switch`, so the tag must project to a 3D type. A `uint ~size` tag rendered as `UINTBE(n)`, which is not a 3D type, and an enum over a big-endian base has no 3D enum type to name in the case labels, so EverParse rejected the generated spec and the codec had no verified validator.

The `casetype` constructor now rejects either tag at construction (looking through the `Map`/`Where` wrappers a `variants` tag carries). A fixed-width integer, bitfield, or little-endian / 1-byte enum tag is unaffected.