### PR TITLE
codec: encode var-bytes fields without per-call closures

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -123,6 +123,12 @@
 
 ### Changed
 
+- Encoding a variable-length byte field (`byte_slice`, `byte_array`,
+  `zeroterm`, `all_bytes`, ...) no longer allocates: on a flambda-off switch
+  the writer rebuilt two short-lived closures per field on every encode.
+  Encoding a record made of scalars and var-bytes fields is now
+  allocation-free (#213, @samoht)
+
 - Decoding a record codec with more than 8 fields no longer allocates a
   short-lived closure on each decode: the constructor is now applied in one
   saturated call for codecs of up to 16 fields. On a flambda-off switch this

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -1887,6 +1887,21 @@ let var_bytes_reader : type a.
   | Single_elem { elem; _ } -> read_elem elem buf (base + fo)
   | _ -> assert false
 
+(* Kept at top level: as local closures they would be heap-allocated on
+   every call (two allocations per variable-bytes field on each encode). *)
+let var_bytes_check_len size_fn buf base ~actual =
+  let expected = size_fn buf base in
+  if actual <> expected then
+    Fmt.invalid_arg
+      "Codec.encode: byte field length %d does not match expected %d \
+       (parametric size, bind via ?env)"
+      actual expected
+
+let var_bytes_write_str buf write_off s =
+  let len = String.length s in
+  Bytes.blit_string s 0 buf write_off len;
+  write_off + len
+
 let var_bytes_writer : type a r.
     a typ ->
     (r -> a) ->
@@ -1898,41 +1913,28 @@ let var_bytes_writer : type a r.
     int =
  fun typ get size_fn v buf base write_off ->
   let value = get v in
-  let check_len ~actual =
-    let expected = size_fn buf base in
-    if actual <> expected then
-      Fmt.invalid_arg
-        "Codec.encode: byte field length %d does not match expected %d \
-         (parametric size, bind via ?env)"
-        actual expected
-  in
-  let write_str s =
-    let len = String.length s in
-    Bytes.blit_string s 0 buf write_off len;
-    write_off + len
-  in
   match typ with
   | Byte_slice _ ->
       let src = (value : Slice.t) in
       let len = Slice.length src in
-      check_len ~actual:len;
+      var_bytes_check_len size_fn buf base ~actual:len;
       Bytes.blit (Slice.bytes src) (Slice.first src) buf write_off len;
       write_off + len
   | Byte_array _ ->
       let s = (value : string) in
-      check_len ~actual:(String.length s);
-      write_str s
+      var_bytes_check_len size_fn buf base ~actual:(String.length s);
+      var_bytes_write_str buf write_off s
   | Byte_array_where _ ->
       let s = (value : string) in
-      check_len ~actual:(String.length s);
-      write_str s
-  | All_bytes -> write_str (value : string)
-  | All_zeros -> write_str (value : string)
+      var_bytes_check_len size_fn buf base ~actual:(String.length s);
+      var_bytes_write_str buf write_off s
+  | All_bytes -> var_bytes_write_str buf write_off (value : string)
+  | All_zeros -> var_bytes_write_str buf write_off (value : string)
   | Zeroterm ->
       let s = (value : string) in
       if String.contains s '\000' then
         invalid_arg "Codec.encode: zeroterm string contains a NUL byte";
-      let e = write_str s in
+      let e = var_bytes_write_str buf write_off s in
       Bytes.set_uint8 buf e 0;
       e + 1
   | Zeroterm_at_most _ ->

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -5406,6 +5406,47 @@ let test_decode_high_arity_roundtrip () =
   Codec.encode alloc_codec17 v17 out 0;
   Alcotest.(check bytes) "17-field roundtrip" buf17 out
 
+(* Encoding a var-bytes field must not allocate. [var_bytes_writer]'s length
+   check and string blit are top-level functions; were they local to the
+   writer, each would be a heap-allocated closure per var-bytes field on
+   every encode under flambda-off. *)
+type alloc_vb = { vb_a : string; vb_b : string; vb_z : string }
+
+let alloc_vb_alen = Field.v "ALen" uint16be
+let alloc_vb_blen = Field.v "BLen" uint16be
+
+let alloc_vb_codec =
+  Codec.v "AllocVb"
+    (fun _alen vb_a _blen vb_b vb_z -> { vb_a; vb_b; vb_z })
+    Codec.
+      [
+        (alloc_vb_alen $ fun r -> String.length r.vb_a);
+        ( Field.v "A" (byte_array ~size:(Field.ref alloc_vb_alen)) $ fun r ->
+          r.vb_a );
+        (alloc_vb_blen $ fun r -> String.length r.vb_b);
+        ( Field.v "B" (byte_array ~size:(Field.ref alloc_vb_blen)) $ fun r ->
+          r.vb_b );
+        (Field.v "Z" zeroterm $ fun r -> r.vb_z);
+      ]
+
+let test_encode_var_bytes_no_closure () =
+  let v =
+    { vb_a = String.make 32 'x'; vb_b = String.make 16 'y'; vb_z = "hi" }
+  in
+  let buf = Bytes.create (2 + 32 + 2 + 16 + 2 + 1) in
+  Codec.encode alloc_vb_codec v buf 0;
+  let iters = 200_000 in
+  Gc.full_major ();
+  let before = Gc.minor_words () in
+  for _ = 1 to iters do
+    Codec.encode alloc_vb_codec v buf 0
+  done;
+  let after = Gc.minor_words () in
+  let words =
+    int_of_float (Float.round ((after -. before) /. float_of_int iters))
+  in
+  Alcotest.(check int) "var-bytes encode allocates nothing" 0 words
+
 (* -- Suite -- *)
 
 let suite =
@@ -5897,4 +5938,7 @@ let suite =
         test_decode_no_partial_closure;
       Alcotest.test_case "decode: high-arity roundtrip" `Quick
         test_decode_high_arity_roundtrip;
+      (* encode allocation *)
+      Alcotest.test_case "encode: var-bytes fields allocate nothing" `Quick
+        test_encode_var_bytes_no_closure;
     ] )


### PR DESCRIPTION
Encoding a variable-length byte field (`byte_slice`, `byte_array`, `zeroterm`, `all_bytes`, ...) used to heap-allocate two short-lived closures per field on a flambda-off switch: `var_bytes_writer` rebuilt its length-check and string-blit helpers on every call, and memtrace traces of a grpc encode bench put the pair among the top allocation sites. The helpers are now top-level functions taking the formerly captured values as arguments, so nothing is allocated on the encode path.

Words allocated per encode of a record with two length-prefixed `byte_array` fields and a `zeroterm` (the codec used by the new regression test, which fails on main and passes here):

    before  33.0 words/encode
    after    0.0 words/encode

Follow-up to #212, which removed the matching per-decode closure.
