### PR TITLE
codec: restructure parse errors as { at; field; kind }

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,33 @@
 
 ### Changed
 
+- Parse errors are now a `{ at; field; kind }` record instead of a flat variant.
+  `at` is the byte offset of the failing field and `field` is the path of field
+  names leading to it, so a failure deep in a nested struct is attributable
+  instead of surfacing as a bare kind with no location. The failure kinds are a
+  closed `error_kind` (`Unexpected_eof`, `Invalid_enum`, `Invalid_tag`,
+  `Missing_terminator`, `Non_zero_padding`, `Value_out_of_range`,
+  `Constraint_failed`); match on `e.kind` and read `e.at`. Consumers with their
+  own domain errors wrap `Wire.parse_error` in a variant of their own (#219,
+  @samoht)
+
+- `Constraint_failed of string` becomes `Constraint_failed { which; value }`:
+  `which` names the predicate that failed (a field constraint, a `where` clause,
+  a field action, or a per-byte refinement) and `value` carries the offending
+  field's value for a single-field self-constraint. A field that fails its
+  `~self_constraint` now reports which field and its value rather than an
+  unmatchable English string (#219, @samoht)
+
+- The `Validation_error` exception is removed; `Codec.validate` and the `_exn`
+  decoders both raise the single `Parse_error`. They were already the same
+  exception at runtime, so replace `Validation_error` with `Parse_error` (#219,
+  @samoht)
+
+- Add `equal_parse_error` / `compare_parse_error` and `pp_error_kind`, so a
+  consumer no longer hand-rolls equality for a parse error in its tests. The
+  `Value_out_of_range` kind now carries an integer-length overflow that the flat
+  type reported as a constraint failure (#219, @samoht)
+
 - Decoding a record codec with 17 to 32 fields no longer allocates a
   short-lived closure on each decode: the closure-free decode ceiling that
   1.0.0 raised to 16 fields now extends to 32. Real protocol headers cross the

--- a/fuzz/diff/fuzz.ml
+++ b/fuzz/diff/fuzz.ml
@@ -14,13 +14,13 @@ open Fuzz_gen
 (* The EverParse validator accepts iff the bytes parse (enough input, valid
    structure) and every refinement holds. [Codec.decode_exn] is exactly that:
    it decodes (length + structure) and validates (refinements), raising
-   [Parse_error] / [Validation_error] on a clean rejection. (Plain [Codec.decode]
+   [Parse_error] on a clean rejection. (Plain [Codec.decode]
    returns a [result], so its rejection is easy to drop by mistake.) Any other
    exception surfaces as a crash, which is itself a divergence to report. *)
 let ocaml_accepts (Pack g) b =
   match ignore (Wire.Codec.decode_exn (codec g) b 0) with
   | () -> true
-  | exception (Wire.Validation_error _ | Wire.Parse_error _) -> false
+  | exception Wire.Parse_error _ -> false
 
 (* Compare both decoders on one codec and flag any accept/reject divergence. *)
 let diff_check label p c_check b =

--- a/fuzz/gen/fuzz_gen.ml
+++ b/fuzz/gen/fuzz_gen.ml
@@ -363,7 +363,7 @@ let all_zeros =
         (s, buf))
   in
   (* Adversarial: bytes with at least one non-zero -- decoder must
-     surface [Constraint_failed], not raise. *)
+     surface [Non_zero_padding], not raise. *)
   let adversarial =
     Alcobar.map
       Alcobar.[ Alcobar.range ~min:1 16; Alcobar.range ~min:1 256 ]
@@ -2806,9 +2806,27 @@ let validate_one ?env g bs =
     Wire.Codec.validate ?env g.codec bs 0;
     `Ok
   with
-  | Wire.Validation_error _ -> `Reject
   | Invalid_argument _ -> `Crash
-  | Wire.Parse_error _ -> `Reject
+  | Wire.Parse_error e ->
+      (* A parse error's offset is never negative. Most kinds point inside the
+         input, but [Unexpected_eof] and [Missing_terminator] report where a
+         read (or a field that does not fit) ran past the end, so their offset
+         may exceed the buffer length. *)
+      let len = Bytes.length bs in
+      let bounded =
+        e.at >= 0
+        &&
+        match e.kind with
+        | Wire.Unexpected_eof _ | Wire.Missing_terminator -> true
+        | _ -> e.at <= len
+      in
+      if not bounded then
+        Alcobar.failf "parse error offset %d invalid for a %d-byte buffer" e.at
+          len;
+      (* Every field-path segment is a real (non-empty) field name. *)
+      if List.exists (fun s -> String.length s = 0) e.field then
+        Alcobar.failf "parse error field path has an empty segment";
+      `Reject
 
 let check_validate_positive label g bs =
   let env = positive_env g in
@@ -4273,7 +4291,7 @@ let check_struct_validator len data_s =
       check_int "Codec.wire_size_info_of_validator" (Bytes.length bytes)
         (size_of bytes 0));
   (try Wire.Codec.validate_struct validator bytes 0 with
-  | Wire.Validation_error e | Wire.Parse_error e ->
+  | Wire.Parse_error e ->
       Alcobar.failf "validate_struct rejected positive: %a" Wire.pp_parse_error
         e
   | Invalid_argument e -> Alcobar.failf "validate_struct crashed: %s" e);
@@ -4726,7 +4744,7 @@ let ep_validate label =
               Wire.Codec.validate ?env g.codec bs 0;
               `Ok
             with
-            | Wire.Validation_error _ | Wire.Parse_error _ -> `Reject
+            | Wire.Parse_error _ -> `Reject
             | Invalid_argument _ -> `Crash
           with
           | `Ok -> ()

--- a/lib/3d/wire_3d.ml
+++ b/lib/3d/wire_3d.ml
@@ -865,7 +865,7 @@ let codec_accepts ?env c buf =
       try
         Wire.Codec.validate ?env c buf 0;
         Wire.Codec.wire_size_at c buf 0 = Bytes.length buf
-      with Wire.Validation_error _ -> false)
+      with Wire.Parse_error _ -> false)
   | Error _ -> false
 
 (* A small param value, biased around the codec's footprint so a parameter that

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -197,13 +197,13 @@ and build_field_encoder : type a. a typ -> bytes -> int -> a -> int =
    computed once so the returned check allocates nothing per decode. *)
 let enum_checker cases =
   let valid = List.map snd cases in
-  fun v ->
-    if List.mem v valid then v
-    else raise (Parse_error (Invalid_enum { value = v; valid }))
+  fun ~at v ->
+    if List.mem v valid then v else raise_invalid_enum ~at ~value:v ~valid
 
 (* An open enum ([closed = false]) accepts any base value: the names only
    document known members, so decode does not reject the rest. *)
-let enum_check cases closed = if closed then enum_checker cases else fun v -> v
+let enum_check cases closed =
+  if closed then enum_checker cases else fun ~at:_ v -> v
 
 (** Build a direct field reader that reads at a fixed offset. No tuples, no refs
     \- just pure value read. Caller must ensure the buffer is large enough. *)
@@ -252,7 +252,7 @@ let rec build_field_reader : type a. a typ -> int -> bytes -> int -> a =
   | Enum { base; cases; closed; _ } ->
       let read = build_field_reader base field_off in
       let check = enum_check cases closed in
-      fun buf base -> check (read buf base)
+      fun buf base -> check ~at:(base + field_off) (read buf base)
   | Map { inner; decode; _ } ->
       let read = build_field_reader inner field_off in
       fun buf base -> decode (read buf base)
@@ -289,6 +289,17 @@ let clear_slots s n =
 
 let set_int_slot s idx v = s.ints.(idx) <- v
 let set_int64_slot s idx v = s.int64s.(idx) <- v
+
+(* Raise a field-constraint failure, reporting the offending field's value so a
+   demux can route on it (e.g. a version field that failed [self = N]).
+   [field_idx] is the field's int slot; [at] is the record's byte offset. *)
+let raise_field_constraint ~field_idx ~at arr =
+  let value =
+    if field_idx >= 0 && field_idx < Array.length arr.ints then
+      Some (Int64.of_int arr.ints.(field_idx))
+    else None
+  in
+  raise_constraint ~at ~which:Field ?value ()
 
 (* Build a populate function that writes a field value into the validator
    array without allocating. Resolves the type at seal time so the hot
@@ -343,7 +354,7 @@ let rec build_populate : type a.
   | Where { inner; _ } -> build_populate inner idx reader
   | Enum { base; cases; closed; _ } ->
       let check = enum_check cases closed in
-      build_populate base idx (fun buf b -> check (reader buf b))
+      build_populate base idx (fun buf b -> check ~at:b (reader buf b))
   | Map { inner; encode; _ } ->
       build_populate inner idx (fun buf base -> encode (reader buf base))
   | Optional_or { inner; _ } ->
@@ -776,9 +787,8 @@ let rec compile_stmt (cc : compile_ctx) (s : Types.action_stmt) :
       let fe = compile_bool_arr cc e in
       fun arr ->
         if fe arr then raise_notrace Return_true
-        else raise (Parse_error (Constraint_failed "field action"))
-  | Types.Abort ->
-      fun _ -> raise (Parse_error (Constraint_failed "field action"))
+        else raise_constraint ~at:0 ~which:Action ()
+  | Types.Abort -> fun _ -> raise_constraint ~at:0 ~which:Action ()
   | If (cond, then_, else_) ->
       let fc = compile_bool_arr cc cond in
       let ft = compile_stmts cc then_ in
@@ -1171,8 +1181,7 @@ and iter_param_refs_fields f fields where =
 
 let zeroterm_nul_pos buf ~first ~limit =
   let rec go i =
-    if i >= limit then
-      raise (Parse_error (Constraint_failed "zeroterm: missing NUL terminator"))
+    if i >= limit then raise_missing_terminator ~at:first
     else if Bytes.get_uint8 buf i = 0 then i
     else go (i + 1)
   in
@@ -1219,10 +1228,10 @@ let rec read_elem : type a. a typ -> bytes -> int -> a =
   | Map { inner; decode; _ } -> decode (read_elem inner buf off)
   | Where { inner; _ } -> read_elem inner buf off
   | Enum { base; cases; closed; _ } ->
-      enum_check cases closed (read_elem base buf off)
+      enum_check cases closed ~at:off (read_elem base buf off)
   | Casetype { tag; cases; _ } ->
       let tag_val = read_elem tag buf off in
-      read_case_body ~tag cases tag_val buf (off + tag_byte_size tag)
+      read_case_body ~at:off ~tag cases tag_val buf (off + tag_byte_size tag)
   | Unit -> ()
   (* NUL-terminated string element: the bytes up to (not including) the NUL. *)
   | Zeroterm ->
@@ -1264,21 +1273,20 @@ let rec read_elem : type a. a typ -> bytes -> int -> a =
    [let rec find] inside [read_elem]: the inner form would allocate a fresh
    closure on every casetype element decoded. *)
 and read_case_body : type a k.
-    tag:k typ -> (a, k) case_branch list -> k -> bytes -> int -> a =
- fun ~tag cases tag_val buf body_off ->
+    at:int -> tag:k typ -> (a, k) case_branch list -> k -> bytes -> int -> a =
+ fun ~at ~tag cases tag_val buf body_off ->
   match cases with
   | [] ->
       (* No branch matched the discriminant. [tag] is integer-typed in the
          common case (a version/type field); a non-integer (string) tag has no
          [int] form and reports index 0. *)
-      let n = Option.value ~default:0 (Eval.int_of tag tag_val) in
-      raise (Parse_error (Invalid_tag n))
+      raise_invalid_tag ~at (Option.value ~default:0 (Eval.int_of tag tag_val))
   | Case_branch { cb_tag = Some t; cb_inner; cb_inject; _ } :: _
     when t = tag_val ->
       cb_inject tag_val (read_elem cb_inner buf body_off)
   | Case_branch { cb_tag = None; cb_inner; cb_inject; _ } :: _ ->
       cb_inject tag_val (read_elem cb_inner buf body_off)
-  | _ :: rest -> read_case_body ~tag rest tag_val buf body_off
+  | _ :: rest -> read_case_body ~at ~tag rest tag_val buf body_off
 
 (* Write one element of a typ at a given buffer position. Used by Repeat. *)
 let rec write_elem : type a. a typ -> bytes -> int -> a -> unit =
@@ -1336,7 +1344,7 @@ let rec elem_size_of : type a. a typ -> bytes -> int -> int =
   | Casetype { tag; cases; _ } ->
       let tag_size = tag_byte_size tag in
       let tag_val = read_elem tag buf off in
-      tag_size + size_case_body ~tag cases tag_val buf (off + tag_size)
+      tag_size + size_case_body ~at:off ~tag cases tag_val buf (off + tag_size)
   | Map { inner; _ } -> elem_size_of inner buf off
   | Where { inner; _ } -> elem_size_of inner buf off
   (* Bytes up to the NUL plus the one-byte terminator. *)
@@ -1358,17 +1366,16 @@ let rec elem_size_of : type a. a typ -> bytes -> int -> int =
    as [read_case_body]: a per-call [let rec find] would allocate a closure on
    every element. *)
 and size_case_body : type a k.
-    tag:k typ -> (a, k) case_branch list -> k -> bytes -> int -> int =
- fun ~tag cases tag_val buf body_off ->
+    at:int -> tag:k typ -> (a, k) case_branch list -> k -> bytes -> int -> int =
+ fun ~at ~tag cases tag_val buf body_off ->
   match cases with
   | [] ->
-      let n = Option.value ~default:0 (Eval.int_of tag tag_val) in
-      raise (Parse_error (Invalid_tag n))
+      raise_invalid_tag ~at (Option.value ~default:0 (Eval.int_of tag tag_val))
   | Case_branch { cb_tag = Some t; cb_inner; _ } :: _ when t = tag_val ->
       elem_size_of cb_inner buf body_off
   | Case_branch { cb_tag = None; cb_inner; _ } :: _ ->
       elem_size_of cb_inner buf body_off
-  | _ :: rest -> size_case_body ~tag rest tag_val buf body_off
+  | _ :: rest -> size_case_body ~at ~tag rest tag_val buf body_off
 
 (* -- Compiled field: intermediate plan for one field's contribution -- *)
 
@@ -1727,9 +1734,7 @@ let repeat_raw_fixed : type elt seq.
      buffer before reading so an oversized length fails cleanly instead of
      crashing [read_elem] with an out-of-range [Bytes.sub]. *)
   if budget < 0 || start + budget > Bytes.length buf then
-    raise
-      (Parse_error
-         (Unexpected_eof { expected = start + budget; got = Bytes.length buf }));
+    raise_eof ~at:start ~expected:(start + budget) ~got:(Bytes.length buf);
   let n = if esz > 0 then budget / esz else 0 in
   let rec loop acc i =
     if i >= n then seq.finish acc
@@ -1750,9 +1755,7 @@ let repeat_raw_variable : type elt seq.
   let start = base + off_fn buf base in
   (* Bound the untrusted budget to the buffer (see [repeat_raw_fixed]). *)
   if budget < 0 || start + budget > Bytes.length buf then
-    raise
-      (Parse_error
-         (Unexpected_eof { expected = start + budget; got = Bytes.length buf }));
+    raise_eof ~at:start ~expected:(start + budget) ~got:(Bytes.length buf);
   let rec loop acc pos remaining =
     if remaining <= 0 then seq.finish acc
     else
@@ -1863,14 +1866,10 @@ let var_bytes_reader : type a.
          [make_or_eod] with a raw [Invalid_argument] that escapes the decode
          result. Fail cleanly instead. *)
       if sz < 0 || first < 0 then
-        raise
-          (Parse_error
-             (Unexpected_eof { expected = first + sz; got = Bytes.length buf }))
+        raise_eof ~at:first ~expected:(first + sz) ~got:(Bytes.length buf)
   | _ ->
       if sz < 0 || first < 0 || first + sz > Bytes.length buf then
-        raise
-          (Parse_error
-             (Unexpected_eof { expected = first + sz; got = Bytes.length buf })));
+        raise_eof ~at:first ~expected:(first + sz) ~got:(Bytes.length buf));
   match typ with
   | Byte_slice _ -> Slice.make_or_eod buf ~first:(base + fo) ~length:sz
   | Byte_array _ -> Bytes.sub_string buf (base + fo) sz
@@ -1886,8 +1885,7 @@ let var_bytes_reader : type a.
       let s = Bytes.sub_string buf (base + fo) sz in
       String.iteri
         (fun i c ->
-          if c <> '\000' then
-            raise (Parse_error (All_zeros_failed { offset = base + fo + i })))
+          if c <> '\000' then raise_non_zero_padding ~at:(base + fo + i))
         s;
       s
   | Casetype _ -> read_elem typ buf (base + fo)
@@ -2115,11 +2113,11 @@ let rec compile_field : type a r.
       let check = enum_check cases closed in
       {
         cf with
-        raw_reader = (fun buf off -> check (cf.raw_reader buf off));
+        raw_reader = (fun buf off -> check ~at:off (cf.raw_reader buf off));
         populate =
           (fun arr buf base ->
             cf.populate arr buf base;
-            ignore (check (cf.int_reader buf base)));
+            ignore (check ~at:base (cf.int_reader buf base)));
       }
   | Where { inner; _ } -> compile_field ctx { fld with typ = inner }
   | Bits { width; base; bit_order } -> compile_bits ctx fld width base bit_order
@@ -2400,6 +2398,56 @@ let compile_field_check cc fld =
 (* The single place that mutates the record accumulator: assemble constraint
    and action checkers, then fold the [compiled_field] into a new record
    state. *)
+(* Whether reading a field of this type performs a decode-side check beyond
+   storing a scalar slot: enum membership, a lookup index bound, an all-zeros /
+   NUL-terminated / refined span, or a nested element's constraints. The
+   provably check-free leaves (scalars, bitfields, plain byte spans, unit, an
+   open enum, a bare bit/bool map) return [false]; everything else is treated as
+   a check ([| _ -> true]), so a new or uncertain type is never wrongly skipped.
+   A field's own [constraint_] / [action] / a [where] clause are accounted for
+   separately, so this is only about the type's intrinsic read-time validation. *)
+let rec field_reader_validates : type a. a Types.typ -> bool = function
+  | Types.Uint8 | Types.Uint16 _ | Types.Uint32 _ | Types.Uint63 _
+  | Types.Uint64 _ | Types.Int8 | Types.Int16 _ | Types.Int32 _ | Types.Int64 _
+  | Types.Float32 _ | Types.Float64 _ | Types.Uint_var _ | Types.Bits _
+  | Types.Byte_array _ | Types.Byte_slice _ | Types.All_bytes | Types.Unit ->
+      false
+  | Types.Enum { closed; _ } -> closed
+  | Types.Map { inner; index_bound; _ } ->
+      index_bound <> None || field_reader_validates inner
+  | Types.Optional { inner; _ } -> field_reader_validates inner
+  | Types.Optional_or { inner; _ } -> field_reader_validates inner
+  | Types.Single_elem { elem; _ } -> field_reader_validates elem
+  | Types.Array { elem; _ } -> field_reader_validates elem
+  | Types.Repeat { elem; _ } -> field_reader_validates elem
+  | _ -> true
+
+(* Prepend [name] to the field path of a parse error escaping [f], so a failure
+   deep in a nested decode accumulates its root-to-leaf path as the exception
+   unwinds. Only fields that can raise an attributable error are wrapped; a plain
+   scalar read raises only [Unexpected_eof] from the record's bounds check, which
+   is recorded without a path. *)
+let prepend_field name f buf base =
+  try f buf base
+  with Types.Parse_error e ->
+    raise (Types.Parse_error { e with field = name :: e.field })
+
+let prepend_field_check name f arr buf base =
+  try f arr buf base
+  with Types.Parse_error e ->
+    raise (Types.Parse_error { e with field = name :: e.field })
+
+(* Tag a field's reader and its two validators with [name] so a parse error
+   escaping any of them carries the field in its path; [attributable = false] (a
+   plain scalar) leaves them untouched, keeping the hot read path free of an
+   exception frame. *)
+let wrap_field_errors ~validates ~check ~act name raw_reader full check_only =
+  if Option.is_some check || Option.is_some act || validates then
+    ( prepend_field name raw_reader,
+      prepend_field_check name full,
+      prepend_field_check name check_only )
+  else (raw_reader, full, check_only)
+
 let apply_compiled : type a f r.
     (a -> f, r) record -> (a, r) field -> (a, r) compiled_field -> (f, r) record
     =
@@ -2424,12 +2472,10 @@ let apply_compiled : type a f r.
   in
   let check = compile_field_check cc fld in
   let act = compile_action cc fld.action in
-  let populate = cf.populate in
   let check_only arr buf base =
-    populate arr buf base;
+    cf.populate arr buf base;
     match check with
-    | Some f when not (f arr) ->
-        raise (Parse_error (Constraint_failed "field constraint"))
+    | Some f when not (f arr) -> raise_field_constraint ~field_idx ~at:base arr
     | _ -> ()
   in
   (* The full validator is the read-and-check plus the field action. Decode and
@@ -2457,11 +2503,16 @@ let apply_compiled : type a f r.
     | Bitfield _ -> fun _ -> cf.size_delta
     | _ -> fun v -> size_of_typ_value field_typ (field_get v)
   in
+  let raw_reader, full, check_only =
+    wrap_field_errors
+      ~validates:(field_reader_validates fld.typ)
+      ~check ~act fld.name cf.raw_reader full check_only
+  in
   Record
     {
       name = r.name;
       make = r.make;
-      readers = Snoc (r.readers, cf.raw_reader);
+      readers = Snoc (r.readers, raw_reader);
       writers_rev = new_writers_rev;
       size_of_value_rev = field_size_of_value :: r.size_of_value_rev;
       min_wire_size = r.min_wire_size + cf.size_delta;
@@ -2663,34 +2714,8 @@ let compile_where_clause param_slots field_readers where =
 let validate_or_eof buf f =
   try f ()
   with Invalid_argument _ ->
-    raise
-      (Parse_error
-         (Unexpected_eof
-            { expected = Bytes.length buf + 1; got = Bytes.length buf }))
-
-(* Whether reading a field of this type performs a decode-side check beyond
-   storing a scalar slot: enum membership, a lookup index bound, an all-zeros /
-   NUL-terminated / refined span, or a nested element's constraints. The
-   provably check-free leaves (scalars, bitfields, plain byte spans, unit, an
-   open enum, a bare bit/bool map) return [false]; everything else is treated as
-   a check ([| _ -> true]), so a new or uncertain type is never wrongly skipped.
-   A field's own [constraint_] / [action] / a [where] clause are accounted for
-   separately, so this is only about the type's intrinsic read-time validation. *)
-let rec field_reader_validates : type a. a Types.typ -> bool = function
-  | Types.Uint8 | Types.Uint16 _ | Types.Uint32 _ | Types.Uint63 _
-  | Types.Uint64 _ | Types.Int8 | Types.Int16 _ | Types.Int32 _ | Types.Int64 _
-  | Types.Float32 _ | Types.Float64 _ | Types.Uint_var _ | Types.Bits _
-  | Types.Byte_array _ | Types.Byte_slice _ | Types.All_bytes | Types.Unit ->
-      false
-  | Types.Enum { closed; _ } -> closed
-  | Types.Map { inner; index_bound; _ } ->
-      index_bound <> None || field_reader_validates inner
-  | Types.Optional { inner; _ } -> field_reader_validates inner
-  | Types.Optional_or { inner; _ } -> field_reader_validates inner
-  | Types.Single_elem { elem; _ } -> field_reader_validates elem
-  | Types.Array { elem; _ } -> field_reader_validates elem
-  | Types.Repeat { elem; _ } -> field_reader_validates elem
-  | _ -> true
+    let len = Bytes.length buf in
+    raise_eof ~at:len ~expected:(len + 1) ~got:len
 
 let build_validators validators_rev checkers_rev compiled_where struct_fields
     n_total =
@@ -2701,8 +2726,7 @@ let build_validators validators_rev checkers_rev compiled_where struct_fields
       validator_fns.(i) arr buf off
     done;
     match compiled_where with
-    | Some f when not (f arr) ->
-        raise (Parse_error (Constraint_failed "where clause"))
+    | Some f when not (f arr) -> raise_constraint ~at:off ~which:Where ()
     | _ -> ()
   in
   let checker_fns = Array.of_list (List.map snd checkers_rev) in
@@ -2768,19 +2792,19 @@ let fill_param_slots tbl param_base handles =
    before a zero-copy [get] reads its fields. *)
 let check_decode_bounds wire_size_info min_size buf off =
   if off + min_size > Bytes.length buf then
-    raise_eof ~expected:min_size ~got:(Bytes.length buf - off);
+    raise_eof ~at:off ~expected:min_size ~got:(Bytes.length buf - off);
   match wire_size_info with
   | Fixed _ -> ()
   | Variable { compute; _ } ->
       let end_off =
         try compute buf off
         with Invalid_argument _ ->
-          raise_eof ~expected:min_size ~got:(Bytes.length buf - off)
+          raise_eof ~at:off ~expected:min_size ~got:(Bytes.length buf - off)
       in
       if end_off < off + min_size then
-        raise_eof ~expected:min_size ~got:(Bytes.length buf - off);
+        raise_eof ~at:off ~expected:min_size ~got:(Bytes.length buf - off);
       if end_off > Bytes.length buf then
-        raise_eof ~expected:(end_off - off) ~got:(Bytes.length buf - off)
+        raise_eof ~at:off ~expected:(end_off - off) ~got:(Bytes.length buf - off)
 
 let build_checked_decode raw_decode wire_size_info min_size =
  fun buf off ->
@@ -3074,20 +3098,20 @@ let build_field_checks acc ~populate ~validator_off ~name ~action ~constraint_ =
   in
   let check = Option.map (compile_bool_arr cc) constraint_ in
   let act = compile_action cc action in
-  let raise_check_failed () =
-    raise (Parse_error (Constraint_failed "field constraint"))
+  let raise_check_failed arr base =
+    raise_field_constraint ~field_idx:acc.n_fields ~at:base arr
   in
   let full arr buf base =
     populate arr buf base;
     (match check with
-    | Some f when not (f arr) -> raise_check_failed ()
+    | Some f when not (f arr) -> raise_check_failed arr base
     | _ -> ());
     Option.iter (fun f -> f arr) act
   in
   let check_only arr buf base =
     populate arr buf base;
     match check with
-    | Some f when not (f arr) -> raise_check_failed ()
+    | Some f when not (f arr) -> raise_check_failed arr base
     | _ -> ()
   in
   (full, check_only, List.length action_vanames)
@@ -3445,7 +3469,7 @@ let rec build_staged_reader : type a. a typ -> field_access -> bytes -> int -> a
   | Enum { base; cases; closed; _ }, _ ->
       let read = build_staged_reader base access in
       let check = enum_check cases closed in
-      fun buf base -> check (read buf base)
+      fun buf base -> check ~at:base (read buf base)
   | Map { inner; decode; _ }, _ ->
       let read = build_staged_reader inner access in
       fun buf base -> decode (read buf base)

--- a/lib/eval.ml
+++ b/lib/eval.ml
@@ -46,13 +46,11 @@ let rec int_of : type a. a typ -> a -> int option =
 
 (* Hot-path variant of [int_of] for the cross-field size/offset/present
    readers, which need a plain [int]. Returns it directly (no [Some] box on the
-   numeric path) and raises [Parse_error] when the value is not a usable int: a
-   [uint64]/[int64] beyond the native int range (adversarial input), or a
-   non-integer field referenced where an integer is required (a schema error). *)
-let int_overflow () =
-  raise
-    (Parse_error
-       (Constraint_failed "integer field value exceeds the native int range"))
+   numeric path). A [uint64]/[int64] beyond the native int range is adversarial
+   input and raises [Parse_error] ([Value_out_of_range]); a non-integer field
+   referenced where an integer is required is a schema error and raises
+   [Invalid_argument]. *)
+let int_overflow v = raise_out_of_range ~at:0 v
 
 let not_an_integer () =
   invalid_arg "Wire: non-integer field referenced where an integer is required"
@@ -66,12 +64,12 @@ let rec int_of_exn : type a. a typ -> a -> int =
   | Uint32 _ -> UInt32.to_int v
   | Uint63 _ -> UInt63.to_int v
   | Uint64 _ -> (
-      match Int64.unsigned_to_int v with Some n -> n | None -> int_overflow ())
+      match Int64.unsigned_to_int v with Some n -> n | None -> int_overflow v)
   | Int8 -> v
   | Int16 _ -> v
   | Int32 _ -> v
   | Int64 _ -> (
-      match Int64.unsigned_to_int v with Some n -> n | None -> int_overflow ())
+      match Int64.unsigned_to_int v with Some n -> n | None -> int_overflow v)
   | Float32 _ -> not_an_integer ()
   | Float64 _ -> not_an_integer ()
   | Bits _ -> v

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -16,6 +16,53 @@ type ('elt, 'seq) seq_map =
 type param_input
 type param_output
 
+(* Parse errors, defined before [typ] so [typ]'s own [Where] / [Field]
+   constructors win type-directed disambiguation everywhere below; the
+   [predicate] constructors are reached only through a [predicate]-typed
+   context (a [~which] argument or an annotated match). *)
+
+(* Which predicate a [Constraint_failed] came from: a field [~self_constraint]
+   or [~constraint_] ([Field]), a codec/typ [~where] ([Where]), a field
+   [~action] ([Action]), or a [byte_array_where] per-byte refinement
+   ([Per_byte]). *)
+type predicate = Where | Field | Action | Per_byte
+
+type error_kind =
+  | Unexpected_eof of { expected : int; got : int }
+  | Invalid_enum of { value : int; valid : int list }
+  | Invalid_tag of int
+  | Missing_terminator
+  | Non_zero_padding
+  | Value_out_of_range of { value : int64 }
+  | Constraint_failed of { which : predicate; value : int64 option }
+
+(* [at] is the absolute byte offset of the failing field in the input; [field]
+   is the root-to-leaf path of field names to it (e.g. ["header"; "vcid"]),
+   empty at a top-level or anonymous position. *)
+type parse_error = { at : int; field : string list; kind : error_kind }
+
+exception Parse_error of parse_error
+
+let err ~at kind = { at; field = []; kind }
+let raise_error ~at kind = raise (Parse_error (err ~at kind))
+
+let raise_eof ~at ~expected ~got =
+  raise_error ~at (Unexpected_eof { expected; got })
+
+let raise_invalid_tag ~at tag = raise_error ~at (Invalid_tag tag)
+
+let raise_invalid_enum ~at ~value ~valid =
+  raise_error ~at (Invalid_enum { value; valid })
+
+let raise_missing_terminator ~at = raise_error ~at Missing_terminator
+let raise_non_zero_padding ~at = raise_error ~at Non_zero_padding
+
+let raise_out_of_range ~at value =
+  raise_error ~at (Value_out_of_range { value })
+
+let raise_constraint ~at ~which ?value () =
+  raise_error ~at (Constraint_failed { which; value })
+
 type ('a, 'k) param_handle = {
   name : string;
   typ : 'a typ;
@@ -362,18 +409,6 @@ let map decode encode inner =
 let bool inner =
   Map { inner; decode = is_set; encode = bit; index_bound = None }
 
-(* Parse errors -- moved here so combinators like [cases] can raise them
-   directly rather than through intermediate exceptions. *)
-
-type parse_error =
-  | Unexpected_eof of { expected : int; got : int }
-  | Constraint_failed of string
-  | Invalid_enum of { value : int; valid : int list }
-  | Invalid_tag of int
-  | All_zeros_failed of { offset : int }
-
-exception Parse_error of parse_error
-
 (* Top-level so [variants_lookup] does not allocate a closure per call.
    Returns -1 if [v] is not in [arr] (used as a non-allocating sentinel
    instead of [int option]). Shared with [variants] below. *)
@@ -386,7 +421,9 @@ let cases variants inner =
   let arr = Array.of_list variants in
   let len = Array.length arr in
   let decode n =
-    if n >= 0 && n < len then arr.(n) else raise (Parse_error (Invalid_tag n))
+    (* [lookup] reads a bare index with no field context, so the failing index
+       is reported without a byte offset (at = 0). *)
+    if n >= 0 && n < len then arr.(n) else raise_invalid_tag ~at:0 n
   in
   let encode v =
     let i = variants_lookup arr v 0 in
@@ -640,16 +677,15 @@ let nested_at_most ~size elem =
 let enum name cases base = Enum { name; cases; base; closed = true }
 let enum_open name cases base = Enum { name; cases; base; closed = false }
 
-let fail_parse_error fmt =
-  Fmt.kstr (fun s -> raise (Parse_error (Constraint_failed s))) fmt
-
 let variants name cases base =
   let enum_cases = List.mapi (fun i (s, _) -> (s, i)) cases in
   let arr = Array.of_list (List.map snd cases) in
   let len = Array.length arr in
+  (* [enum name enum_cases base] is closed, so [enum_check] rejects any value
+     outside [0, len) before [decode] runs; the [else] is a defensive fallback. *)
   let decode n =
     if n >= 0 && n < len then arr.(n)
-    else fail_parse_error "Wire.variants %s: unknown value %d" name n
+    else raise_invalid_enum ~at:0 ~value:n ~valid:(List.init len Fun.id)
   in
   let encode v =
     let i = variants_lookup arr v 0 in
@@ -2662,20 +2698,75 @@ let to_3d_file ?(enum_as_type = false) path m =
     ~finally:(fun () -> close_out oc)
     (fun () -> output_string oc (to_3d ~enum_as_type m ^ "\n"))
 
-let raise_eof ~expected ~got =
-  raise (Parse_error (Unexpected_eof { expected; got }))
+let pp_predicate ppf (p : predicate) =
+  match p with
+  | Where -> Fmt.string ppf "where clause"
+  | Field -> Fmt.string ppf "field constraint"
+  | Action -> Fmt.string ppf "field action"
+  | Per_byte -> Fmt.string ppf "per-byte refinement"
 
-let pp_parse_error ppf = function
+let pp_error_kind ppf = function
   | Unexpected_eof { expected; got } ->
       Fmt.pf ppf "unexpected EOF: expected %d bytes, got %d" expected got
-  | Constraint_failed msg -> Fmt.pf ppf "constraint failed: %s" msg
   | Invalid_enum { value; valid } ->
       Fmt.pf ppf "invalid enum value %d, valid: [%a]" value
         Fmt.(list ~sep:comma int)
         valid
   | Invalid_tag tag -> Fmt.pf ppf "invalid tag: %d" tag
-  | All_zeros_failed { offset } ->
-      Fmt.pf ppf "non-zero byte at offset %d" offset
+  | Missing_terminator -> Fmt.string ppf "missing NUL terminator"
+  | Non_zero_padding -> Fmt.string ppf "non-zero padding byte"
+  | Value_out_of_range { value } -> Fmt.pf ppf "value out of range: %Ld" value
+  | Constraint_failed { which; value } -> (
+      match value with
+      | Some v -> Fmt.pf ppf "%a violated (value %Ld)" pp_predicate which v
+      | None -> Fmt.pf ppf "%a violated" pp_predicate which)
+
+let pp_parse_error ppf { at; field; kind } =
+  (match field with
+  | [] -> ()
+  | _ -> Fmt.(list ~sep:(any ".") string) ppf field);
+  Fmt.pf ppf "@%d: %a" at pp_error_kind kind
+
+let predicate_rank (p : predicate) =
+  match p with Where -> 0 | Field -> 1 | Action -> 2 | Per_byte -> 3
+
+let compare_predicate a b = Int.compare (predicate_rank a) (predicate_rank b)
+
+let kind_rank = function
+  | Unexpected_eof _ -> 0
+  | Invalid_enum _ -> 1
+  | Invalid_tag _ -> 2
+  | Missing_terminator -> 3
+  | Non_zero_padding -> 4
+  | Value_out_of_range _ -> 5
+  | Constraint_failed _ -> 6
+
+let compare_error_kind a b =
+  match (a, b) with
+  | Unexpected_eof a, Unexpected_eof b ->
+      let c = Int.compare a.expected b.expected in
+      if c <> 0 then c else Int.compare a.got b.got
+  | Invalid_enum a, Invalid_enum b ->
+      let c = Int.compare a.value b.value in
+      if c <> 0 then c else List.compare Int.compare a.valid b.valid
+  | Invalid_tag a, Invalid_tag b -> Int.compare a b
+  | Value_out_of_range a, Value_out_of_range b -> Int64.compare a.value b.value
+  | Constraint_failed a, Constraint_failed b ->
+      let c = compare_predicate a.which b.which in
+      if c <> 0 then c else Option.compare Int64.compare a.value b.value
+  | Missing_terminator, Missing_terminator | Non_zero_padding, Non_zero_padding
+    ->
+      0
+  | _ -> Int.compare (kind_rank a) (kind_rank b)
+
+let compare_parse_error a b =
+  let c = compare_error_kind a.kind b.kind in
+  if c <> 0 then c
+  else
+    let c = Int.compare a.at b.at in
+    if c <> 0 then c else List.compare String.compare a.field b.field
+
+let equal_parse_error a b = compare_parse_error a b = 0
 
 (* Encoded byte size of [v] under [typ], computed from the value rather
    than from a buffer. Mirrors [field_wire_size] for fixed cases and

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -2,6 +2,30 @@
 
 type endian = Little | Big  (** Byte order. *)
 
+(* The parse-error types are declared here, before {!typ}, so that {!typ}'s own
+   [Where] / [Field] constructors win type-directed disambiguation throughout;
+   the {!predicate} constructors are reached only through a [predicate]-typed
+   context. See {!section:parse-errors} for the exception and helpers. *)
+
+(** Which predicate a {!Constraint_failed} came from. *)
+type predicate = Where | Field | Action | Per_byte
+
+type error_kind =
+  | Unexpected_eof of { expected : int; got : int }
+  | Invalid_enum of { value : int; valid : int list }
+  | Invalid_tag of int
+  | Missing_terminator
+  | Non_zero_padding
+  | Value_out_of_range of { value : int64 }
+  | Constraint_failed of { which : predicate; value : int64 option }
+      (** [value] is the offending field's value for a single-field
+          self-constraint, [None] for a cross-field or where predicate. *)
+
+type parse_error = { at : int; field : string list; kind : error_kind }
+(** [at] is the absolute byte offset of the failing field. Alongside it the
+    parse error records the path of field names leading to that field (root to
+    leaf, empty at a top-level or anonymous position) and the failure kind. *)
+
 type bit_order =
   | Msb_first
   | Lsb_first
@@ -768,22 +792,49 @@ val to_3d_file : ?enum_as_type:bool -> string -> module_ -> unit
 val escape_3d : string -> string
 (** [escape_3d name] appends [_] if [name] is a 3D or C reserved word. *)
 
-(** {1 Parse Errors} *)
+(** {1:parse-errors Parse Errors}
 
-type parse_error =
-  | Unexpected_eof of { expected : int; got : int }
-  | Constraint_failed of string
-  | Invalid_enum of { value : int; valid : int list }
-  | Invalid_tag of int
-  | All_zeros_failed of { offset : int }  (** Structured parse error. *)
+    The {!predicate}, {!error_kind}, and {!parse_error} types are declared near
+    the top of this interface. *)
 
 exception Parse_error of parse_error
 
-val raise_eof : expected:int -> got:int -> 'a
+val raise_error : at:int -> error_kind -> 'a
+(** Raise {!Parse_error} with an empty field path. *)
+
+val raise_eof : at:int -> expected:int -> got:int -> 'a
 (** Raise {!Parse_error} for unexpected end-of-input. *)
+
+val raise_invalid_tag : at:int -> int -> 'a
+(** Raise {!Parse_error} for a tag or lookup index with no matching case. *)
+
+val raise_invalid_enum : at:int -> value:int -> valid:int list -> 'a
+(** Raise {!Parse_error} for an enum value outside its named set. *)
+
+val raise_missing_terminator : at:int -> 'a
+(** Raise {!Parse_error} for a NUL-terminated string with no terminator. *)
+
+val raise_non_zero_padding : at:int -> 'a
+(** Raise {!Parse_error} for a non-zero byte where zero padding is required. *)
+
+val raise_out_of_range : at:int -> int64 -> 'a
+(** Raise {!Parse_error} for an integer beyond the native integer range. *)
+
+val raise_constraint : at:int -> which:predicate -> ?value:int64 -> unit -> 'a
+(** Raise {!Parse_error} for a violated predicate [which], optionally carrying
+    the offending field's [value]. *)
 
 val pp_parse_error : Format.formatter -> parse_error -> unit
 (** Pretty-print a parse error. *)
+
+val pp_error_kind : Format.formatter -> error_kind -> unit
+(** Pretty-print a parse error kind, without location. *)
+
+val equal_parse_error : parse_error -> parse_error -> bool
+(** Structural equality on parse errors. *)
+
+val compare_parse_error : parse_error -> parse_error -> int
+(** Total order on parse errors. *)
 
 val field_wire_size : 'a typ -> int option
 (** Fixed wire size of a field type, if determinable. *)

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -129,11 +129,8 @@ end
 module Reader = Bytesrw.Bytes.Reader
 module Slice = Bytesrw.Bytes.Slice
 
-exception Validation_error = Parse_error
-
 let[@inline] check_eof len need =
-  if need > len then
-    raise (Parse_error (Unexpected_eof { expected = need; got = len }))
+  if need > len then raise_eof ~at:len ~expected:need ~got:len
 
 (* The single decoder kernel. Bytes-based, returns [(value, end_off)].
    All types handled here -- no fallback. Expressions are evaluated in
@@ -148,8 +145,7 @@ let parse_all_zeros buf off len =
   let s = Bytes.sub_string buf off n in
   let rec check i =
     if i >= n then s
-    else if s.[i] <> '\000' then
-      raise (Parse_error (All_zeros_failed { offset = off + i }))
+    else if s.[i] <> '\000' then raise_non_zero_padding ~at:(off + i)
     else check (i + 1)
   in
   (check 0, len)
@@ -166,8 +162,7 @@ let parse_codec_typ codec_decode fixed_size size_of buf off len =
            truncated input returns [Error _] instead of crashing. *)
         try size_of buf off
         with Invalid_argument _ ->
-          raise (Parse_error (Unexpected_eof { expected = len + 1; got = len }))
-        )
+          raise_eof ~at:off ~expected:(len + 1) ~got:len)
   in
   check_eof len (off + sz);
   (codec_decode buf off, off + sz)
@@ -175,11 +170,10 @@ let parse_codec_typ codec_decode fixed_size size_of buf off len =
 (* Only a closed enum enforces membership; an open enum names known codes but
    accepts any value. [Codec.decode] gates on [closed] the same way, so the two
    decode paths agree on an unlisted code. *)
-let check_enum_membership ~closed cases v =
+let check_enum_membership ~at ~closed cases v =
   if closed then begin
     let valid = List.map snd cases in
-    if not (List.mem v valid) then
-      raise (Parse_error (Invalid_enum { value = v; valid }))
+    if not (List.mem v valid) then raise_invalid_enum ~at ~value:v ~valid
   end
 
 let parse_struct_typ s buf off len =
@@ -283,7 +277,7 @@ let rec parse_direct : type a. a typ -> bytes -> int -> int -> a * int =
       for i = 0 to n - 1 do
         let v = Bytes.get_uint8 buf (off + i) in
         if not (Eval.expr (Eval.bind elt_var v Eval.empty) cond) then
-          raise (Parse_error (Constraint_failed "byte_array_where: per-byte"))
+          raise_constraint ~at:(off + i) ~which:Per_byte ()
       done;
       (Bytes.sub_string buf off n, off + n)
   | Byte_slice { size } ->
@@ -301,7 +295,7 @@ let rec parse_direct : type a. a typ -> bytes -> int -> int -> a * int =
   | Where { cond; inner } -> parse_where inner cond buf off len
   | Enum { base; cases; closed; _ } ->
       let v, off' = parse_direct base buf off len in
-      check_enum_membership ~closed cases v;
+      check_enum_membership ~at:off ~closed cases v;
       (v, off')
   | Codec { codec_decode; codec_fixed_size; codec_size_of; _ } ->
       parse_codec_typ codec_decode codec_fixed_size codec_size_of buf off len
@@ -329,7 +323,7 @@ and parse_where : type a. a typ -> bool expr -> bytes -> int -> int -> a * int =
  fun inner cond buf off len ->
   let v, off' = parse_direct inner buf off len in
   if Eval.expr Eval.empty cond then (v, off')
-  else raise (Parse_error (Constraint_failed "where clause"))
+  else raise_constraint ~at:off ~which:Where ()
 
 and parse_casetype : type a k.
     k typ -> (a, k) case_branch list -> bytes -> int -> int -> a * int =
@@ -337,8 +331,8 @@ and parse_casetype : type a k.
   let tag_val, off' = parse_direct tag buf off len in
   let rec find_case = function
     | [] ->
-        let n = Option.value ~default:0 (Eval.int_of tag tag_val) in
-        raise (Parse_error (Invalid_tag n))
+        raise_invalid_tag ~at:off
+          (Option.value ~default:0 (Eval.int_of tag tag_val))
     | Case_branch { cb_tag = Some expected; cb_inner; cb_inject; _ } :: rest ->
         if expected = tag_val then
           let body, off'' = parse_direct cb_inner buf off' len in
@@ -448,7 +442,7 @@ let read_exact reader (n : int) =
       let slice = Reader.read reader in
       if Slice.is_eod slice then begin
         push_back_bytes reader buf 0 off;
-        raise (Parse_error (Unexpected_eof { expected = n; got = off }))
+        raise_eof ~at:off ~expected:n ~got:off
       end
       else
         let slice_len = Slice.length slice in
@@ -475,10 +469,12 @@ let parse_or_rewind typ reader bytes len =
       push_back_bytes reader bytes 0 len;
       raise (Parse_error e)
 
-let missing_more_input = function
-  | Unexpected_eof _ -> true
-  (* must match the message raised by [Codec.zeroterm_nul_pos] *)
-  | Constraint_failed "zeroterm: missing NUL terminator" -> true
+let missing_more_input e =
+  (* A truncated zeroterm reports [Missing_terminator] (from
+     [Codec.zeroterm_nul_pos]); both it and an [Unexpected_eof] mean the reader
+     should fetch more input before giving up. *)
+  match e.kind with
+  | Unexpected_eof _ | Missing_terminator -> true
   | _ -> false
 
 let of_reader_incremental typ reader =
@@ -509,8 +505,7 @@ let of_reader_incremental typ reader =
     | exception Invalid_argument _ ->
         read_more (fun () ->
             push_back_bytes reader bytes 0 len;
-            raise
-              (Parse_error (Unexpected_eof { expected = len + 1; got = len })))
+            raise_eof ~at:len ~expected:(len + 1) ~got:len)
   in
   loop ()
 

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -749,22 +749,41 @@ val size : 'a typ -> int option
     a constraint violation, from semantic failure such as an invalid enum or
     tag. *)
 
-type parse_error =
+(** Which predicate a {!Constraint_failed} came from. *)
+type predicate = Where | Field | Action | Per_byte
+
+type error_kind =
   | Unexpected_eof of { expected : int; got : int }
-  | Constraint_failed of string
   | Invalid_enum of { value : int; valid : int list }
   | Invalid_tag of int
-  | All_zeros_failed of { offset : int }
+  | Missing_terminator
+  | Non_zero_padding
+  | Value_out_of_range of { value : int64 }
+  | Constraint_failed of { which : predicate; value : int64 option }
+      (** [value] is the offending field's value for a single-field
+          self-constraint, [None] for a cross-field or where predicate. *)
+
+type parse_error = { at : int; field : string list; kind : error_kind }
+(** [at] is the absolute byte offset of the failing field. Alongside it the
+    parse error records the path of field names leading to that field (root to
+    leaf, empty at a top-level or anonymous position) and the failure kind. *)
 
 exception Parse_error of parse_error
 (** Raised by the [_exn] direct decoders ({!of_string_exn}, {!of_bytes_exn},
-    {!of_reader_exn}) and by {!Codec.decode_exn} on parse failure. *)
-
-exception Validation_error of parse_error
-(** Raised by {!Codec.validate} on constraint or where-clause failure. *)
+    {!of_reader_exn}), by {!Codec.decode_exn}, and by {!Codec.validate} on parse
+    or constraint failure. *)
 
 val pp_parse_error : Format.formatter -> parse_error -> unit
-(** Pretty-printer for decode errors. *)
+(** Pretty-printer for decode errors, including the offset and field path. *)
+
+val pp_error_kind : Format.formatter -> error_kind -> unit
+(** Pretty-print an error kind without its location. *)
+
+val equal_parse_error : parse_error -> parse_error -> bool
+(** Structural equality on parse errors. *)
+
+val compare_parse_error : parse_error -> parse_error -> int
+(** Total order on parse errors. *)
 
 (** {1 Direct Decoding and Encoding}
 

--- a/test/diff/fuzz_schema.ml
+++ b/test/diff/fuzz_schema.ml
@@ -20,7 +20,12 @@ let encode_record codec v =
 let decode_record codec s =
   let ws = Codec.wire_size codec in
   if String.length s < ws then
-    Error (Unexpected_eof { expected = ws; got = String.length s })
+    Error
+      {
+        at = 0;
+        field = [];
+        kind = Unexpected_eof { expected = ws; got = String.length s };
+      }
   else Codec.decode codec (Bytes.of_string s) 0
 
 (** Test SimpleHeader roundtrip *)

--- a/test/helpers/test_helpers.ml
+++ b/test/helpers/test_helpers.ml
@@ -113,9 +113,15 @@ let decode_ok = function
 
 let expect_constraint_fail = function
   | Ok _ -> Alcotest.fail "expected a Constraint_failed parse error"
-  | Error (Constraint_failed _) -> ()
+  | Error { kind = Constraint_failed _; _ } -> ()
   | Error e ->
       Alcotest.failf "expected Constraint_failed, got %a" pp_parse_error e
+
+(* Assert a decode failed with a [kind] satisfying [pred]. *)
+let expect_kind pred = function
+  | Ok _ -> Alcotest.fail "expected a parse error"
+  | Error { kind; _ } when pred kind -> ()
+  | Error e -> Alcotest.failf "unexpected parse error: %a" pp_parse_error e
 
 let roundtrip name typ testable v =
   Alcotest.check testable name v (decode_ok (of_string typ (to_string typ v)))

--- a/test/helpers/test_helpers.mli
+++ b/test/helpers/test_helpers.mli
@@ -74,8 +74,12 @@ val decode_ok : ('a, parse_error) result -> 'a
 (** [decode_ok r] returns the decoded value, failing the test on [Error]. *)
 
 val expect_constraint_fail : ('a, parse_error) result -> unit
-(** [expect_constraint_fail r] asserts [r] is [Error (Constraint_failed _)],
-    failing the test otherwise. *)
+(** [expect_constraint_fail r] asserts [r] is [Error] with a [Constraint_failed]
+    kind, failing the test otherwise. *)
+
+val expect_kind : (error_kind -> bool) -> ('a, parse_error) result -> unit
+(** [expect_kind pred r] asserts [r] is [Error] whose [kind] satisfies [pred].
+*)
 
 val roundtrip : string -> 'a typ -> 'a Alcotest.testable -> 'a -> unit
 (** [roundtrip name typ testable v] checks that decoding the encoding of [v]

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -21,7 +21,12 @@ let encode_record codec v =
 let decode_record codec s =
   let ws = Codec.wire_size codec in
   if String.length s < ws then
-    Error (Unexpected_eof { expected = ws; got = String.length s })
+    Error
+      {
+        at = 0;
+        field = [];
+        kind = Unexpected_eof { expected = ws; got = String.length s };
+      }
   else Codec.decode codec (Bytes.of_string s) 0
 
 (* -- Record codec tests -- *)
@@ -109,14 +114,14 @@ let test_codec_metadata_decode_ok () =
 let test_metadata_constraint_fail () =
   let buf = Bytes.of_string "\x0B" in
   match Codec.decode meta_codec buf 0 with
-  | Error (Constraint_failed "field constraint") -> ()
+  | Error { kind = Constraint_failed { which = Field; _ }; _ } -> ()
   | Error e -> Alcotest.failf "wrong error: %a" pp_parse_error e
   | Ok _ -> Alcotest.fail "expected decode failure"
 
 let test_metadata_action_fail () =
   let buf = Bytes.of_string "\x09" in
   match Codec.decode meta_codec buf 0 with
-  | Error (Constraint_failed "field action") -> ()
+  | Error { kind = Constraint_failed { which = Action; _ }; _ } -> ()
   | Error e -> Alcotest.failf "wrong error: %a" pp_parse_error e
   | Ok _ -> Alcotest.fail "expected decode failure"
 
@@ -151,7 +156,7 @@ let test_metadata_where_fail () =
   let env = Codec.env projection_codec |> Param.bind projection_limit 7 in
   let buf = Bytes.of_string "\x08" in
   match Codec.decode ~env projection_codec buf 0 with
-  | Error (Constraint_failed "where clause") -> ()
+  | Error { kind = Constraint_failed { which = Where; _ }; _ } -> ()
   | Error e -> Alcotest.failf "wrong error: %a" pp_parse_error e
   | Ok _ -> Alcotest.fail "expected decode failure"
 
@@ -180,7 +185,7 @@ let test_validate_rejects_bad_where () =
   (* validate catches the violation *)
   match Codec.validate validate_codec buf 0 with
   | () -> Alcotest.fail "expected validate to reject where violation"
-  | exception Validation_error (Constraint_failed _) -> ()
+  | exception Parse_error { kind = Constraint_failed _; _ } -> ()
 
 let test_validate_rejects_bad_constraint () =
   (* constraint requires x <= 10, set x = 11 *)
@@ -189,7 +194,7 @@ let test_validate_rejects_bad_constraint () =
   Alcotest.(check int) "get bypasses constraint" 11 (get_x buf 0);
   match Codec.validate validate_codec buf 0 with
   | () -> Alcotest.fail "expected validate to reject constraint violation"
-  | exception Validation_error (Constraint_failed _) -> ()
+  | exception Parse_error { kind = Constraint_failed _; _ } -> ()
 
 let test_validate_then_get () =
   (* x = 8 satisfies both where (= 8) and constraint (<= 10) *)
@@ -209,8 +214,8 @@ let test_validate_bounds_constraint_free () =
       Codec.[ Field.v "a" uint32be $ fst; Field.v "b" uint32be $ snd ]
   in
   (match Codec.validate c (Bytes.make 2 '\000') 0 with
-  | exception Validation_error (Unexpected_eof _) -> ()
-  | exception Validation_error _ ->
+  | exception Parse_error { kind = Unexpected_eof _; _ } -> ()
+  | exception Parse_error _ ->
       Alcotest.fail "validate failed with the wrong error on a short buffer"
   | () -> Alcotest.fail "validate accepted a buffer too short for the codec");
   (* A full buffer still validates. *)
@@ -226,20 +231,77 @@ let test_validate_all_zeros () =
   in
   Codec.validate c (Bytes.of_string "\x01\x00\x00\x00") 0;
   let tampered = Bytes.of_string "\x01\x00\x05\x00" in
-  (* The 0x05 sits at absolute offset 2; decoding through a struct field now
-     reports the same typed [All_zeros_failed] with that offset as the direct
-     [of_string] path, instead of a stringly constraint failure. *)
   (match Codec.decode c tampered 0 with
-  | Error (All_zeros_failed { offset }) ->
-      Alcotest.(check int) "decode non-zero offset" 2 offset
+  | Error { kind = Non_zero_padding; _ } -> ()
   | Ok _ -> Alcotest.fail "decode accepted non-zero all_zeros padding"
   | Error _ -> Alcotest.fail "decode failed with the wrong error");
   match Codec.validate c tampered 0 with
-  | exception Validation_error (All_zeros_failed { offset }) ->
-      Alcotest.(check int) "validate non-zero offset" 2 offset
+  | exception Parse_error { kind = Non_zero_padding; _ } -> ()
   | () -> Alcotest.fail "validate accepted non-zero all_zeros padding"
-  | exception Validation_error _ ->
+  | exception Parse_error _ ->
       Alcotest.fail "validate failed with the wrong error"
+
+(* A field [~self_constraint] violation reports which predicate failed and the
+   offending field value, so a demux can route on it (e.g. a version field that
+   failed [self = 2] hands back [value = Some 1L]). *)
+let test_self_constraint_reports_value () =
+  let c =
+    Codec.v "Ver"
+      (fun v rest -> (v, rest))
+      Codec.
+        [
+          Field.v "version" uint8 ~self_constraint:(fun s -> Expr.(s = int 2))
+          $ fst;
+          Field.v "rest" uint8 $ snd;
+        ]
+  in
+  match Codec.decode c (Bytes.of_string "\x01\x00") 0 with
+  | Error
+      { kind = Constraint_failed { which = Field; value = Some 1L }; field; _ }
+    ->
+      Alcotest.(check (list string)) "field path" [ "version" ] field
+  | Error e -> Alcotest.failf "wrong error: %a" pp_parse_error e
+  | Ok _ -> Alcotest.fail "decode accepted a version violating its constraint"
+
+(* Regression: the non-zero [all_zeros] byte's offset is carried on the struct
+   field path, not only the direct [of_string] path. The struct path used to
+   discard it into a stringly [Constraint_failed]. *)
+let test_all_zeros_offset_on_struct_path () =
+  let c =
+    Codec.v "Pad"
+      (fun tag pad -> (tag, pad))
+      Codec.[ Field.v "tag" uint8 $ fst; Field.v "pad" all_zeros $ snd ]
+  in
+  match Codec.decode c (Bytes.of_string "\x01\x00\x05\x00") 0 with
+  | Error { kind = Non_zero_padding; at; field } ->
+      Alcotest.(check int) "non-zero byte offset" 2 at;
+      Alcotest.(check (list string)) "field path" [ "pad" ] field
+  | Error e -> Alcotest.failf "wrong error: %a" pp_parse_error e
+  | Ok _ -> Alcotest.fail "decode accepted non-zero padding"
+
+(* A failure inside a nested sub-codec accumulates the root-to-leaf field path
+   as the error unwinds. *)
+let test_field_path_nested () =
+  let inner =
+    Codec.v "Inner" Fun.id
+      Codec.
+        [
+          Field.v "leaf" uint8 ~self_constraint:(fun s -> Expr.(s = int 2))
+          $ Fun.id;
+        ]
+  in
+  let outer =
+    Codec.v "Outer"
+      (fun tag data -> (tag, data))
+      Codec.[ Field.v "tag" uint8 $ fst; Field.v "inner" (codec inner) $ snd ]
+  in
+  (* tag = 1, then inner.leaf = 9 violates [leaf = 2] *)
+  match Codec.decode outer (Bytes.of_string "\x01\x09") 0 with
+  | Error { kind = Constraint_failed { which = Field; _ }; field; _ } ->
+      Alcotest.(check (list string))
+        "nested field path" [ "inner"; "leaf" ] field
+  | Error e -> Alcotest.failf "wrong error: %a" pp_parse_error e
+  | Ok _ -> Alcotest.fail "decode accepted a violating nested field"
 
 (* A field's own decode-side check (enum membership, lookup bound, a bounded
    embedded element) lives in its reader, not in a user constraint, so
@@ -252,7 +314,7 @@ let test_validate_matches_decode_rejections () =
     | Error _ -> ()
     | Ok _ -> Alcotest.failf "%s: decode accepted a bad input" what);
     match Codec.validate c buf 0 with
-    | exception Validation_error _ -> ()
+    | exception Parse_error _ -> ()
     | () -> Alcotest.failf "%s: validate accepted what decode rejects" what
   in
   let enum_c =
@@ -320,7 +382,7 @@ let typ_where_codec =
 
 let test_decode_enforces_typ_where () =
   (match Codec.decode typ_where_codec (Bytes.of_string "\006\000") 0 with
-  | Error (Constraint_failed _) -> ()
+  | Error { kind = Constraint_failed _; _ } -> ()
   | Ok _ -> Alcotest.fail "decode accepted a Wire.where violation"
   | Error _ -> Alcotest.fail "decode failed with the wrong error");
   match Codec.decode typ_where_codec (Bytes.of_string "\001\000") 0 with
@@ -330,7 +392,7 @@ let test_decode_enforces_typ_where () =
 let test_validate_enforces_typ_where () =
   (match Codec.validate typ_where_codec (Bytes.of_string "\006\000") 0 with
   | () -> Alcotest.fail "validate accepted a Wire.where violation"
-  | exception Validation_error (Constraint_failed _) -> ());
+  | exception Parse_error { kind = Constraint_failed _; _ } -> ());
   Codec.validate typ_where_codec (Bytes.of_string "\001\000") 0
 
 (* decode runs field actions; validate must run the same ones, or the two paths
@@ -348,13 +410,13 @@ let action_validate_codec =
 
 let test_validate_runs_field_action () =
   (match Codec.decode action_validate_codec (Bytes.of_string "\200\000") 0 with
-  | Error (Constraint_failed _) -> ()
+  | Error { kind = Constraint_failed _; _ } -> ()
   | _ -> Alcotest.fail "decode did not reject the action violation");
   (match
      Codec.validate action_validate_codec (Bytes.of_string "\200\000") 0
    with
   | () -> Alcotest.fail "validate skipped the field action decode enforces"
-  | exception Validation_error (Constraint_failed _) -> ());
+  | exception Parse_error { kind = Constraint_failed _; _ } -> ());
   Codec.validate action_validate_codec (Bytes.of_string "\100\000") 0
 
 (* A [Wire.where] inside a container element has no 3D projection (EverParse
@@ -1596,7 +1658,7 @@ let test_view_bounds_check () =
   in
   let buf = Bytes.create 2 in
   match Codec.decode codec buf 0 with
-  | Error (Unexpected_eof _) -> ()
+  | Error { kind = Unexpected_eof _; _ } -> ()
   | Error e -> Alcotest.failf "wrong error: %a" pp_parse_error e
   | Ok _ -> Alcotest.fail "expected decode failure"
 
@@ -1776,7 +1838,7 @@ let test_action_fires_on_get () =
   (* Odd value: action rejects *)
   match get_v (Bytes.of_string "\x43") 0 with
   | _ -> Alcotest.fail "expected action to reject odd value"
-  | exception Validation_error (Constraint_failed _) -> ()
+  | exception Parse_error { kind = Constraint_failed _; _ } -> ()
 
 let test_action_unfired_by_validate () =
   (* validate checks constraints + where, but does NOT fire actions. *)
@@ -1894,7 +1956,7 @@ let test_get_action_abort_field () =
   let get_v = Staged.unstage (Codec.get codec cf_v) in
   match get_v (Bytes.of_string "\x42") 0 with
   | _ -> Alcotest.fail "expected abort"
-  | exception Validation_error (Constraint_failed _) -> ()
+  | exception Parse_error { kind = Constraint_failed _; _ } -> ()
 
 let test_get_noaction_ignores_env () =
   (* Passing ~env to get on a field without action is harmless *)
@@ -1954,7 +2016,7 @@ let test_get_action_with_inputparam () =
   (* 0x40 = 64 > 50: action rejects *)
   match get_v buf_bad 0 with
   | _ -> Alcotest.fail "expected rejection from input param check"
-  | exception Validation_error (Constraint_failed _) -> ()
+  | exception Parse_error { kind = Constraint_failed _; _ } -> ()
 
 let test_get_action_inputparam_noenv () =
   (* Action references an input param but no env passed -- param reads as 0 *)
@@ -1977,7 +2039,7 @@ let test_get_action_inputparam_noenv () =
   (* 1 > 0: fails *)
   match get_v (Bytes.of_string "\x01") 0 with
   | _ -> Alcotest.fail "expected rejection without env"
-  | exception Validation_error (Constraint_failed _) -> ()
+  | exception Parse_error { kind = Constraint_failed _; _ } -> ()
 
 (* -- Param forwarding into embedded sub-codecs -- *)
 
@@ -2144,7 +2206,7 @@ let test_validate_constraint_only () =
   Codec.validate codec good 0;
   match Codec.validate codec bad 0 with
   | () -> Alcotest.fail "expected constraint failure"
-  | exception Validation_error (Constraint_failed _) -> ()
+  | exception Parse_error { kind = Constraint_failed _; _ } -> ()
 
 let test_validate_where_only () =
   (* Codec with where clause but no field constraints *)
@@ -2161,7 +2223,7 @@ let test_validate_where_only () =
   Codec.validate codec good 0;
   match Codec.validate codec bad 0 with
   | () -> Alcotest.fail "expected where failure"
-  | exception Validation_error (Constraint_failed _) -> ()
+  | exception Parse_error { kind = Constraint_failed _; _ } -> ()
 
 let test_get_twostaged_same_field () =
   (* Two staged getters from the same codec+field with different envs *)
@@ -2296,7 +2358,7 @@ let test_decode_short_buffer () =
   let buf = Bytes.of_string "\x42" in
   match Codec.decode codec buf 0 with
   | Ok _ -> Alcotest.fail "expected EOF error"
-  | Error (Unexpected_eof _) -> ()
+  | Error { kind = Unexpected_eof _; _ } -> ()
   | Error e -> Alcotest.failf "wrong error: %a" pp_parse_error e
 
 let test_encode_short_buffer () =
@@ -3021,9 +3083,9 @@ let test_dep_size_out_of_range () =
     (fun (name, v) ->
       match Codec.decode u64_sized_codec (u64_len_buf v) 0 with
       | Ok _ -> Alcotest.failf "%s: expected Parse_error, decoded ok" name
-      | Error (Constraint_failed _) -> ()
+      | Error { kind = Value_out_of_range _; _ } -> ()
       | Error e ->
-          Alcotest.failf "%s: expected Constraint_failed, got %a" name
+          Alcotest.failf "%s: expected Value_out_of_range, got %a" name
             pp_parse_error e)
     cases
 
@@ -3066,7 +3128,7 @@ let test_int64_field_constraint_accepts_signed_magnitude_domain () =
 let test_int64_field_constraint_rejects_negative_zero () =
   match Codec.decode signed_magnitude_seek_codec (seek_buf Int64.min_int) 0 with
   | Ok _ -> Alcotest.fail "expected signed-magnitude negative zero to fail"
-  | Error (Constraint_failed _) -> ()
+  | Error { kind = Constraint_failed _; _ } -> ()
   | Error e ->
       Alcotest.failf "expected Constraint_failed, got %a" pp_parse_error e
 
@@ -3088,7 +3150,7 @@ let test_uint64_int_ref_constraint_enforced () =
     (decode_ok (Codec.decode codec (buf 3L) 0));
   match Codec.decode codec (buf 20L) 0 with
   | Ok _ -> Alcotest.fail "20 exceeds the bound and must be rejected"
-  | Error (Constraint_failed _) -> ()
+  | Error { kind = Constraint_failed _; _ } -> ()
   | Error e ->
       Alcotest.failf "expected Constraint_failed, got %a" pp_parse_error e
 
@@ -3414,7 +3476,7 @@ let test_codec_crossref_field_oversized () =
   Bytes.set_uint8 buf 4 0xCC;
   match Codec.decode tc_frame_codec buf 0 with
   | Ok _ -> Alcotest.fail "expected EOF on oversized data field"
-  | Error (Unexpected_eof _) -> ()
+  | Error { kind = Unexpected_eof _; _ } -> ()
   | Error e -> Alcotest.failf "wrong error: %a" pp_parse_error e
 
 (* Attacker sets frame_len=2 -> data size = 2-3 = -1. Must error, not crash. *)
@@ -4287,7 +4349,8 @@ let test_casetype_no_match_invalid_tag () =
   in
   let c = Codec.v "ClosedCt" Fun.id Codec.[ Field.v "d" typ $ Fun.id ] in
   match Codec.decode c (Bytes.of_string "\x63\x00") 0 with
-  | Error (Invalid_tag n) -> Alcotest.(check int) "unmatched tag" 99 n
+  | Error { kind = Invalid_tag n; _ } ->
+      Alcotest.(check int) "unmatched tag" 99 n
   | Ok _ -> Alcotest.fail "decode accepted an unmatched casetype tag"
   | Error _ -> Alcotest.fail "wrong error for an unmatched casetype tag"
 
@@ -5756,6 +5819,12 @@ let suite =
         `Quick test_validate_bounds_constraint_free;
       Alcotest.test_case "validate: enforces all_zeros padding" `Quick
         test_validate_all_zeros;
+      Alcotest.test_case "error: self_constraint reports the offending value"
+        `Quick test_self_constraint_reports_value;
+      Alcotest.test_case "error: all_zeros offset on the struct path" `Quick
+        test_all_zeros_offset_on_struct_path;
+      Alcotest.test_case "error: nested field path" `Quick
+        test_field_path_nested;
       Alcotest.test_case "validate: check-free codec allocates nothing" `Quick
         test_validate_check_free_no_alloc;
       Alcotest.test_case "validate: matches decode rejections" `Quick

--- a/test/test_eval.ml
+++ b/test/test_eval.ml
@@ -19,14 +19,16 @@ let test_int_of () =
     (Eval.int_of Types.uint64be 0xFFFF_FFFF_FFFF_FFFFL);
   Alcotest.(check (option int)) "unit" None (Eval.int_of Types.Unit ())
 
-(* [int_of_exn] returns the same value as [int_of] on the representable cases.
-   Where [int_of] returns [None] it does not silently coerce to 0: an
-   out-of-range 64-bit value is adversarial input and raises [Parse_error],
-   while a non-integer type is a schema mistake and raises [Invalid_argument]. *)
-let raises_constraint name f =
+(* [int_of_exn] returns the same value as [int_of] on the representable cases,
+   but where [int_of] returns [None] it fails instead of silently coercing to 0:
+   an out-of-range 64-bit value raises [Parse_error (Value_out_of_range _)], and
+   a non-integer type is a schema error that raises [Invalid_argument]. *)
+let raises_out_of_range name f =
   match f () with
   | _ -> Alcotest.failf "%s: expected Parse_error, got a value" name
-  | exception Types.Parse_error (Types.Constraint_failed _) -> ()
+  | exception Types.Parse_error { Types.kind = Types.Value_out_of_range _; _ }
+    ->
+      ()
   | exception e ->
       Alcotest.failf "%s: expected Parse_error, got %s" name
         (Printexc.to_string e)
@@ -54,16 +56,16 @@ let test_int_of_exn_ok () =
 let test_int_of_exn_overflow () =
   (* Adversarial 64-bit lengths that do not fit a native int must fail the
      parse rather than be read as 0. *)
-  raises_constraint "uint64 all-ones" (fun () ->
+  raises_out_of_range "uint64 all-ones" (fun () ->
       Eval.int_of_exn Types.uint64be 0xFFFF_FFFF_FFFF_FFFFL);
-  raises_constraint "uint64 = 2^63" (fun () ->
+  raises_out_of_range "uint64 = 2^63" (fun () ->
       Eval.int_of_exn Types.uint64be 0x8000_0000_0000_0000L);
-  raises_constraint "uint64 = max_int + 1" (fun () ->
+  raises_out_of_range "uint64 = max_int + 1" (fun () ->
       Eval.int_of_exn Types.uint64be (Int64.add (Int64.of_int max_int) 1L));
   (* A signed int64 with the top bit set is a huge unsigned value. *)
-  raises_constraint "int64 = -1" (fun () ->
+  raises_out_of_range "int64 = -1" (fun () ->
       Eval.int_of_exn Types.(Int64 Big) (-1L));
-  raises_constraint "int64 = min_int" (fun () ->
+  raises_out_of_range "int64 = min_int" (fun () ->
       Eval.int_of_exn Types.(Int64 Big) Int64.min_int)
 
 let test_int_of_exn_non_integer () =

--- a/test/test_param.ml
+++ b/test/test_param.ml
@@ -142,7 +142,7 @@ let test_where_clause_fail () =
   let env = Codec.env c |> Param.bind max_val 10 in
   match Codec.decode ~env c buf 0 with
   | Ok _ -> Alcotest.fail "expected where failure"
-  | Error (Constraint_failed "where clause") -> ()
+  | Error { kind = Constraint_failed { which = Where; _ }; _ } -> ()
   | Error e -> Alcotest.failf "wrong error: %a" pp_parse_error e
 
 let test_bind_by_name () =
@@ -167,7 +167,7 @@ let test_bind_by_name () =
   let env = Codec.env c |> Param.bind_by_name "max_val" 10 in
   (match Codec.decode ~env c buf 0 with
   | Ok _ -> Alcotest.fail "expected where failure"
-  | Error (Constraint_failed "where clause") -> ()
+  | Error { kind = Constraint_failed { which = Where; _ }; _ } -> ()
   | Error e -> Alcotest.failf "wrong error: %a" pp_parse_error e);
   (* an unreferenced name is a no-op, not an error *)
   let env =
@@ -254,7 +254,7 @@ let test_codec_param_where_fail () =
   let buf = Bytes.of_string "\x05" in
   let env = Codec.env c |> Param.bind limit 3 in
   match Codec.decode ~env c buf 0 with
-  | Error (Constraint_failed "where clause") -> ()
+  | Error { kind = Constraint_failed { which = Where; _ }; _ } -> ()
   | Error e -> Alcotest.failf "wrong error: %a" pp_parse_error e
   | Ok _ -> Alcotest.fail "expected decode failure"
 

--- a/test/test_wire.ml
+++ b/test/test_wire.ml
@@ -158,7 +158,7 @@ let test_finite_rejects_nan () =
   let buf = Bytes.create 8 in
   Bytes.set_int64_be buf 0 0x7FF8_0000_0000_0001L;
   match Codec.decode (finite_codec ()) buf 0 with
-  | Error (Constraint_failed _) -> ()
+  | Error { kind = Constraint_failed _; _ } -> ()
   | Ok _ -> Alcotest.fail "is_finite should have rejected NaN"
   | Error e -> Alcotest.failf "wrong error: %a" pp_parse_error e
 
@@ -173,7 +173,7 @@ let test_finite_rejects_inf () =
   let buf = Bytes.create 8 in
   Bytes.set_int64_be buf 0 (Int64.bits_of_float Float.infinity);
   match Codec.decode (finite_codec ()) buf 0 with
-  | Error (Constraint_failed _) -> ()
+  | Error { kind = Constraint_failed _; _ } -> ()
   | _ -> Alcotest.fail "is_finite should have rejected +inf"
 
 let test_rest_of_buffer_codec () =
@@ -291,7 +291,7 @@ let test_bawhere_rejects () =
   let t = byte_array_where ~size:(int 4) ~per_byte:printable_byte in
   match of_string t "ab\x01c" with
   | Ok _ -> Alcotest.fail "expected per-byte refinement to reject"
-  | Error (Constraint_failed _) -> ()
+  | Error { kind = Constraint_failed _; _ } -> ()
   | Error e ->
       Alcotest.failf "expected Constraint_failed, got %a" pp_parse_error e
 
@@ -313,7 +313,7 @@ let test_parse_variants_invalid () =
   let t = variants "Test" [ ("A", `A); ("B", `B); ("C", `C) ] uint8 in
   match of_string t input with
   | Ok _ -> Alcotest.fail "expected error for invalid enum"
-  | Error (Invalid_enum { value; _ }) ->
+  | Error { kind = Invalid_enum { value; _ }; _ } ->
       Alcotest.(check int) "invalid enum value" 255 value
   | Error e -> Alcotest.failf "wrong error: %a" pp_parse_error e
 
@@ -333,7 +333,7 @@ let test_parse_all_zeros_invalid () =
   let input = "\x00\x01\x00" in
   match of_string all_zeros input with
   | Ok _ -> Alcotest.fail "expected error for non-zero byte"
-  | Error (All_zeros_failed { offset }) ->
+  | Error { kind = Non_zero_padding; at = offset; _ } ->
       Alcotest.(check int) "non-zero offset" 1 offset
   | Error e -> Alcotest.failf "wrong error: %a" pp_parse_error e
 
@@ -348,7 +348,7 @@ let test_parse_eof () =
   let input = "\x01" in
   match of_string uint16 input with
   | Ok _ -> Alcotest.fail "expected EOF error"
-  | Error (Unexpected_eof { expected; got }) ->
+  | Error { kind = Unexpected_eof { expected; got }; _ } ->
       Alcotest.(check int) "expected bytes" 2 expected;
       Alcotest.(check int) "got bytes" 1 got
   | Error e -> Alcotest.failf "wrong error: %a" pp_parse_error e
@@ -383,7 +383,7 @@ let test_parse_struct_constraint_fail () =
   let t = struct_typ s in
   match of_string t input with
   | Ok _ -> Alcotest.fail "expected constraint failure"
-  | Error (Constraint_failed _) -> ()
+  | Error { kind = Constraint_failed _; _ } -> ()
   | Error e -> Alcotest.failf "wrong error: %a" pp_parse_error e
 
 let test_parse_action_return_true () =
@@ -418,7 +418,7 @@ let test_parse_action_return_false () =
   in
   match of_string (struct_typ s) input with
   | Ok () -> Alcotest.fail "expected action failure"
-  | Error (Constraint_failed "field action") -> ()
+  | Error { kind = Constraint_failed { which = Action; _ }; _ } -> ()
   | Error e -> Alcotest.failf "wrong error: %a" pp_parse_error e
 
 let test_parse_struct_action_var () =
@@ -450,7 +450,7 @@ let test_parse_struct_action_abort () =
   in
   match of_string (struct_typ s) input with
   | Ok () -> Alcotest.fail "expected abort"
-  | Error (Constraint_failed "field action") -> ()
+  | Error { kind = Constraint_failed { which = Action; _ }; _ } -> ()
   | Error e -> Alcotest.failf "wrong error: %a" pp_parse_error e
 
 type bounded_payload = { length : int; data : string }
@@ -576,7 +576,7 @@ let test_parse_param_where_fail () =
   let buf = Bytes.of_string "\x00\x03abc" in
   match Codec.decode ~env c buf 0 with
   | Ok _ -> Alcotest.fail "expected where failure"
-  | Error (Constraint_failed "where clause") -> ()
+  | Error { kind = Constraint_failed { which = Where; _ }; _ } -> ()
   | Error e -> Alcotest.failf "wrong error: %a" pp_parse_error e
 
 (* -- sizeof / sizeof_this / field_pos -- *)
@@ -595,7 +595,7 @@ let test_sizeof () =
   (* x=3 => sizeof(uint32be) = 4, constraint fails *)
   match of_string (struct_typ s) "\x03" with
   | Ok _ -> Alcotest.fail "expected sizeof constraint failure"
-  | Error (Constraint_failed _) -> ()
+  | Error { kind = Constraint_failed _; _ } -> ()
   | Error e -> Alcotest.failf "wrong error: %a" pp_parse_error e
 
 let test_sizeof_this () =
@@ -625,7 +625,7 @@ let test_sizeof_this_fail () =
   (* sizeof_this=1 at b, constraint says =2: fails *)
   match of_string (struct_typ s) "\x01\x02" with
   | Ok _ -> Alcotest.fail "expected sizeof_this constraint failure"
-  | Error (Constraint_failed _) -> ()
+  | Error { kind = Constraint_failed _; _ } -> ()
   | Error e -> Alcotest.failf "wrong error: %a" pp_parse_error e
 
 let test_field_pos () =
@@ -654,7 +654,7 @@ let test_field_pos_fail () =
   in
   match of_string (struct_typ s) "\x01\x02" with
   | Ok _ -> Alcotest.fail "expected field_pos constraint failure"
-  | Error (Constraint_failed _) -> ()
+  | Error { kind = Constraint_failed _; _ } -> ()
   | Error e -> Alcotest.failf "wrong error: %a" pp_parse_error e
 
 type sizeof_action_record = { a : int; b : int; c : int }
@@ -874,7 +874,7 @@ let test_stream_rewind_fixed () =
   let bad = enum "Tag" [ ("A", 1); ("B", 2) ] uint8 in
   let reader = Bytesrw.Bytes.Reader.of_string ~slice_length:8 "\xff\x01\x02" in
   (match Wire.of_reader bad reader with
-  | Error (Invalid_enum _) -> ()
+  | Error { kind = Invalid_enum _; _ } -> ()
   | Ok v -> Alcotest.failf "expected enum failure, got %d" v
   | Error e -> Alcotest.failf "expected Invalid_enum: %a" pp_parse_error e);
   Alcotest.(check int) "rewound first" 0xff (reader_decode_ok uint8 reader);
@@ -883,7 +883,7 @@ let test_stream_rewind_fixed () =
 let test_stream_rewind_partial_fixed () =
   let reader = Bytesrw.Bytes.Reader.of_string ~slice_length:1 "\x01\x02\x03" in
   (match Wire.of_reader uint32be reader with
-  | Error (Unexpected_eof _) -> ()
+  | Error { kind = Unexpected_eof _; _ } -> ()
   | Ok v -> Alcotest.failf "expected eof, got %d" v
   | Error e -> Alcotest.failf "expected Unexpected_eof: %a" pp_parse_error e);
   Alcotest.(check int) "rewound" 0x0102 (reader_decode_ok uint16be reader);
@@ -892,18 +892,18 @@ let test_stream_rewind_partial_fixed () =
 let test_stream_rewind_incremental () =
   let reader = Bytesrw.Bytes.Reader.of_string ~slice_length:1 "abc" in
   (match Wire.of_reader zeroterm reader with
-  | Error (Constraint_failed _) -> ()
+  | Error { kind = Missing_terminator; _ } -> ()
   | Ok s -> Alcotest.failf "expected missing NUL, got %S" s
-  | Error e -> Alcotest.failf "expected Constraint_failed: %a" pp_parse_error e);
+  | Error e -> Alcotest.failf "expected Missing_terminator: %a" pp_parse_error e);
   Alcotest.(check int) "rewound" 0x61 (reader_decode_ok uint8 reader);
   Alcotest.(check int) "rest intact" 0x6263 (reader_decode_ok uint16be reader)
 
 let test_stream_rewind_consumes_rest () =
   let reader = Bytesrw.Bytes.Reader.of_string ~slice_length:1 "ab" in
   (match Wire.of_reader all_zeros reader with
-  | Error (All_zeros_failed _) -> ()
+  | Error { kind = Non_zero_padding; _ } -> ()
   | Ok s -> Alcotest.failf "expected all_zeros failure, got %S" s
-  | Error e -> Alcotest.failf "expected All_zeros_failed: %a" pp_parse_error e);
+  | Error e -> Alcotest.failf "expected Non_zero_padding: %a" pp_parse_error e);
   Alcotest.(check int) "rewound" 0x6162 (reader_decode_ok uint16be reader)
 
 let test_stream_bitfield_chunk1 () =
@@ -979,7 +979,7 @@ let test_validate_short_buffer_no_crash () =
   in
   match Codec.validate c (Bytes.create 0) 0 with
   | () -> Alcotest.fail "validate accepted an empty buffer"
-  | exception Wire.Validation_error _ -> ()
+  | exception Wire.Parse_error _ -> ()
   | exception Invalid_argument m ->
       Alcotest.failf "validate crashed on a short buffer: %s" m
 
@@ -994,7 +994,7 @@ let test_validate_rejects_all_zeros_failure () =
       Alcotest.failf "decode crashed on non-zero all_zeros: %s" m);
   match Codec.validate c bad 0 with
   | () -> Alcotest.fail "validate accepted a non-zero all_zeros byte"
-  | exception Wire.Validation_error _ -> ()
+  | exception Wire.Parse_error _ -> ()
   | exception Invalid_argument m ->
       Alcotest.failf "validate crashed on non-zero all_zeros: %s" m
 
@@ -1012,7 +1012,7 @@ let test_validate_rejects_negative_byte_slice () =
       Alcotest.failf "decode crashed on a negative byte_slice size: %s" m);
   match Codec.validate c bad 0 with
   | () -> Alcotest.fail "validate accepted a negative byte_slice size"
-  | exception Wire.Validation_error _ -> ()
+  | exception Wire.Parse_error _ -> ()
   | exception Invalid_argument m ->
       Alcotest.failf "validate crashed on a negative byte_slice size: %s" m
 
@@ -1024,7 +1024,7 @@ let check_decode_and_validate_reject label c bad =
       Alcotest.failf "decode crashed on %s: %s" label m);
   match Codec.validate c bad 0 with
   | () -> Alcotest.failf "validate accepted %s" label
-  | exception (Wire.Validation_error _ | Wire.Parse_error _) -> ()
+  | exception Wire.Parse_error _ -> ()
   | exception Invalid_argument m ->
       Alcotest.failf "validate crashed on %s: %s" label m
 


### PR DESCRIPTION
Wire's `parse_error` was too thin for a binary codec on adversarial input: four of five constructors carried no byte offset, and `Constraint_failed of string` folded eight distinct failures into one unmatchable string, so a failure deep in a decode was neither locatable nor attributable. Two exceptions (`Parse_error`, `Validation_error`) aliased one runtime constructor, and the type had no `equal` / `compare`, so every consumer hand-rolled one.

This reshapes `parse_error` into a `{ at; field; kind }` record with a closed `error_kind`. `at` is the failing field's byte offset and `field` is the root-to-leaf path of field names to it (a failure in a nested sub-codec reads `["outer"; "inner"; "leaf"]`), accumulated as the error unwinds by tagging each field that can raise an attributable error, while a plain scalar is left unwrapped to keep the hot read path free of an exception frame. `kind` splits the string bag into matchable cases, and `Constraint_failed { which; value }` names the predicate and carries the offending field value, so a demultiplexer routes on a version field that failed its `~self_constraint` from the error alone. `Validation_error` is removed (it was the same exception at runtime), and the type gains `equal_parse_error` / `compare_parse_error`.

Lands under `## unreleased`. Stacks on #220, which makes the underlying all_zeros, casetype no-match, and non-integer reporting consistent on the flat type first; this PR is the type restructuring on top. To migrate, match on `e.kind`, read `e.at`, replace `Validation_error` with `Parse_error`, and wrap `Wire.parse_error` in a variant of your own for domain errors.