### PR TITLE
codec: enforce all_zeros padding in validate

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -220,6 +220,11 @@
 
 ### Fixed
 
+- `Codec.validate` now enforces an `all_zeros` padding field, rejecting a
+  non-zero byte exactly as `Codec.decode` does. The zero check lived only in the
+  decode reader, so validating a frame with tampered padding succeeded and a
+  following zero-copy read accepted it (#205, @samoht)
+
 - `Codec.validate` now runs decode's structural bounds check for every codec,
   including one with no field constraints or `where`. It used to be a no-op for
   a constraint-free codec, so validating a truncated buffer succeeded and a

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -361,6 +361,11 @@ let rec build_populate : type a.
         match reader buf base with
         | Some _ -> inner_populate slots buf base
         | None -> ())
+  | All_zeros ->
+      (* No int projection, but the reader checks every byte is zero. Run it for
+         that effect so [Codec.validate] enforces the all-zeros contract decode
+         does, instead of silently accepting tampered padding. *)
+      fun _slots buf base -> ignore (reader buf base)
   | _ ->
       (* Aggregate / string-valued types have no scalar int projection.
          [Field.ref] over them reads 0; treat as deliberate (no slot
@@ -2594,6 +2599,18 @@ let validate_or_eof buf f =
          (Unexpected_eof
             { expected = Bytes.length buf + 1; got = Bytes.length buf }))
 
+(* An [all_zeros] field carries no constraint or action, but its populate checks
+   every byte is zero, so a struct holding one (through the transparent wrappers)
+   needs the validator pass to run even when nothing else does, or [Codec.validate]
+   would skip the all-zeros contract that decode enforces. *)
+let rec typ_checks_bytes : type a. a Types.typ -> bool = function
+  | Types.All_zeros -> true
+  | Types.Where { inner; _ } -> typ_checks_bytes inner
+  | Types.Map { inner; _ } -> typ_checks_bytes inner
+  | Types.Optional { inner; _ } -> typ_checks_bytes inner
+  | Types.Optional_or { inner; _ } -> typ_checks_bytes inner
+  | _ -> false
+
 let build_validators validators_rev checkers_rev compiled_where struct_fields
     n_total =
   let validator_fns = Array.of_list (List.map snd validators_rev) in
@@ -2617,7 +2634,9 @@ let build_validators validators_rev checkers_rev compiled_where struct_fields
   let has_checks =
     compiled_where <> None
     || List.exists
-         (fun (Types.Field f) -> f.constraint_ <> None || f.action <> None)
+         (fun (Types.Field f) ->
+           f.constraint_ <> None || f.action <> None
+           || typ_checks_bytes f.field_typ)
          struct_fields
   in
   let validate =

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -216,6 +216,26 @@ let test_validate_bounds_constraint_free () =
   (* A full buffer still validates. *)
   Codec.validate c (Bytes.make 8 '\000') 0
 
+(* [all_zeros] padding must read as all-zero. Decode enforces it; [Codec.validate]
+   must too, or validate-then-get silently accepts tampered padding bytes. *)
+let test_validate_all_zeros () =
+  let c =
+    Codec.v "Pad"
+      (fun tag pad -> (tag, pad))
+      Codec.[ Field.v "tag" uint8 $ fst; Field.v "pad" all_zeros $ snd ]
+  in
+  Codec.validate c (Bytes.of_string "\x01\x00\x00\x00") 0;
+  let tampered = Bytes.of_string "\x01\x00\x05\x00" in
+  (match Codec.decode c tampered 0 with
+  | Error (Constraint_failed _) -> ()
+  | Ok _ -> Alcotest.fail "decode accepted non-zero all_zeros padding"
+  | Error _ -> Alcotest.fail "decode failed with the wrong error");
+  match Codec.validate c tampered 0 with
+  | exception Validation_error (Constraint_failed _) -> ()
+  | () -> Alcotest.fail "validate accepted non-zero all_zeros padding"
+  | exception Validation_error _ ->
+      Alcotest.fail "validate failed with the wrong error"
+
 (* A [Wire.where] cond carried in a field's typ ([where (len < 2) uint8]) must be
    enforced by both decode and validate, not only projected to 3D. The cond
    reaches the EverParse refinement, so leaving it unchecked on the OCaml side
@@ -5175,6 +5195,8 @@ let suite =
       Alcotest.test_case "validate: then get" `Quick test_validate_then_get;
       Alcotest.test_case "validate: bounds-checks a constraint-free codec"
         `Quick test_validate_bounds_constraint_free;
+      Alcotest.test_case "validate: enforces all_zeros padding" `Quick
+        test_validate_all_zeros;
       Alcotest.test_case "decode: enforces typ-level where" `Quick
         test_decode_enforces_typ_where;
       Alcotest.test_case "validate: enforces typ-level where" `Quick


### PR DESCRIPTION
An `all_zeros` field's per-byte zero check lived only in the decode reader and was never compiled into the validator pass, so `Codec.validate` accepted a frame with tampered (non-zero) padding that `Codec.decode` rejects. A caller that validates then reads zero-copy thus trusted padding it never checked.

`build_populate` now runs the reader for its checking effect on an `all_zeros` field, and such a field counts toward `has_checks`, so the validator pass runs even for a struct whose only check is the padding. Stacked on #204.