### PR TITLE
codec: add public parse_error and eof constructors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,32 +2,20 @@
 
 ### Changed
 
-- Parse errors are now a `{ at; field; kind }` record instead of a flat variant.
-  `at` is the byte offset of the failing field and `field` is the path of field
-  names leading to it, so a failure deep in a nested struct is attributable
-  instead of surfacing as a bare kind with no location. The failure kinds are a
-  closed `error_kind` (`Unexpected_eof`, `Invalid_enum`, `Invalid_tag`,
+- Decode errors are redesigned. `parse_error` is now a `{ at; field; kind }`
+  record instead of a flat variant: `at` is the failing field's byte offset,
+  `field` the root-to-leaf path of field names to it, and `kind` a closed
+  `error_kind` (`Unexpected_eof`, `Invalid_enum`, `Invalid_tag`,
   `Missing_terminator`, `Non_zero_padding`, `Value_out_of_range`,
-  `Constraint_failed`); match on `e.kind` and read `e.at`. Consumers with their
-  own domain errors wrap `Wire.parse_error` in a variant of their own (#219,
-  @samoht)
-
-- `Constraint_failed of string` becomes `Constraint_failed { which; value }`:
-  `which` names the predicate that failed (a field constraint, a `where` clause,
-  a field action, or a per-byte refinement) and `value` carries the offending
-  field's value for a single-field self-constraint. A field that fails its
-  `~self_constraint` now reports which field and its value rather than an
-  unmatchable English string (#219, @samoht)
-
-- The `Validation_error` exception is removed; `Codec.validate` and the `_exn`
-  decoders both raise the single `Parse_error`. They were already the same
-  exception at runtime, so replace `Validation_error` with `Parse_error` (#219,
-  @samoht)
-
-- Add `equal_parse_error` / `compare_parse_error` and `pp_error_kind`, so a
-  consumer no longer hand-rolls equality for a parse error in its tests. The
-  `Value_out_of_range` kind now carries an integer-length overflow that the flat
-  type reported as a constraint failure (#219, @samoht)
+  `Constraint_failed`), so a failure deep in a nested struct is both locatable
+  and matchable. `Constraint_failed of string` becomes
+  `Constraint_failed { which; value }`, naming the predicate that failed and
+  carrying the offending field's value. `Validation_error` is removed
+  (`Codec.validate` and the `_exn` decoders raise the single `Parse_error`), and
+  the type gains `equal_parse_error` / `compare_parse_error`, `pp_error_kind`,
+  and public `parse_error` / `eof` constructors. Match on `e.kind`, read `e.at`,
+  replace `Validation_error` with `Parse_error`, and wrap `Wire.parse_error` in
+  your own variant for domain errors (#219, @samoht)
 
 - Decoding a record codec with 17 to 32 fields no longer allocates a
   short-lived closure on each decode: the closure-free decode ceiling that

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -43,7 +43,12 @@ type parse_error = { at : int; field : string list; kind : error_kind }
 
 exception Parse_error of parse_error
 
-let err ~at kind = { at; field = []; kind }
+let parse_error ?(at = 0) ?(field = []) kind = { at; field; kind }
+
+let eof ?(at = 0) ?(field = []) ~expected ~got () =
+  { at; field; kind = Unexpected_eof { expected; got } }
+
+let err ~at kind = parse_error ~at kind
 let raise_error ~at kind = raise (Parse_error (err ~at kind))
 
 let raise_eof ~at ~expected ~got =

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -26,6 +26,22 @@ type parse_error = { at : int; field : string list; kind : error_kind }
     parse error records the path of field names leading to that field (root to
     leaf, empty at a top-level or anonymous position) and the failure kind. *)
 
+val parse_error : ?at:int -> ?field:string list -> error_kind -> parse_error
+(** [parse_error kind] builds a decode error carrying [kind]. The byte offset
+    defaults to 0 and the field path to [[]] (a top-level or whole-buffer
+    failure), so a caller synthesizing an error outside a codec run, such as a
+    length pre-check or a mapping decoder, need only give the kind. *)
+
+val eof :
+  ?at:int ->
+  ?field:string list ->
+  expected:int ->
+  got:int ->
+  unit ->
+  parse_error
+(** [eof ~expected ~got ()] is [parse_error (Unexpected_eof { expected; got })]:
+    the input ended with [got] bytes where [expected] were needed. *)
+
 type bit_order =
   | Msb_first
   | Lsb_first

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -785,6 +785,22 @@ val equal_parse_error : parse_error -> parse_error -> bool
 val compare_parse_error : parse_error -> parse_error -> int
 (** Total order on parse errors. *)
 
+val parse_error : ?at:int -> ?field:string list -> error_kind -> parse_error
+(** [parse_error kind] builds a decode error carrying [kind]. The byte offset
+    defaults to 0 and the field path to [[]] (a top-level or whole-buffer
+    failure), so a caller synthesizing an error outside a codec run, such as a
+    length pre-check or a mapping decoder, need only give the kind. *)
+
+val eof :
+  ?at:int ->
+  ?field:string list ->
+  expected:int ->
+  got:int ->
+  unit ->
+  parse_error
+(** [eof ~expected ~got ()] is [parse_error (Unexpected_eof { expected; got })]:
+    the input ended with [got] bytes where [expected] were needed. *)
+
 (** {1 Direct Decoding and Encoding}
 
     These functions interpret a ['a typ] directly and exchange ordinary OCaml

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -303,6 +303,21 @@ let test_field_path_nested () =
   | Error e -> Alcotest.failf "wrong error: %a" pp_parse_error e
   | Ok _ -> Alcotest.fail "decode accepted a violating nested field"
 
+(* The public [parse_error] / [eof] constructors build the record with the
+   documented defaults, for a caller synthesizing an error outside a codec run. *)
+let test_error_constructors () =
+  let e = parse_error (Invalid_tag 7) in
+  Alcotest.(check int) "parse_error default at" 0 e.at;
+  Alcotest.(check (list string)) "parse_error default field" [] e.field;
+  (match e.kind with
+  | Invalid_tag 7 -> ()
+  | _ -> Alcotest.fail "parse_error kind");
+  let f = eof ~at:3 ~expected:4 ~got:2 () in
+  Alcotest.(check int) "eof at" 3 f.at;
+  match f.kind with
+  | Unexpected_eof { expected = 4; got = 2 } -> ()
+  | _ -> Alcotest.fail "eof kind"
+
 (* A field's own decode-side check (enum membership, lookup bound, a bounded
    embedded element) lives in its reader, not in a user constraint, so
    [Codec.validate] must run the validator pass for every codec or it would
@@ -5825,6 +5840,8 @@ let suite =
         test_all_zeros_offset_on_struct_path;
       Alcotest.test_case "error: nested field path" `Quick
         test_field_path_nested;
+      Alcotest.test_case "error: parse_error / eof constructors" `Quick
+        test_error_constructors;
       Alcotest.test_case "validate: check-free codec allocates nothing" `Quick
         test_validate_check_free_no_alloc;
       Alcotest.test_case "validate: matches decode rejections" `Quick


### PR DESCRIPTION
The `{ at; field; kind }` error record from the parse-error redesign has no public builder, so a consumer synthesizing a decode error outside a codec run, such as a length pre-check before `Codec.decode` or a `map` decoder, has to spell out the record. `parse_error kind` fills `at = 0` and `field = []` so the caller need only pass the kind, and `eof ~expected ~got ()` is the `Unexpected_eof` shorthand . Both are exposed from `Wire` and `Types`.

Also folds the changelog's four separate error entries into a single paragraph.