### PR TITLE
everparse: consolidate projection API into project/write

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,8 +46,9 @@
   renders as a `/* ... */` comment above the field in the generated 3D. A
   protocol spec can now cite the standard each individual field comes from, not
   just the struct as a whole, and EverParse accepts the comment (#157, @samoht)
-- The documentation pipeline (`Wire_3d.main ~mode:`Doc`) now auto-generates a
-  differential self-check: `dune runtest` fuzzes inputs, records whether the
+- The standalone projection pipeline (`Wire_3d.main ~mode:`Standalone`) now
+  auto-generates a differential self-check: `dune runtest` fuzzes inputs,
+  records whether the
   OCaml codec accepts each, and replays them through the EverParse-generated C
   validator, failing on any input the two decide differently. This catches a
   doc projection that drifts from the codec (a wrong bit order, a constraint
@@ -61,16 +62,16 @@
   spec then documents which standard each protocol struct comes from, and
   EverParse accepts the comment (#155, @samoht)
 - `Wire_3d`'s documentation helpers (`generate_doc`, `generate_dune_doc`, and
-  `main ~mode:`Doc`) take an optional `?name` that sets the generated
+  `main ~mode:`Standalone`) take an optional `?name` that sets the generated
   `<Name>.3d` / `<Name>.c` file base independently of the opam `~package`, so a
   package like `ocaml-tcp` can emit a `Tcp.3d` spec while still installing under
   its own name (#154, @samoht)
-- `Wire.Everparse.doc` and `Wire.Everparse.write_doc` project a codec, or a
-  whole family of codecs, to a clean `.3d` with no FFI scaffolding: enums
-  render as named 3D enum types, types shared across codecs are emitted once,
-  and a protocol family lands in one readable `<Name>.3d`. The result doubles
-  as a protocol specification and as input to EverParse, which compiles it to a
-  standalone C validator with no FFI (#151, @samoht)
+- `Wire.Everparse.project ~mode:`Standalone` and `Wire.Everparse.write` project
+  a codec, or a whole family of codecs, to a clean `.3d` with no FFI
+  scaffolding: enums render as named 3D enum types, types shared across codecs
+  are emitted once, and a protocol family lands in one readable `<Name>.3d`. The
+  result doubles as a protocol specification and as input to EverParse, which
+  compiles it to a standalone verified C parser with no FFI (#151, @samoht)
 - `Wire.Codec.rename` returns a codec with a new name, leaving its wire
   encoding and field constraints unchanged, so a generically built codec can
   be given a unique, meaningful name before code generation (@samoht)
@@ -122,6 +123,18 @@
 
 ### Changed
 
+- The EverParse projection API is consolidated to two entry points. The two
+  projections, previously `Wire.Everparse.schema` and `Wire.Everparse.doc`, are
+  now `Wire.Everparse.project ?mode`, where `` `Standalone `` (the default)
+  emits a clean `.3d` that EverParse compiles to a standalone verified C parser
+  (the production output, which also reads as a spec) and `` `Ffi `` emits the
+  OCaml-callable bridge with `WireCtx` extern callbacks. Writing is likewise one
+  `Wire.Everparse.write ?mode` (replacing `write_3d` and `write_doc`). The
+  struct-level entry points `struct_of_codec` and `schema_of_struct` move under
+  `Wire.Everparse.Raw` (as `struct_of_codec` and `project_struct`), and
+  `Wire_3d.main`'s mode is now `` `Standalone `` rather than `` `Doc `` (#210,
+  @samoht)
+
 - A long `?doc` note on a field or codec (an RFC citation, say) now wraps across
   several comment lines in the generated `.3d` instead of rendering as one line
   past 80 columns, so the generated spec stays readable (#191, @samoht)
@@ -137,13 +150,13 @@
   demand (#168, @samoht)
 
 - `Wire_3d.main` now takes packed codecs (`Wire_3d.pack codec`) and a
-  mandatory `~mode:[`Ffi | `Doc]`, so every `gen.ml` states what it emits.
-  `` `Ffi `` keeps the per-codec FFI parsers; `` `Doc `` emits one FFI-free
-  `<Package>.3d` specification and a single validator-only `<Package>.c` for
-  the whole package, through the new `Wire_3d.generate_doc` and
+  mandatory `~mode:[`Ffi | `Standalone]`, so every `gen.ml` states what it
+  emits. `` `Ffi `` keeps the per-codec FFI parsers; `` `Standalone `` emits one
+  FFI-free `<Package>.3d` specification and a single standalone `<Package>.c`
+  parser for the whole package, through the new `Wire_3d.generate_doc` and
   `Wire_3d.generate_dune_doc`. Migrate a `gen.ml` by replacing
-  `[schema c; ...]` with `~mode:`Ffi [pack c; ...]`, or `~mode:`Doc` for the
-  single-file output (#152, @samoht)
+  `[schema c; ...]` with `~mode:`Ffi [pack c; ...]`, or `~mode:`Standalone` for
+  the single-file output (#152, @samoht)
 - Reading or writing a `uint32` or `uint63` field now stays in the native
   `int` instead of round-tripping through a boxed `Int32` or `Int64`. The
   boxing surfaced as per-field allocation in tight decode and encode loops;
@@ -220,11 +233,11 @@
 
 ### Fixed
 
-- `Wire.Everparse.schema` (and `doc`) now reject a codec that cannot project to
-  3D when the schema is built, not later when it is rendered. A constraint with
-  no 3D projection (a `field_pos`, or a subtraction or multiplication over a
-  field) used to build a schema that only raised once passed to `to_3d`, so
-  `schema` was not a reliable projectability check (#209, @samoht)
+- `Wire.Everparse.project` now rejects a codec that cannot project to 3D when
+  the schema is built, not later when it is rendered. A constraint with no 3D
+  projection (a `field_pos`, or a subtraction or multiplication over a field)
+  used to build a schema that only raised once passed to `to_3d`, so the
+  projection was not a reliable projectability check (#209, @samoht)
 
 - `Codec.validate` now enforces every check `Codec.decode` does, for any codec.
   It used to skip a field's own decode-side checks (enum and variant membership,

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ the format, then:
 - **Read and write fields in-place** via `Codec.get` / `Codec.set` -- zero-copy,
   zero-allocation for immediate types (int, bool)
 - **Decode and encode records** via `Codec.decode` / `Codec.encode`
-- **Export EverParse `.3d` schemas** via `Everparse.schema` / `Everparse.write_3d`
+- **Export EverParse `.3d` schemas** via `Everparse.project` / `Everparse.write`
 - **Generate verified C artifacts** via `Wire_3d.run`
 - **Generate OCaml FFI stubs** via `Wire_stubs` when OCaml should call the C
 - **Render RFC-style ASCII diagrams** via `Ascii.of_codec`
@@ -93,9 +93,9 @@ let f_data = Field.v "Data" (byte_array ~size:(Field.ref f_len))
 The same codec produces `.3d` files:
 
 ```ocaml
-let schema = Everparse.schema codec
+let schema = Everparse.project ~mode:`Ffi codec
 
-let _write () = Everparse.write_3d ~outdir:"schemas" [ schema ]
+let _write () = Everparse.write ~mode:`Ffi ~outdir:"schemas" [ schema ]
 ```
 
 The 3D output uses the EverParse output-types pattern: the generated C

--- a/bench/demo/demo_bench_cases.ml
+++ b/bench/demo/demo_bench_cases.ml
@@ -8,7 +8,7 @@ let n_data = 1024
    This derives the projection from the codec's own field list, avoiding
    hand-copied field layouts that can drift from the codec definition. *)
 let project (type r) (codec : r Codec.t) ~name ~keep =
-  Everparse.Raw.struct_project (Everparse.struct_of_codec codec) ~name ~keep
+  Everparse.Raw.struct_project (Everparse.Raw.struct_of_codec codec) ~name ~keep
 
 let project_one (type r a) (codec : r Codec.t) ~name ~keep:(f : a Field.t) =
   project codec ~name ~keep:[ Field.Named f ]

--- a/bench/gen_stubs.ml
+++ b/bench/gen_stubs.ml
@@ -168,7 +168,9 @@ let generate_c oc =
 let () =
   if ml_only then generate_ml stdout
   else begin
-    let schemas = List.map Wire.Everparse.schema_of_struct structs in
+    let schemas =
+      List.map (Wire.Everparse.Raw.project_struct ~mode:`Ffi) structs
+    in
 
     (* 1. Generate .3d *)
     Wire_3d.generate_3d ~outdir:schema_dir schemas;

--- a/examples/demo/demo.ml
+++ b/examples/demo/demo.ml
@@ -21,7 +21,7 @@ let bf_minimal_value = Codec.(f_minimal_value $ fun m -> m.m_value)
 let minimal_codec =
   Codec.v "Minimal" (fun v -> { m_value = v }) [ bf_minimal_value ]
 
-let minimal_struct = Everparse.struct_of_codec minimal_codec
+let minimal_struct = Everparse.Raw.struct_of_codec minimal_codec
 let minimal_size = Codec.wire_size minimal_codec
 let minimal_default = { m_value = 42 }
 
@@ -58,7 +58,7 @@ let all_ints_codec =
         bf_ints_u64be;
       ]
 
-let all_ints_struct = Everparse.struct_of_codec all_ints_codec
+let all_ints_struct = Everparse.Raw.struct_of_codec all_ints_codec
 let all_ints_size = Codec.wire_size all_ints_codec
 
 let all_ints_default =
@@ -94,7 +94,7 @@ let bf8_codec =
     (fun tag value -> { tag; value })
     Codec.[ (Field.v "Tag" (bits ~width:3 U8) $ fun b -> b.tag); bf_bf8_value ]
 
-let bf8_struct = Everparse.struct_of_codec bf8_codec
+let bf8_struct = Everparse.Raw.struct_of_codec bf8_codec
 let bf8_size = Codec.wire_size bf8_codec
 let bf8_default = { tag = 5; value = 19 }
 
@@ -122,7 +122,7 @@ let bf16_codec =
         bf_bf16_id;
       ]
 
-let bf16_struct = Everparse.struct_of_codec bf16_codec
+let bf16_struct = Everparse.Raw.struct_of_codec bf16_codec
 let bf16_size = Codec.wire_size bf16_codec
 let bf16_default = { flag = 1; type_ = 9; id = 1023 }
 
@@ -151,7 +151,7 @@ let bf32_codec =
         bf_bf32_pri;
       ]
 
-let bf32_struct = Everparse.struct_of_codec bf32_codec
+let bf32_struct = Everparse.Raw.struct_of_codec bf32_codec
 let bf32_size = Codec.wire_size bf32_codec
 let bf32_default = { flags = 5; chan = 26; seq = 4660; pri = 171 }
 
@@ -185,7 +185,7 @@ let bool_fields_codec =
         (Field.v "Code" uint8 $ fun b -> b.code);
       ]
 
-let bool_fields_struct = Everparse.struct_of_codec bool_fields_codec
+let bool_fields_struct = Everparse.Raw.struct_of_codec bool_fields_codec
 let bool_fields_size = Codec.wire_size bool_fields_codec
 
 let bool_fields_default =
@@ -246,7 +246,7 @@ let large_mixed_codec =
         bf_mixed_timestamp;
       ]
 
-let large_mixed_struct = Everparse.struct_of_codec large_mixed_codec
+let large_mixed_struct = Everparse.Raw.struct_of_codec large_mixed_codec
 let large_mixed_size = Codec.wire_size large_mixed_codec
 
 let large_mixed_default =
@@ -310,7 +310,7 @@ let mapped_codec =
     (fun pri value -> { priority = pri; value })
     Codec.[ bf_mp_priority; (f_mp_value $ fun m -> m.value) ]
 
-let mapped_struct = Everparse.struct_of_codec mapped_codec
+let mapped_struct = Everparse.Raw.struct_of_codec mapped_codec
 let mapped_size = Codec.wire_size mapped_codec
 let mapped_default = { priority = High; value = 42 }
 
@@ -345,7 +345,7 @@ let cases_demo_codec =
     (fun ptype id -> { type_ = ptype; id })
     Codec.[ bf_cd_type; (f_cd_id $ fun c -> c.id) ]
 
-let cases_demo_struct = Everparse.struct_of_codec cases_demo_codec
+let cases_demo_struct = Everparse.Raw.struct_of_codec cases_demo_codec
 let cases_demo_size = Codec.wire_size cases_demo_codec
 let cases_demo_default = { type_ = Telemetry; id = 42 }
 
@@ -383,7 +383,7 @@ let enum_demo_codec =
     (fun status code -> { status; code })
     Codec.[ bf_en_status; (f_en_code $ fun e -> e.code) ]
 
-let enum_demo_struct = Everparse.struct_of_codec enum_demo_codec
+let enum_demo_struct = Everparse.Raw.struct_of_codec enum_demo_codec
 let enum_demo_size = Codec.wire_size enum_demo_codec
 let enum_demo_default = { status = `Ok; code = 42 }
 
@@ -417,7 +417,7 @@ let constrained_codec =
     (fun version data -> { version; data })
     Codec.[ (f_co_version $ fun c -> c.version); bf_co_data ]
 
-let constrained_struct = Everparse.struct_of_codec constrained_codec
+let constrained_struct = Everparse.Raw.struct_of_codec constrained_codec
 let constrained_size = Codec.wire_size constrained_codec
 let constrained_default = { version = 0; data = 42 }
 

--- a/examples/gen_3d.ml
+++ b/examples/gen_3d.ml
@@ -34,11 +34,11 @@ let () =
       Demo.param_payload_struct;
       Space.clcw_struct;
       Space.packet_struct;
-      Wire.Everparse.struct_of_codec Space.full_packet_codec;
+      Wire.Everparse.Raw.struct_of_codec Space.full_packet_codec;
       Space.tm_frame_struct;
-      Wire.Everparse.struct_of_codec Space.tm_with_ocf_codec;
-      Wire.Everparse.struct_of_codec Space.inner_cmd_codec;
-      Wire.Everparse.struct_of_codec Space.outer_hdr_codec;
+      Wire.Everparse.Raw.struct_of_codec Space.tm_with_ocf_codec;
+      Wire.Everparse.Raw.struct_of_codec Space.inner_cmd_codec;
+      Wire.Everparse.Raw.struct_of_codec Space.outer_hdr_codec;
       Net.ethernet_struct;
       Net.ipv4_struct;
       Net.tcp_struct;
@@ -52,18 +52,27 @@ let () =
       ("Outer.3d", Demo.type_ref_module);
     ];
   (* Documentation specs: a whole protocol family in one readable [.3d],
-     projected without the FFI scaffolding (see [Wire.Everparse.doc]). *)
+     projected without the FFI scaffolding (see [Wire.Everparse.project]). *)
   List.iter
-    (fun (name, ts) -> Wire.Everparse.write_doc ~outdir:"." ~name ts)
+    (fun (name, ts) ->
+      Wire.Everparse.write ~mode:`Standalone ~outdir:"." ~name ts)
     Wire.Everparse.
       [
         ( "net",
           [
-            doc Net.ethernet_codec;
-            doc Net.ipv4_codec;
-            doc Net.tcp_codec;
-            doc Net.udp_codec;
+            project ~mode:`Standalone Net.ethernet_codec;
+            project ~mode:`Standalone Net.ipv4_codec;
+            project ~mode:`Standalone Net.tcp_codec;
+            project ~mode:`Standalone Net.udp_codec;
           ] );
-        ("space", [ doc Space.clcw_codec; doc Space.packet_codec ]);
-        ("demo", [ doc Demo.enum_demo_codec; doc Demo.cases_demo_codec ]);
+        ( "space",
+          [
+            project ~mode:`Standalone Space.clcw_codec;
+            project ~mode:`Standalone Space.packet_codec;
+          ] );
+        ( "demo",
+          [
+            project ~mode:`Standalone Demo.enum_demo_codec;
+            project ~mode:`Standalone Demo.cases_demo_codec;
+          ] );
       ]

--- a/examples/net/gen_spec.ml
+++ b/examples/net/gen_spec.ml
@@ -3,13 +3,13 @@
    so the checked-in spec never drifts from the codecs in [net.ml]. *)
 let () =
   let dir = Filename.temp_dir "net_spec" "" in
-  Wire.Everparse.write_doc ~outdir:dir ~name:"net"
+  Wire.Everparse.write ~mode:`Standalone ~outdir:dir ~name:"net"
     Wire.Everparse.
       [
-        doc Net.ethernet_codec;
-        doc Net.ipv4_codec;
-        doc Net.tcp_codec;
-        doc Net.udp_codec;
+        project ~mode:`Standalone Net.ethernet_codec;
+        project ~mode:`Standalone Net.ipv4_codec;
+        project ~mode:`Standalone Net.tcp_codec;
+        project ~mode:`Standalone Net.udp_codec;
       ];
   let path = Filename.concat dir "Net.3d" in
   print_string (In_channel.with_open_text path In_channel.input_all)

--- a/examples/net/net.ml
+++ b/examples/net/net.ml
@@ -40,7 +40,7 @@ let ethernet_codec =
         bf_eth_payload;
       ]
 
-let ethernet_struct = Everparse.struct_of_codec ethernet_codec
+let ethernet_struct = Everparse.Raw.struct_of_codec ethernet_codec
 let ethernet_size = Codec.wire_size ethernet_codec
 
 (* -- IPv4 header: 20 bytes fixed (no options) + payload -- *)
@@ -172,7 +172,7 @@ let ipv4_codec =
         bf_ip_payload;
       ]
 
-let ipv4_struct = Everparse.struct_of_codec ipv4_codec
+let ipv4_struct = Everparse.Raw.struct_of_codec ipv4_codec
 let ipv4_size = Codec.wire_size ipv4_codec
 
 (* -- TCP header: 20 bytes fixed (no options) -- *)
@@ -255,7 +255,7 @@ let tcp_codec =
         (Field.v "UrgentPtr" uint16be $ fun t -> t.urgent_ptr);
       ]
 
-let tcp_struct = Everparse.struct_of_codec tcp_codec
+let tcp_struct = Everparse.Raw.struct_of_codec tcp_codec
 let tcp_size = Codec.wire_size tcp_codec
 
 (* -- UDP header: 8 bytes -- *)
@@ -284,7 +284,7 @@ let udp_codec =
         (f_udp_checksum $ fun u -> u.checksum);
       ]
 
-let udp_struct = Everparse.struct_of_codec udp_codec
+let udp_struct = Everparse.Raw.struct_of_codec udp_codec
 let udp_size = Codec.wire_size udp_codec
 
 (* -- Utilities -- *)

--- a/examples/space/space.ml
+++ b/examples/space/space.ml
@@ -44,7 +44,7 @@ let packet_codec =
         bf_sp_data_len;
       ]
 
-let packet_struct = Everparse.struct_of_codec packet_codec
+let packet_struct = Everparse.Raw.struct_of_codec packet_codec
 let packet_size = Codec.wire_size packet_codec
 
 let packet_default =
@@ -174,7 +174,7 @@ let clcw_codec =
         bf_cw_report;
       ]
 
-let clcw_struct = Everparse.struct_of_codec clcw_codec
+let clcw_struct = Everparse.Raw.struct_of_codec clcw_codec
 let clcw_size = Codec.wire_size clcw_codec
 
 let clcw_default =
@@ -271,7 +271,7 @@ let tm_frame_codec =
         bf_tf_first_hdr;
       ]
 
-let tm_frame_struct = Everparse.struct_of_codec tm_frame_codec
+let tm_frame_struct = Everparse.Raw.struct_of_codec tm_frame_codec
 let tm_frame_size = Codec.wire_size tm_frame_codec
 
 let tm_frame_default =

--- a/examples/validate_3d.ml
+++ b/examples/validate_3d.ml
@@ -5,7 +5,7 @@ module Raw = Wire.Everparse.Raw
 
 (* Two emission paths matter and both should produce parseable 3D:
    - [Raw]: a hand-built struct or module written via [to_3d_file].
-   - [Codec]: a Wire codec projected via [Wire.Everparse.schema] and
+   - [Codec]: a Wire codec projected via [Wire.Everparse.project ~mode:`Ffi] and
      [Wire_3d.generate_3d]. This path adds entrypoint params, output
      types, and the [<Name>Set*] callbacks that the C validator uses. *)
 type case =
@@ -13,7 +13,7 @@ type case =
   | Codec : string * 'a Wire.Codec.t -> case
   | Doc of string * Wire.Everparse.t list
       (** A whole protocol family projected with {!Wire.Everparse.doc} and
-          merged into one [<Name>.3d] by {!Wire.Everparse.write_doc}. *)
+          merged into one [<Name>.3d] by {!Wire.Everparse.write}. *)
 
 let case_name = function Raw (n, _) | Codec (n, _) | Doc (n, _) -> n
 
@@ -30,17 +30,25 @@ let doc_cases =
       ( "Net",
         Wire.Everparse.
           [
-            doc Net.ethernet_codec;
-            doc Net.ipv4_codec;
-            doc Net.tcp_codec;
-            doc Net.udp_codec;
+            project ~mode:`Standalone Net.ethernet_codec;
+            project ~mode:`Standalone Net.ipv4_codec;
+            project ~mode:`Standalone Net.tcp_codec;
+            project ~mode:`Standalone Net.udp_codec;
           ] );
     Doc
-      ("Space", Wire.Everparse.[ doc Space.clcw_codec; doc Space.packet_codec ]);
+      ( "Space",
+        Wire.Everparse.
+          [
+            project ~mode:`Standalone Space.clcw_codec;
+            project ~mode:`Standalone Space.packet_codec;
+          ] );
     Doc
       ( "Demo",
-        Wire.Everparse.[ doc Demo.enum_demo_codec; doc Demo.cases_demo_codec ]
-      );
+        Wire.Everparse.
+          [
+            project ~mode:`Standalone Demo.enum_demo_codec;
+            project ~mode:`Standalone Demo.cases_demo_codec;
+          ] );
   ]
 
 let cases =
@@ -90,11 +98,11 @@ let emit ~outdir = function
       Raw.to_3d_file path module_;
       name ^ ".3d"
   | Codec (_, codec) ->
-      let s = Wire.Everparse.schema codec in
+      let s = Wire.Everparse.project ~mode:`Ffi codec in
       Wire_3d.generate_3d ~outdir [ s ];
       Wire.Everparse.filename s
   | Doc (name, ts) ->
-      Wire.Everparse.write_doc ~outdir ~name ts;
+      Wire.Everparse.write ~mode:`Standalone ~outdir ~name ts;
       String.capitalize_ascii name ^ ".3d"
 
 let validate_one case =

--- a/fuzz/3d/fuzz_everparse.ml
+++ b/fuzz/3d/fuzz_everparse.ml
@@ -28,7 +28,8 @@ open Alcobar
 let no_3d_projection = [ "expr_ops"; "sizeof" ]
 
 let to_3d_of g =
-  Wire.Everparse.Raw.to_3d (Wire.Everparse.schema (Fuzz_gen.codec g)).module_
+  Wire.Everparse.Raw.to_3d
+    (Wire.Everparse.project ~mode:`Ffi (Fuzz_gen.codec g)).module_
 
 (* For a shape with no 3D projection: [to_3d] must raise [Invalid_argument] with
    a clear message, not produce 3D EverParse would reject. *)
@@ -100,7 +101,7 @@ let batch_schemas =
     Fuzz_gen.registry
     |> List.filter (fun (name, _) -> not (List.mem name no_3d_projection))
     |> List.mapi (fun i (label, Fuzz_gen.Pack g) ->
-        let s = Wire.Everparse.schema (Fuzz_gen.codec g) in
+        let s = Wire.Everparse.project ~mode:`Ffi (Fuzz_gen.codec g) in
         { s with Wire.Everparse.name = batch_module_name i label })
 
 let batch_result =

--- a/fuzz/diff/gen/diff_codecs.ml
+++ b/fuzz/diff/gen/diff_codecs.ml
@@ -23,7 +23,8 @@ let starts_with s p =
 let lines_of (Fuzz_gen.Pack g) =
   String.split_on_char '\n'
     (Wire.Everparse.Raw.to_3d
-       (Wire.Everparse.schema (Fuzz_gen.codec g)).Wire.Everparse.module_)
+       (Wire.Everparse.project ~mode:`Ffi (Fuzz_gen.codec g))
+         .Wire.Everparse.module_)
 
 type exclusion = Variable_size | Zero_size | Parameterised | Casetype
 
@@ -38,7 +39,7 @@ let string_of_exclusion = function
    fixed-size validator; a parameterised one needs an env the harness does not
    set up. *)
 let scope_exclusion (Fuzz_gen.Pack g as p) =
-  let s = Wire.Everparse.schema (Fuzz_gen.codec g) in
+  let s = Wire.Everparse.project ~mode:`Ffi (Fuzz_gen.codec g) in
   match s.Wire.Everparse.wire_size with
   | None -> Some Variable_size
   | Some 0 -> Some Zero_size

--- a/fuzz/diff/gen/gen_diff.ml
+++ b/fuzz/diff/gen/gen_diff.ml
@@ -20,7 +20,7 @@ let lower_name g =
     (Wire.Everparse.Raw.struct_name
        (Option.get
           (Wire.Everparse.entrypoint_struct
-             (Wire.Everparse.schema (Fuzz_gen.codec g)))))
+             (Wire.Everparse.project ~mode:`Ffi (Fuzz_gen.codec g)))))
 
 let copy_file ~src ~dst =
   In_channel.with_open_bin src (fun ic ->
@@ -73,7 +73,8 @@ let job_count () =
       match int_of_string_opt s with Some k when k >= 1 -> k | _ -> 4)
   | None -> max 1 (min 4 (Domain.recommended_domain_count ()))
 
-let schema_of (_, Fuzz_gen.Pack g) = Wire.Everparse.schema (Fuzz_gen.codec g)
+let schema_of (_, Fuzz_gen.Pack g) =
+  Wire.Everparse.project ~mode:`Ffi (Fuzz_gen.codec g)
 
 let base_of item =
   Filename.remove_extension (Wire.Everparse.filename (schema_of item))

--- a/fuzz/gen/fuzz_gen.ml
+++ b/fuzz/gen/fuzz_gen.ml
@@ -4356,10 +4356,10 @@ let check_metadata_helpers () =
   | Ok _ -> check_int "Param.get output" 7 (Param.get env p_out)
   | Error e -> Alcobar.failf "param/action decode failed: %a" pp_parse_error e);
   check_string "Codec schema name" "ApiParam"
-    (Wire.Everparse.schema codec).Wire.Everparse.name;
+    (Wire.Everparse.project ~mode:`Ffi codec).Wire.Everparse.name;
   let renamed = Wire.Codec.rename "ApiParamRenamed" codec in
   check_string "Codec.rename" "ApiParamRenamed"
-    (Wire.Everparse.schema renamed).Wire.Everparse.name;
+    (Wire.Everparse.project ~mode:`Ffi renamed).Wire.Everparse.name;
   if Wire.Codec.doc codec <> None then
     Alcobar.failf "Codec.doc unexpectedly set";
   let pp_value = Fmt.str "%a" (pp_value codec) (7, 1) in
@@ -4386,7 +4386,7 @@ let public_raw_struct () =
   (len_field, raw_struct)
 
 let check_everparse_schema raw_struct =
-  let schema = Wire.Everparse.schema_of_struct raw_struct in
+  let schema = Wire.Everparse.Raw.project_struct ~mode:`Ffi raw_struct in
   check_string "Everparse.filename" "ApiRaw.3d" (Wire.Everparse.filename schema);
   if not (Wire.Everparse.uses_wire_ctx schema) then
     Alcobar.failf "schema_of_struct did not use WireCtx";
@@ -4487,8 +4487,8 @@ let check_raw_module_helpers raw_struct p param_struct =
   in
   check_string "Raw.of_module" "ApiModule" module_schema.Wire.Everparse.name;
   let codec = fst5 (api_access_codec ()) in
-  let st = Wire.Everparse.struct_of_codec codec in
-  let _ = Wire.Everparse.doc codec in
+  let st = Wire.Everparse.Raw.struct_of_codec codec in
+  let _ = Wire.Everparse.project ~mode:`Standalone codec in
   let _ = Fmt.str "%a" Wire.Ascii.pp_struct st in
   let _ = Fmt.str "%a" Wire.Ascii.pp_codec codec in
   ()
@@ -4513,14 +4513,14 @@ let once_case name check =
 
 let check_write_helpers_once () =
   let codec = fst5 (api_access_codec ()) in
-  let schema = Wire.Everparse.schema codec in
-  let doc_schema = Wire.Everparse.doc codec in
+  let schema = Wire.Everparse.project ~mode:`Ffi codec in
+  let doc_schema = Wire.Everparse.project ~mode:`Standalone codec in
   let outdir =
     Filename.concat (Filename.get_temp_dir_name ()) "wire_fuzz_api"
   in
   (try Sys.mkdir outdir 0o700 with Sys_error _ -> ());
-  Wire.Everparse.write_3d ~outdir [ schema ];
-  Wire.Everparse.write_doc ~outdir ~name:"ApiDoc" [ doc_schema ];
+  Wire.Everparse.write ~mode:`Ffi ~outdir [ schema ];
+  Wire.Everparse.write ~mode:`Standalone ~outdir ~name:"ApiDoc" [ doc_schema ];
   Wire.Everparse.Raw.to_3d_file ~enum_as_type:true
     (Filename.concat outdir "ApiRawDirect.3d")
     schema.module_
@@ -4572,7 +4572,7 @@ let everparse_cases label g =
       (label ^ " projects+prints")
       Alcobar.[ Alcobar.const () ]
       (fun () ->
-        match Wire.Everparse.schema g.codec with
+        match Wire.Everparse.project ~mode:`Ffi g.codec with
         | s -> ignore (Wire.Everparse.Raw.to_3d s.module_ : string)
         | exception e ->
             Alcobar.failf "%s: 3D projection raised %s" label
@@ -4588,7 +4588,7 @@ let everparse_nested_cases label depth =
       (fun (Any a) ->
         let comp = a.label and codec = a.g.codec in
         fun () ->
-          match Wire.Everparse.schema codec with
+          match Wire.Everparse.project ~mode:`Ffi codec with
           | s -> ignore (Wire.Everparse.Raw.to_3d s.module_ : string)
           | exception e ->
               Alcobar.failf "%s [%s]: 3D projection raised %s" label comp
@@ -4607,7 +4607,7 @@ let everparse_projectable (_, Pack g) =
      or a non-projectable arithmetic constraint), not just in [schema]. Run both
      so such a codec is excluded from the sweep rather than crashing it. *)
   try
-    let s = Wire.Everparse.schema g.codec in
+    let s = Wire.Everparse.project ~mode:`Ffi g.codec in
     ignore (Wire.Everparse.Raw.to_3d s.module_ : string);
     true
   with Invalid_argument _ -> false
@@ -4625,7 +4625,7 @@ let afl_everparse_cases ?max_len label =
   afl_contract_cases ?max_len label afl_everparse_registry
     ~check:(fun case (Pack g) _input ->
       match
-        let s = Wire.Everparse.schema g.codec in
+        let s = Wire.Everparse.project ~mode:`Ffi g.codec in
         ignore (Wire.Everparse.Raw.to_3d s.module_ : string)
       with
       | () -> ()

--- a/lib/3d/wire_3d.ml
+++ b/lib/3d/wire_3d.ml
@@ -171,7 +171,7 @@ let read_validate_name ~outdir s =
   | Some n -> n
   | None -> Fmt.failwith "could not find Validate function name in %s" path
 
-let write_3d = Wire.Everparse.write_3d
+let write_3d ~outdir schemas = Wire.Everparse.write ~mode:`Ffi ~outdir schemas
 
 let copy_file ~src ~dst =
   let ic = open_in_bin src in
@@ -766,17 +766,17 @@ let generate_dune ~outdir ~package schemas =
   Format.pp_print_flush ppf ();
   close_out oc
 
-(* A codec awaiting projection. [main] and the doc helpers take these rather
-   than already-projected [Wire.Everparse.t] so the caller never has to choose
-   between [doc] and [schema]: the projection is picked here from the mode, not
-   at the call site, which removes the [~mode:`Doc] + [schema ...] mismatch. *)
+(* A codec awaiting projection. [main] and the standalone helpers take these
+   rather than an already-projected [Wire.Everparse.t] so the caller never has
+   to choose the projection mode: it is picked here from [main]'s [~mode], not at
+   the call site, which removes any [~mode] + projection-mode mismatch. *)
 type packed = Pack : 'a Wire.Codec.t -> packed
 
 let pack c = Pack c
 
-(* -- Documentation / single-file pipeline. [main ~mode:`Doc] drives these:
-   project each codec with [Wire.Everparse.doc] (FFI-free), merge the family
-   into one [<Package>.3d] with [write_doc], and compile that single spec to a
+(* -- Documentation / single-file pipeline. [main ~mode:`Standalone] drives these:
+   project each codec with [Wire.Everparse.project] (FFI-free), merge the family
+   into one [<Package>.3d] with [write], and compile that single spec to a
    validator-only [<Package>.c] -- no per-codec files, no [_Fields] plug, no FFI
    stubs. The package name becomes the 3D module name, so turn it into a valid
    EverParse identifier (CamelCase, no hyphens): "my-pkg" -> "MyPkg". -- *)
@@ -794,7 +794,7 @@ let doc_module_name package =
 (* The 3D module / file base for the doc pipeline: [?name] when given, else the
    opam [~package]. Lets the emitted [<Base>.3d] / [.c] be named independently of
    the install package (whose name [~package] keeps for the install stanza). *)
-let doc_base ?name ~package () =
+let standalone_base ?name ~package () =
   doc_module_name (match name with Some n -> n | None -> package)
 
 (* -- Differential self-check for the doc pipeline. The doc projection emits a
@@ -851,7 +851,7 @@ let generate_corpus ?(count = 256) ppf codecs =
   let rng = Random.State.make [| 0x5eed51 |] in
   List.iter
     (fun (Pack c) ->
-      let s = doc c in
+      let s = project ~mode:`Standalone c in
       let name = s.name in
       let pnames =
         match s.source with Some st -> Raw.input_param_names st | None -> []
@@ -1007,11 +1007,11 @@ let emit_agree_main ppf =
    name would surface as a link error when the differential test compiles
    [agree.c] against the real wrapper. *)
 let generate_agree ?name ~outdir ~package codecs =
-  let base = doc_base ?name ~package () in
+  let base = standalone_base ?name ~package () in
   let triples =
     List.map
       (fun (Pack c) ->
-        let s = doc c in
+        let s = project ~mode:`Standalone c in
         let ptypes =
           match s.source with
           | Some st -> Raw.input_param_c_types st
@@ -1033,23 +1033,24 @@ let generate_agree ?name ~outdir ~package codecs =
   Format.pp_print_flush ppf ();
   close_out oc
 
-let generate_3d_doc ?name ~outdir ~package codecs =
+let generate_3d_standalone ?name ~outdir ~package codecs =
   ensure_dir outdir;
-  write_doc ~outdir
-    ~name:(doc_base ?name ~package ())
-    (List.map (fun (Pack c) -> doc c) codecs)
+  write ~mode:`Standalone ~outdir
+    ~name:(standalone_base ?name ~package ())
+    (List.map (fun (Pack c) -> project ~mode:`Standalone c) codecs)
 
-let generate_c_doc ?(quiet = true) ?name ~outdir ~package () =
+let generate_c_standalone ?(quiet = true) ?name ~outdir ~package () =
   ensure_dir outdir;
   if has_3d_exe () then
-    run_everparse_files ~quiet ~outdir [ doc_base ?name ~package () ^ ".3d" ]
+    run_everparse_files ~quiet ~outdir
+      [ standalone_base ?name ~package () ^ ".3d" ]
   else
     failwith
       "3d.exe not found in PATH. Install EverParse to regenerate C files."
 
-let generate_doc ?(quiet = true) ?name ~outdir ~package codecs =
-  generate_3d_doc ?name ~outdir ~package codecs;
-  generate_c_doc ~quiet ?name ~outdir ~package ();
+let generate_standalone ?(quiet = true) ?name ~outdir ~package codecs =
+  generate_3d_standalone ?name ~outdir ~package codecs;
+  generate_c_standalone ~quiet ?name ~outdir ~package ();
   generate_agree ?name ~outdir ~package codecs
 
 (* The [.3d] and [agree.c] are pure OCaml ([gen.exe 3d] / [gen.exe agree]), so
@@ -1061,7 +1062,7 @@ let generate_doc ?(quiet = true) ?name ~outdir ~package codecs =
    committed C goes stale -- the runtest differential below catches that, since
    it regenerates the corpus and [agree.c] from the current codec and runs them
    against the committed validator. *)
-let emit_doc_gen_rules ppf ~three_d ~c_files =
+let emit_standalone_gen_rules ppf ~three_d ~c_files =
   Fmt.pf ppf
     "(rule\n\
     \ (alias 3d)\n\
@@ -1086,7 +1087,7 @@ let emit_doc_gen_rules ppf ~three_d ~c_files =
     (String.concat " " c_files)
     three_d
 
-let emit_doc_build_rules ppf ~base ~archive ~c_files =
+let emit_standalone_build_rules ppf ~base ~archive ~c_files =
   (* Build the validator into an archive, installed with the package, so
      consumers get a ready-to-link library and a downstream build fails loudly
      if the spec stops projecting to compilable C. *)
@@ -1126,15 +1127,15 @@ let emit_doc_build_rules ppf ~base ~archive ~c_files =
     \  (run %%{dep:agree} corpus)))\n\n"
     archive base base strict_cc_flags everparse_type_defines archive
 
-let emit_doc_install ppf ~package ~three_d ~archive ~c_files =
+let emit_standalone_install ppf ~package ~three_d ~archive ~c_files =
   let pr fmt = Fmt.pf ppf fmt in
   pr "(install\n (package %s)\n (section lib)\n (files\n" package;
   List.iter (fun f -> pr "  (%s as c/%s)\n" f f) (three_d :: archive :: c_files);
   pr "  (EverParse.h as c/EverParse.h)\n";
   pr "  (EverParseEndianness.h as c/EverParseEndianness.h)))\n"
 
-let generate_dune_doc ?name ~outdir ~package _codecs =
-  let base = doc_base ?name ~package () in
+let generate_dune_standalone ?name ~outdir ~package _codecs =
+  let base = standalone_base ?name ~package () in
   let three_d = base ^ ".3d" in
   let c_files =
     [ base ^ ".c"; base ^ ".h"; base ^ "Wrapper.c"; base ^ "Wrapper.h" ]
@@ -1142,9 +1143,9 @@ let generate_dune_doc ?name ~outdir ~package _codecs =
   let archive = "lib" ^ String.lowercase_ascii base ^ ".a" in
   let oc = open_out (Filename.concat outdir "dune.inc") in
   let ppf = Format.formatter_of_out_channel oc in
-  emit_doc_gen_rules ppf ~three_d ~c_files;
-  emit_doc_build_rules ppf ~base ~archive ~c_files;
-  emit_doc_install ppf ~package ~three_d ~archive ~c_files;
+  emit_standalone_gen_rules ppf ~three_d ~c_files;
+  emit_standalone_build_rules ppf ~base ~archive ~c_files;
+  emit_standalone_install ppf ~package ~three_d ~archive ~c_files;
   Format.pp_print_flush ppf ();
   close_out oc
 
@@ -1152,17 +1153,18 @@ let main ?name ~mode ~package codecs =
   let argv = Array.to_list Sys.argv in
   match mode with
   | `Ffi -> (
-      let schemas = List.map (fun (Pack c) -> schema c) codecs in
+      let schemas = List.map (fun (Pack c) -> project ~mode:`Ffi c) codecs in
       match argv with
       | [ _; "3d" ] -> generate_3d ~outdir:"." schemas
       | [ _; "c" ] -> generate_c ~outdir:"." schemas
       | [ _; "dune" ] -> generate_dune ~outdir:"." ~package schemas
       | _ -> run ~outdir:"." schemas)
-  | `Doc -> (
+  | `Standalone -> (
       match argv with
-      | [ _; "3d" ] -> generate_3d_doc ?name ~outdir:"." ~package codecs
-      | [ _; "c" ] -> generate_c_doc ?name ~outdir:"." ~package ()
+      | [ _; "3d" ] -> generate_3d_standalone ?name ~outdir:"." ~package codecs
+      | [ _; "c" ] -> generate_c_standalone ?name ~outdir:"." ~package ()
       | [ _; "agree" ] -> generate_agree ?name ~outdir:"." ~package codecs
-      | [ _; "dune" ] -> generate_dune_doc ?name ~outdir:"." ~package codecs
+      | [ _; "dune" ] ->
+          generate_dune_standalone ?name ~outdir:"." ~package codecs
       | [ _; "corpus" ] -> generate_corpus Format.std_formatter codecs
-      | _ -> generate_doc ?name ~outdir:"." ~package codecs)
+      | _ -> generate_standalone ?name ~outdir:"." ~package codecs)

--- a/lib/3d/wire_3d.mli
+++ b/lib/3d/wire_3d.mli
@@ -25,9 +25,9 @@
     let main () = Wire_3d.main ~mode:`Ffi ~package:"hdr" [ Wire_3d.pack codec ]
     ]}
 
-    [mode] is mandatory: [`Ffi] emits the per-codec FFI artifacts above, [`Doc]
-    a single FFI-free [<Package>.3d] spec and validator for the whole package.
-    The codecs are the same either way.
+    [mode] is mandatory: [`Ffi] emits the per-codec FFI artifacts above,
+    [`Standalone] a single FFI-free [<Package>.3d] spec and validator for the
+    whole package. The codecs are the same either way.
 
     With a minimal [dune] that includes the generated rules:
     {v
@@ -148,36 +148,36 @@ val run : ?quiet:bool -> outdir:string -> Wire.Everparse.t list -> unit
 
 type packed
 (** A codec with its type erased, so codecs of different record types share one
-    list. Build with {!pack}. {!main} and the doc helpers take these rather than
-    already-projected {!Wire.Everparse.t}, so the [doc]-vs-[schema] projection
-    is chosen from the mode, not at the call site. *)
+    list. Build with {!pack}. {!main} and the standalone helpers take these
+    rather than an already-projected {!Wire.Everparse.t}, so the [`Ffi]-vs-
+    [`Standalone] projection mode is chosen by {!main}, not at the call site. *)
 
 val pack : 'a Wire.Codec.t -> packed
 (** [pack codec] erases [codec]'s type for a {!packed} list. *)
 
-val generate_doc :
+val generate_standalone :
   ?quiet:bool ->
   ?name:string ->
   outdir:string ->
   package:string ->
   packed list ->
   unit
-(** [generate_doc ?quiet ?name ~outdir ~package codecs] runs the documentation
-    pipeline: project each codec with {!Wire.Everparse.doc}, merge them into one
-    [<Name>.3d], and (when [3d.exe] is available) compile it to a single
-    validator-only [<Name>.c] (no [_Fields] plug, no FFI). The file base is
-    [name] when given, else [package], normalised to a CamelCase identifier
+(** [generate_standalone ?quiet ?name ~outdir ~package codecs] runs the
+    documentation pipeline: project each codec with {!Wire.Everparse.doc}, merge
+    them into one [<Name>.3d], and (when [3d.exe] is available) compile it to a
+    single validator-only [<Name>.c] (no [_Fields] plug, no FFI). The file base
+    is [name] when given, else [package], normalised to a CamelCase identifier
     (["my-pkg"] becomes [MyPkg]); [package] always names the opam package. *)
 
-val generate_dune_doc :
+val generate_dune_standalone :
   ?name:string -> outdir:string -> package:string -> packed list -> unit
-(** [generate_dune_doc ?name ~outdir ~package codecs] writes a [dune.inc] for
-    the single-file documentation build: rules that emit [<Name>.3d] and compile
-    it to [<Name>.c], a rule that builds the validator into an installed
+(** [generate_dune_standalone ?name ~outdir ~package codecs] writes a [dune.inc]
+    for the single-file documentation build: rules that emit [<Name>.3d] and
+    compile it to [<Name>.c], a rule that builds the validator into an installed
     [lib<name>.a] archive, a [runtest] rule that runs the differential
     self-check (see {!generate_corpus} / {!generate_agree}), and an install
     stanza (under opam [package]) for the spec, parser, and archive. [name]
-    defaults to [package]; see {!generate_doc}. *)
+    defaults to [package]; see {!generate_standalone}. *)
 
 val generate_corpus : ?count:int -> Format.formatter -> packed list -> unit
 (** [generate_corpus ?count ppf codecs] prints, for each codec, [count] fuzzed
@@ -195,11 +195,15 @@ val generate_agree :
     EverParse-generated validators and exits nonzero on any input where the
     validator's accept/reject decision differs from the recorded verdict. It
     reads the [<Name>Check<Codec>] helper names from the generated
-    [<Name>Wrapper.h], so {!generate_c_doc} (or [3d.exe]) must have run first.
-*)
+    [<Name>Wrapper.h], so {!generate_c_standalone} (or [3d.exe]) must have run
+    first. *)
 
 val main :
-  ?name:string -> mode:[ `Ffi | `Doc ] -> package:string -> packed list -> unit
+  ?name:string ->
+  mode:[ `Ffi | `Standalone ] ->
+  package:string ->
+  packed list ->
+  unit
 (** [main ?name ~mode ~package codecs] dispatches based on [Sys.argv]:
     - [3d] writes the [.3d] file(s)
     - [c] produces the C parser(s)
@@ -207,14 +211,15 @@ val main :
     - otherwise runs the full pipeline.
 
     [mode] is mandatory, so every [gen.ml] states what it emits. With
-    [~mode:`Ffi] it projects each codec with {!Wire.Everparse.schema} and drives
-    the multi-file FFI pipeline, one set per codec. With [~mode:`Doc] it
-    projects with {!Wire.Everparse.doc} and drives the single-file documentation
-    pipeline, one [<Name>.3d] and [<Name>.c] for the whole family. The codecs
-    are the same either way; only the mode changes.
+    [~mode:`Ffi] it projects each codec with {!Wire.Everparse.project} in [`Ffi]
+    mode and drives the multi-file FFI pipeline, one set per codec. With
+    [~mode:`Standalone] it projects in [`Standalone] mode and drives the
+    single-file pipeline, one [<Name>.3d] and [<Name>.c] standalone parser for
+    the whole family. The codecs are the same either way; only the mode changes.
 
-    [name] overrides the doc file base (see {!generate_doc}); it has no effect
-    in [`Ffi] mode, whose file names come from the individual codecs. *)
+    [name] overrides the standalone file base (see {!generate_standalone}); it
+    has no effect in [`Ffi] mode, whose file names come from the individual
+    codecs. *)
 
 val has_3d_exe : unit -> bool
 (** [has_3d_exe ()] returns [true] if [3d.exe] is available in PATH or

--- a/lib/codec.mli
+++ b/lib/codec.mli
@@ -39,8 +39,8 @@ val v :
   'r t
 (** [v name constructor fields] seals a codec from a field list. [?doc] attaches
     a free-text note (e.g. an RFC citation) that the documentation projection
-    renders as a [/*++ ... --*/] comment on the codec's 3D typedef; see {!doc}.
-*)
+    renders as a [/*++ ... --*/] comment on the codec's 3D typedef; see
+    {!Everparse.project}. *)
 
 val wire_size : 'r t -> int
 (** Fixed wire size in bytes. Raises if variable-length. *)
@@ -174,10 +174,11 @@ val name : 'r t -> string
 
 val rename : string -> 'r t -> 'r t
 (** [rename n c] is [c] with its name set to [n]. The name is metadata: it only
-    determines the generated 3D struct name (via {!Everparse.struct_of_codec}),
-    not the wire encoding, so renaming leaves encode/decode and all field
-    constraints unchanged. Use it to give a generically built codec a unique,
-    meaningful name for projection or code generation. *)
+    determines the generated 3D struct name (via
+    {!Everparse.Raw.struct_of_codec}), not the wire encoding, so renaming leaves
+    encode/decode and all field constraints unchanged. Use it to give a
+    generically built codec a unique, meaningful name for projection or code
+    generation. *)
 
 val doc : 'r t -> string option
 (** [doc c] is the note attached via {!v}'s [?doc], if any. *)

--- a/lib/everparse.ml
+++ b/lib/everparse.ml
@@ -417,7 +417,7 @@ let rewrite_absent_optional (Types.Field f) =
       Types.Field { f with field_typ = Types.Unit; constraint_ = None }
   | _ -> Types.Field f
 
-let with_output (s : Types.struct_) : Types.decl list =
+let ffi_decls (s : Types.struct_) : Types.decl list =
   let s = { s with fields = List.map rewrite_absent_optional s.fields } in
   (* Extern declarations for the callback mechanism *)
   let ctx_struct = Types.struct_ "WireCtx" [] in
@@ -449,13 +449,13 @@ let with_output (s : Types.struct_) : Types.decl list =
   [ ctx_decl ] @ extern_decls @ refined_decls @ [ parse_decl ]
 
 (* Documentation / pure-validator projection: the same structural 3D as
-   [with_output] but without the FFI scaffolding. No [WireCtx] extern, no
+   [ffi_decls] but without the FFI scaffolding. No [WireCtx] extern, no
    [WireSet*] setters, no extraction action injected on each field. Keeps the
    struct, bitfields, [where] clause, refined-byte typedefs, enums, and
    casetypes -- everything that describes the wire format. Reads as a protocol
    spec, and 3d.exe still compiles it to a real (validator-only) C parser with
    no FFI. *)
-let doc_decls ?doc (s : Types.struct_) : Types.decl list =
+let standalone_decls ?doc (s : Types.struct_) : Types.decl list =
   let s = { s with fields = List.map rewrite_absent_optional s.fields } in
   let parse_fields = reorder_bit_groups_for_3d s.fields in
   let parse_struct =
@@ -498,15 +498,15 @@ let coalesced_wire_size fields =
     Some (close_bit_group total open_base)
   with Bail -> None
 
-let schema_of_struct (s : Types.struct_) : t =
+let ffi_of_struct (s : Types.struct_) : t =
   (* Split string-tagged casetype fields up-front so [source] and
-     [with_output] see the same field list. Downstream codegen
+     [ffi_decls] see the same field list. Downstream codegen
      (plug fields, stubs) walks [source] to expose every named field --
      it must include the synthesised body field of each casetype. *)
   let s = Types.split_string_casetype_fields s in
   let name = Types.struct_name s in
   let wire_size = coalesced_wire_size s.fields in
-  let decls = with_output s in
+  let decls = ffi_decls s in
   let m = Types.module_ decls in
   (* [schema] is the authoritative projectability gate: a constraint with no 3D
      projection (a [field_pos], a subtraction or multiplication over a field) is
@@ -517,21 +517,29 @@ let schema_of_struct (s : Types.struct_) : t =
   ignore (Types.to_3d m : string);
   { name; module_ = m; wire_size; source = Some s }
 
-let schema (type r) (codec : r Codec.t) : t =
-  schema_of_struct (Codec.to_struct codec)
-
-let doc_of_struct ?doc (s : Types.struct_) : t =
+let standalone_of_struct ?doc (s : Types.struct_) : t =
   let s = Types.split_string_casetype_fields s in
   let name = Types.struct_name s in
   let wire_size = coalesced_wire_size s.fields in
-  let m = Types.module_ (doc_decls ?doc s) in
-  (* Authoritative projectability gate, as in [schema_of_struct]; the doc
+  let m = Types.module_ (standalone_decls ?doc s) in
+  (* Authoritative projectability gate, as in [ffi_of_struct]; the doc
      projection renders enums as named types. *)
   ignore (Types.to_3d ~enum_as_type:true m : string);
   { name; module_ = m; wire_size; source = Some s }
 
-let doc (type r) (codec : r Codec.t) : t =
-  doc_of_struct ?doc:(Codec.doc codec) (Codec.to_struct codec)
+type mode = [ `Ffi | `Standalone ]
+
+(* [`Ffi] emits the [WireCtx] extern plus a per-field setter callback, so the
+   generated C validator is callable from OCaml and extracts fields through the
+   plug (the bridge used by benchmarks and differential testing). [`Standalone]
+   emits a clean [.3d] with no FFI scaffolding, which EverParse compiles to a
+   standalone verified C parser; it also reads as a protocol specification. *)
+let project : type r. ?mode:mode -> r Codec.t -> t =
+ fun ?(mode = `Standalone) codec ->
+  match mode with
+  | `Ffi -> ffi_of_struct (Codec.to_struct codec)
+  | `Standalone ->
+      standalone_of_struct ?doc:(Codec.doc codec) (Codec.to_struct codec)
 
 let filename (s : t) = String.capitalize_ascii s.name ^ ".3d"
 
@@ -617,7 +625,7 @@ let field_action_forms (st : Types.struct_) =
       (f.field_name, is_bitfield f.field_typ, form))
     st.fields
 
-let write_3d ~outdir schemas =
+let write_ffi ~outdir schemas =
   List.iter
     (fun s -> Types.to_3d_file (Filename.concat outdir (filename s)) s.module_)
     schemas
@@ -654,10 +662,20 @@ let merge ~name (ts : t list) : t =
   in
   { name; module_ = Types.module_ decls; wire_size = None; source = None }
 
-let write_doc ~outdir ~name (ts : t list) =
+let write_standalone ~outdir ~name (ts : t list) =
   Types.to_3d_file ~enum_as_type:true
     (Filename.concat outdir (String.capitalize_ascii name ^ ".3d"))
     (merge ~name ts).module_
+
+(* [`Ffi] writes one [.3d] per schema (file name from each schema). [`Standalone]
+   merges the schemas into one [<name>.3d] so a protocol family reads as a single
+   spec, and so requires [~name]. *)
+let write ?(mode = `Standalone) ~outdir ?name (ts : t list) =
+  match (mode, name) with
+  | `Ffi, _ -> write_ffi ~outdir ts
+  | `Standalone, Some name -> write_standalone ~outdir ~name ts
+  | `Standalone, None ->
+      invalid_arg "Everparse.write: ~mode:`Standalone requires ~name"
 
 (* Public C-facing types *)
 
@@ -687,6 +705,12 @@ module Raw = struct
   let module_ = Types.module_
   let to_3d = Types.to_3d
   let to_3d_file = Types.to_3d_file
+  let struct_of_codec = struct_of_codec
+
+  let project_struct ?(mode = `Standalone) s =
+    match mode with
+    | `Ffi -> ffi_of_struct s
+    | `Standalone -> standalone_of_struct s
 
   let field name ?constraint_ ?action typ =
     Field.Named (Field.v name ?constraint_ ?action typ)

--- a/lib/everparse.mli
+++ b/lib/everparse.mli
@@ -1,7 +1,7 @@
 (** EverParse 3D export derived from wire descriptions.
 
-    The main path is {!struct_of_codec}, {!schema}, and {!write_3d}. For unusual
-    3D constructs that have no codec equivalent yet, use {!Raw}.
+    The main path is {!project} and {!write}. For unusual 3D constructs that
+    have no codec equivalent yet, use {!Raw}.
 
     {2 3D projection rules}
 
@@ -55,9 +55,9 @@ type t = {
   module_ : Types.module_;
   wire_size : int option;
   source : Types.struct_ option;
-      (** Pre-[with_output] source struct, [Some] for codec-derived schemas and
+      (** Pre-[ffi_decls] source struct, [Some] for codec-derived schemas and
           [None] for raw-module schemas. Used by downstream codegen to walk
-          named fields without parsing back the post-[with_output] output. *)
+          named fields without parsing back the post-[ffi_decls] output. *)
 }
 (** A named 3D schema with its module and wire size ([None] for variable-size
     schemas). *)
@@ -72,8 +72,8 @@ val filename : t -> string
 val uses_wire_ctx : t -> bool
 (** [uses_wire_ctx s] is [true] when the schema declares the [WireCtx] extern
     typedef, meaning its generated C header [#include]s
-    [<Name>_ExternalTypedefs.h]. Schemas built via {!schema} /
-    {!schema_of_struct} always satisfy this; raw modules assembled via
+    [<Name>_ExternalTypedefs.h]. Schemas built via {!project} /
+    {!Raw.project_struct} always satisfy this; raw modules assembled via
     {!Raw.of_module} do so only if they explicitly declare the extern typedef.
 *)
 
@@ -107,22 +107,17 @@ type decl = Types.decl
 type decl_case = Types.decl_case
 type module_ = Types.module_
 
-val struct_of_codec : 'r Codec.t -> struct_
-(** Project a codec to a 3D struct. *)
+type mode = [ `Ffi | `Standalone ]
+(** How a codec projects to 3D. [`Standalone] (the default) emits a clean [.3d]
+    that EverParse compiles to a standalone verified C parser, which also reads
+    as a protocol specification. [`Ffi] emits the [WireCtx] extern and per-field
+    setter callbacks ([WireSet*]), so the C validator is callable from OCaml and
+    extracts every field through the plug (used by benchmarks and differential
+    testing). *)
 
-val schema_of_struct : struct_ -> t
-(** [schema_of_struct s] builds a one-struct schema from a raw struct
-    description.
-
-    This uses the same EverParse output-types pattern as {!schema}: named fields
-    get [WireSet*] extraction callbacks, while anonymous fields remain
-    validation-only. *)
-
-val schema : 'r Codec.t -> t
-(** [schema codec] builds a one-struct schema from a codec. The resulting module
-    contains a single entrypoint typedef with the EverParse output-types
-    pattern: extern callbacks ([WireSet*]) that extract all field values during
-    validation. *)
+val project : ?mode:mode -> 'r Codec.t -> t
+(** [project ?mode codec] projects [codec] to a 3D schema; [mode] defaults to
+    [`Standalone]. The struct-level and raw entry points live in {!Raw}. *)
 
 val entrypoint_struct : t -> struct_ option
 (** [entrypoint_struct s] returns the entrypoint typedef struct in the schema's
@@ -140,22 +135,13 @@ val field_action_forms :
     carry {!constructor-On_act}, scalars {!constructor-On_success}, anonymous
     fields {!constructor-No_action}. *)
 
-val write_3d : outdir:string -> t list -> unit
-(** [write_3d ~outdir ts] writes one [.3d] file per schema in [outdir]. *)
-
-val doc : 'r Codec.t -> t
-(** [doc codec] projects [codec] to a clean schema for documentation and pure-C
-    parser generation. It carries the same structural 3D as {!schema} (struct,
-    bitfields, [where] clause, enums, casetypes, refined-byte typedefs) but
-    drops the FFI scaffolding: no [WireCtx] extern, no [WireSet*] extraction
-    callbacks. The result reads as a protocol specification, and 3d.exe compiles
-    it to a validator-only C parser with no FFI. *)
-
-val write_doc : outdir:string -> name:string -> t list -> unit
-(** [write_doc ~outdir ~name ts] merges the (doc) schemas [ts] into a single
-    module -- a type shared across several codecs is emitted once -- and writes
-    one [<Name>.3d] in [outdir], so a whole protocol family reads as one
-    document. Build each element with {!doc}. *)
+val write : ?mode:mode -> outdir:string -> ?name:string -> t list -> unit
+(** [write ?mode ~outdir ?name ts] writes the projected schemas to [outdir].
+    With [`Ffi], one [.3d] per schema (its file name taken from the schema) and
+    [~name] is ignored. With [`Standalone] (the default), the schemas are merged
+    into a single [<name>.3d] -- a type shared across several codecs is emitted
+    once -- so a whole protocol family reads as one spec, and [~name] is
+    required. *)
 
 module Raw : sig
   type nonrec struct_ = struct_
@@ -207,6 +193,13 @@ module Raw : sig
 
   val to_3d_file : ?enum_as_type:bool -> string -> module_ -> unit
   (** Write a rendered 3D module to a file. See {!to_3d} for [enum_as_type]. *)
+
+  val struct_of_codec : 'r Codec.t -> struct_
+  (** Lower a codec to its 3D struct, the intermediate the stubs and benchmark
+      codegen operate on. *)
+
+  val project_struct : ?mode:mode -> struct_ -> t
+  (** [project_struct ?mode s] is {!project} on an already-lowered struct. *)
 
   val field :
     string ->

--- a/lib/stubs/wire_stubs.ml
+++ b/lib/stubs/wire_stubs.ml
@@ -272,7 +272,9 @@ let write_file path content =
 type packed_codec = C : _ Wire.Codec.t -> packed_codec
 
 let of_structs ~schema_dir ~outdir structs =
-  let schemas = List.map Wire.Everparse.schema_of_struct structs in
+  let schemas =
+    List.map (Wire.Everparse.Raw.project_struct ~mode:`Ffi) structs
+  in
   Wire_3d.write_external_typedefs ~outdir:schema_dir schemas;
   Wire_3d.write_fields ~outdir:schema_dir schemas;
   write_file (Filename.concat outdir "wire_ffi.c") (to_c_stubs structs);
@@ -280,6 +282,6 @@ let of_structs ~schema_dir ~outdir structs =
 
 let generate ~schema_dir ~outdir codecs =
   let structs =
-    List.map (fun (C c) -> Wire.Everparse.struct_of_codec c) codecs
+    List.map (fun (C c) -> Wire.Everparse.Raw.struct_of_codec c) codecs
   in
   of_structs ~schema_dir ~outdir structs

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -336,7 +336,7 @@ end
     Define each field once with {!Field.v}, then reuse it everywhere: bind it
     into a {!Codec} for zero-copy access and full-record round-trips, reference
     it from dependent expressions with {!Field.ref}, or project it to EverParse
-    3D via {!Everparse.schema}.
+    3D via {!Everparse.project}.
 
     {[
     open Wire
@@ -859,7 +859,7 @@ val to_string : 'a typ -> 'a -> string
       then {!Codec.extract} retrieves each sub-field with pure shift+mask.
 
     All three modes derive from the same definition, so the layout is always
-    consistent. {!Everparse.schema} projects the same codec to a verified C
+    consistent. {!Everparse.project} projects the same codec to a verified C
     parser -- no separate description to maintain. *)
 
 module Codec : sig
@@ -880,7 +880,8 @@ module Codec : sig
     string -> ?where:bool expr -> ?doc:string -> 'f -> ('f, 'r) fields -> 'r t
   (** [v name constructor fields] seals a codec. [?doc] attaches a free-text
       note (e.g. an RFC citation) that the documentation projection renders as a
-      [/*++ ... --*/] comment on the codec's 3D typedef; see {!doc}.
+      [/*++ ... --*/] comment on the codec's 3D typedef; see
+      {!Everparse.project}.
 
       {[
       let codec =
@@ -1074,8 +1075,8 @@ val codec : 'r Codec.t -> 'r typ
     {!Everparse} is the pure export layer. The normal workflow is:
 
     - build a record-shaped description with {!Field} and {!Codec};
-    - project it with {!Everparse.schema};
-    - emit one [.3d] file per schema with {!Everparse.write_3d};
+    - project it with {!Everparse.project};
+    - emit one [.3d] file per schema with {!Everparse.write};
     - run EverParse/C tooling with [Wire_3d];
     - optionally generate OCaml FFI stubs with [Wire_stubs].
 
@@ -1100,24 +1101,23 @@ module Everparse : sig
     module_ : module_;
     wire_size : int option;
     source : struct_ option;
-        (** Pre-[with_output] source struct, [Some] for codec-derived schemas
-            and [None] for raw-module schemas. *)
+        (** Pre-[ffi_decls] source struct, [Some] for codec-derived schemas and
+            [None] for raw-module schemas. *)
   }
   (** A named 3D schema with its module and wire size ([None] for variable-size
       schemas). *)
 
-  val struct_of_codec : 'r Codec.t -> struct_
-  (** Projects a record codec to a 3D struct. *)
+  type mode = [ `Ffi | `Standalone ]
+  (** How a codec projects to 3D. [`Standalone] (the default) emits a clean
+      [.3d] that EverParse compiles to a standalone verified C parser, which
+      also reads as a protocol specification. [`Ffi] emits the [WireCtx] extern
+      and per-field setter callbacks ([<Name>Set*]), so the C validator is
+      callable from OCaml and extracts every field through the plug (used by
+      benchmarks and differential testing). *)
 
-  val schema_of_struct : struct_ -> t
-  (** [schema_of_struct s] builds a schema from a raw 3D struct while using the
-      same EverParse output-types pattern as {!schema}. Named fields extract via
-      [WireSet*] callbacks; anonymous fields remain validation-only. *)
-
-  val schema : 'r Codec.t -> t
-  (** [schema codec] builds a schema from a codec. The resulting module uses the
-      EverParse output-types pattern: the generated C validates AND extracts all
-      field values via schema-prefixed extern callbacks ([<Name>Set*]). *)
+  val project : ?mode:mode -> 'r Codec.t -> t
+  (** [project ?mode codec] projects [codec] to a 3D schema; [mode] defaults to
+      [`Standalone]. The struct-level and raw entry points live in {!Raw}. *)
 
   val filename : t -> string
   (** [filename s] is the [.3d] output filename for schema [s]. *)
@@ -1126,7 +1126,7 @@ module Everparse : sig
   (** [uses_wire_ctx s] is [true] when the schema declares the [WireCtx] extern
       typedef. The generated C header then [#include]s
       [<Name>_ExternalTypedefs.h], so that file must be present at compile time.
-      Schemas built via {!schema} always satisfy this. *)
+      Schemas built via {!project} always satisfy this. *)
 
   type plug_field = {
     name : string;
@@ -1161,29 +1161,20 @@ module Everparse : sig
       {!constructor:On_act}, scalars {!constructor:On_success}, anonymous fields
       {!constructor:No_action}. *)
 
-  val write_3d : outdir:string -> t list -> unit
-  (** Writes one [.3d] file per schema into [outdir]. *)
-
-  val doc : 'r Codec.t -> t
-  (** [doc codec] projects [codec] to a clean schema for documentation and
-      pure-C parser generation: the same structural 3D as {!schema} (struct,
-      bitfields, {!val-where} clause, enums, casetypes, refined-byte typedefs)
-      but without the FFI scaffolding (no [WireCtx] extern, no [WireSet*]
-      callbacks). It reads as a protocol specification, and 3d.exe compiles it
-      to a validator-only C parser with no FFI. *)
-
-  val write_doc : outdir:string -> name:string -> t list -> unit
-  (** [write_doc ~outdir ~name ts] merges the (doc) schemas [ts] into one module
-      -- a type shared across codecs is emitted once -- and writes a single
-      [<Name>.3d] into [outdir], so a whole protocol family reads as one
-      document. *)
+  val write : ?mode:mode -> outdir:string -> ?name:string -> t list -> unit
+  (** [write ?mode ~outdir ?name ts] writes the projected schemas to [outdir].
+      With [`Ffi], one [.3d] per schema (its file name taken from the schema)
+      and [~name] is ignored. With [`Standalone] (the default), the schemas are
+      merged into a single [<name>.3d] -- a type shared across several codecs is
+      emitted once -- so a whole protocol family reads as one spec, and [~name]
+      is required. *)
 
   module Raw : sig
     (** Escape hatch for manual 3D authoring.
 
         These constructors exist for EverParse features that currently have no
-        codec-level equivalent. Most users should stay on the {!Field}/{!Codec}
-        path and use {!struct_of_codec} or {!schema}. *)
+        codec-level equivalent, plus the struct-level projection knobs. Most
+        users should stay on the {!Field}/{!Codec} path and use {!project}. *)
 
     type nonrec struct_ = struct_
     type field = Field.packed
@@ -1234,6 +1225,13 @@ module Everparse : sig
     val to_3d_file : ?enum_as_type:bool -> string -> module_ -> unit
     (** Writes a rendered 3D module to a file. See {!to_3d} for [enum_as_type].
     *)
+
+    val struct_of_codec : 'r Codec.t -> struct_
+    (** Lower a codec to its 3D struct, the intermediate the stubs and benchmark
+        codegen operate on. *)
+
+    val project_struct : ?mode:mode -> struct_ -> t
+    (** [project_struct ?mode s] is {!project} on an already-lowered struct. *)
 
     val field :
       string -> ?constraint_:bool expr -> ?action:Action.t -> 'a typ -> field

--- a/test/3d/gen_3d.ml
+++ b/test/3d/gen_3d.ml
@@ -131,19 +131,28 @@ let () =
   assert (List.length Net.all_schemas = List.length Net.all_structs);
 
   (* Documentation specs: a protocol family in one FFI-free [.3d] (see
-     [Wire.Everparse.doc]). The [3d] alias batch-compiles these to pure C, so
+     [Wire.Everparse.project]). The [3d] alias batch-compiles these to pure C, so
      the validator-only projection is verified end to end. *)
   List.iter
-    (fun (name, ts) -> Wire.Everparse.write_doc ~outdir:"." ~name ts)
+    (fun (name, ts) ->
+      Wire.Everparse.write ~mode:`Standalone ~outdir:"." ~name ts)
     Wire.Everparse.
       [
         ( "net",
           [
-            doc Net.ethernet_codec;
-            doc Net.ipv4_codec;
-            doc Net.tcp_codec;
-            doc Net.udp_codec;
+            project ~mode:`Standalone Net.ethernet_codec;
+            project ~mode:`Standalone Net.ipv4_codec;
+            project ~mode:`Standalone Net.tcp_codec;
+            project ~mode:`Standalone Net.udp_codec;
           ] );
-        ("space", [ doc Space.clcw_codec; doc Space.packet_codec ]);
-        ("demo", [ doc Demo.enum_demo_codec; doc Demo.cases_demo_codec ]);
+        ( "space",
+          [
+            project ~mode:`Standalone Space.clcw_codec;
+            project ~mode:`Standalone Space.packet_codec;
+          ] );
+        ( "demo",
+          [
+            project ~mode:`Standalone Demo.enum_demo_codec;
+            project ~mode:`Standalone Demo.cases_demo_codec;
+          ] );
       ]

--- a/test/3d/test_wire_3d.ml
+++ b/test/3d/test_wire_3d.ml
@@ -83,7 +83,7 @@ let test_generate_3d_files () =
   Unix.rmdir tmpdir
 
 let test_schema_of_struct () =
-  let s = Wire.Everparse.schema_of_struct simple_struct in
+  let s = Wire.Everparse.Raw.project_struct ~mode:`Ffi simple_struct in
   (* generate_3d uses the schema -- check we can produce a .3d file *)
   let tmpdir = Filename.temp_dir "wire_3d_test2" "" in
   Wire_3d.generate_3d ~outdir:tmpdir [ s ];
@@ -104,7 +104,7 @@ let test_generate_c () =
   (* generate_c requires 3d.exe; skip when not available *)
   if Wire_3d.has_3d_exe () then begin
     let tmpdir = Filename.temp_dir "wire_3d_gen_c" "" in
-    let s = Wire.Everparse.schema_of_struct simple_struct in
+    let s = Wire.Everparse.Raw.project_struct ~mode:`Ffi simple_struct in
     Wire_3d.generate_3d ~outdir:tmpdir [ s ];
     Wire_3d.generate_c ~outdir:tmpdir [ s ];
     let c_path = Filename.concat tmpdir "TestSimple.c" in
@@ -125,11 +125,11 @@ let read_file path =
 let doc_codec name =
   Codec.v name (fun v -> v) Codec.[ (Field.v "v" uint8 $ fun v -> v) ]
 
-let test_generate_dune_doc () =
+let test_generate_dune_standalone () =
   (* The doc pipeline emits a single-file [dune.inc]: the package name becomes a
      CamelCase module name and there is no FFI plug or test harness. *)
   let tmpdir = Filename.temp_dir "wire_3d_dune_doc" "" in
-  Wire_3d.generate_dune_doc ~outdir:tmpdir ~package:"my-pkg"
+  Wire_3d.generate_dune_standalone ~outdir:tmpdir ~package:"my-pkg"
     [ Wire_3d.pack (doc_codec "Pkt") ];
   let dune_inc = read_file (Filename.concat tmpdir "dune.inc") in
   ignore (Fmt.kstr Sys.command "rm -rf %s" tmpdir);
@@ -155,10 +155,11 @@ let test_generate_dune_doc () =
   Alcotest.(check bool) "no FFI plug" false (has "_Fields");
   Alcotest.(check bool) "no FFI test harness" false (has "test.c")
 
-let test_generate_dune_doc_name_override () =
+let test_generate_dune_standalone_name_override () =
   (* [~name] sets the file base independently of the opam [~package]. *)
   let tmpdir = Filename.temp_dir "wire_3d_dune_name" "" in
-  Wire_3d.generate_dune_doc ~name:"proto-spec" ~outdir:tmpdir ~package:"my-pkg"
+  Wire_3d.generate_dune_standalone ~name:"proto-spec" ~outdir:tmpdir
+    ~package:"my-pkg"
     [ Wire_3d.pack (doc_codec "Pkt") ];
   let dune_inc = read_file (Filename.concat tmpdir "dune.inc") in
   ignore (Fmt.kstr Sys.command "rm -rf %s" tmpdir);
@@ -169,11 +170,11 @@ let test_generate_dune_doc_name_override () =
   Alcotest.(check bool)
     "install still uses the opam package" true (has "(package my-pkg)")
 
-let test_generate_doc () =
-  (* generate_doc needs 3d.exe; skip when not available. *)
+let test_generate_standalone () =
+  (* generate_standalone needs 3d.exe; skip when not available. *)
   if Wire_3d.has_3d_exe () then begin
     let tmpdir = Filename.temp_dir "wire_3d_gen_doc" "" in
-    Wire_3d.generate_doc ~outdir:tmpdir ~package:"my-pkg"
+    Wire_3d.generate_standalone ~outdir:tmpdir ~package:"my-pkg"
       [ Wire_3d.pack (doc_codec "Pkt"); Wire_3d.pack (doc_codec "Pkt2") ];
     let exists f = Sys.file_exists (Filename.concat tmpdir f) in
     Alcotest.(check bool) "single merged .3d" true (exists "MyPkg.3d");
@@ -233,7 +234,7 @@ let diff_param_codec =
 
 let differential_ok ~name ~package ~count codecs =
   let tmpdir = Filename.temp_dir ("wire_3d_diff_" ^ package) "" in
-  Wire_3d.generate_doc ~outdir:tmpdir ~name ~package codecs;
+  Wire_3d.generate_standalone ~outdir:tmpdir ~name ~package codecs;
   let oc = open_out (Filename.concat tmpdir "corpus") in
   let ppf = Format.formatter_of_out_channel oc in
   Wire_3d.generate_corpus ~count ppf codecs;
@@ -336,7 +337,7 @@ let compile_and_run ~name codec =
   if not (Wire_3d.has_3d_exe ()) then ()
   else begin
     let tmpdir = Filename.temp_dir ("wire_3d_e2e_" ^ name) "" in
-    let schema = Everparse.schema codec in
+    let schema = Everparse.project ~mode:`Ffi codec in
     Wire_3d.generate_3d ~outdir:tmpdir [ schema ];
     Wire_3d.generate_c ~outdir:tmpdir [ schema ];
     let base = String.capitalize_ascii schema.Everparse.name in
@@ -707,7 +708,7 @@ let test_e2e_compile_run () =
   compile_and_run ~name:"UnderflowCheck" e2e_underflow_codec
 
 let test_uses_wire_ctx () =
-  let s = Wire.Everparse.schema_of_struct simple_struct in
+  let s = Wire.Everparse.Raw.project_struct ~mode:`Ffi simple_struct in
   Alcotest.(check bool)
     "schema_of_struct uses WireCtx" true
     (Wire.Everparse.uses_wire_ctx s);
@@ -730,7 +731,7 @@ let test_main_exists () =
   let _ =
     (Wire_3d.main
       : ?name:string ->
-        mode:[ `Ffi | `Doc ] ->
+        mode:[ `Ffi | `Standalone ] ->
         package:string ->
         Wire_3d.packed list ->
         unit)
@@ -743,7 +744,7 @@ let test_main_exists () =
    wrong amount of data; if the expected value is itself wrong, hand-computed
    constants catch that too. *)
 let check_size ~name ~expected codec =
-  let schema = Everparse.schema codec in
+  let schema = Everparse.project ~mode:`Ffi codec in
   let codec_size = Codec.wire_size codec in
   Alcotest.(check int)
     (Fmt.str "%s: Codec.wire_size = %d" name expected)
@@ -855,7 +856,7 @@ let test_projection_filenames () =
     Everparse.Raw.struct_ "rpmsg_endpoint_info"
       [ Everparse.Raw.field "v" uint8; Everparse.Raw.field "id" uint16be ]
   in
-  let schema = Everparse.schema_of_struct s in
+  let schema = Everparse.Raw.project_struct ~mode:`Ffi s in
   let tmpdir = Filename.temp_dir "wire_3d_filenames" "" in
   Wire_3d.generate_dune ~outdir:tmpdir ~package:"pkg" [ schema ];
   let dune_inc =
@@ -1075,7 +1076,7 @@ let test_field_optional_byte_array () =
           Field.optional "Body" ~present:cond (byte_array ~size:(int 8)) $ snd;
         ]
   in
-  let s = Everparse.struct_of_codec codec in
+  let s = Everparse.Raw.struct_of_codec codec in
   let out = to_3d_string s in
   Alcotest.(check bool)
     "byte-size suffix uses inner size" true (contains out "8")
@@ -1107,7 +1108,7 @@ let test_nested_field_projects () =
           ]
     in
     let dir = Filename.temp_dir "wire_3d_nested" "" in
-    let s = Everparse.schema codec in
+    let s = Everparse.project ~mode:`Ffi codec in
     Wire_3d.generate_3d ~outdir:dir [ s ];
     (* Runs 3d.exe; raises if EverParse rejects the generated .3d. *)
     Wire_3d.generate_c ~outdir:dir [ s ];
@@ -1135,10 +1136,12 @@ let suite =
       Alcotest.test_case "schema_of_struct" `Quick test_schema_of_struct;
       Alcotest.test_case "ensure_dir" `Quick test_ensure_dir;
       Alcotest.test_case "generate_c (needs 3d.exe)" `Quick test_generate_c;
-      Alcotest.test_case "generate_dune_doc" `Quick test_generate_dune_doc;
-      Alcotest.test_case "generate_dune_doc name override" `Quick
-        test_generate_dune_doc_name_override;
-      Alcotest.test_case "generate_doc (needs 3d.exe)" `Quick test_generate_doc;
+      Alcotest.test_case "generate_dune_standalone" `Quick
+        test_generate_dune_standalone;
+      Alcotest.test_case "generate_dune_standalone name override" `Quick
+        test_generate_dune_standalone_name_override;
+      Alcotest.test_case "generate_standalone (needs 3d.exe)" `Quick
+        test_generate_standalone;
       Alcotest.test_case "doc differential (needs 3d.exe)" `Quick
         test_doc_differential;
       Alcotest.test_case "doc differential no params (needs 3d.exe)" `Quick

--- a/test/diff/schema.ml
+++ b/test/diff/schema.ml
@@ -20,7 +20,7 @@ let simple_header_codec =
       ]
 
 (* Generate 3D schema *)
-let simple_header_struct = Everparse.struct_of_codec simple_header_codec
+let simple_header_struct = Everparse.Raw.struct_of_codec simple_header_codec
 
 let simple_header_module =
   module_ ~doc:"Simple header for differential testing"
@@ -44,5 +44,5 @@ let constrained_packet_module =
   module_ ~doc:"Constrained packet for differential testing"
     [
       typedef ~entrypoint:true
-        (Everparse.struct_of_codec constrained_packet_codec);
+        (Everparse.Raw.struct_of_codec constrained_packet_codec);
     ]

--- a/test/stubs/test_wire_stubs.ml
+++ b/test/stubs/test_wire_stubs.ml
@@ -314,8 +314,8 @@ let test_e2e_no_params () =
       (fun version length -> (version, length))
       [ (f_version $ fun (v, _) -> v); (f_length $ fun (_, l) -> l) ]
   in
-  let schema = Wire.Everparse.schema codec in
-  let s = Wire.Everparse.struct_of_codec codec in
+  let schema = Wire.Everparse.project ~mode:`Ffi codec in
+  let s = Wire.Everparse.Raw.struct_of_codec codec in
   e2e ~name:"TestHeader" ~structs:[ s ] ~module_:schema.module_
     ~test_ml:
       {|let () =
@@ -336,8 +336,8 @@ let test_e2e_with_constraint () =
     let open Wire.Codec in
     v "Constrained" (fun x -> x) [ (f_x $ fun x -> x) ]
   in
-  let schema = Wire.Everparse.schema codec in
-  let s = Wire.Everparse.struct_of_codec codec in
+  let schema = Wire.Everparse.project ~mode:`Ffi codec in
+  let s = Wire.Everparse.Raw.struct_of_codec codec in
   e2e ~name:"Constrained" ~structs:[ s ] ~module_:schema.module_
     ~test_ml:
       {|let () =
@@ -371,8 +371,8 @@ let test_e2e_bitfields () =
         (f_length $ fun (_, _, l) -> l);
       ]
   in
-  let schema = Wire.Everparse.schema codec in
-  let s = Wire.Everparse.struct_of_codec codec in
+  let schema = Wire.Everparse.project ~mode:`Ffi codec in
+  let s = Wire.Everparse.Raw.struct_of_codec codec in
   e2e ~name:"BfHeader" ~structs:[ s ] ~module_:schema.module_
     ~test_ml:
       {|let () =
@@ -388,7 +388,7 @@ let test_e2e_bitfields () =
 
 (* -- Output pattern invariants --
 
-   Structural tests over the post-[with_output] module. Every assertion
+   Structural tests over the post-[ffi_decls] module. Every assertion
    inspects typed AST data returned by the public [Wire.Everparse] API so
    cosmetic output format changes don't break the tests and real regressions
    are caught precisely. *)
@@ -407,7 +407,7 @@ let expected_action_form ~named ~is_bitfield =
    whose form matches the field's kind (bitfield -> :act, otherwise
    :on-success). Anonymous fields carry no action. *)
 let check_action_forms codec =
-  let schema = Wire.Everparse.schema codec in
+  let schema = Wire.Everparse.project ~mode:`Ffi codec in
   let ep =
     match Wire.Everparse.entrypoint_struct schema with
     | Some st -> st
@@ -432,7 +432,7 @@ let plug_field_names s =
    0. Catches indexing drift between the schema pipeline and the plug
    generator. *)
 let check_plug_completeness codec =
-  let schema = Wire.Everparse.schema codec in
+  let schema = Wire.Everparse.project ~mode:`Ffi codec in
   let source = Option.get schema.source in
   let expected = Wire.Everparse.Raw.field_names source in
   let got = plug_field_names schema in
@@ -447,8 +447,8 @@ let check_plug_completeness codec =
 (* Invariant 3: setter names are namespaced per schema; two schemas' setter
    sets never collide. *)
 let check_setter_scoping codec_a codec_b =
-  let sa = Wire.Everparse.schema codec_a in
-  let sb = Wire.Everparse.schema codec_b in
+  let sa = Wire.Everparse.project ~mode:`Ffi codec_a in
+  let sb = Wire.Everparse.project ~mode:`Ffi codec_b in
   let names s = List.map fst (Wire.Everparse.plug_setters s) in
   let na = names sa in
   let nb = names sb in
@@ -467,7 +467,7 @@ let check_setter_scoping codec_a codec_b =
    plug_setters is actually declared in the module as an extern_fn. Catches
    drift between what plug_fields claims and what the 3D module declares. *)
 let check_setter_declarations codec =
-  let schema = Wire.Everparse.schema codec in
+  let schema = Wire.Everparse.project ~mode:`Ffi codec in
   let declared_externs = Wire.Everparse.extern_fn_names schema in
   List.iter
     (fun (setter, _) ->
@@ -593,11 +593,11 @@ let test_e2e_output_parse () =
           (f_tag $ fun (_, _, t) -> t);
         ]
     in
-    let s = Wire.Everparse.struct_of_codec codec in
+    let s = Wire.Everparse.Raw.struct_of_codec codec in
     let name = Wire.Everparse.Raw.struct_name s in
     (* 2. Generate 3D with output pattern and run EverParse *)
-    let schema = Wire.Everparse.schema codec in
-    Wire.Everparse.write_3d ~outdir:dir [ schema ];
+    let schema = Wire.Everparse.project ~mode:`Ffi codec in
+    Wire.Everparse.write ~mode:`Ffi ~outdir:dir [ schema ];
     Wire_3d.run_everparse ~outdir:dir [ schema ];
     (* 3. Emit default ExternalTypedefs + _Fields plug (Fields plug is what
        wire.stubs now stack-allocates against in wire_ffi.c). *)
@@ -651,9 +651,9 @@ let test_e2e_full_stack () =
     let dir = Filename.temp_dir "wire_e2e_stack" "" in
     let schemas =
       [
-        Wire.Everparse.schema Net.ethernet_codec;
-        Wire.Everparse.schema Net.ipv4_codec;
-        Wire.Everparse.schema Net.tcp_codec;
+        Wire.Everparse.project ~mode:`Ffi Net.ethernet_codec;
+        Wire.Everparse.project ~mode:`Ffi Net.ipv4_codec;
+        Wire.Everparse.project ~mode:`Ffi Net.tcp_codec;
       ]
     in
     List.iter

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -8,7 +8,7 @@ let contains ~sub s = Re.execp (Re.compile (Re.str sub)) s
 
 (* Project a codec to its 3D rendering for substring assertions. *)
 let render_3d codec =
-  to_3d (module_ [ typedef (Everparse.struct_of_codec codec) ])
+  to_3d (module_ [ typedef (Everparse.Raw.struct_of_codec codec) ])
 
 (* Helper: encode record to string using Codec API *)
 let encode_record codec v =

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -144,7 +144,7 @@ let test_3d_uint63_projects_to_uint64 () =
           (Field.v "b" uint63be $ fun (_, b) -> b);
         ]
   in
-  let output = to_3d (module_ [ typedef (Everparse.struct_of_codec c) ]) in
+  let output = to_3d (module_ [ typedef (Everparse.Raw.struct_of_codec c) ]) in
   Alcotest.(check bool)
     "no invalid UINT63" false
     (contains ~sub:"UINT63" output);
@@ -171,7 +171,7 @@ let test_3d_signed_float_setters () =
           (Field.v "d" int32be $ fun (_, _, _, d) -> d);
         ]
   in
-  let output = to_3d (Everparse.schema c).module_ in
+  let output = to_3d (Everparse.project ~mode:`Ffi c).module_ in
   Alcotest.(check bool)
     "float32be routes to SetU32BE" true
     (contains ~sub:"SetU32BE" output);
@@ -196,7 +196,7 @@ let test_3d_arith_constraint_widens () =
         Expr.(Field.int f_a + b <= int 10))
   in
   let c = Codec.v "Arith" (fun a b -> (a, b)) Codec.[ f_a $ fst; f_b $ snd ] in
-  let output = to_3d (Everparse.schema c).module_ in
+  let output = to_3d (Everparse.project ~mode:`Ffi c).module_ in
   Alcotest.(check bool)
     "both Add operands widened to UINT64" true
     (contains ~sub:"((UINT64) a) + ((UINT64) b)" output);
@@ -215,7 +215,7 @@ let test_3d_array_enum_element_decl () =
       (fun v -> v)
       Codec.[ (Field.v "v" (array ~len:(int 4) e) $ fun v -> v) ]
   in
-  let output = to_3d (Everparse.schema c).module_ in
+  let output = to_3d (Everparse.project ~mode:`Ffi c).module_ in
   Alcotest.(check bool)
     "enum declaration emitted" true
     (contains ~sub:"enum Color" output);
@@ -235,7 +235,7 @@ let test_3d_array_open_enum_element () =
       (fun v -> v)
       Codec.[ (Field.v "v" (array ~len:(int 4) e) $ fun v -> v) ]
   in
-  let output = to_3d (Everparse.schema c).module_ in
+  let output = to_3d (Everparse.project ~mode:`Ffi c).module_ in
   Alcotest.(check bool)
     "open-enum array element renders as its base scalar" true
     (contains ~sub:"UINT8 v[" output);
@@ -254,7 +254,8 @@ let test_3d_enum_membership () =
   in
   Alcotest.(check bool)
     "scalar enum bounds its value" true
-    (contains ~sub:"(v == 1)" (to_3d (Everparse.schema scalar).module_));
+    (contains ~sub:"(v == 1)"
+       (to_3d (Everparse.project ~mode:`Ffi scalar).module_));
   let rec_ =
     Codec.v "Rec"
       (fun a b -> (a, b))
@@ -271,7 +272,8 @@ let test_3d_enum_membership () =
   in
   Alcotest.(check bool)
     "enum nested in a sub-codec bounds its value" true
-    (contains ~sub:"(e == 1)" (to_3d (Everparse.schema arr).module_))
+    (contains ~sub:"(e == 1)"
+       (to_3d (Everparse.project ~mode:`Ffi arr).module_))
 
 (* A closed enum used as a list element or optional inner must enforce membership
    in the verified C too. As a wide / big-endian array element, a repeat element
@@ -286,7 +288,7 @@ let test_3d_enum_membership_list_elements () =
       (fun v -> v)
       Codec.[ (Field.v "v" (array ~len:(int 3) e16) $ fun v -> v) ]
   in
-  let out_arr = to_3d (Everparse.schema arr).module_ in
+  let out_arr = to_3d (Everparse.project ~mode:`Ffi arr).module_ in
   Alcotest.(check bool)
     "wide-enum array element goes through a refined struct" true
     (contains ~sub:"_EnumElt_Wide" out_arr);
@@ -301,7 +303,7 @@ let test_3d_enum_membership_list_elements () =
       (fun v -> v)
       Codec.[ (Field.repeat "v" ~size:(int 3) e8 $ fun v -> v) ]
   in
-  let out_rep = to_3d (Everparse.schema rep).module_ in
+  let out_rep = to_3d (Everparse.project ~mode:`Ffi rep).module_ in
   Alcotest.(check bool)
     "repeat enum element goes through a refined struct" true
     (contains ~sub:"_EnumElt_Small" out_rep);
@@ -320,7 +322,7 @@ let test_3d_enum_membership_list_elements () =
           $ fun (_, b) -> b );
         ]
   in
-  let out_opt = to_3d (Everparse.schema opt).module_ in
+  let out_opt = to_3d (Everparse.project ~mode:`Ffi opt).module_ in
   Alcotest.(check bool)
     "optional enum inner goes through a refined struct" true
     (contains ~sub:"_EnumElt_Wide" out_opt)
@@ -336,7 +338,7 @@ let test_enum_open_accepts_and_no_refinement () =
   (match Codec.decode c buf 0 with
   | Ok v -> Alcotest.(check int) "open accepts unlisted value" 5 v
   | Error _ -> Alcotest.fail "open enum wrongly rejected an unlisted value");
-  let out = to_3d (Everparse.schema c).module_ in
+  let out = to_3d (Everparse.project ~mode:`Ffi c).module_ in
   Alcotest.(check bool)
     "no membership refinement" false (contains ~sub:"== 0" out);
   Alcotest.(check bool)
@@ -352,8 +354,10 @@ let test_doc_drops_ffi_scaffolding () =
   let c =
     Codec.v "Pkt" (fun v -> v) Codec.[ (Field.v "v" uint8 $ fun v -> v) ]
   in
-  let schema = to_3d (Everparse.schema c).module_ in
-  let doc = to_3d ~enum_as_type:true (Everparse.doc c).module_ in
+  let schema = to_3d (Everparse.project ~mode:`Ffi c).module_ in
+  let doc =
+    to_3d ~enum_as_type:true (Everparse.project ~mode:`Standalone c).module_
+  in
   Alcotest.(check bool)
     "schema has WireCtx" true
     (contains ~sub:"WireCtx" schema);
@@ -366,7 +370,9 @@ let test_doc_enum_as_type () =
      membership through the type rather than an explicit refinement. *)
   let e = enum "Color" [ ("Red", 0); ("Green", 1); ("Blue", 2) ] uint8 in
   let c = Codec.v "Pix" (fun v -> v) Codec.[ (Field.v "Hue" e $ fun v -> v) ] in
-  let doc = to_3d ~enum_as_type:true (Everparse.doc c).module_ in
+  let doc =
+    to_3d ~enum_as_type:true (Everparse.project ~mode:`Standalone c).module_
+  in
   Alcotest.(check bool)
     "declares the enum" true
     (contains ~sub:"enum Color" doc);
@@ -377,7 +383,7 @@ let test_doc_enum_as_type () =
     "drops the membership refinement" false (contains ~sub:"== 0" doc);
   Alcotest.(check bool)
     "codegen schema keeps membership" true
-    (contains ~sub:"== 0" (to_3d (Everparse.schema c).module_))
+    (contains ~sub:"== 0" (to_3d (Everparse.project ~mode:`Ffi c).module_))
 
 let test_doc_codec_citation () =
   (* [Codec.v ~doc] renders as a [/*++ ... --*/] comment on the typedef, so a
@@ -389,7 +395,9 @@ let test_doc_codec_citation () =
   in
   Alcotest.(check (option string))
     "codec exposes its doc" (Some "RFC 9999 section 1") (Codec.doc c);
-  let out = to_3d ~enum_as_type:true (Everparse.doc c).module_ in
+  let out =
+    to_3d ~enum_as_type:true (Everparse.project ~mode:`Standalone c).module_
+  in
   Alcotest.(check bool)
     "typedef carries the citation comment" true
     (contains ~sub:"/*++ RFC 9999 section 1 --*/" out)
@@ -408,7 +416,7 @@ let test_doc_comment_wraps_at_80 () =
       (fun v -> v)
       Codec.[ (Field.v "v" uint8 ~doc:long $ fun v -> v) ]
   in
-  let out = to_3d (Everparse.schema c).module_ in
+  let out = to_3d (Everparse.project ~mode:`Ffi c).module_ in
   let longest =
     String.split_on_char '\n' out
     |> List.fold_left (fun m l -> max m (String.length l)) 0
@@ -427,7 +435,11 @@ let test_doc_merge_dedup () =
   let c2 = Codec.v "Two" (fun v -> v) Codec.[ (Field.v "y" e $ fun v -> v) ] in
   let dir = Filename.get_temp_dir_name () in
   let name = "wire_doc_merge_test" in
-  Everparse.write_doc ~outdir:dir ~name [ Everparse.doc c1; Everparse.doc c2 ];
+  Everparse.write ~mode:`Standalone ~outdir:dir ~name
+    [
+      Everparse.project ~mode:`Standalone c1;
+      Everparse.project ~mode:`Standalone c2;
+    ];
   let path = Filename.concat dir (String.capitalize_ascii name ^ ".3d") in
   let content = In_channel.with_open_text path In_channel.input_all in
   Sys.remove path;
@@ -448,7 +460,9 @@ let test_doc_field_citation () =
   Alcotest.(check (option string))
     "field exposes its doc" (Some "RFC 9999 section 4.2") (Field.doc f);
   let c = Codec.v "Pkt" (fun v -> v) Codec.[ (f $ fun v -> v) ] in
-  let out = to_3d ~enum_as_type:true (Everparse.doc c).module_ in
+  let out =
+    to_3d ~enum_as_type:true (Everparse.project ~mode:`Standalone c).module_
+  in
   Alcotest.(check bool)
     "field carries the citation comment" true
     (contains ~sub:"/* RFC 9999 section 4.2 */" out)
@@ -483,8 +497,8 @@ let test_doc_bit_order_matches_schema () =
   in
   Alcotest.(check (list (pair (option string) bool)))
     "doc reorders bitfields exactly as the schema projection does"
-    (bit_order_of (Everparse.schema c))
-    (bit_order_of (Everparse.doc c))
+    (bit_order_of (Everparse.project ~mode:`Ffi c))
+    (bit_order_of (Everparse.project ~mode:`Standalone c))
 
 let test_3d_nested_byte_array_where () =
   (* A byte_array_where inside a nested region needs its synthesised refined-byte
@@ -498,7 +512,7 @@ let test_3d_nested_byte_array_where () =
       (fun v -> v)
       Codec.[ (Field.v "n" (nested ~size:(int 4) inner) $ fun v -> v) ]
   in
-  let output = to_3d (Everparse.schema c).module_ in
+  let output = to_3d (Everparse.project ~mode:`Ffi c).module_ in
   Alcotest.(check bool)
     "refined-byte typedef is defined, not just referenced" true
     (contains ~sub:"} _RefByte_" output)
@@ -514,7 +528,8 @@ let test_3d_static_optional_transparent () =
       Codec.[ (Field.optional "o" ~present:Expr.true_ inner $ fun v -> v) ]
   in
   let out_ba =
-    to_3d (Everparse.schema (opt (byte_array ~size:(int 4)))).module_
+    to_3d
+      (Everparse.project ~mode:`Ffi (opt (byte_array ~size:(int 4)))).module_
   in
   Alcotest.(check bool)
     "byte-span optional uses an offset setter" true
@@ -522,7 +537,7 @@ let test_3d_static_optional_transparent () =
   let baw =
     byte_array_where ~size:(int 4) ~per_byte:(fun b -> Expr.(b < int 10))
   in
-  let out_baw = to_3d (Everparse.schema (opt baw)).module_ in
+  let out_baw = to_3d (Everparse.project ~mode:`Ffi (opt baw)).module_ in
   Alcotest.(check bool)
     "byte_array_where optional emits its refined typedef" true
     (contains ~sub:"} _RefByte_" out_baw)
@@ -536,7 +551,7 @@ let test_3d_absent_optional_projects_to_unit () =
       (fun v -> v)
       Codec.[ (Field.optional "o" ~present:Expr.false_ inner $ fun v -> v) ]
   in
-  let out = to_3d (Everparse.schema (c uint8)).module_ in
+  let out = to_3d (Everparse.project ~mode:`Ffi (c uint8)).module_ in
   Alcotest.(check bool)
     "absent optional projects as unit" true
     (contains ~sub:"unit o" out);
@@ -558,7 +573,7 @@ let test_3d_on_act_drops_bool_return () =
            [ Action.assign out (Field.ref f_v); Action.return_bool Expr.true_ ])
   in
   let codec = Codec.v "ActOnAct" (fun v -> v) Codec.[ (f $ fun v -> v) ] in
-  let out3d = to_3d (Everparse.schema codec).module_ in
+  let out3d = to_3d (Everparse.project ~mode:`Ffi codec).module_ in
   Alcotest.(check bool) "emits an :act block" true (contains ~sub:":act" out3d);
   Alcotest.(check bool)
     "the :act block has no bool return" false
@@ -581,7 +596,7 @@ let test_3d_on_success_conditional_return () =
            ])
   in
   let codec = Codec.v "ActIf" (fun v -> v) Codec.[ (f $ fun v -> v) ] in
-  let out3d = to_3d (Everparse.schema codec).module_ in
+  let out3d = to_3d (Everparse.project ~mode:`Ffi codec).module_ in
   Alcotest.(check bool) "if is present" true (contains ~sub:"if (" out3d);
   Alcotest.(check bool)
     "an else branch is synthesised" true
@@ -591,7 +606,7 @@ let test_3d_on_success_conditional_return () =
     (contains ~sub:"ActIfSetU8" out3d)
 
 let projects_or_raises codec =
-  match to_3d (Everparse.schema codec).module_ with
+  match to_3d (Everparse.project ~mode:`Ffi codec).module_ with
   | (_ : string) -> false
   | exception Invalid_argument _ -> true
 
@@ -657,7 +672,7 @@ let test_3d_field_sub_mul_rejected () =
     (projects_or_raises constc)
 
 let test_schema_authoritative () =
-  (* [Everparse.schema] is the projectability gate: a non-projectable constraint
+  (* [Everparse.project] is the projectability gate: a non-projectable constraint
      raises when the codec is projected, not only later when it is rendered, so
      a consumer of [schema] gets an honest answer. *)
   let f = Field.v "a" uint8 in
@@ -675,7 +690,7 @@ let test_schema_authoritative () =
   Alcotest.(check bool)
     "schema rejects a non-projectable codec" true
     (try
-       ignore (Everparse.schema bad : Everparse.t);
+       ignore (Everparse.project ~mode:`Ffi bad : Everparse.t);
        false
      with Invalid_argument _ -> true);
   (* A projectable codec still produces a schema. *)
@@ -683,7 +698,7 @@ let test_schema_authoritative () =
   Alcotest.(check bool)
     "schema accepts a projectable codec" false
     (try
-       ignore (Everparse.schema ok : Everparse.t);
+       ignore (Everparse.project ~mode:`Ffi ok : Everparse.t);
        false
      with Invalid_argument _ -> true)
 
@@ -696,7 +711,7 @@ let test_signed_constraint_twos_complement () =
     Field.v "x" int8 ~self_constraint:(fun self -> Expr.(self < int 100))
   in
   let codec = Codec.v "Signed" (fun v -> v) Codec.[ (f $ fun v -> v) ] in
-  let out = to_3d (Everparse.schema codec).module_ in
+  let out = to_3d (Everparse.project ~mode:`Ffi codec).module_ in
   Alcotest.(check bool)
     "two's-complement refinement emitted" true
     (contains ~sub:"(x ^ 128) < 228" out);
@@ -711,7 +726,7 @@ let test_signed_equality_twos_complement () =
      compares the raw byte and diverges from the OCaml decoder. *)
   let proj name k =
     to_3d
-      (Everparse.schema
+      (Everparse.project ~mode:`Ffi
          (Codec.v name
             (fun v -> v)
             Codec.[ (Field.v "v" int8 ~self_constraint:k $ fun v -> v) ]))
@@ -759,7 +774,7 @@ let test_if_then_else_projects () =
           (Field.v "Data" (byte_array ~size) $ fun (_, d) -> d);
         ]
   in
-  let out = to_3d (Everparse.schema c).module_ in
+  let out = to_3d (Everparse.project ~mode:`Ffi c).module_ in
   Alcotest.(check bool)
     "renders the conditional" true
     (contains ~sub:"? 65536 : N" out)
@@ -770,7 +785,7 @@ let test_3d_int64_literal_uses_unsigned_decimal () =
         Expr.(self > int64 Int64.min_int))
   in
   let codec = Codec.v "I64Lit" Fun.id Codec.[ f $ Fun.id ] in
-  let out3d = to_3d (Everparse.schema codec).module_ in
+  let out3d = to_3d (Everparse.project ~mode:`Ffi codec).module_ in
   Alcotest.(check bool)
     "high-bit int64 literal prints unsigned" true
     (contains ~sub:"9223372036854775808uL" out3d)
@@ -824,8 +839,8 @@ let tm_like_codec ~ocf ~fecf =
 
 let test_3d_codec_embed () =
   (* Codec embed: field type should reference the sub-codec's struct name *)
-  let s_inner = Everparse.struct_of_codec inner_codec in
-  let s_outer = Everparse.struct_of_codec outer_codec in
+  let s_inner = Everparse.Raw.struct_of_codec inner_codec in
+  let s_outer = Everparse.Raw.struct_of_codec outer_codec in
   let m = module_ [ typedef s_inner; typedef s_outer ] in
   let output = to_3d m in
   (* Inner struct must be defined *)
@@ -845,7 +860,7 @@ let test_3d_codec_embed () =
 
 let test_3d_codec_nested () =
   (* Two-level nesting: L0 -> L1 -> L2, each should reference by name *)
-  let s0 = Everparse.struct_of_codec l0_codec in
+  let s0 = Everparse.Raw.struct_of_codec l0_codec in
   let m = module_ [ typedef s0 ] in
   let output = to_3d m in
   (* L0's struct should reference L1 by name *)
@@ -854,7 +869,7 @@ let test_3d_codec_nested () =
 
 let test_3d_optional_present () =
   (* Optional present: field should appear as normal UINT16BE *)
-  let s = Everparse.struct_of_codec opt_codec_present in
+  let s = Everparse.Raw.struct_of_codec opt_codec_present in
   let m = module_ [ typedef s ] in
   let output = to_3d m in
   Alcotest.(check bool) "contains Hdr" true (contains ~sub:"Hdr" output);
@@ -868,7 +883,7 @@ let test_3d_optional_present () =
 
 let test_3d_optional_absent () =
   (* Optional absent: zero-length field *)
-  let s = Everparse.struct_of_codec opt_codec_absent in
+  let s = Everparse.Raw.struct_of_codec opt_codec_absent in
   let m = module_ [ typedef s ] in
   let output = to_3d m in
   Alcotest.(check bool) "contains Hdr" true (contains ~sub:"Hdr" output);
@@ -879,8 +894,8 @@ let test_3d_optional_absent () =
 
 let test_3d_repeat () =
   (* Repeat: should render as variable-length array with :byte-size *)
-  let s_inner = Everparse.struct_of_codec inner_codec in
-  let s = Everparse.struct_of_codec repeat_codec in
+  let s_inner = Everparse.Raw.struct_of_codec inner_codec in
+  let s = Everparse.Raw.struct_of_codec repeat_codec in
   let m = module_ [ typedef s_inner; typedef s ] in
   let output = to_3d m in
   Alcotest.(check bool) "contains Length" true (contains ~sub:"Length" output);
@@ -900,8 +915,8 @@ let test_3d_repeat () =
 let test_3d_tm_like () =
   (* Full TM-like composition: all nested types should project to 3D *)
   let c = tm_like_codec ~ocf:true ~fecf:true in
-  let s_pkt = Everparse.struct_of_codec packet_codec in
-  let s = Everparse.struct_of_codec c in
+  let s_pkt = Everparse.Raw.struct_of_codec packet_codec in
+  let s = Everparse.Raw.struct_of_codec c in
   let m = module_ [ typedef s_pkt; typedef s ] in
   let output = to_3d m in
   Alcotest.(check bool) "contains Hdr" true (contains ~sub:"Hdr" output);
@@ -944,7 +959,7 @@ let test_3d_bitorder_u8msb_reorder () =
         Field.v "b" (bits ~width:5 U8) $ snd;
       ]
   in
-  let schema = Everparse.schema codec in
+  let schema = Everparse.project ~mode:`Ffi codec in
   let s = Wire.Everparse.Raw.to_3d schema.module_ in
   let ia = index_of ~sub:"UINT8 a" s in
   let ib = index_of ~sub:"UINT8 b" s in
@@ -966,7 +981,7 @@ let test_3d_bitorder_u8msb_padding () =
         Field.v "b" (bits ~width:3 U8) $ snd;
       ]
   in
-  let schema = Everparse.schema codec in
+  let schema = Everparse.project ~mode:`Ffi codec in
   let s = Wire.Everparse.Raw.to_3d schema.module_ in
   Alcotest.(check bool)
     "has anonymous padding field" true
@@ -997,7 +1012,7 @@ let test_3d_bitorder_constraint_collapse () =
     let open Codec in
     v "Ranged" (fun a b -> (a, b)) [ f_a $ fst; f_b $ snd ]
   in
-  let schema = Wire.Everparse.schema codec in
+  let schema = Wire.Everparse.project ~mode:`Ffi codec in
   let s = Wire.Everparse.Raw.to_3d schema.module_ in
   (* b appears first in 3D (reversed), without a constraint block. *)
   let ia = index_of ~sub:"UINT8 a : 4" s in
@@ -1022,7 +1037,7 @@ let test_3d_bitorder_native_noreorder () =
         Field.v "y" (bits ~width:28 U32be) $ snd;
       ]
   in
-  let schema = Everparse.schema codec in
+  let schema = Everparse.project ~mode:`Ffi codec in
   let s = Wire.Everparse.Raw.to_3d schema.module_ in
   let ix = index_of ~sub:"UINT32BE x" s in
   let iy = index_of ~sub:"UINT32BE y" s in
@@ -1050,7 +1065,7 @@ let dep_frame_codec =
       ]
 
 let test_3d_dep_size_schema () =
-  let schema = Everparse.schema dep_frame_codec in
+  let schema = Everparse.project ~mode:`Ffi dep_frame_codec in
   Alcotest.(check bool) "variable wire_size" true (schema.wire_size = None);
   let s = Wire.Everparse.Raw.to_3d schema.module_ in
   Alcotest.(check bool)
@@ -1088,7 +1103,7 @@ let param_frame_codec =
 let test_3d_param_in_size () =
   (* A byte_array whose size is driven by a formal parameter must thread
      the parameter into the 3D typedef signature. *)
-  let schema = Everparse.schema param_frame_codec in
+  let schema = Everparse.project ~mode:`Ffi param_frame_codec in
   let s = Wire.Everparse.Raw.to_3d schema.module_ in
   Alcotest.(check bool)
     "typedef carries len param" true
@@ -1110,7 +1125,9 @@ let test_3d_param_embed () =
       (fun s -> s)
       Codec.[ Field.v "s" (Wire.codec sub) $ Fun.id ]
   in
-  let s = Wire.Everparse.Raw.to_3d (Everparse.schema outer).module_ in
+  let s =
+    Wire.Everparse.Raw.to_3d (Everparse.project ~mode:`Ffi outer).module_
+  in
   Alcotest.(check bool)
     "sub typedef carries the formal" true
     (contains ~sub:"_PSub(UINT8 lim)" s);
@@ -1131,7 +1148,9 @@ let test_3d_nested_over_array () =
           $ Fun.id;
         ]
   in
-  let s = Wire.Everparse.Raw.to_3d (Everparse.schema codec).module_ in
+  let s =
+    Wire.Everparse.Raw.to_3d (Everparse.project ~mode:`Ffi codec).module_
+  in
   Alcotest.(check bool)
     "wrapper struct holds the array" true
     (contains ~sub:"UINT64BE v[:byte-size" s);
@@ -1193,7 +1212,7 @@ let test_3d_byte_array_where () =
       (fun len data -> (len, data))
       Codec.[ f_len $ fst; f_data $ snd ]
   in
-  let schema = Wire.Everparse.schema codec in
+  let schema = Wire.Everparse.project ~mode:`Ffi codec in
   let s = Wire.Everparse.Raw.to_3d schema.module_ in
   Alcotest.(check bool)
     "synth typedef present" true
@@ -1223,7 +1242,9 @@ let test_lookup_index_bound () =
       (fun v -> v)
       Codec.[ (Field.v "v" (lookup [ 'a'; 'b'; 'c'; 'd' ] uint8) $ fun v -> v) ]
   in
-  let output = to_3d (module_ [ typedef (Everparse.struct_of_codec codec) ]) in
+  let output =
+    to_3d (module_ [ typedef (Everparse.Raw.struct_of_codec codec) ])
+  in
   Alcotest.(check bool)
     "lookup field bounds its index" true
     (contains ~sub:"(v < 4)" output)
@@ -1245,7 +1266,7 @@ let test_array_lookup_element_bound () =
   in
   (* The synthesised element struct is emitted by the full schema projection,
      not [struct_of_codec] alone, so render the whole module. *)
-  let output = to_3d (Everparse.schema codec).module_ in
+  let output = to_3d (Everparse.project ~mode:`Ffi codec).module_ in
   Alcotest.(check bool)
     "array element bounds its index" true
     (contains ~sub:"(__elt_lk4 < 4)" output);


### PR DESCRIPTION
The EverParse projection surface had grown confusing: `schema` vs `doc` (where the "doc" projection is actually the standalone production C parser, not just documentation), `write_3d` vs `write_doc`, plus `struct_of_codec` and `schema_of_struct` at the top level. This collapses it to two entry points with an explicit mode:

```
project ?mode:[`Ffi | `Standalone]   (* was schema / doc *)
write   ?mode ~outdir ?name          (* was write_3d / write_doc *)
```

`` `Standalone `` (the default) is the clean standalone verified C parser; `` `Ffi `` is the OCaml-callable bridge with `WireCtx` callbacks. The struct-level knobs move under `Everparse.Raw` (`struct_of_codec`, `project_struct`), and the internal projection helpers are renamed off "doc" onto the Ffi/Standalone axis. `Wire_3d.main`'s mode is now `` `Standalone `` instead of the misleading `` `Doc ``, and its standalone pipeline functions (`generate_doc` -> `generate_standalone`, `generate_dune_doc` -> `generate_dune_standalone`, etc.) are renamed to match, so no "doc" names remain for what is really the production-parser path.