### PR TITLE
3d: reject field subtraction and multiplication in constraints

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -220,6 +220,14 @@
 
 ### Fixed
 
+- A field constraint that subtracts or multiplies a field (such as
+  `Expr.(a * b = int 0)` or `Expr.(a - b >= int 5)`) is now rejected at
+  projection. Such an expression under- or overflows the field's narrow width,
+  which EverParse refuses to verify, leaving the codec with no validator; unlike
+  addition (widened to avoid overflow), neither has a sound projection. A
+  constant `Sub` / `Mul` and additive field arithmetic are unaffected
+  (#206, @samoht)
+
 - `Codec.validate` now enforces an `all_zeros` padding field, rejecting a
   non-zero byte exactly as `Codec.decode` does. The zero check lived only in the
   decode reader, so validating a frame with tampered padding succeeded and a

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -2182,6 +2182,39 @@ let rec widenable_unsigned : type a. a typ -> bool = function
    matches the decoder's. Only [Add] is rewritten: [Sub] can underflow (an
    unsigned wrap the decoder does not do), and a wider or signed operand has no
    sound widening, so those are left untouched and keep their current behaviour. *)
+(* The field-reference names an expression mentions. [collect_refs_packed] is the
+   same walk through a comparison's existentially-typed operands. *)
+let rec collect_refs : type a. a expr -> string list = function
+  | Int _ | Int64 _ | Bool _ | Param_ref _ | Sizeof _ | Sizeof_this | Field_pos
+    ->
+      []
+  | Ref (_, name) -> [ name ]
+  | Add (a, b)
+  | Sub (a, b)
+  | Mul (a, b)
+  | Div (a, b)
+  | Mod (a, b)
+  | Land (a, b)
+  | Lor (a, b)
+  | Lxor (a, b)
+  | Lsl (a, b)
+  | Lsr (a, b) ->
+      collect_refs a @ collect_refs b
+  | Lnot a -> collect_refs a
+  | Lt (a, b) -> collect_refs_packed a @ collect_refs_packed b
+  | Le (a, b) -> collect_refs_packed a @ collect_refs_packed b
+  | Gt (a, b) -> collect_refs_packed a @ collect_refs_packed b
+  | Ge (a, b) -> collect_refs_packed a @ collect_refs_packed b
+  | And (a, b) | Or (a, b) -> collect_refs a @ collect_refs b
+  | Not a -> collect_refs a
+  | Cast (_, a) -> collect_refs a
+  | If_then_else (c, a, b) -> collect_refs c @ collect_refs a @ collect_refs b
+  | Eq (a, b) -> collect_refs_packed a @ collect_refs_packed b
+  | Ne (a, b) -> collect_refs_packed a @ collect_refs_packed b
+
+and collect_refs_packed : type a. a expr -> string list =
+ fun e -> collect_refs e
+
 let rec widen_add : type a. string list -> a expr -> a expr =
  fun ws e ->
   let r e = widen_add ws e in
@@ -2216,6 +2249,62 @@ let rec widen_add : type a. string list -> a expr -> a expr =
   | Not a -> Not (r a)
   | Cast (w, x) -> Cast (w, r x)
   | If_then_else (c, a, b) -> If_then_else (r c, r a, r b)
+
+(* EverParse computes a constraint at the field's own narrow width, so a [Sub] or
+   [Mul] naming a field underflows or overflows there: 3d.exe refuses to verify
+   it ("cannot verify u8 subtraction / multiplication"), leaving the codec with
+   no validator. Unlike [Add], neither has a sound widening: a widened [Sub]
+   wraps on underflow where the OCaml decoder goes negative, and a widened [Mul]
+   of wide operands overflows the decoder's own native int. Reject such a
+   constraint at construction; a [Sub] / [Mul] of constants (which folds) is
+   fine, as is additive field arithmetic. *)
+let rec reject_field_sub_mul : type a. string -> a expr -> unit =
+ fun name e ->
+  let both : type x. x expr -> x expr -> unit =
+   fun a b ->
+    reject_field_sub_mul name a;
+    reject_field_sub_mul name b
+  in
+  match e with
+  | (Sub _ | Mul _) when collect_refs e <> [] ->
+      let op = match e with Sub _ -> "subtraction" | _ -> "multiplication" in
+      Fmt.invalid_arg
+        "Wire: field %S has a constraint whose %s over a field has no 3D \
+         projection (it under/overflows the field's narrow width); keep field \
+         arithmetic in a constraint additive, or move it out of the constraint"
+        name op
+  | Sub (a, b) | Mul (a, b) -> both a b
+  | Add (a, b)
+  | Div (a, b)
+  | Mod (a, b)
+  | Land (a, b)
+  | Lor (a, b)
+  | Lxor (a, b)
+  | Lsl (a, b)
+  | Lsr (a, b) ->
+      both a b
+  | Eq (a, b) -> both a b
+  | Ne (a, b) -> both a b
+  | Lt (a, b) -> both a b
+  | Le (a, b) -> both a b
+  | Gt (a, b) -> both a b
+  | Ge (a, b) -> both a b
+  | And (a, b) | Or (a, b) -> both a b
+  | Lnot a -> reject_field_sub_mul name a
+  | Not a -> reject_field_sub_mul name a
+  | Cast (_, a) -> reject_field_sub_mul name a
+  | If_then_else (c, a, b) ->
+      reject_field_sub_mul name c;
+      both a b
+  | Int _ | Int64 _ | Bool _ | Ref _ | Param_ref _ | Sizeof _ | Sizeof_this
+  | Field_pos ->
+      ()
+
+(* The narrow-width arithmetic a projected field constraint needs: reject a field
+   [Sub] / [Mul] (no sound projection), then widen each [Add] operand. *)
+let project_field_arith name widenable cond =
+  reject_field_sub_mul name cond;
+  widen_add widenable cond
 
 (* The generated .3d doubles as protocol documentation, so a [?doc] note (often
    an RFC citation) should not run past ~80 columns as one long comment. Wrap the
@@ -2309,9 +2398,9 @@ let pp_field widenable ppf (Field f) =
       (project_refinement ~name:raw_name ~kind:(scalar_kind typ))
       constraint_
   in
-  (* Widen [a + b] over narrow unsigned fields so the 3D sum does not overflow
-     the field width, matching the OCaml decoder's wide-int computation. *)
-  let constraint_ = Option.map (widen_add widenable) constraint_ in
+  let constraint_ =
+    Option.map (project_field_arith raw_name widenable) constraint_
+  in
   let suffix, pp_base = field_suffix typ in
   let pp_base =
     match doc_enum with
@@ -2337,37 +2426,6 @@ let pp_params ppf params =
 (* Collect every [Ref name] occurring in an expression. Used to detect
    field references in struct-level [where] clauses, which 3D's grammar
    does not allow (the [where] there sees only parameters). *)
-let rec collect_refs : type a. a expr -> string list = function
-  | Int _ | Int64 _ | Bool _ | Param_ref _ | Sizeof _ | Sizeof_this | Field_pos
-    ->
-      []
-  | Ref (_, name) -> [ name ]
-  | Add (a, b)
-  | Sub (a, b)
-  | Mul (a, b)
-  | Div (a, b)
-  | Mod (a, b)
-  | Land (a, b)
-  | Lor (a, b)
-  | Lxor (a, b)
-  | Lsl (a, b)
-  | Lsr (a, b) ->
-      collect_refs a @ collect_refs b
-  | Lnot a -> collect_refs a
-  | Lt (a, b) -> collect_refs_packed a @ collect_refs_packed b
-  | Le (a, b) -> collect_refs_packed a @ collect_refs_packed b
-  | Gt (a, b) -> collect_refs_packed a @ collect_refs_packed b
-  | Ge (a, b) -> collect_refs_packed a @ collect_refs_packed b
-  | And (a, b) | Or (a, b) -> collect_refs a @ collect_refs b
-  | Not a -> collect_refs a
-  | Cast (_, a) -> collect_refs a
-  | If_then_else (c, a, b) -> collect_refs c @ collect_refs a @ collect_refs b
-  | Eq (a, b) -> collect_refs_packed a @ collect_refs_packed b
-  | Ne (a, b) -> collect_refs_packed a @ collect_refs_packed b
-
-and collect_refs_packed : type a. a expr -> string list =
- fun e -> collect_refs e
-
 (* If a struct-level [where] references fields (rather than only params),
    attach it as the [constraint_] of the last referenced field instead --
    3D's [where] clause only sees parameters. *)

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -609,6 +609,53 @@ let test_3d_negative_literal_rejected () =
   Alcotest.(check bool)
     "negative literal rejected by projection" true (projects_or_raises codec)
 
+let test_3d_field_sub_mul_rejected () =
+  (* A [Sub] / [Mul] over a field in a constraint has no sound narrow-width 3D
+     projection (3d.exe refuses to verify the under/overflow), so it is rejected
+     at projection. A constant [Sub] / [Mul] folds and an additive field
+     constraint still projects. *)
+  let f = Field.v "a" uint8 in
+  let mul =
+    Codec.v "MulC"
+      (fun a b -> (a, b))
+      Codec.
+        [
+          f $ fst;
+          Field.v "b" uint8 ~self_constraint:(fun b ->
+              Expr.(Field.int f * b = int 0))
+          $ snd;
+        ]
+  in
+  let sub =
+    Codec.v "SubC"
+      (fun a b -> (a, b))
+      Codec.
+        [
+          f $ fst;
+          Field.v "b" uint8 ~self_constraint:(fun b ->
+              Expr.(Field.int f - b >= int 5))
+          $ snd;
+        ]
+  in
+  Alcotest.(check bool)
+    "field multiplication rejected" true (projects_or_raises mul);
+  Alcotest.(check bool)
+    "field subtraction rejected" true (projects_or_raises sub);
+  (* A constant arithmetic bound still projects. *)
+  let constc =
+    Codec.v "ConstC"
+      (fun a -> a)
+      Codec.
+        [
+          Field.v "a" uint8 ~self_constraint:(fun a ->
+              Expr.(a < int 10 * int 5))
+          $ Fun.id;
+        ]
+  in
+  Alcotest.(check bool)
+    "constant arithmetic still projects" false
+    (projects_or_raises constc)
+
 let test_signed_constraint_twos_complement () =
   (* A signed field projects to an unsigned UINT, so an ordering constraint must
      be rewritten to its two's-complement form ([x < 100] over [int8] becomes
@@ -1225,6 +1272,8 @@ let suite =
         test_3d_signed_float_setters;
       Alcotest.test_case "3d: arithmetic constraint widens operands" `Quick
         test_3d_arith_constraint_widens;
+      Alcotest.test_case "3d: field sub/mul constraint rejected" `Quick
+        test_3d_field_sub_mul_rejected;
       Alcotest.test_case "3d: array enum element decl" `Quick
         test_3d_array_enum_element_decl;
       Alcotest.test_case "3d: array open enum element renders base" `Quick


### PR DESCRIPTION
A field constraint that subtracts or multiplies a field (such as `Expr.(a * b = int 0)` or `Expr.(a - b >= int 5)`) projects to a refinement EverParse refuses to verify ("cannot verify u8 subtraction / multiplication"), so the codec had no validator. Addition is already widened to `UINT64` so its 3D sum cannot overflow, but neither subtraction nor multiplication has a sound projection: a widened `Sub` wraps on underflow where the OCaml decoder goes negative, and a widened `Mul` of wide operands overflows the decoder's own native int.

A field `Sub` / `Mul` in a projected constraint is now rejected with a clear error; a constant `Sub` / `Mul` (which folds) and additive field arithmetic still project. Stacked on #205.