### PR TITLE
codec: fail cleanly on a negative byte_slice size

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -220,6 +220,12 @@
 
 ### Fixed
 
+- A `byte_slice` whose resolved size is negative, for example a `Sub` on a
+  length field that underflows on crafted input, now fails with a `Codec` parse
+  error instead of escaping `Codec.decode` with a raw `Invalid_argument`. The
+  slice read skipped the bounds check the other byte spans run and crashed
+  (#202, @samoht)
+
 - A `Wire.casetype` whose tag is a `uint ~size` value, or an enum over a
   big-endian base, is now rejected at construction. Neither projects to a 3D
   type the dispatch can name, so the codec built without a verified validator.

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -1843,7 +1843,16 @@ let var_bytes_reader : type a.
      crash [Bytes.sub]; fail cleanly instead. [Byte_slice] is handled by
      [make_or_eod]. *)
   (match typ with
-  | Byte_slice _ -> ()
+  | Byte_slice _ ->
+      (* A byte_slice reading at or past the end yields an eod slice (an oversize
+         length is caught by the top-level bounds check), but a negative size or
+         offset, from a [Sub] or an overrun length field, would crash
+         [make_or_eod] with a raw [Invalid_argument] that escapes the decode
+         result. Fail cleanly instead. *)
+      if sz < 0 || first < 0 then
+        raise
+          (Parse_error
+             (Unexpected_eof { expected = first + sz; got = Bytes.length buf }))
   | _ ->
       if sz < 0 || first < 0 || first + sz > Bytes.length buf then
         raise

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -577,6 +577,38 @@ let test_repeat_oversized_length_rejected () =
   Alcotest.(check bool)
     "length past buffer fails cleanly" true (decodes "\x00\x10abc")
 
+(* A byte_slice whose resolved size goes negative (here a [Sub] on an untrusted
+   length field) must fail cleanly: [make_or_eod] would otherwise raise a raw
+   [Invalid_argument] that escapes the decode result. A large variable field
+   ahead of it keeps the framing past the top-level bounds check, so the negative
+   size reaches the slice read. *)
+let test_byte_slice_negative_size () =
+  let f_l = Field.v "l" uint8 in
+  let f_n = Field.v "n" uint8 in
+  let c =
+    Codec.v "SliceNeg"
+      (fun l pre n sl -> (l, pre, n, sl))
+      Codec.
+        [
+          (f_l $ fun (l, _, _, _) -> l);
+          ( Field.v "pre" (byte_array ~size:(Field.ref f_l))
+          $ fun (_, p, _, _) -> p );
+          (f_n $ fun (_, _, n, _) -> n);
+          ( Field.v "sl" (byte_slice ~size:Expr.(Field.ref f_n - int 100))
+          $ fun (_, _, _, s) -> s );
+        ]
+  in
+  let buf = Bytes.make 202 '\000' in
+  Bytes.set_uint8 buf 0 200;
+  Bytes.set_uint8 buf 201 1;
+  match Codec.decode c buf 0 with
+  | Error _ -> ()
+  | Ok _ ->
+      Alcotest.fail "expected a parse error for a negative byte_slice size"
+  | exception Invalid_argument _ ->
+      Alcotest.fail
+        "negative byte_slice size crashed instead of failing cleanly"
+
 (* A bitfield has no standalone element form, so [array] / [Field.repeat] over
    one is rejected at construction rather than crashing at decode. *)
 let raises_invalid f =
@@ -5160,6 +5192,8 @@ let suite =
         test_rest_bytes_projection_guard;
       Alcotest.test_case "repeat oversized length rejected" `Quick
         test_repeat_oversized_length_rejected;
+      Alcotest.test_case "byte_slice negative size fails cleanly" `Quick
+        test_byte_slice_negative_size;
       Alcotest.test_case "repeat/array reject bitfield element" `Quick
         test_repeat_array_reject_bitfield;
       Alcotest.test_case "array/repeat reject zero-width element" `Quick


### PR DESCRIPTION
A `byte_slice` whose resolved size goes negative (a `Sub` on a length field, or an overrun length, on crafted input) used to escape `Codec.decode` with a raw `Invalid_argument` from `make_or_eod`, rather than the `Ok`/`Error` result the decode contract promises, so a caller crashes instead of seeing `Error`. The slice read skipped the bounds check the other byte spans run, since an oversize slice is meant to yield an `eod` slice.

The slice read now rejects a negative size or offset with a parse error, while still letting an at-or-past-end read yield `eod` and leaving the oversize case to the top-level bounds check.