### PR TITLE
3d: harden no-decoration cram against compiler diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ocaml-compiler: ['5.3', '5.2']
+        ocaml-compiler: ['5.4', '5.3', '5.2']
         include:
           - os: macos-latest
-            ocaml-compiler: '5.3'
+            ocaml-compiler: '5.4'
 
     runs-on: ${{ matrix.os }}
 

--- a/test/cram/no_decoration_at_typ_level.t
+++ b/test/cram/no_decoration_at_typ_level.t
@@ -18,12 +18,8 @@ returning a typ.
   > open Wire
   > let _ = array ~len:(int 4) (Wire.optional Expr.true_ uint8)
   > EOF
-  $ dune build probe.exe 2>&1
-  File "probe.ml", line 2, characters 28-41:
-  2 | let _ = array ~len:(int 4) (Wire.optional Expr.true_ uint8)
-                                  ^^^^^^^^^^^^^
+  $ dune build probe.exe 2>&1 | grep 'Unbound value' | tr -d '"'
   Error: Unbound value Wire.optional
-  [1]
 
 [Wire.optional_or] does not exist:
 
@@ -31,12 +27,8 @@ returning a typ.
   > open Wire
   > let _ = where Expr.true_ (Wire.optional_or Expr.true_ ~default:0 uint8)
   > EOF
-  $ dune build probe.exe 2>&1
-  File "probe.ml", line 2, characters 26-42:
-  2 | let _ = where Expr.true_ (Wire.optional_or Expr.true_ ~default:0 uint8)
-                                ^^^^^^^^^^^^^^^^
+  $ dune build probe.exe 2>&1 | grep 'Unbound value' | tr -d '"'
   Error: Unbound value Wire.optional_or
-  [1]
 
 [Wire.repeat] does not exist:
 
@@ -46,12 +38,8 @@ returning a typ.
   >   [ case ~index:0 (Wire.repeat ~size:(int 8) uint8)
   >       ~inject:(fun x -> x) ~project:(fun x -> Some x) ]
   > EOF
-  $ dune build probe.exe 2>&1
-  File "probe.ml", line 3, characters 19-30:
-  3 |   [ case ~index:0 (Wire.repeat ~size:(int 8) uint8)
-                         ^^^^^^^^^^^
+  $ dune build probe.exe 2>&1 | grep 'Unbound value' | tr -d '"'
   Error: Unbound value Wire.repeat
-  [1]
 
 [Wire.repeat_seq] does not exist:
 
@@ -59,12 +47,8 @@ returning a typ.
   > open Wire
   > let _ = Wire.repeat_seq seq_list ~size:(int 8) uint8
   > EOF
-  $ dune build probe.exe 2>&1
-  File "probe.ml", line 2, characters 8-23:
-  2 | let _ = Wire.repeat_seq seq_list ~size:(int 8) uint8
-              ^^^^^^^^^^^^^^^
+  $ dune build probe.exe 2>&1 | grep 'Unbound value' | tr -d '"'
   Error: Unbound value Wire.repeat_seq
-  [1]
 
 The same operations are exposed at the field level and accept
 fixed-size scalars as well as sized payloads (e.g. [byte_array {size}]):


### PR DESCRIPTION
The `no_decoration_at_typ_level` cram test pinned the compiler's exact `Unbound value` diagnostic for four typ-level names. OCaml quotes unbound identifiers in some patch releases and not others, so the test passed this repo's CI (newer 5.2/5.3 patches, unquoted) but failed opam-repo-ci on the debian-13-ocaml-5.2 image (older patch, quoted), blocking the 1.0.0 release. The guarded invariant, that `optional`, `optional_or`, `repeat` and `repeat_seq` are not exposed at the typ level, still holds.

Commit a800f668 asserts only the stable `Unbound value <name>` line and strips the quoting, so the test tracks the invariant rather than the diagnostic format. Commit e6aec649 adds OCaml 5.4 to the CI matrix, the version development already targets but CI did not cover.