### PR TITLE
stubs: bounds-check the FFI parser offset

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,14 @@
 
 ### Fixed
 
+- A generated FFI parser (`parse buf off`) now raises `Invalid_argument` when
+  `off` is negative or past the end of `buf`, instead of reading out of bounds.
+  The C stub computed its length as `Bytes.length buf - off` in unsigned
+  arithmetic, so an out-of-range `off` (which can carry a length or offset field
+  parsed from untrusted input) underflowed the length into a huge span and
+  pushed the read pointer past the buffer before the validator ran. An in-range
+  `off` is unaffected (#222, @samoht)
+
 - A non-zero byte in an `all_zeros` padding field now reports the same error
   whether the field is decoded through a struct (`Codec.decode` /
   `Codec.validate`) or directly (`Wire.of_string`). The struct path used to

--- a/lib/stubs/wire_stubs.ml
+++ b/lib/stubs/wire_stubs.ml
@@ -22,6 +22,18 @@ let c_stub_validate ppf ~lower ~ep =
     "  if (!EverParseIsSuccess(r)) caml_failwith(\"%s: validation failed\");@\n"
     lower
 
+(* [off] is caller-supplied and may carry attacker-controlled data (a length or
+   offset parsed from the input). Outside [0, buf_len] it would underflow [len]
+   into a huge span and push [data] past the buffer, so the validator would read
+   out of bounds; reject it with [Invalid_argument] before touching memory. *)
+let pp_c_stub_bounds ppf ~lower =
+  Fmt.pf ppf "  intnat off = Int_val(v_off);@\n";
+  Fmt.pf ppf "  mlsize_t buf_len = caml_string_length(v_buf);@\n";
+  Fmt.pf ppf "  if (off < 0 || (mlsize_t) off > buf_len)@\n";
+  Fmt.pf ppf "    caml_invalid_argument(\"%s: offset out of bounds\");@\n" lower;
+  Fmt.pf ppf "  uint8_t *data = (uint8_t *)Bytes_val(v_buf) + off;@\n";
+  Fmt.pf ppf "  uint32_t len = (uint32_t)(buf_len - (mlsize_t) off);@\n"
+
 let pp_field_value ppf (fname, kind) =
   match kind with
   | Wire.Everparse.Raw.Int64 ->
@@ -48,9 +60,7 @@ let pp_c_stub_output ppf ~lower ~ep (s : Wire.Everparse.Raw.struct_) =
       lower;
     Fmt.pf ppf "  CAMLparam3(v_k, v_buf, v_off);@\n";
     Fmt.pf ppf "  CAMLlocal1(v_result);@\n";
-    Fmt.pf ppf
-      "  uint8_t *data = (uint8_t *)Bytes_val(v_buf) + Int_val(v_off);@\n";
-    Fmt.pf ppf "  uint32_t len = caml_string_length(v_buf) - Int_val(v_off);@\n";
+    pp_c_stub_bounds ppf ~lower;
     c_stub_validate ppf ~lower ~ep;
     Fmt.pf ppf "  value args[%d];@\n" n_fields;
     List.iteri
@@ -65,9 +75,7 @@ let pp_c_stub_output ppf ~lower ~ep (s : Wire.Everparse.Raw.struct_) =
     Fmt.pf ppf
       "CAMLprim value caml_wire_%s_parse(value v_buf, value v_off) {@\n" lower;
     Fmt.pf ppf "  CAMLparam2(v_buf, v_off);@\n";
-    Fmt.pf ppf
-      "  uint8_t *data = (uint8_t *)Bytes_val(v_buf) + Int_val(v_off);@\n";
-    Fmt.pf ppf "  uint32_t len = caml_string_length(v_buf) - Int_val(v_off);@\n";
+    pp_c_stub_bounds ppf ~lower;
     c_stub_validate ppf ~lower ~ep;
     Fmt.pf ppf "  CAMLreturn(Val_unit);@\n";
     Fmt.pf ppf "}@\n@\n"

--- a/test/stubs/test_wire_stubs.ml
+++ b/test/stubs/test_wire_stubs.ml
@@ -237,6 +237,21 @@ let test_c_stubs_many_params () =
     (contains ~sub:"caml_wire_manyparams_parse" c);
   Alcotest.(check bool) "has WIRECTX" true (contains ~sub:"WIRECTX" c)
 
+let test_c_stubs_bounds_check () =
+  let s =
+    struct_ "SimpleHeader" [ field "version" uint8; field "length" uint16 ]
+  in
+  let c = Wire_stubs.to_c_stubs [ s ] in
+  Alcotest.(check bool)
+    "rejects an out-of-range offset" true
+    (contains ~sub:"caml_invalid_argument" c);
+  Alcotest.(check bool)
+    "guards both the sign and the upper bound of off" true
+    (contains ~sub:"off < 0 || (mlsize_t) off > buf_len" c);
+  Alcotest.(check bool)
+    "no unchecked length subtraction remains" false
+    (contains ~sub:"caml_string_length(v_buf) - Int_val(v_off)" c)
+
 (* -- to_ml_stub_name -- *)
 
 let test_name_camel () =
@@ -325,6 +340,37 @@ let test_e2e_no_params () =
   let r = Stubs.testheader_parse buf 0 in
   assert (r.Stubs.version = 1);
   assert (r.Stubs.length = 42)
+|}
+
+let test_e2e_offset_bounds () =
+  let f_version = Wire.Field.v "version" uint8 in
+  let f_length = Wire.Field.v "length" uint16be in
+  let codec =
+    let open Wire.Codec in
+    v "OffsetHeader"
+      (fun version length -> (version, length))
+      [ (f_version $ fun (v, _) -> v); (f_length $ fun (_, l) -> l) ]
+  in
+  let schema = Wire.Everparse.project ~mode:`Ffi codec in
+  let s = Wire.Everparse.Raw.struct_of_codec codec in
+  e2e ~name:"OffsetHeader" ~structs:[ s ] ~module_:schema.module_
+    ~test_ml:
+      {|let () =
+  let buf = Bytes.create 3 in
+  Bytes.set_uint8 buf 0 1;
+  Bytes.set_uint16_be buf 1 42;
+  (* in-range parse still works *)
+  let r = Stubs.offsetheader_parse buf 0 in
+  assert (r.Stubs.version = 1);
+  assert (r.Stubs.length = 42);
+  (* off past the end must be rejected, not underflow into an OOB read *)
+  (match Stubs.offsetheader_parse buf 4 with
+   | _ -> assert false
+   | exception Invalid_argument _ -> ());
+  (* a negative off must be rejected too *)
+  (match Stubs.offsetheader_parse buf (-1) with
+   | _ -> assert false
+   | exception Invalid_argument _ -> ())
 |}
 
 let test_e2e_with_constraint () =
@@ -757,12 +803,15 @@ let suite =
       Alcotest.test_case "c stubs: many params" `Quick test_c_stubs_many_params;
       Alcotest.test_case "c stubs: <Name>Fields uses EverParse-normalised name"
         `Quick test_normalised_fields_name;
+      Alcotest.test_case "c stubs: offset bounds check" `Quick
+        test_c_stubs_bounds_check;
       (* stub name *)
       Alcotest.test_case "name: camelCase" `Quick test_name_camel;
       Alcotest.test_case "name: ALLCAPS" `Quick test_name_allcaps;
       Alcotest.test_case "name: single word" `Quick test_name_single;
       (* end-to-end: generate -> EverParse -> compile -> call *)
       Alcotest.test_case "e2e: no params" `Slow test_e2e_no_params;
+      Alcotest.test_case "e2e: offset bounds" `Slow test_e2e_offset_bounds;
       Alcotest.test_case "e2e: constraint" `Slow test_e2e_with_constraint;
       Alcotest.test_case "e2e: bitfields" `Slow test_e2e_bitfields;
       Alcotest.test_case "e2e: output parse" `Slow test_e2e_output_parse;


### PR DESCRIPTION
The generated FFI parser `parse buf off` used to pass `off` straight into its C stub, which derived the buffer length as `Bytes.length buf - off` in unsigned arithmetic and the read pointer as `base + off`. An `off` outside `[0, Bytes.length buf]` underflowed the length into a huge span and pushed the pointer past the buffer, so the EverParse validator read out of bounds. `off` can carry a length or offset field parsed from untrusted input, so the out-of-bounds read was reachable from safe OCaml.

The stub now rejects a negative or too-large `off` with `Invalid_argument` before any pointer arithmetic; an in-range offset is unchanged.