### PR TITLE
test: drop redundant vb_ prefix on alloc_vb fields

### DIFF
--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -5410,29 +5410,25 @@ let test_decode_high_arity_roundtrip () =
    check and string blit are top-level functions; were they local to the
    writer, each would be a heap-allocated closure per var-bytes field on
    every encode under flambda-off. *)
-type alloc_vb = { vb_a : string; vb_b : string; vb_z : string }
+type alloc_vb = { a : string; b : string; z : string }
 
 let alloc_vb_alen = Field.v "ALen" uint16be
 let alloc_vb_blen = Field.v "BLen" uint16be
 
 let alloc_vb_codec =
   Codec.v "AllocVb"
-    (fun _alen vb_a _blen vb_b vb_z -> { vb_a; vb_b; vb_z })
+    (fun _alen a _blen b z -> { a; b; z })
     Codec.
       [
-        (alloc_vb_alen $ fun r -> String.length r.vb_a);
-        ( Field.v "A" (byte_array ~size:(Field.ref alloc_vb_alen)) $ fun r ->
-          r.vb_a );
-        (alloc_vb_blen $ fun r -> String.length r.vb_b);
-        ( Field.v "B" (byte_array ~size:(Field.ref alloc_vb_blen)) $ fun r ->
-          r.vb_b );
-        (Field.v "Z" zeroterm $ fun r -> r.vb_z);
+        (alloc_vb_alen $ fun r -> String.length r.a);
+        (Field.v "A" (byte_array ~size:(Field.ref alloc_vb_alen)) $ fun r -> r.a);
+        (alloc_vb_blen $ fun r -> String.length r.b);
+        (Field.v "B" (byte_array ~size:(Field.ref alloc_vb_blen)) $ fun r -> r.b);
+        (Field.v "Z" zeroterm $ fun r -> r.z);
       ]
 
 let test_encode_var_bytes_no_closure () =
-  let v =
-    { vb_a = String.make 32 'x'; vb_b = String.make 16 'y'; vb_z = "hi" }
-  in
+  let v = { a = String.make 32 'x'; b = String.make 16 'y'; z = "hi" } in
   let buf = Bytes.create (2 + 32 + 2 + 16 + 2 + 1) in
   Codec.encode alloc_vb_codec v buf 0;
   let iters = 200_000 in


### PR DESCRIPTION
The `alloc_vb` test record gives every field a `vb_` prefix, which merlint E334 flags as redundant since the record type already names the concept and OCaml disambiguates the bare field at the use site. It was left over from #213 and made `main` merlint-red. Renaming the fields to `a`/`b`/`z` clears the warning with no behaviour change.