### PR TITLE
3d: reject trailing bytes in generated Check wrappers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -246,6 +246,15 @@
 
 ### Fixed
 
+- The generated C `<Name>Check<Codec>` wrapper now validates the whole buffer:
+  it returns `FALSE` unless the validator consumed every input byte, so a valid
+  record followed by trailing bytes is rejected instead of accepted as a valid
+  prefix. The differential corpus oracle applies the same whole-buffer rule, so
+  the OCaml and C verdicts still agree. The raw `<Name>Validate<Codec>` entry
+  point keeps its prefix semantics and returns the consumed position. `wire`
+  now depends on `re` at runtime, previously a test-only dependency (#215,
+  @samoht)
+
 - `Wire.Everparse.project` now rejects a codec that cannot project to 3D when
   the schema is built, not later when it is rendered. A constraint with no 3D
   projection (a `field_pos`, or a subtraction or multiplication over a field)

--- a/dune-project
+++ b/dune-project
@@ -29,6 +29,6 @@
   (memtrace :with-test)
   (alcotest :with-test)
   (alcobar :with-test)
-  (re :with-test)
+  (re (>= 1.11))
   (mdx :with-test)
   (odoc :with-doc)))

--- a/lib/3d/dune
+++ b/lib/3d/dune
@@ -1,7 +1,7 @@
 (library
  (name wire_3d)
  (public_name wire.3d)
- (libraries wire fmt unix))
+ (libraries wire fmt re unix))
 
 (mdx
  (files wire_3d.mli)

--- a/lib/3d/wire_3d.ml
+++ b/lib/3d/wire_3d.ml
@@ -368,6 +368,47 @@ let fields_c_files schemas =
       else None)
     schemas
 
+(* EverParse's [<Base>Check<Codec>] wrapper returns TRUE on any successful
+   validator result, but a success result is the consumed position: a valid
+   record followed by trailing bytes still returns TRUE, making the wrapper a
+   prefix recognizer rather than a validator. Wire's contract is whole-buffer
+   validation, so rewrite each success tail to also require full consumption.
+   Textual on EverParse's wrapper shape (the tail is identical for
+   parameterized and plain entrypoints, [print_c_entry] in the upstream
+   [src/3d/Target.fst]): if a future EverParse emits neither the known tail
+   nor its own consumption check, fail loudly rather than silently shipping a
+   prefix recognizer. The behavioural backstop is the differential runtest,
+   whose corpus includes over-length inputs the oracle rejects. *)
+let wrapper_success_tail = "\t\treturn FALSE;\n\t}\n\treturn TRUE;\n}"
+let wrapper_consumption_check = "result != (uint64_t) len"
+
+let wrapper_hardened_tail =
+  "\t\treturn FALSE;\n\
+   \t}\n\
+   \tif (result != (uint64_t) len)\n\
+   \t{\n\
+   \t\treturn FALSE;\n\
+   \t}\n\
+   \treturn TRUE;\n\
+   }"
+
+let harden_wrapper ~outdir base =
+  let path = Filename.concat outdir (base ^ "Wrapper.c") in
+  if Sys.file_exists path then begin
+    let src = In_channel.with_open_text path In_channel.input_all in
+    let tail = Re.compile (Re.str wrapper_success_tail) in
+    if Re.execp tail src then
+      Out_channel.with_open_text path (fun oc ->
+          Out_channel.output_string oc
+            (Re.replace_string tail ~by:wrapper_hardened_tail src))
+    else if not (Re.execp (Re.compile (Re.str wrapper_consumption_check)) src)
+    then
+      Fmt.failwith
+        "%s: unrecognized EverParse wrapper shape; cannot insert the \
+         full-consumption check"
+        path
+  end
+
 let run_everparse_files ?(quiet = true) ~outdir files =
   let exe =
     match locate_3d_exe () with
@@ -379,7 +420,8 @@ let run_everparse_files ?(quiet = true) ~outdir files =
       let redirect = if quiet then " > /dev/null 2>&1" else "" in
       let cmd = Fmt.str "cd %s && %s --batch %s%s" outdir exe f redirect in
       let ret = Sys.command cmd in
-      if ret <> 0 then Fmt.failwith "EverParse failed on %s with code %d" f ret)
+      if ret <> 0 then Fmt.failwith "EverParse failed on %s with code %d" f ret;
+      harden_wrapper ~outdir (Filename.remove_extension (Filename.basename f)))
     files;
   copy_everparse_endianness ~outdir
 
@@ -813,14 +855,16 @@ let hex_of_bytes b =
   Buffer.contents buf
 
 (* The accept/reject decision the validator must reproduce: the OCaml codec
-   both decodes (structure plus constraints) and validates (constraints and
-   where-clauses) the bytes. *)
+   decodes (structure plus constraints), validates (constraints and
+   where-clauses), and the record spans the whole buffer -- the hardened
+   [<Base>Check<Codec>] wrapper rejects trailing bytes (see [harden_wrapper]),
+   so the oracle must too. *)
 let codec_accepts ?env c buf =
   match Wire.Codec.decode ?env c buf 0 with
   | Ok _ -> (
       try
         Wire.Codec.validate ?env c buf 0;
-        true
+        Wire.Codec.wire_size_at c buf 0 = Bytes.length buf
       with Wire.Validation_error _ -> false)
   | Error _ -> false
 

--- a/lib/3d/wire_3d.mli
+++ b/lib/3d/wire_3d.mli
@@ -136,6 +136,12 @@ val generate_c : ?quiet:bool -> outdir:string -> Wire.Everparse.t list -> unit
 (** [generate_c ?quiet ~outdir schemas] invokes EverParse on existing [.3d]
     files to produce C parsers and generates [test.c].
 
+    The EverParse-emitted [<Name>Check<Codec>] wrapper is hardened after
+    generation: it returns [FALSE] unless the validator consumed the whole
+    buffer, so a valid record followed by trailing bytes is rejected. The raw
+    [<Name>Validate<Codec>] function keeps EverParse's prefix semantics and
+    returns the consumed position.
+
     If [quiet] is [true] (the default), EverParse output is suppressed. If
     [quiet] is [false], EverParse stdout/stderr are left visible.
 
@@ -167,7 +173,9 @@ val generate_standalone :
     them into one [<Name>.3d], and (when [3d.exe] is available) compile it to a
     single validator-only [<Name>.c] (no [_Fields] plug, no FFI). The file base
     is [name] when given, else [package], normalised to a CamelCase identifier
-    (["my-pkg"] becomes [MyPkg]); [package] always names the opam package. *)
+    (["my-pkg"] becomes [MyPkg]); [package] always names the opam package. The
+    generated [<Name>Check<Codec>] wrappers validate the whole buffer, rejecting
+    trailing bytes (see {!generate_c}). *)
 
 val generate_dune_standalone :
   ?name:string -> outdir:string -> package:string -> packed list -> unit
@@ -182,11 +190,13 @@ val generate_dune_standalone :
 val generate_corpus : ?count:int -> Format.formatter -> packed list -> unit
 (** [generate_corpus ?count ppf codecs] prints, for each codec, [count] fuzzed
     inputs as [<codec> <hex> <verdict>] lines, where [verdict] is [1] when the
-    OCaml codec accepts the bytes (decodes and validates) and [0] otherwise, and
-    [<hex>] is [-] for the empty input. Lengths are biased around each codec's
-    minimum size so the corpus straddles the accept/reject boundary. This is the
-    oracle half of the doc pipeline's differential self-check; {!main}'s
-    [corpus] subcommand calls it on stdout. *)
+    OCaml codec accepts the bytes (decodes, validates, and the record spans the
+    whole input -- matching the hardened [Check] wrapper's whole-buffer
+    contract) and [0] otherwise, and [<hex>] is [-] for the empty input. Lengths
+    are biased around each codec's minimum size so the corpus straddles the
+    accept/reject boundary. This is the oracle half of the doc pipeline's
+    differential self-check; {!main}'s [corpus] subcommand calls it on stdout.
+*)
 
 val generate_agree :
   ?name:string -> outdir:string -> package:string -> packed list -> unit

--- a/test/3d/test_wire_3d.ml
+++ b/test/3d/test_wire_3d.ml
@@ -232,12 +232,15 @@ let diff_param_codec =
     (fun len data -> (len, data))
     [ Codec.( $ ) f_length fst; Codec.( $ ) f_data snd ]
 
-let differential_ok ~name ~package ~count codecs =
+let differential_ok ~name ~package ~corpus codecs =
   let tmpdir = Filename.temp_dir ("wire_3d_diff_" ^ package) "" in
   Wire_3d.generate_standalone ~outdir:tmpdir ~name ~package codecs;
   let oc = open_out (Filename.concat tmpdir "corpus") in
-  let ppf = Format.formatter_of_out_channel oc in
-  Wire_3d.generate_corpus ~count ppf codecs;
+  (match corpus with
+  | `Fuzz count ->
+      let ppf = Format.formatter_of_out_channel oc in
+      Wire_3d.generate_corpus ~count ppf codecs
+  | `Lines lines -> List.iter (fun l -> output_string oc (l ^ "\n")) lines);
   close_out oc;
   let base = String.capitalize_ascii name in
   let cmd =
@@ -260,7 +263,7 @@ let differential_ok ~name ~package ~count codecs =
 let test_doc_differential () =
   if not (Wire_3d.has_3d_exe ()) then ()
   else
-    differential_ok ~name:"protospec" ~package:"demo-doc" ~count:400
+    differential_ok ~name:"protospec" ~package:"demo-doc" ~corpus:(`Fuzz 400)
       [
         Wire_3d.pack diff_enum_codec;
         Wire_3d.pack diff_range_codec;
@@ -274,7 +277,7 @@ let test_doc_differential_no_params () =
      strict flags) when no codec takes parameters. *)
   if not (Wire_3d.has_3d_exe ()) then ()
   else
-    differential_ok ~name:"plainspec" ~package:"plain-doc" ~count:100
+    differential_ok ~name:"plainspec" ~package:"plain-doc" ~corpus:(`Fuzz 100)
       [ Wire_3d.pack diff_enum_codec; Wire_3d.pack diff_range_codec ]
 
 (* A signed field with an ordering constraint: it projects to an unsigned UINT,
@@ -291,7 +294,7 @@ let diff_signed_codec =
 let test_doc_differential_signed () =
   if not (Wire_3d.has_3d_exe ()) then ()
   else
-    differential_ok ~name:"signedspec" ~package:"signed-doc" ~count:256
+    differential_ok ~name:"signedspec" ~package:"signed-doc" ~corpus:(`Fuzz 256)
       [ Wire_3d.pack diff_signed_codec ]
 
 (* An 8192-byte payload makes each corpus line 16384 hex chars; the agree
@@ -306,7 +309,7 @@ let diff_large_payload_codec =
 let test_doc_differential_large_payload () =
   if not (Wire_3d.has_3d_exe ()) then ()
   else
-    differential_ok ~name:"sharedspec" ~package:"shared-doc" ~count:40
+    differential_ok ~name:"sharedspec" ~package:"shared-doc" ~corpus:(`Fuzz 40)
       [ Wire_3d.pack diff_large_payload_codec ]
 
 (* Interior consecutive caps: EverParse normalizes the validator symbol to
@@ -321,8 +324,23 @@ let diff_caps_name_codec =
 let test_doc_differential_caps_name () =
   if not (Wire_3d.has_3d_exe ()) then ()
   else
-    differential_ok ~name:"spacewire" ~package:"space-wire" ~count:40
+    differential_ok ~name:"spacewire" ~package:"space-wire" ~corpus:(`Fuzz 40)
       [ Wire_3d.pack diff_caps_name_codec ]
+
+(* A valid record followed by trailing bytes must be rejected. EverParse's
+   stock [Check] wrapper returns TRUE on any successful validation -- success
+   is the consumed position, so a valid prefix passes -- and the pipeline
+   hardens it to require full consumption. The handwritten corpus pins the
+   exact boundary: the 2-byte RangeMsg accepts exactly-sized input and rejects
+   both one byte over and one byte short. *)
+let test_doc_differential_trailing_bytes () =
+  if not (Wire_3d.has_3d_exe ()) then ()
+  else
+    differential_ok ~name:"trailspec" ~package:"trail-doc"
+      ~corpus:
+        (`Lines
+           [ "RangeMsg - 0102 1"; "RangeMsg - 010203 0"; "RangeMsg - 01 0" ])
+      [ Wire_3d.pack diff_range_codec ]
 
 (* End-to-end compile+run. Generates C for a schema, invokes the same
    cc command [generate_dune] emits, runs the resulting binary. This is
@@ -1152,6 +1170,8 @@ let suite =
         test_doc_differential_large_payload;
       Alcotest.test_case "doc differential caps name (needs 3d.exe)" `Quick
         test_doc_differential_caps_name;
+      Alcotest.test_case "doc differential trailing bytes (needs 3d.exe)" `Quick
+        test_doc_differential_trailing_bytes;
       Alcotest.test_case "uses_wire_ctx" `Quick test_uses_wire_ctx;
       Alcotest.test_case "has_3d_exe" `Quick test_has_3d_exe;
       Alcotest.test_case "main exists" `Quick test_main_exists;

--- a/wire.opam
+++ b/wire.opam
@@ -18,7 +18,7 @@ depends: [
   "memtrace" {with-test}
   "alcotest" {with-test}
   "alcobar" {with-test}
-  "re" {with-test}
+  "re" {>= "1.11"}
   "mdx" {with-test}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
The EverParse-generated `<Base>Check<Codec>` wrapper used to return TRUE whenever the validator succeeded; a success result is the consumed position, so a valid record followed by trailing bytes passed and the wrapper was a prefix recognizer rather than a validator. The wrapper is now rewritten after EverParse runs to return FALSE unless the whole buffer was consumed, and the differential corpus oracle applies the same whole-buffer rule so the OCaml and C verdicts keep agreeing. The raw `<Base>Validate<Codec>` entry point keeps its prefix semantics and still returns the consumed position.

A handwritten-corpus differential test pins the boundary: a 2-byte record accepts exactly-sized input and rejects one byte over and one byte short. Downstream packages with committed generated C will report a differential mismatch until the C is regenerated with BUILD_EVERPARSE=1.