### PR TITLE
codec: validate enforces every decode-side field check

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -220,6 +220,13 @@
 
 ### Fixed
 
+- `Codec.validate` now enforces every check `Codec.decode` does, for any codec.
+  It used to skip a field's own decode-side checks (enum and variant membership,
+  a lookup index bound, a refined or NUL-terminated span, an embedded codec or
+  array element's constraints) whenever the struct had no top-level constraint
+  or `where`, so validating untrusted input accepted values decode rejects and a
+  following zero-copy `Codec.get` trusted them (#207, @samoht)
+
 - A field constraint that subtracts or multiplies a field (such as
   `Expr.(a * b = int 0)` or `Expr.(a - b >= int 5)`) is now rejected at
   projection. Such an expression under- or overflows the field's narrow width,

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -361,17 +361,12 @@ let rec build_populate : type a.
         match reader buf base with
         | Some _ -> inner_populate slots buf base
         | None -> ())
-  | All_zeros ->
-      (* No int projection, but the reader checks every byte is zero. Run it for
-         that effect so [Codec.validate] enforces the all-zeros contract decode
-         does, instead of silently accepting tampered padding. *)
-      fun _slots buf base -> ignore (reader buf base)
   | _ ->
-      (* Aggregate / string-valued types have no scalar int projection.
-         [Field.ref] over them reads 0; treat as deliberate (no slot
-         write) rather than an error since [ref] currently accepts any
-         field type. *)
-      fun _arr _buf _base -> ()
+      (* No int slot to populate, but run the reader for its effect: it performs
+         the same decode-side checks (all-zeros span, NUL terminator, refined
+         span, embedded codec / array element constraints), so [Codec.validate]
+         rejects exactly what [decode] does. The value is discarded. *)
+      fun _slots buf base -> ignore (reader buf base)
 
 (* Bitfield extraction descriptor: word reader + packed shift/mask.
    Packing shift and mask into a single int lets [extract] be a direct
@@ -2150,7 +2145,18 @@ and compile_map : type a w r.
     }
   in
   let cf = compile_field ctx inner_fld in
-  { cf with raw_reader = (fun buf off -> decode (cf.raw_reader buf off)) }
+  let checked_reader buf off = decode (cf.raw_reader buf off) in
+  {
+    cf with
+    raw_reader = checked_reader;
+    (* [decode] is where a lookup checks its index is in range; run it in
+       populate too so [Codec.validate] enforces the bound decode does. The inner
+       populate still fills the int slot from the raw value. *)
+    populate =
+      (fun arr buf base ->
+        cf.populate arr buf base;
+        ignore (checked_reader buf base));
+  }
 
 and compile_optional : type a r.
     layout_ctx ->
@@ -2599,20 +2605,7 @@ let validate_or_eof buf f =
          (Unexpected_eof
             { expected = Bytes.length buf + 1; got = Bytes.length buf }))
 
-(* An [all_zeros] field carries no constraint or action, but its populate checks
-   every byte is zero, so a struct holding one (through the transparent wrappers)
-   needs the validator pass to run even when nothing else does, or [Codec.validate]
-   would skip the all-zeros contract that decode enforces. *)
-let rec typ_checks_bytes : type a. a Types.typ -> bool = function
-  | Types.All_zeros -> true
-  | Types.Where { inner; _ } -> typ_checks_bytes inner
-  | Types.Map { inner; _ } -> typ_checks_bytes inner
-  | Types.Optional { inner; _ } -> typ_checks_bytes inner
-  | Types.Optional_or { inner; _ } -> typ_checks_bytes inner
-  | _ -> false
-
-let build_validators validators_rev checkers_rev compiled_where struct_fields
-    n_total =
+let build_validators validators_rev checkers_rev compiled_where n_total =
   let validator_fns = Array.of_list (List.map snd validators_rev) in
   let n_validators = Array.length validator_fns in
   let validate_arr arr buf off =
@@ -2631,31 +2624,23 @@ let build_validators validators_rev checkers_rev compiled_where struct_fields
       checker_fns.(i) arr buf off
     done
   in
-  let has_checks =
-    compiled_where <> None
-    || List.exists
-         (fun (Types.Field f) ->
-           f.constraint_ <> None || f.action <> None
-           || typ_checks_bytes f.field_typ)
-         struct_fields
-  in
   let validate =
-    if has_checks then (
-      let arr = alloc_slots n_total in
-      fun ?env_slots buf off ->
-        clear_slots arr n_total;
-        (match env_slots with
-        | Some slots ->
-            (* Seed param slots from the supplied env so [where] clauses
-               that reference [Param.input] evaluate correctly. *)
-            let n = Array.length slots in
-            Array.blit slots 0 arr.ints (n_total - n) n
-        | None -> ());
-        (* Validate through the same kernel decode uses ([validate_arr]), so
-           [Codec.validate] and [decode] never disagree on field constraints,
-           actions, or the [where] clause. *)
-        validate_or_eof buf (fun () -> validate_arr arr buf off))
-    else fun ?env_slots:_ _buf _off -> ()
+    (* Always run [validate_arr], never gate on whether the struct has a user
+       constraint: a field's own decode-side checks (enum membership, lookup
+       bound, all-zeros / NUL / refined span, embedded element constraints) run
+       here too, and gating them out let [Codec.validate] accept inputs [decode]
+       rejects. *)
+    let arr = alloc_slots n_total in
+    fun ?env_slots buf off ->
+      clear_slots arr n_total;
+      (match env_slots with
+      | Some slots ->
+          (* Seed param slots so [where] clauses referencing [Param.input]
+             evaluate correctly. *)
+          let n = Array.length slots in
+          Array.blit slots 0 arr.ints (n_total - n) n
+      | None -> ());
+      validate_or_eof buf (fun () -> validate_arr arr buf off)
   in
   (validate_arr, populate, validate)
 
@@ -2842,8 +2827,7 @@ let seal : type r. (r, r) record -> r t =
     compile_where_clause r.param_slots r.field_readers r.where
   in
   let validate_arr, populate, validate_checks =
-    build_validators validators (List.rev r.checkers_rev) compiled_where
-      struct_fields n_total
+    build_validators validators (List.rev r.checkers_rev) compiled_where n_total
   in
   (* Per-field action runners *)
   let field_actions = List.rev r.field_actions_rev in
@@ -3093,7 +3077,7 @@ and validator_of_struct (s : Types.struct_) : validator =
     build_validators
       (List.rev acc.validators_rev)
       (List.rev acc.checkers_rev)
-      compiled_where s.fields n_total
+      compiled_where n_total
   in
   (* Full validation: fire field actions and check the where clause.
      [build_validators]'s third return [validate] is checkers-only (no

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -236,6 +236,44 @@ let test_validate_all_zeros () =
   | exception Validation_error _ ->
       Alcotest.fail "validate failed with the wrong error"
 
+(* A field's own decode-side check (enum membership, lookup bound, a bounded
+   embedded element) lives in its reader, not in a user constraint, so
+   [Codec.validate] must run the validator pass for every codec or it would
+   accept inputs [decode] rejects. Each case feeds bytes both reject. *)
+let test_validate_matches_decode_rejections () =
+  let rejects what c bytes =
+    let buf = Bytes.of_string bytes in
+    (match Codec.decode c buf 0 with
+    | Error _ -> ()
+    | Ok _ -> Alcotest.failf "%s: decode accepted a bad input" what);
+    match Codec.validate c buf 0 with
+    | exception Validation_error _ -> ()
+    | () -> Alcotest.failf "%s: validate accepted what decode rejects" what
+  in
+  let enum_c =
+    Codec.v "E" Fun.id
+      Codec.[ Field.v "v" (enum "C" [ ("A", 1); ("B", 2) ] uint8) $ Fun.id ]
+  in
+  rejects "unknown enum" enum_c "\xee";
+  let lookup_c =
+    Codec.v "L" Fun.id
+      Codec.[ Field.v "v" (lookup [ "a"; "b"; "c" ] uint8) $ Fun.id ]
+  in
+  rejects "out-of-range lookup index" lookup_c "\x07";
+  let elem =
+    Codec.v "Bnd" Fun.id
+      Codec.
+        [
+          Field.v "v" uint8 ~self_constraint:(fun r -> Expr.(r <= int 10))
+          $ Fun.id;
+        ]
+  in
+  let arr_c =
+    Codec.v "Arr" Fun.id
+      Codec.[ Field.v "vs" (array ~len:(int 2) (codec elem)) $ Fun.id ]
+  in
+  rejects "array element constraint" arr_c "\x01\x63"
+
 (* A [Wire.where] cond carried in a field's typ ([where (len < 2) uint8]) must be
    enforced by both decode and validate, not only projected to 3D. The cond
    reaches the EverParse refinement, so leaving it unchecked on the OCaml side
@@ -5197,6 +5235,8 @@ let suite =
         `Quick test_validate_bounds_constraint_free;
       Alcotest.test_case "validate: enforces all_zeros padding" `Quick
         test_validate_all_zeros;
+      Alcotest.test_case "validate: matches decode rejections" `Quick
+        test_validate_matches_decode_rejections;
       Alcotest.test_case "decode: enforces typ-level where" `Quick
         test_decode_enforces_typ_where;
       Alcotest.test_case "validate: enforces typ-level where" `Quick


### PR DESCRIPTION
`Codec.validate` gated its validator pass on whether the struct carried a top-level constraint or `where` clause. But a field's own decode-side checks (enum and variant membership, a lookup index bound, an `all_zeros` / NUL-terminated / refined span, and an embedded codec or array element's constraints) live in that pass too, so an enum-only or lookup-only codec got a `validate` that accepted inputs `decode` rejects. Since `validate` is the documented safety gate before a batch of zero-copy `Codec.get` calls on untrusted input, those values were then trusted unchecked.

`validate` now always runs the validator kernel; a non-int field's reader runs for its checking effect in `build_populate`, and a `Map`'s `decode` (where a lookup checks its index bound) runs in populate. `Codec.validate` rejects exactly what `decode` rejects. Follows up the partial #204 / #205, which only covered the bounds and `all_zeros` cases.