### PR TITLE
codec: bounds-check validate for a constraint-free codec

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -220,6 +220,12 @@
 
 ### Fixed
 
+- `Codec.validate` now runs decode's structural bounds check for every codec,
+  including one with no field constraints or `where`. It used to be a no-op for
+  a constraint-free codec, so validating a truncated buffer succeeded and a
+  following zero-copy `Codec.get` read out of bounds; the documented safety gate
+  now rejects a short buffer (#204, @samoht)
+
 - A signed field equality constraint (an `int8` field whose `~self_constraint`
   is `Expr.(s = int k)`) now projects to the two's-complement byte the unsigned
   validator reads, and folds to a constant when the target is outside the signed

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -2660,11 +2660,14 @@ let fill_param_slots tbl param_base handles =
     (fun i (Param.Pack p) -> Hashtbl.replace tbl p.Types.name (param_base + i))
     handles
 
-let build_checked_decode raw_decode wire_size_info min_size =
- fun buf off ->
+(* The structural bounds check decode runs before reading any field: the buffer
+   must hold at least [min_size] bytes, and the codec's resolved wire size must
+   fit. Shared with [validate] so a constraint-free codec is still bounds-checked
+   before a zero-copy [get] reads its fields. *)
+let check_decode_bounds wire_size_info min_size buf off =
   if off + min_size > Bytes.length buf then
     raise_eof ~expected:min_size ~got:(Bytes.length buf - off);
-  (match wire_size_info with
+  match wire_size_info with
   | Fixed _ -> ()
   | Variable { compute; _ } ->
       let end_off =
@@ -2675,8 +2678,21 @@ let build_checked_decode raw_decode wire_size_info min_size =
       if end_off < off + min_size then
         raise_eof ~expected:min_size ~got:(Bytes.length buf - off);
       if end_off > Bytes.length buf then
-        raise_eof ~expected:(end_off - off) ~got:(Bytes.length buf - off));
+        raise_eof ~expected:(end_off - off) ~got:(Bytes.length buf - off)
+
+let build_checked_decode raw_decode wire_size_info min_size =
+ fun buf off ->
+  check_decode_bounds wire_size_info min_size buf off;
   raw_decode buf off
+
+(* [Codec.validate] is the safety gate before a batch of zero-copy [get] calls on
+   untrusted input, so it must run decode's structural bounds check even for a
+   constraint-free codec (whose constraint validator [validate_checks] is a
+   no-op), or a [get] on a truncated buffer would read out of bounds. *)
+let validate_with_bounds wire_size_info min_size validate_checks =
+ fun ?env_slots buf off ->
+  check_decode_bounds wire_size_info min_size buf off;
+  validate_checks ?env_slots buf off
 
 (* Whether a field consumes the rest of the buffer: a greedy leaf ([all_bytes] /
    [all_zeros]), an embedded sub-codec whose own last field does, or a casetype
@@ -2806,7 +2822,7 @@ let seal : type r. (r, r) record -> r t =
   let compiled_where =
     compile_where_clause r.param_slots r.field_readers r.where
   in
-  let validate_arr, populate, validate =
+  let validate_arr, populate, validate_checks =
     build_validators validators (List.rev r.checkers_rev) compiled_where
       struct_fields n_total
   in
@@ -2843,7 +2859,7 @@ let seal : type r. (r, r) record -> r t =
         !write_off);
     wire_size = wire_size_info;
     struct_fields;
-    validate;
+    validate = validate_with_bounds wire_size_info min_size validate_checks;
     validate_arr;
     populate;
     n_array_slots = n_total;

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -198,6 +198,24 @@ let test_validate_then_get () =
   let get_x = Staged.unstage (Codec.get validate_codec validate_cf_x) in
   Alcotest.(check int) "validate then get" 8 (get_x buf 0)
 
+(* [Codec.validate] is the safety gate before a zero-copy [get] on untrusted
+   input, so it must run decode's structural bounds check even for a codec with
+   no constraints (whose constraint validator is a no-op). A short buffer must be
+   rejected, not silently accepted. *)
+let test_validate_bounds_constraint_free () =
+  let c =
+    Codec.v "NoConstr"
+      (fun a b -> (a, b))
+      Codec.[ Field.v "a" uint32be $ fst; Field.v "b" uint32be $ snd ]
+  in
+  (match Codec.validate c (Bytes.make 2 '\000') 0 with
+  | exception Validation_error (Unexpected_eof _) -> ()
+  | exception Validation_error _ ->
+      Alcotest.fail "validate failed with the wrong error on a short buffer"
+  | () -> Alcotest.fail "validate accepted a buffer too short for the codec");
+  (* A full buffer still validates. *)
+  Codec.validate c (Bytes.make 8 '\000') 0
+
 (* A [Wire.where] cond carried in a field's typ ([where (len < 2) uint8]) must be
    enforced by both decode and validate, not only projected to 3D. The cond
    reaches the EverParse refinement, so leaving it unchecked on the OCaml side
@@ -5155,6 +5173,8 @@ let suite =
       Alcotest.test_case "validate: rejects bad constraint" `Quick
         test_validate_rejects_bad_constraint;
       Alcotest.test_case "validate: then get" `Quick test_validate_then_get;
+      Alcotest.test_case "validate: bounds-checks a constraint-free codec"
+        `Quick test_validate_bounds_constraint_free;
       Alcotest.test_case "decode: enforces typ-level where" `Quick
         test_decode_enforces_typ_where;
       Alcotest.test_case "validate: enforces typ-level where" `Quick


### PR DESCRIPTION
`Codec.validate` gated its work on whether the codec had any field constraint or `where` clause: a constraint-free codec got a no-op `validate` that skipped the structural bounds check `decode` runs. The module documents `validate` as the safety gate to run before a batch of zero-copy `Codec.get` calls on untrusted input, so validating a truncated buffer succeeded and a following `get` then read out of bounds.

`validate` now runs decode's bounds check unconditionally (the buffer must hold the codec's resolved wire size), sharing the logic through a `check_decode_bounds` helper. A constraint-free codec rejects a short buffer; the constraint-bearing path is unchanged. Stacked on #203.