### PR TITLE
codec: give three decode failures their typed error kind

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-## 1.0.1
+## unreleased
 
 ### Changed
 
@@ -9,6 +9,24 @@
   out, or telemetry and IPv4 headers in the high twenties, which now allocate
   only the record they return. A codec wider than 32 fields keeps the recursive
   fallback (#214, @samoht)
+
+### Fixed
+
+- A non-zero byte in an `all_zeros` padding field now reports the same error
+  whether the field is decoded through a struct (`Codec.decode` /
+  `Codec.validate`) or directly (`Wire.of_string`). The struct path used to
+  report a stringly `Constraint_failed` that dropped the byte offset while the
+  direct path reported the typed `All_zeros_failed` with the offset; both now
+  report `All_zeros_failed` carrying the offset (#220, @samoht)
+
+- A `casetype` whose discriminant matches no case now fails with the typed
+  `Invalid_tag` carrying the tag value, the same class as an out-of-range lookup
+  index, instead of a stringly `Constraint_failed` (#220, @samoht)
+
+- A non-integer field referenced where an integer is required (a schema mistake,
+  such as a float used as a length) now raises `Invalid_argument` rather than a
+  parse error, keeping schema errors distinct from malformed input (#220,
+  @samoht)
 
 ## 1.0.0
 

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -1222,7 +1222,7 @@ let rec read_elem : type a. a typ -> bytes -> int -> a =
       enum_check cases closed (read_elem base buf off)
   | Casetype { tag; cases; _ } ->
       let tag_val = read_elem tag buf off in
-      read_case_body cases tag_val buf (off + tag_byte_size tag)
+      read_case_body ~tag cases tag_val buf (off + tag_byte_size tag)
   | Unit -> ()
   (* NUL-terminated string element: the bytes up to (not including) the NUL. *)
   | Zeroterm ->
@@ -1263,17 +1263,22 @@ let rec read_elem : type a. a typ -> bytes -> int -> a =
 (* Dispatch a casetype's matched case body. A top-level recursion rather than a
    [let rec find] inside [read_elem]: the inner form would allocate a fresh
    closure on every casetype element decoded. *)
-and read_case_body : type a k. (a, k) case_branch list -> k -> bytes -> int -> a
-    =
- fun cases tag_val buf body_off ->
+and read_case_body : type a k.
+    tag:k typ -> (a, k) case_branch list -> k -> bytes -> int -> a =
+ fun ~tag cases tag_val buf body_off ->
   match cases with
-  | [] -> raise (Parse_error (Constraint_failed "casetype: no matching case"))
+  | [] ->
+      (* No branch matched the discriminant. [tag] is integer-typed in the
+         common case (a version/type field); a non-integer (string) tag has no
+         [int] form and reports index 0. *)
+      let n = Option.value ~default:0 (Eval.int_of tag tag_val) in
+      raise (Parse_error (Invalid_tag n))
   | Case_branch { cb_tag = Some t; cb_inner; cb_inject; _ } :: _
     when t = tag_val ->
       cb_inject tag_val (read_elem cb_inner buf body_off)
   | Case_branch { cb_tag = None; cb_inner; cb_inject; _ } :: _ ->
       cb_inject tag_val (read_elem cb_inner buf body_off)
-  | _ :: rest -> read_case_body rest tag_val buf body_off
+  | _ :: rest -> read_case_body ~tag rest tag_val buf body_off
 
 (* Write one element of a typ at a given buffer position. Used by Repeat. *)
 let rec write_elem : type a. a typ -> bytes -> int -> a -> unit =
@@ -1331,7 +1336,7 @@ let rec elem_size_of : type a. a typ -> bytes -> int -> int =
   | Casetype { tag; cases; _ } ->
       let tag_size = tag_byte_size tag in
       let tag_val = read_elem tag buf off in
-      tag_size + size_case_body cases tag_val buf (off + tag_size)
+      tag_size + size_case_body ~tag cases tag_val buf (off + tag_size)
   | Map { inner; _ } -> elem_size_of inner buf off
   | Where { inner; _ } -> elem_size_of inner buf off
   (* Bytes up to the NUL plus the one-byte terminator. *)
@@ -1353,15 +1358,17 @@ let rec elem_size_of : type a. a typ -> bytes -> int -> int =
    as [read_case_body]: a per-call [let rec find] would allocate a closure on
    every element. *)
 and size_case_body : type a k.
-    (a, k) case_branch list -> k -> bytes -> int -> int =
- fun cases tag_val buf body_off ->
+    tag:k typ -> (a, k) case_branch list -> k -> bytes -> int -> int =
+ fun ~tag cases tag_val buf body_off ->
   match cases with
-  | [] -> raise (Parse_error (Constraint_failed "casetype: no matching case"))
+  | [] ->
+      let n = Option.value ~default:0 (Eval.int_of tag tag_val) in
+      raise (Parse_error (Invalid_tag n))
   | Case_branch { cb_tag = Some t; cb_inner; _ } :: _ when t = tag_val ->
       elem_size_of cb_inner buf body_off
   | Case_branch { cb_tag = None; cb_inner; _ } :: _ ->
       elem_size_of cb_inner buf body_off
-  | _ :: rest -> size_case_body rest tag_val buf body_off
+  | _ :: rest -> size_case_body ~tag rest tag_val buf body_off
 
 (* -- Compiled field: intermediate plan for one field's contribution -- *)
 
@@ -1877,10 +1884,10 @@ let var_bytes_reader : type a.
       Bytes.sub_string buf first (nul - first)
   | All_zeros ->
       let s = Bytes.sub_string buf (base + fo) sz in
-      String.iter
-        (fun c ->
+      String.iteri
+        (fun i c ->
           if c <> '\000' then
-            raise (Parse_error (Constraint_failed "all_zeros: non-zero byte")))
+            raise (Parse_error (All_zeros_failed { offset = base + fo + i })))
         s;
       s
   | Casetype _ -> read_elem typ buf (base + fo)

--- a/lib/eval.ml
+++ b/lib/eval.ml
@@ -55,10 +55,7 @@ let int_overflow () =
        (Constraint_failed "integer field value exceeds the native int range"))
 
 let not_an_integer () =
-  raise
-    (Parse_error
-       (Constraint_failed
-          "non-integer field referenced where an integer is required"))
+  invalid_arg "Wire: non-integer field referenced where an integer is required"
 
 let rec int_of_exn : type a. a typ -> a -> int =
  fun typ v ->

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -336,7 +336,9 @@ and parse_casetype : type a k.
  fun tag cases buf off len ->
   let tag_val, off' = parse_direct tag buf off len in
   let rec find_case = function
-    | [] -> raise (Parse_error (Constraint_failed "casetype: no matching case"))
+    | [] ->
+        let n = Option.value ~default:0 (Eval.int_of tag tag_val) in
+        raise (Parse_error (Invalid_tag n))
     | Case_branch { cb_tag = Some expected; cb_inner; cb_inject; _ } :: rest ->
         if expected = tag_val then
           let body, off'' = parse_direct cb_inner buf off' len in

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -226,12 +226,17 @@ let test_validate_all_zeros () =
   in
   Codec.validate c (Bytes.of_string "\x01\x00\x00\x00") 0;
   let tampered = Bytes.of_string "\x01\x00\x05\x00" in
+  (* The 0x05 sits at absolute offset 2; decoding through a struct field now
+     reports the same typed [All_zeros_failed] with that offset as the direct
+     [of_string] path, instead of a stringly constraint failure. *)
   (match Codec.decode c tampered 0 with
-  | Error (Constraint_failed _) -> ()
+  | Error (All_zeros_failed { offset }) ->
+      Alcotest.(check int) "decode non-zero offset" 2 offset
   | Ok _ -> Alcotest.fail "decode accepted non-zero all_zeros padding"
   | Error _ -> Alcotest.fail "decode failed with the wrong error");
   match Codec.validate c tampered 0 with
-  | exception Validation_error (Constraint_failed _) -> ()
+  | exception Validation_error (All_zeros_failed { offset }) ->
+      Alcotest.(check int) "validate non-zero offset" 2 offset
   | () -> Alcotest.fail "validate accepted non-zero all_zeros padding"
   | exception Validation_error _ ->
       Alcotest.fail "validate failed with the wrong error"
@@ -4266,6 +4271,26 @@ let test_casetype_field_default () =
   let r = decode_ok (Codec.decode casetype_field_codec buf 0) in
   Alcotest.(check bool) "Other 7" true (r.data = `Other 7)
 
+(* A casetype whose discriminant matches no case fails with a typed
+   [Invalid_tag] carrying the tag value, not a stringly constraint failure. *)
+let test_casetype_no_match_invalid_tag () =
+  let typ =
+    Wire.casetype "Closed" Wire.uint8
+      [
+        Wire.case ~index:1 Wire.uint8
+          ~inject:(fun v -> `A v)
+          ~project:(function `A v -> Some v | _ -> None);
+        Wire.case ~index:2 Wire.uint8
+          ~inject:(fun v -> `B v)
+          ~project:(function `B v -> Some v | _ -> None);
+      ]
+  in
+  let c = Codec.v "ClosedCt" Fun.id Codec.[ Field.v "d" typ $ Fun.id ] in
+  match Codec.decode c (Bytes.of_string "\x63\x00") 0 with
+  | Error (Invalid_tag n) -> Alcotest.(check int) "unmatched tag" 99 n
+  | Ok _ -> Alcotest.fail "decode accepted an unmatched casetype tag"
+  | Error _ -> Alcotest.fail "wrong error for an unmatched casetype tag"
+
 (* The default branch recovers the matched tag and re-encodes it, so an
    arbitrary unclaimed tag round-trips (the DHCP / TCP-options shape). *)
 type tlv = Known of int | Unknown of (int * string)
@@ -6119,6 +6144,8 @@ let suite =
         test_casetype_field_logout;
       Alcotest.test_case "casetype field: default" `Quick
         test_casetype_field_default;
+      Alcotest.test_case "casetype field: no match is Invalid_tag" `Quick
+        test_casetype_no_match_invalid_tag;
       Alcotest.test_case "casetype default recovers matched tag" `Quick
         test_casetype_default_recovers_tag;
       Alcotest.test_case "casetype field: roundtrip" `Quick

--- a/test/test_eval.ml
+++ b/test/test_eval.ml
@@ -19,16 +19,24 @@ let test_int_of () =
     (Eval.int_of Types.uint64be 0xFFFF_FFFF_FFFF_FFFFL);
   Alcotest.(check (option int)) "unit" None (Eval.int_of Types.Unit ())
 
-(* [int_of_exn] returns the same value as [int_of] on the representable cases,
-   but where [int_of] returns [None] -- an out-of-range 64-bit value or a
-   non-integer type -- it raises [Parse_error (Constraint_failed _)] instead of
-   silently coercing to 0. *)
+(* [int_of_exn] returns the same value as [int_of] on the representable cases.
+   Where [int_of] returns [None] it does not silently coerce to 0: an
+   out-of-range 64-bit value is adversarial input and raises [Parse_error],
+   while a non-integer type is a schema mistake and raises [Invalid_argument]. *)
 let raises_constraint name f =
   match f () with
   | _ -> Alcotest.failf "%s: expected Parse_error, got a value" name
   | exception Types.Parse_error (Types.Constraint_failed _) -> ()
   | exception e ->
       Alcotest.failf "%s: expected Parse_error, got %s" name
+        (Printexc.to_string e)
+
+let raises_invalid_arg name f =
+  match f () with
+  | _ -> Alcotest.failf "%s: expected Invalid_argument, got a value" name
+  | exception Invalid_argument _ -> ()
+  | exception e ->
+      Alcotest.failf "%s: expected Invalid_argument, got %s" name
         (Printexc.to_string e)
 
 let test_int_of_exn_ok () =
@@ -59,9 +67,9 @@ let test_int_of_exn_overflow () =
       Eval.int_of_exn Types.(Int64 Big) Int64.min_int)
 
 let test_int_of_exn_non_integer () =
-  raises_constraint "unit" (fun () -> Eval.int_of_exn Types.Unit ());
-  raises_constraint "float64" (fun () -> Eval.int_of_exn Types.float64be 1.5);
-  raises_constraint "byte_array" (fun () ->
+  raises_invalid_arg "unit" (fun () -> Eval.int_of_exn Types.Unit ());
+  raises_invalid_arg "float64" (fun () -> Eval.int_of_exn Types.float64be 1.5);
+  raises_invalid_arg "byte_array" (fun () ->
       Eval.int_of_exn (Types.byte_array ~size:(Types.Int 4)) "abcd")
 
 let test_expr_const () =


### PR DESCRIPTION
Three decode failures reported an error inconsistently or too loosely on the flat `parse_error` type.

A non-zero byte in an `all_zeros` field was a stringly `Constraint_failed` on the struct-field path (`Codec.decode` / `Codec.validate`), which dropped the byte offset, while the direct `Wire.of_string` path used the typed `All_zeros_failed { offset }`. Both now raise `All_zeros_failed` with the offset (`String.iteri` hands it back for free), so the two paths agree.

A `casetype` whose discriminant matched no case raised a stringly `Constraint_failed`, though `Invalid_tag of int` already exists for that class (the same one an out-of-range lookup index uses). Threading the tag type into `read_case_body` / `size_case_body` lets the no-match coerce the tag and raise `Invalid_tag`.

A non-integer field referenced where an integer is required is a schema mistake, not malformed input, so it now raises `Invalid_argument` rather than a parse error. Each fix has a test; `test_int_of_exn_non_integer` and `test_validate_all_zeros` are updated, and a closed-casetype no-match test is added.