### PR TITLE
types: refuse to load on a platform with a narrow int

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,11 @@
 
 ### Fixed
 
+- Wire now fails at load on a platform whose native `int` is narrower than 63
+  bits (32-bit native, js_of_ocaml, wasm_of_ocaml) instead of silently
+  truncating: a uint32 with bit 31 set, such as a TCP sequence number, decoded
+  with the high bit dropped there (#225, @samoht)
+
 - Codec values are now safe to share across domains: their validation scratch
   and parameter backing are per-domain, so encoding, decoding, or validating one
   codec concurrently no longer corrupts the result (#223, #224, @samoht)

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -1,3 +1,19 @@
+(* Wire decodes integers by composing shifts in the native [int]: [UInt32] and
+   [UInt63] fold 16-bit reads, [Bitfield] folds bytes, and the [`U32] cast masks
+   with [0xFFFF_FFFF]. All of it assumes a 63-bit [int]. On a narrower one
+   (32-bit native, js_of_ocaml, wasm_of_ocaml) [hi lsl 16] overflows and drops
+   bit 31, so a uint32 with the top bit set, such as the TCP sequence number
+   0xa695853b, decodes as 0x2695853b; the mask literal is worse, wrapping to -1
+   so [land] becomes the identity. Refuse to load rather than hand back silently
+   corrupted wire data. *)
+let () =
+  if Sys.int_size < 63 then
+    Fmt.failwith
+      "wire: requires a 63-bit OCaml int, but Sys.int_size = %d. Integer \
+       decoding silently truncates on this platform, so 32-bit native, \
+       js_of_ocaml and wasm_of_ocaml targets are unsupported."
+      Sys.int_size
+
 type endian = Little | Big
 type bit_order = Msb_first | Lsb_first
 


### PR DESCRIPTION
Wire composes shifts in the native `int` to decode integers: `UInt32` and `UInt63` fold 16-bit reads, `Bitfield` folds bytes, and the `U32` cast masks with `0xFFFF_FFFF`. All of it assumes a 63-bit `int`. On a narrower one, such as js_of_ocaml or wasm_of_ocaml, `hi lsl 16` overflows and drops bit 31, so a uint32 with the top bit set decodes wrong: a TCP sequence number `0xa695853b` reads back as `0x2695853b`, and the peer never sees its ACK. The `land 0xFFFF_FFFF` literal wraps to `-1` on those targets, so the cast masks nothing. All of it is silent.

Wire now fails at load when `Sys.int_size < 63` rather than handing back corrupted wire data. This is a guard, not the fix: making the decoders correct on a narrow `int` means `int32`, which boxes and would cost the zero-alloc read path the current representation exists to protect. That widening is tracked separately.
