### PR TITLE
everparse: make schema the authoritative projectability gate

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -220,6 +220,12 @@
 
 ### Fixed
 
+- `Wire.Everparse.schema` (and `doc`) now reject a codec that cannot project to
+  3D when the schema is built, not later when it is rendered. A constraint with
+  no 3D projection (a `field_pos`, or a subtraction or multiplication over a
+  field) used to build a schema that only raised once passed to `to_3d`, so
+  `schema` was not a reliable projectability check (#209, @samoht)
+
 - `Codec.validate` now enforces every check `Codec.decode` does, for any codec.
   It used to skip a field's own decode-side checks (enum and variant membership,
   a lookup index bound, a refined or NUL-terminated span, an embedded codec or

--- a/lib/everparse.ml
+++ b/lib/everparse.ml
@@ -508,6 +508,13 @@ let schema_of_struct (s : Types.struct_) : t =
   let wire_size = coalesced_wire_size s.fields in
   let decls = with_output s in
   let m = Types.module_ decls in
+  (* [schema] is the authoritative projectability gate: a constraint with no 3D
+     projection (a [field_pos], a subtraction or multiplication over a field) is
+     rejected here, when the codec is projected, rather than slipping through to
+     an unguarded [to_3d] later. The rejection lives in the renderer, so validate
+     by rendering once; [pp_struct] resets its counters, so this does not affect
+     a subsequent render. *)
+  ignore (Types.to_3d m : string);
   { name; module_ = m; wire_size; source = Some s }
 
 let schema (type r) (codec : r Codec.t) : t =
@@ -517,12 +524,11 @@ let doc_of_struct ?doc (s : Types.struct_) : t =
   let s = Types.split_string_casetype_fields s in
   let name = Types.struct_name s in
   let wire_size = coalesced_wire_size s.fields in
-  {
-    name;
-    module_ = Types.module_ (doc_decls ?doc s);
-    wire_size;
-    source = Some s;
-  }
+  let m = Types.module_ (doc_decls ?doc s) in
+  (* Authoritative projectability gate, as in [schema_of_struct]; the doc
+     projection renders enums as named types. *)
+  ignore (Types.to_3d ~enum_as_type:true m : string);
+  { name; module_ = m; wire_size; source = Some s }
 
 let doc (type r) (codec : r Codec.t) : t =
   doc_of_struct ?doc:(Codec.doc codec) (Codec.to_struct codec)

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -656,6 +656,37 @@ let test_3d_field_sub_mul_rejected () =
     "constant arithmetic still projects" false
     (projects_or_raises constc)
 
+let test_schema_authoritative () =
+  (* [Everparse.schema] is the projectability gate: a non-projectable constraint
+     raises when the codec is projected, not only later when it is rendered, so
+     a consumer of [schema] gets an honest answer. *)
+  let f = Field.v "a" uint8 in
+  let bad =
+    Codec.v "SchemaSub"
+      (fun a b -> (a, b))
+      Codec.
+        [
+          f $ fst;
+          Field.v "b" uint8 ~self_constraint:(fun b ->
+              Expr.(Field.int f - b >= int 5))
+          $ snd;
+        ]
+  in
+  Alcotest.(check bool)
+    "schema rejects a non-projectable codec" true
+    (try
+       ignore (Everparse.schema bad : Everparse.t);
+       false
+     with Invalid_argument _ -> true);
+  (* A projectable codec still produces a schema. *)
+  let ok = Codec.v "SchemaOk" Fun.id Codec.[ Field.v "x" uint8 $ Fun.id ] in
+  Alcotest.(check bool)
+    "schema accepts a projectable codec" false
+    (try
+       ignore (Everparse.schema ok : Everparse.t);
+       false
+     with Invalid_argument _ -> true)
+
 let test_signed_constraint_twos_complement () =
   (* A signed field projects to an unsigned UINT, so an ordering constraint must
      be rewritten to its two's-complement form ([x < 100] over [int8] becomes
@@ -1274,6 +1305,8 @@ let suite =
         test_3d_arith_constraint_widens;
       Alcotest.test_case "3d: field sub/mul constraint rejected" `Quick
         test_3d_field_sub_mul_rejected;
+      Alcotest.test_case "3d: schema is the projectability gate" `Quick
+        test_schema_authoritative;
       Alcotest.test_case "3d: array enum element decl" `Quick
         test_3d_array_enum_element_decl;
       Alcotest.test_case "3d: array open enum element renders base" `Quick


### PR DESCRIPTION
A constraint with no 3D projection (a `field_pos`, or a subtraction or multiplication over a field) is rejected only while rendering, inside `pp_field` / `pp_expr`. So `Wire.Everparse.schema` built a schema without complaint and the rejection fired later in an unguarded `to_3d` (or `write_3d`), which means `schema` was not a reliable answer to "does this codec project?". A consumer that trusted it broke: the fuzz everparse filter checked `schema` alone and then crashed when the sweep rendered an unprojectable codec.

`schema_of_struct` and `doc_of_struct` now validate the projection when the schema is built (rendering once for its effect), so a non-projectable codec raises at `schema` time. `pp_struct` resets its counters, so the validation render does not affect a later one. OCaml-only construction is unchanged; this only moves the 3D-projection rejection earlier.