### PR TITLE
codec: decode records up to 32 fields without a closure

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,15 @@
+## 1.0.1
+
+### Changed
+
+- Decoding a record codec with 17 to 32 fields no longer allocates a
+  short-lived closure on each decode: the closure-free decode ceiling that
+  1.0.0 raised to 16 fields now extends to 32. Real protocol headers cross the
+  old limit routinely, such as an 18-field TCP header with its flag bits broken
+  out, or telemetry and IPv4 headers in the high twenties, which now allocate
+  only the record they return. A codec wider than 32 fields keeps the recursive
+  fallback (#214, @samoht)
+
 ## 1.0.0
 
 ### Added

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -2486,11 +2486,12 @@ let add_field : type a f r. (a -> f, r) record -> (a, r) field -> (f, r) record
 (* Forward reader list: cons-list dual of [readers] snoc-list.
    Built once at seal time by [to_fwd]; applied at decode time by
    [apply_fwd], which saturates the constructor in a single call for up to
-   16 fields and otherwise unrolls 16 per step (1 partial application per
-   extra 16 fields). A saturated call returns the record with no
+   32 fields and otherwise unrolls 32 per step (1 partial application per
+   extra 32 fields). A saturated call returns the record with no
    intermediate closure; a partial application allocates a [caml_curry]
    closure per decode (visible only under flambda-off), so the threshold is
-   set above a typical protocol header (CLCW 13, CFDP 14 fields). *)
+   set above the widest real protocol header (IPv4 and USLP reach ~28
+   fields; a wide TCP header with its 8 flag bits split out is 18). *)
 type (_, _) readers_fwd =
   | FNil : ('r, 'r) readers_fwd
   | FCons :
@@ -2514,14 +2515,15 @@ let to_fwd : type full result.
   go readers FNil
 
 (* Apply a forward reader list to [make], saturating the constructor in a
-   single call for up to 16 fields, so no intermediate closure is allocated
-   per decode. Beyond 16 fields one partial application is made per extra 16
-   (a [caml_curry] chain under flambda-off); the threshold clears a typical
-   protocol header (CLCW 13, CFDP 14 fields) in one saturated call.
+   single call for up to 32 fields, so no intermediate closure is allocated
+   per decode. Beyond 32 fields one partial application is made per extra 32
+   (a [caml_curry] chain under flambda-off); the threshold clears every real
+   protocol header (the widest, IPv4 and USLP, reach ~28 fields) in one
+   saturated call.
 
    The cases are a saturation table, one row per arity. The formatter is
    disabled here because it would otherwise staircase the deep [FCons]
-   patterns across ~240 lines; the flat table is both shorter and easier to
+   patterns across ~500 lines; the flat table is both shorter and easier to
    read. *)
 let rec apply_fwd : type mid result.
     mid -> (mid, result) readers_fwd -> bytes -> int -> result =
@@ -2558,8 +2560,40 @@ let rec apply_fwd : type mid result.
       f (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off) (r5 buf off) (r6 buf off) (r7 buf off) (r8 buf off) (r9 buf off) (r10 buf off) (r11 buf off) (r12 buf off) (r13 buf off) (r14 buf off)
   | FCons (r1, FCons (r2, FCons (r3, FCons (r4, FCons (r5, FCons (r6, FCons (r7, FCons (r8, FCons (r9, FCons (r10, FCons (r11, FCons (r12, FCons (r13, FCons (r14, FCons (r15, FNil))))))))))))))) ->
       f (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off) (r5 buf off) (r6 buf off) (r7 buf off) (r8 buf off) (r9 buf off) (r10 buf off) (r11 buf off) (r12 buf off) (r13 buf off) (r14 buf off) (r15 buf off)
-  | FCons (r1, FCons (r2, FCons (r3, FCons (r4, FCons (r5, FCons (r6, FCons (r7, FCons (r8, FCons (r9, FCons (r10, FCons (r11, FCons (r12, FCons (r13, FCons (r14, FCons (r15, FCons (r16, rest)))))))))))))))) ->
-      apply_fwd (f (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off) (r5 buf off) (r6 buf off) (r7 buf off) (r8 buf off) (r9 buf off) (r10 buf off) (r11 buf off) (r12 buf off) (r13 buf off) (r14 buf off) (r15 buf off) (r16 buf off)) rest buf off
+  | FCons (r1, FCons (r2, FCons (r3, FCons (r4, FCons (r5, FCons (r6, FCons (r7, FCons (r8, FCons (r9, FCons (r10, FCons (r11, FCons (r12, FCons (r13, FCons (r14, FCons (r15, FCons (r16, FNil)))))))))))))))) ->
+      f (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off) (r5 buf off) (r6 buf off) (r7 buf off) (r8 buf off) (r9 buf off) (r10 buf off) (r11 buf off) (r12 buf off) (r13 buf off) (r14 buf off) (r15 buf off) (r16 buf off)
+  | FCons (r1, FCons (r2, FCons (r3, FCons (r4, FCons (r5, FCons (r6, FCons (r7, FCons (r8, FCons (r9, FCons (r10, FCons (r11, FCons (r12, FCons (r13, FCons (r14, FCons (r15, FCons (r16, FCons (r17, FNil))))))))))))))))) ->
+      f (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off) (r5 buf off) (r6 buf off) (r7 buf off) (r8 buf off) (r9 buf off) (r10 buf off) (r11 buf off) (r12 buf off) (r13 buf off) (r14 buf off) (r15 buf off) (r16 buf off) (r17 buf off)
+  | FCons (r1, FCons (r2, FCons (r3, FCons (r4, FCons (r5, FCons (r6, FCons (r7, FCons (r8, FCons (r9, FCons (r10, FCons (r11, FCons (r12, FCons (r13, FCons (r14, FCons (r15, FCons (r16, FCons (r17, FCons (r18, FNil)))))))))))))))))) ->
+      f (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off) (r5 buf off) (r6 buf off) (r7 buf off) (r8 buf off) (r9 buf off) (r10 buf off) (r11 buf off) (r12 buf off) (r13 buf off) (r14 buf off) (r15 buf off) (r16 buf off) (r17 buf off) (r18 buf off)
+  | FCons (r1, FCons (r2, FCons (r3, FCons (r4, FCons (r5, FCons (r6, FCons (r7, FCons (r8, FCons (r9, FCons (r10, FCons (r11, FCons (r12, FCons (r13, FCons (r14, FCons (r15, FCons (r16, FCons (r17, FCons (r18, FCons (r19, FNil))))))))))))))))))) ->
+      f (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off) (r5 buf off) (r6 buf off) (r7 buf off) (r8 buf off) (r9 buf off) (r10 buf off) (r11 buf off) (r12 buf off) (r13 buf off) (r14 buf off) (r15 buf off) (r16 buf off) (r17 buf off) (r18 buf off) (r19 buf off)
+  | FCons (r1, FCons (r2, FCons (r3, FCons (r4, FCons (r5, FCons (r6, FCons (r7, FCons (r8, FCons (r9, FCons (r10, FCons (r11, FCons (r12, FCons (r13, FCons (r14, FCons (r15, FCons (r16, FCons (r17, FCons (r18, FCons (r19, FCons (r20, FNil)))))))))))))))))))) ->
+      f (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off) (r5 buf off) (r6 buf off) (r7 buf off) (r8 buf off) (r9 buf off) (r10 buf off) (r11 buf off) (r12 buf off) (r13 buf off) (r14 buf off) (r15 buf off) (r16 buf off) (r17 buf off) (r18 buf off) (r19 buf off) (r20 buf off)
+  | FCons (r1, FCons (r2, FCons (r3, FCons (r4, FCons (r5, FCons (r6, FCons (r7, FCons (r8, FCons (r9, FCons (r10, FCons (r11, FCons (r12, FCons (r13, FCons (r14, FCons (r15, FCons (r16, FCons (r17, FCons (r18, FCons (r19, FCons (r20, FCons (r21, FNil))))))))))))))))))))) ->
+      f (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off) (r5 buf off) (r6 buf off) (r7 buf off) (r8 buf off) (r9 buf off) (r10 buf off) (r11 buf off) (r12 buf off) (r13 buf off) (r14 buf off) (r15 buf off) (r16 buf off) (r17 buf off) (r18 buf off) (r19 buf off) (r20 buf off) (r21 buf off)
+  | FCons (r1, FCons (r2, FCons (r3, FCons (r4, FCons (r5, FCons (r6, FCons (r7, FCons (r8, FCons (r9, FCons (r10, FCons (r11, FCons (r12, FCons (r13, FCons (r14, FCons (r15, FCons (r16, FCons (r17, FCons (r18, FCons (r19, FCons (r20, FCons (r21, FCons (r22, FNil)))))))))))))))))))))) ->
+      f (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off) (r5 buf off) (r6 buf off) (r7 buf off) (r8 buf off) (r9 buf off) (r10 buf off) (r11 buf off) (r12 buf off) (r13 buf off) (r14 buf off) (r15 buf off) (r16 buf off) (r17 buf off) (r18 buf off) (r19 buf off) (r20 buf off) (r21 buf off) (r22 buf off)
+  | FCons (r1, FCons (r2, FCons (r3, FCons (r4, FCons (r5, FCons (r6, FCons (r7, FCons (r8, FCons (r9, FCons (r10, FCons (r11, FCons (r12, FCons (r13, FCons (r14, FCons (r15, FCons (r16, FCons (r17, FCons (r18, FCons (r19, FCons (r20, FCons (r21, FCons (r22, FCons (r23, FNil))))))))))))))))))))))) ->
+      f (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off) (r5 buf off) (r6 buf off) (r7 buf off) (r8 buf off) (r9 buf off) (r10 buf off) (r11 buf off) (r12 buf off) (r13 buf off) (r14 buf off) (r15 buf off) (r16 buf off) (r17 buf off) (r18 buf off) (r19 buf off) (r20 buf off) (r21 buf off) (r22 buf off) (r23 buf off)
+  | FCons (r1, FCons (r2, FCons (r3, FCons (r4, FCons (r5, FCons (r6, FCons (r7, FCons (r8, FCons (r9, FCons (r10, FCons (r11, FCons (r12, FCons (r13, FCons (r14, FCons (r15, FCons (r16, FCons (r17, FCons (r18, FCons (r19, FCons (r20, FCons (r21, FCons (r22, FCons (r23, FCons (r24, FNil)))))))))))))))))))))))) ->
+      f (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off) (r5 buf off) (r6 buf off) (r7 buf off) (r8 buf off) (r9 buf off) (r10 buf off) (r11 buf off) (r12 buf off) (r13 buf off) (r14 buf off) (r15 buf off) (r16 buf off) (r17 buf off) (r18 buf off) (r19 buf off) (r20 buf off) (r21 buf off) (r22 buf off) (r23 buf off) (r24 buf off)
+  | FCons (r1, FCons (r2, FCons (r3, FCons (r4, FCons (r5, FCons (r6, FCons (r7, FCons (r8, FCons (r9, FCons (r10, FCons (r11, FCons (r12, FCons (r13, FCons (r14, FCons (r15, FCons (r16, FCons (r17, FCons (r18, FCons (r19, FCons (r20, FCons (r21, FCons (r22, FCons (r23, FCons (r24, FCons (r25, FNil))))))))))))))))))))))))) ->
+      f (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off) (r5 buf off) (r6 buf off) (r7 buf off) (r8 buf off) (r9 buf off) (r10 buf off) (r11 buf off) (r12 buf off) (r13 buf off) (r14 buf off) (r15 buf off) (r16 buf off) (r17 buf off) (r18 buf off) (r19 buf off) (r20 buf off) (r21 buf off) (r22 buf off) (r23 buf off) (r24 buf off) (r25 buf off)
+  | FCons (r1, FCons (r2, FCons (r3, FCons (r4, FCons (r5, FCons (r6, FCons (r7, FCons (r8, FCons (r9, FCons (r10, FCons (r11, FCons (r12, FCons (r13, FCons (r14, FCons (r15, FCons (r16, FCons (r17, FCons (r18, FCons (r19, FCons (r20, FCons (r21, FCons (r22, FCons (r23, FCons (r24, FCons (r25, FCons (r26, FNil)))))))))))))))))))))))))) ->
+      f (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off) (r5 buf off) (r6 buf off) (r7 buf off) (r8 buf off) (r9 buf off) (r10 buf off) (r11 buf off) (r12 buf off) (r13 buf off) (r14 buf off) (r15 buf off) (r16 buf off) (r17 buf off) (r18 buf off) (r19 buf off) (r20 buf off) (r21 buf off) (r22 buf off) (r23 buf off) (r24 buf off) (r25 buf off) (r26 buf off)
+  | FCons (r1, FCons (r2, FCons (r3, FCons (r4, FCons (r5, FCons (r6, FCons (r7, FCons (r8, FCons (r9, FCons (r10, FCons (r11, FCons (r12, FCons (r13, FCons (r14, FCons (r15, FCons (r16, FCons (r17, FCons (r18, FCons (r19, FCons (r20, FCons (r21, FCons (r22, FCons (r23, FCons (r24, FCons (r25, FCons (r26, FCons (r27, FNil))))))))))))))))))))))))))) ->
+      f (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off) (r5 buf off) (r6 buf off) (r7 buf off) (r8 buf off) (r9 buf off) (r10 buf off) (r11 buf off) (r12 buf off) (r13 buf off) (r14 buf off) (r15 buf off) (r16 buf off) (r17 buf off) (r18 buf off) (r19 buf off) (r20 buf off) (r21 buf off) (r22 buf off) (r23 buf off) (r24 buf off) (r25 buf off) (r26 buf off) (r27 buf off)
+  | FCons (r1, FCons (r2, FCons (r3, FCons (r4, FCons (r5, FCons (r6, FCons (r7, FCons (r8, FCons (r9, FCons (r10, FCons (r11, FCons (r12, FCons (r13, FCons (r14, FCons (r15, FCons (r16, FCons (r17, FCons (r18, FCons (r19, FCons (r20, FCons (r21, FCons (r22, FCons (r23, FCons (r24, FCons (r25, FCons (r26, FCons (r27, FCons (r28, FNil)))))))))))))))))))))))))))) ->
+      f (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off) (r5 buf off) (r6 buf off) (r7 buf off) (r8 buf off) (r9 buf off) (r10 buf off) (r11 buf off) (r12 buf off) (r13 buf off) (r14 buf off) (r15 buf off) (r16 buf off) (r17 buf off) (r18 buf off) (r19 buf off) (r20 buf off) (r21 buf off) (r22 buf off) (r23 buf off) (r24 buf off) (r25 buf off) (r26 buf off) (r27 buf off) (r28 buf off)
+  | FCons (r1, FCons (r2, FCons (r3, FCons (r4, FCons (r5, FCons (r6, FCons (r7, FCons (r8, FCons (r9, FCons (r10, FCons (r11, FCons (r12, FCons (r13, FCons (r14, FCons (r15, FCons (r16, FCons (r17, FCons (r18, FCons (r19, FCons (r20, FCons (r21, FCons (r22, FCons (r23, FCons (r24, FCons (r25, FCons (r26, FCons (r27, FCons (r28, FCons (r29, FNil))))))))))))))))))))))))))))) ->
+      f (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off) (r5 buf off) (r6 buf off) (r7 buf off) (r8 buf off) (r9 buf off) (r10 buf off) (r11 buf off) (r12 buf off) (r13 buf off) (r14 buf off) (r15 buf off) (r16 buf off) (r17 buf off) (r18 buf off) (r19 buf off) (r20 buf off) (r21 buf off) (r22 buf off) (r23 buf off) (r24 buf off) (r25 buf off) (r26 buf off) (r27 buf off) (r28 buf off) (r29 buf off)
+  | FCons (r1, FCons (r2, FCons (r3, FCons (r4, FCons (r5, FCons (r6, FCons (r7, FCons (r8, FCons (r9, FCons (r10, FCons (r11, FCons (r12, FCons (r13, FCons (r14, FCons (r15, FCons (r16, FCons (r17, FCons (r18, FCons (r19, FCons (r20, FCons (r21, FCons (r22, FCons (r23, FCons (r24, FCons (r25, FCons (r26, FCons (r27, FCons (r28, FCons (r29, FCons (r30, FNil)))))))))))))))))))))))))))))) ->
+      f (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off) (r5 buf off) (r6 buf off) (r7 buf off) (r8 buf off) (r9 buf off) (r10 buf off) (r11 buf off) (r12 buf off) (r13 buf off) (r14 buf off) (r15 buf off) (r16 buf off) (r17 buf off) (r18 buf off) (r19 buf off) (r20 buf off) (r21 buf off) (r22 buf off) (r23 buf off) (r24 buf off) (r25 buf off) (r26 buf off) (r27 buf off) (r28 buf off) (r29 buf off) (r30 buf off)
+  | FCons (r1, FCons (r2, FCons (r3, FCons (r4, FCons (r5, FCons (r6, FCons (r7, FCons (r8, FCons (r9, FCons (r10, FCons (r11, FCons (r12, FCons (r13, FCons (r14, FCons (r15, FCons (r16, FCons (r17, FCons (r18, FCons (r19, FCons (r20, FCons (r21, FCons (r22, FCons (r23, FCons (r24, FCons (r25, FCons (r26, FCons (r27, FCons (r28, FCons (r29, FCons (r30, FCons (r31, FNil))))))))))))))))))))))))))))))) ->
+      f (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off) (r5 buf off) (r6 buf off) (r7 buf off) (r8 buf off) (r9 buf off) (r10 buf off) (r11 buf off) (r12 buf off) (r13 buf off) (r14 buf off) (r15 buf off) (r16 buf off) (r17 buf off) (r18 buf off) (r19 buf off) (r20 buf off) (r21 buf off) (r22 buf off) (r23 buf off) (r24 buf off) (r25 buf off) (r26 buf off) (r27 buf off) (r28 buf off) (r29 buf off) (r30 buf off) (r31 buf off)
+  | FCons (r1, FCons (r2, FCons (r3, FCons (r4, FCons (r5, FCons (r6, FCons (r7, FCons (r8, FCons (r9, FCons (r10, FCons (r11, FCons (r12, FCons (r13, FCons (r14, FCons (r15, FCons (r16, FCons (r17, FCons (r18, FCons (r19, FCons (r20, FCons (r21, FCons (r22, FCons (r23, FCons (r24, FCons (r25, FCons (r26, FCons (r27, FCons (r28, FCons (r29, FCons (r30, FCons (r31, FCons (r32, rest)))))))))))))))))))))))))))))))) ->
+      apply_fwd (f (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off) (r5 buf off) (r6 buf off) (r7 buf off) (r8 buf off) (r9 buf off) (r10 buf off) (r11 buf off) (r12 buf off) (r13 buf off) (r14 buf off) (r15 buf off) (r16 buf off) (r17 buf off) (r18 buf off) (r19 buf off) (r20 buf off) (r21 buf off) (r22 buf off) (r23 buf off) (r24 buf off) (r25 buf off) (r26 buf off) (r27 buf off) (r28 buf off) (r29 buf off) (r30 buf off) (r31 buf off) (r32 buf off)) rest buf off
 [@@ocamlformat "disable"]
 
 let build_decode : type full r. full -> (full, r) readers -> bytes -> int -> r =

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -5369,6 +5369,232 @@ let alloc_codec17 =
         (Field.v "c17" uint8 $ fun (r : alloc_r17) -> r.c17);
       ]
 
+(* 32 fields is the saturated-table ceiling: it decodes in one saturated
+   [make] call, no closure. 33 fields is the first arity past the table, so it
+   makes one partial application and exercises the recursive unroll. *)
+type alloc_r32 = {
+  d1 : int;
+  d2 : int;
+  d3 : int;
+  d4 : int;
+  d5 : int;
+  d6 : int;
+  d7 : int;
+  d8 : int;
+  d9 : int;
+  d10 : int;
+  d11 : int;
+  d12 : int;
+  d13 : int;
+  d14 : int;
+  d15 : int;
+  d16 : int;
+  d17 : int;
+  d18 : int;
+  d19 : int;
+  d20 : int;
+  d21 : int;
+  d22 : int;
+  d23 : int;
+  d24 : int;
+  d25 : int;
+  d26 : int;
+  d27 : int;
+  d28 : int;
+  d29 : int;
+  d30 : int;
+  d31 : int;
+  d32 : int;
+}
+
+type alloc_r33 = {
+  e1 : int;
+  e2 : int;
+  e3 : int;
+  e4 : int;
+  e5 : int;
+  e6 : int;
+  e7 : int;
+  e8 : int;
+  e9 : int;
+  e10 : int;
+  e11 : int;
+  e12 : int;
+  e13 : int;
+  e14 : int;
+  e15 : int;
+  e16 : int;
+  e17 : int;
+  e18 : int;
+  e19 : int;
+  e20 : int;
+  e21 : int;
+  e22 : int;
+  e23 : int;
+  e24 : int;
+  e25 : int;
+  e26 : int;
+  e27 : int;
+  e28 : int;
+  e29 : int;
+  e30 : int;
+  e31 : int;
+  e32 : int;
+  e33 : int;
+}
+
+let alloc_codec32 =
+  Codec.v "Alloc32"
+    (fun d1 d2 d3 d4 d5 d6 d7 d8 d9 d10 d11 d12 d13 d14 d15 d16 d17 d18 d19 d20
+         d21 d22 d23 d24 d25 d26 d27 d28 d29 d30 d31 d32 ->
+      ({
+         d1;
+         d2;
+         d3;
+         d4;
+         d5;
+         d6;
+         d7;
+         d8;
+         d9;
+         d10;
+         d11;
+         d12;
+         d13;
+         d14;
+         d15;
+         d16;
+         d17;
+         d18;
+         d19;
+         d20;
+         d21;
+         d22;
+         d23;
+         d24;
+         d25;
+         d26;
+         d27;
+         d28;
+         d29;
+         d30;
+         d31;
+         d32;
+       }
+        : alloc_r32))
+    Codec.
+      [
+        (Field.v "d1" uint8 $ fun (r : alloc_r32) -> r.d1);
+        (Field.v "d2" uint8 $ fun (r : alloc_r32) -> r.d2);
+        (Field.v "d3" uint8 $ fun (r : alloc_r32) -> r.d3);
+        (Field.v "d4" uint8 $ fun (r : alloc_r32) -> r.d4);
+        (Field.v "d5" uint8 $ fun (r : alloc_r32) -> r.d5);
+        (Field.v "d6" uint8 $ fun (r : alloc_r32) -> r.d6);
+        (Field.v "d7" uint8 $ fun (r : alloc_r32) -> r.d7);
+        (Field.v "d8" uint8 $ fun (r : alloc_r32) -> r.d8);
+        (Field.v "d9" uint8 $ fun (r : alloc_r32) -> r.d9);
+        (Field.v "d10" uint8 $ fun (r : alloc_r32) -> r.d10);
+        (Field.v "d11" uint8 $ fun (r : alloc_r32) -> r.d11);
+        (Field.v "d12" uint8 $ fun (r : alloc_r32) -> r.d12);
+        (Field.v "d13" uint8 $ fun (r : alloc_r32) -> r.d13);
+        (Field.v "d14" uint8 $ fun (r : alloc_r32) -> r.d14);
+        (Field.v "d15" uint8 $ fun (r : alloc_r32) -> r.d15);
+        (Field.v "d16" uint8 $ fun (r : alloc_r32) -> r.d16);
+        (Field.v "d17" uint8 $ fun (r : alloc_r32) -> r.d17);
+        (Field.v "d18" uint8 $ fun (r : alloc_r32) -> r.d18);
+        (Field.v "d19" uint8 $ fun (r : alloc_r32) -> r.d19);
+        (Field.v "d20" uint8 $ fun (r : alloc_r32) -> r.d20);
+        (Field.v "d21" uint8 $ fun (r : alloc_r32) -> r.d21);
+        (Field.v "d22" uint8 $ fun (r : alloc_r32) -> r.d22);
+        (Field.v "d23" uint8 $ fun (r : alloc_r32) -> r.d23);
+        (Field.v "d24" uint8 $ fun (r : alloc_r32) -> r.d24);
+        (Field.v "d25" uint8 $ fun (r : alloc_r32) -> r.d25);
+        (Field.v "d26" uint8 $ fun (r : alloc_r32) -> r.d26);
+        (Field.v "d27" uint8 $ fun (r : alloc_r32) -> r.d27);
+        (Field.v "d28" uint8 $ fun (r : alloc_r32) -> r.d28);
+        (Field.v "d29" uint8 $ fun (r : alloc_r32) -> r.d29);
+        (Field.v "d30" uint8 $ fun (r : alloc_r32) -> r.d30);
+        (Field.v "d31" uint8 $ fun (r : alloc_r32) -> r.d31);
+        (Field.v "d32" uint8 $ fun (r : alloc_r32) -> r.d32);
+      ]
+
+let alloc_codec33 =
+  Codec.v "Alloc33"
+    (fun e1 e2 e3 e4 e5 e6 e7 e8 e9 e10 e11 e12 e13 e14 e15 e16 e17 e18 e19 e20
+         e21 e22 e23 e24 e25 e26 e27 e28 e29 e30 e31 e32 e33 ->
+      ({
+         e1;
+         e2;
+         e3;
+         e4;
+         e5;
+         e6;
+         e7;
+         e8;
+         e9;
+         e10;
+         e11;
+         e12;
+         e13;
+         e14;
+         e15;
+         e16;
+         e17;
+         e18;
+         e19;
+         e20;
+         e21;
+         e22;
+         e23;
+         e24;
+         e25;
+         e26;
+         e27;
+         e28;
+         e29;
+         e30;
+         e31;
+         e32;
+         e33;
+       }
+        : alloc_r33))
+    Codec.
+      [
+        (Field.v "e1" uint8 $ fun (r : alloc_r33) -> r.e1);
+        (Field.v "e2" uint8 $ fun (r : alloc_r33) -> r.e2);
+        (Field.v "e3" uint8 $ fun (r : alloc_r33) -> r.e3);
+        (Field.v "e4" uint8 $ fun (r : alloc_r33) -> r.e4);
+        (Field.v "e5" uint8 $ fun (r : alloc_r33) -> r.e5);
+        (Field.v "e6" uint8 $ fun (r : alloc_r33) -> r.e6);
+        (Field.v "e7" uint8 $ fun (r : alloc_r33) -> r.e7);
+        (Field.v "e8" uint8 $ fun (r : alloc_r33) -> r.e8);
+        (Field.v "e9" uint8 $ fun (r : alloc_r33) -> r.e9);
+        (Field.v "e10" uint8 $ fun (r : alloc_r33) -> r.e10);
+        (Field.v "e11" uint8 $ fun (r : alloc_r33) -> r.e11);
+        (Field.v "e12" uint8 $ fun (r : alloc_r33) -> r.e12);
+        (Field.v "e13" uint8 $ fun (r : alloc_r33) -> r.e13);
+        (Field.v "e14" uint8 $ fun (r : alloc_r33) -> r.e14);
+        (Field.v "e15" uint8 $ fun (r : alloc_r33) -> r.e15);
+        (Field.v "e16" uint8 $ fun (r : alloc_r33) -> r.e16);
+        (Field.v "e17" uint8 $ fun (r : alloc_r33) -> r.e17);
+        (Field.v "e18" uint8 $ fun (r : alloc_r33) -> r.e18);
+        (Field.v "e19" uint8 $ fun (r : alloc_r33) -> r.e19);
+        (Field.v "e20" uint8 $ fun (r : alloc_r33) -> r.e20);
+        (Field.v "e21" uint8 $ fun (r : alloc_r33) -> r.e21);
+        (Field.v "e22" uint8 $ fun (r : alloc_r33) -> r.e22);
+        (Field.v "e23" uint8 $ fun (r : alloc_r33) -> r.e23);
+        (Field.v "e24" uint8 $ fun (r : alloc_r33) -> r.e24);
+        (Field.v "e25" uint8 $ fun (r : alloc_r33) -> r.e25);
+        (Field.v "e26" uint8 $ fun (r : alloc_r33) -> r.e26);
+        (Field.v "e27" uint8 $ fun (r : alloc_r33) -> r.e27);
+        (Field.v "e28" uint8 $ fun (r : alloc_r33) -> r.e28);
+        (Field.v "e29" uint8 $ fun (r : alloc_r33) -> r.e29);
+        (Field.v "e30" uint8 $ fun (r : alloc_r33) -> r.e30);
+        (Field.v "e31" uint8 $ fun (r : alloc_r33) -> r.e31);
+        (Field.v "e32" uint8 $ fun (r : alloc_r33) -> r.e32);
+        (Field.v "e33" uint8 $ fun (r : alloc_r33) -> r.e33);
+      ]
+
 let per_decode_words codec nfields =
   let buf = Bytes.make nfields '\042' in
   ignore (Sys.opaque_identity (Codec.decode_exn codec buf 0));
@@ -5384,19 +5610,29 @@ let per_decode_words codec nfields =
 let test_decode_no_partial_closure () =
   let w8 = per_decode_words alloc_codec8 8 in
   let w16 = per_decode_words alloc_codec16 16 in
+  let w32 = per_decode_words alloc_codec32 32 in
   (* Each [int] record field is one word and the header is one more, so a
-     closure-free decode grows by exactly the 8 added fields. A partial-app
+     closure-free decode grows by exactly the added fields. A partial-app
      closure would add several more words on top. *)
-  let growth = int_of_float (Float.round (w16 -. w8)) in
+  let growth_16_8 = int_of_float (Float.round (w16 -. w8)) in
   Alcotest.(check int)
-    "16-vs-8-field decode grows by 8 record slots only (no closure)" 8 growth
+    "16-vs-8-field decode grows by 8 record slots only (no closure)" 8
+    growth_16_8;
+  (* A record wider than 16 fields used to trip [apply_fwd]'s recursive arm and
+     allocate one [caml_curry] closure per decode. With the saturation table
+     raised to 32, the 32-field decode grows by exactly its 16 extra slots. *)
+  let growth_32_16 = int_of_float (Float.round (w32 -. w16)) in
+  Alcotest.(check int)
+    "32-vs-16-field decode grows by 16 record slots only (no closure)" 16
+    growth_32_16
 
 let test_decode_high_arity_roundtrip () =
-  (* Exercise the saturated 16-field case and the recursive >16 unroll. *)
+  (* Exercise the saturated 16-field case. *)
   let buf16 = Bytes.init 16 (fun i -> Char.chr (i + 1)) in
   let v16 = Codec.decode_exn alloc_codec16 buf16 0 in
   Alcotest.(check int) "b1" 1 v16.b1;
   Alcotest.(check int) "b16" 16 v16.b16;
+  (* 17 fields: still saturated after the table was widened to 32. *)
   let buf17 = Bytes.init 17 (fun i -> Char.chr (i + 1)) in
   let v17 = Codec.decode_exn alloc_codec17 buf17 0 in
   Alcotest.(check int) "c1" 1 v17.c1;
@@ -5404,7 +5640,24 @@ let test_decode_high_arity_roundtrip () =
   Alcotest.(check int) "c17" 17 v17.c17;
   let out = Bytes.create 17 in
   Codec.encode alloc_codec17 v17 out 0;
-  Alcotest.(check bytes) "17-field roundtrip" buf17 out
+  Alcotest.(check bytes) "17-field roundtrip" buf17 out;
+  (* 32 fields: the saturated-table ceiling. *)
+  let buf32 = Bytes.init 32 (fun i -> Char.chr (i + 1)) in
+  let v32 = Codec.decode_exn alloc_codec32 buf32 0 in
+  Alcotest.(check int) "d1" 1 v32.d1;
+  Alcotest.(check int) "d32" 32 v32.d32;
+  let out32 = Bytes.create 32 in
+  Codec.encode alloc_codec32 v32 out32 0;
+  Alcotest.(check bytes) "32-field roundtrip" buf32 out32;
+  (* 33 fields: the first arity past the table, exercising the recursive arm. *)
+  let buf33 = Bytes.init 33 (fun i -> Char.chr (i + 1)) in
+  let v33 = Codec.decode_exn alloc_codec33 buf33 0 in
+  Alcotest.(check int) "e1" 1 v33.e1;
+  Alcotest.(check int) "e32" 32 v33.e32;
+  Alcotest.(check int) "e33" 33 v33.e33;
+  let out33 = Bytes.create 33 in
+  Codec.encode alloc_codec33 v33 out33 0;
+  Alcotest.(check bytes) "33-field roundtrip" buf33 out33
 
 (* Encoding a var-bytes field must not allocate. [var_bytes_writer]'s length
    check and string blit are top-level functions; were they local to the


### PR DESCRIPTION
Decoding a record codec wider than 16 fields used to apply its constructor by a partial application, which allocates a caml_curry closure on every decode under flambda-off. Real protocol headers cross that ceiling routinely: a TCP header with its flag bits broken out is 18 fields, and telemetry and IPv4 headers reach the high twenties. On the TCP data plane this partial-application closure was the dominant decode-time allocation.

Widening the exact-arity saturation table in `apply_fwd` from 16 to 32 lets every real header decode in a single saturated call, so it allocates only the record it returns. Past 32 fields the recursive fallback stays for correctness. A regression test decodes a 32-field record and checks its per-decode allocation grows by exactly its extra record slots and nothing more, with round-trip coverage at the 32-field ceiling and the 33-field recursive boundary.

Follow-up to #212, which raised the ceiling from 8 to 16.
