### PR TITLE
codec: make a parametric codec's parameter cell domain-local

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,9 +27,9 @@
 
 ### Fixed
 
-- Decoding or validating one codec value concurrently from multiple domains is
-  now safe: validation scratch is per-domain, so concurrent decodes no longer
-  corrupt each other's fields and reject valid input (#223, @samoht)
+- Codec values are now safe to share across domains: their validation scratch
+  and parameter backing are per-domain, so encoding, decoding, or validating one
+  codec concurrently no longer corrupts the result (#223, #224, @samoht)
 
 - A generated FFI parser (`parse buf off`) now raises `Invalid_argument` when
   `off` is negative or past the end of `buf`, instead of reading out of bounds.

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -701,7 +701,7 @@ let bytes_leaves ?(sizeof_this : bytes -> int -> int = fun _ _ -> 0)
           "Codec: full-width field ref %S is only available in field \
            constraints"
           name);
-    param_ref = (fun (Pack_param p) _ _ -> !(p.cell));
+    param_ref = (fun (Pack_param p) _ _ -> !(p.cell ()));
     sizeof_typ =
       (fun (Pack_typ t) ->
         match field_wire_size t with
@@ -755,7 +755,7 @@ let array_leaves (cc : compile_ctx) : (slots, unit) leaves =
            an embedding) falls back to the shared cell. *)
         match Hashtbl.find_opt cc.param_slots p.Types.name with
         | Some i -> a.ints.(i)
-        | None -> !(p.cell));
+        | None -> !(p.cell ()));
     sizeof_typ =
       (fun (Pack_typ t) ->
         let n = field_wire_size t |> Option.value ~default:0 in
@@ -794,7 +794,7 @@ let rec compile_stmt (cc : compile_ctx) (s : Types.action_stmt) :
         let v = fe arr in
         match Hashtbl.find_opt cc.param_slots p.Types.name with
         | Some slot -> set_int_slot arr slot v
-        | None -> p.Types.cell := v)
+        | None -> p.Types.cell () := v)
   | Field_assign (_, _, _) | Extern_call (_, _) -> fun _ -> ()
   | Return e ->
       let fe = compile_bool_arr cc e in
@@ -3285,14 +3285,16 @@ let is_fixed (t : _ t) =
 let raw_decode (t : _ t) buf off = t.decode buf off
 
 (* Copy each input param's env value into its [cell]. The encode
-   closures read [Param_ref p] via [!(p.cell)] (see [bytes_leaves]
+   closures read [Param_ref p] via [!(p.cell ())] (see [bytes_leaves]
    in [compile_expr]), so the cells are the runtime backing for
    parametric field sizes. Mirror of the env -> array blit in
    [decode_exn]. *)
 let load_env_into_cells (t : 'r t) (env : Param.env) =
   (* The env slot of [param_handles.(i)] is [i] (the env is built in the same
      order, see [env] below). *)
-  List.iteri (fun i (Param.Pack p) -> p.cell := env.slots.(i)) t.param_handles
+  List.iteri
+    (fun i (Param.Pack p) -> p.cell () := env.slots.(i))
+    t.param_handles
 
 (* Reject [encode] on a parametric codec without an env, and reject envs
    that left an input param unbound. Either case would silently resolve
@@ -3350,7 +3352,7 @@ let embed_decode (t : 'r t) buf off =
   let v = t.decode buf off in
   let env_slots =
     Array.of_list
-      (List.map (fun (Param.Pack p) -> !(p.Types.cell)) t.param_handles)
+      (List.map (fun (Param.Pack p) -> !(p.Types.cell ())) t.param_handles)
   in
   t.validate ~env_slots buf off;
   v
@@ -3377,7 +3379,7 @@ let decode_exn ?env:e t buf off =
      input, so it raises [Invalid_argument] rather than returning a parse error. *)
   require_env ~op:"decode" t e;
   (* Seed the input cells from the env before reading fields: the field
-     readers resolve [Param_ref p] via [!(p.cell)], so a parametric size
+     readers resolve [Param_ref p] via [!(p.cell ())], so a parametric size
      (byte_array / byte_slice / uint_var) must see the env's value. Mirror of
      the seeding [encode] does. [Param.bind] also writes the cell directly, but
      [Param.bind_by_name] only has the name and writes [env.slots]; without
@@ -3401,7 +3403,7 @@ let decode_exn ?env:e t buf off =
         (fun i (Param.Pack p) ->
           let v = arr.ints.(t.param_base + i) in
           e.slots.(i) <- v;
-          p.cell := v)
+          p.cell () := v)
         t.param_handles
   | None -> ());
   v
@@ -3587,7 +3589,7 @@ let[@inline] get (type a r) ?env (codec : r t) (f : (a, r) field) :
                   (fun i (Param.Pack p) ->
                     let v = arr.ints.(param_base + i) in
                     e.slots.(i) <- v;
-                    p.cell := v)
+                    p.cell () := v)
                   param_handles),
               fun arr ->
                 if n_params > 0 then

--- a/lib/eval.ml
+++ b/lib/eval.ml
@@ -101,7 +101,7 @@ let rec expr : type a. ctx -> a expr -> a =
       failwith
         ("Eval.expr: unbound int64 field " ^ name
        ^ " (cross-field references are only valid inside a struct)")
-  | Param_ref p -> !(p.cell)
+  | Param_ref p -> !(p.cell ())
   | Sizeof t -> field_wire_size t |> Option.value ~default:0
   | Sizeof_this -> 0
   | Field_pos -> 0

--- a/lib/param.ml
+++ b/lib/param.ml
@@ -62,6 +62,14 @@ let check_typ name typ =
     Fmt.invalid_arg "Param.%s: only integer-representable types are supported"
       name
 
+(* A per-domain backing ref for a handle's [cell]. The handle is created once
+   and shared across domains, so a plain [ref 0] would let concurrent
+   encode/decode of the same parametric codec overwrite each other's value;
+   [Domain.DLS] gives each domain its own ref, still reused within the domain. *)
+let domain_local_cell () =
+  let key = Domain.DLS.new_key (fun () -> ref 0) in
+  fun () -> Domain.DLS.get key
+
 let input name typ =
   check_typ "input" typ;
   {
@@ -69,7 +77,7 @@ let input name typ =
     typ;
     packed_typ = Types.Pack_typ typ;
     mutable_ = false;
-    cell = ref 0;
+    cell = domain_local_cell ();
   }
 
 let output name typ =
@@ -79,7 +87,7 @@ let output name typ =
     typ;
     packed_typ = Types.Pack_typ typ;
     mutable_ = true;
-    cell = ref 0;
+    cell = domain_local_cell ();
   }
 
 let decl (t : ('a, 'k) t) : Types.param =
@@ -111,7 +119,7 @@ let bind (p : ('a, input) t) (v : 'a) (env : env) : env =
     slots.(i) <- iv;
     bound.(i) <- true
   end;
-  p.cell := iv;
+  p.cell () := iv;
   { env with Types.slots; bound }
 
 let bind_by_name name (iv : int) (env : env) : env =
@@ -127,6 +135,6 @@ let bind_by_name name (iv : int) (env : env) : env =
 
 let get (env : env) (p : ('a, 'k) t) : 'a =
   let i = env_idx env p.Types.name in
-  if i < 0 then of_int p.typ !(p.cell) else of_int p.typ env.slots.(i)
+  if i < 0 then of_int p.typ !(p.cell ()) else of_int p.typ env.slots.(i)
 
 type packed = Pack : ('a, 'k) t -> packed

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -73,12 +73,15 @@ type ('a, 'k) param_handle = {
   typ : 'a typ;
   packed_typ : packed_typ;
   mutable_ : bool;
-  cell : int ref;
+  cell : unit -> int ref;
       (* [cell] is the per-handle backing read by encode/size expressions and
-         the value-forwarding vehicle for embedded sub-codecs. Slot resolution
-         (decode array index, env index) is NOT stored here: it is per-codec,
-         since one handle may be referenced both standalone and from an
-         embedding, which would clash on a single mutable field. *)
+         the value-forwarding vehicle for embedded sub-codecs. Domain-local: a
+         handle lives inside a codec shared across domains, so a single [int ref]
+         would race across domains the way the validator scratch did; [cell ()]
+         returns this domain's ref. Slot resolution (decode array index, env
+         index) is NOT stored here: it is per-codec, since one handle may be
+         referenced both standalone and from an embedding, which would clash on
+         a single mutable field. *)
 }
 
 and packed_typ = Pack_typ : 'a typ -> packed_typ

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -84,7 +84,7 @@ type ('a, 'k) param_handle = {
   typ : 'a typ;
   packed_typ : packed_typ;
   mutable_ : bool;
-  cell : int ref;
+  cell : unit -> int ref;
 }
 
 and packed_typ = Pack_typ : 'a typ -> packed_typ

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -1873,7 +1873,7 @@ let test_action_unfired_by_validate () =
   (* validate does NOT fire actions *)
   Alcotest.(check int)
     "action not fired by validate" 0
-    !(action_out2.Wire.Private.Types.cell)
+    !(action_out2.Wire.Private.Types.cell ())
 
 let test_get_noaction_zero_overhead () =
   (* get on a field without an action should not allocate.


### PR DESCRIPTION
Follow-up to #223, which made the validation scratch domain-local. A parametric codec (a `byte_array`, `byte_slice`, or `uint_var` whose size comes from a parameter) resolves that size through a per-parameter `cell`, a mutable ref embedded in the codec value. Because the codec is shared across domains, two domains encoding or decoding it at once raced on the cell exactly as they raced on the scratch, so a field could be sized from another domain's value.

Each cell is now backed by `Domain.DLS`, giving every domain its own ref while still reusing it within a domain.
