### PR TITLE
uint: decode uint32/uint63 through optint

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,13 @@
 
 ### Changed
 
+- `uint32`/`uint32be` now decode to `Optint.t` and `uint63`/`uint63be` to
+  `Optint.Int63.t` rather than a native `int`, so a value with bit 31 (or the
+  high half) set is no longer silently truncated on a target whose `int` is
+  narrower than 63 bits (js_of_ocaml, wasm_of_ocaml); a TCP sequence number now
+  round-trips there. Read such a field with `Optint.to_int` / `Optint.to_int32`;
+  a `uint32` used as a size parameter must become `int32be` (#226, @samoht)
+
 - Decode errors are redesigned. `parse_error` is now a `{ at; field; kind }`
   record instead of a flat variant: `at` is the failing field's byte offset,
   `field` the root-to-leaf path of field names to it, and `kind` a closed

--- a/bench/demo/demo_bench_cases.ml
+++ b/bench/demo/demo_bench_cases.ml
@@ -427,10 +427,10 @@ let ipv4_case =
       set;
       write_template = Bytes.copy ipv4_dataset.items.(0);
       write_offset = 0;
-      write_value = 0x0A00_0001;
-      equal = Int.equal;
+      write_value = Optint.of_int 0x0A00_0001;
+      equal = Optint.equal;
       bench_read = true;
-      of_c_field = id_int;
+      of_c_field = of_int Optint.of_int;
     }
 
 let tcp_case =

--- a/bench/demo/demo_bench_cases.mli
+++ b/bench/demo/demo_bench_cases.mli
@@ -74,7 +74,7 @@ val clcw_case : int read_case
 val packet_case : int read_case
 (** CCSDS Space Packet APID (11-bit bitfield). *)
 
-val ipv4_case : int read_case
+val ipv4_case : Optint.t read_case
 (** IPv4 source address (uint32be). *)
 
 val tcp_case : int read_case

--- a/bench/memtrace/bench.ml
+++ b/bench/memtrace/bench.ml
@@ -153,7 +153,7 @@ type kexinit = {
   lang_c2s : Slice.t;
   lang_s2c : Slice.t;
   first_follows : int;
-  reserved : int;
+  reserved : Optint.t;
 }
 
 let kex_len name = Wire.Field.v name Wire.uint32be
@@ -194,25 +194,25 @@ let kexinit_codec =
       [
         ( Wire.Field.v "Cookie" (Wire.byte_slice ~size:(Wire.int 16)) $ fun r ->
           r.cookie );
-        (f_kex_len $ fun r -> Slice.length r.kex);
+        (f_kex_len $ fun r -> Optint.of_int (Slice.length r.kex));
         (name_list "Kex" f_kex_len $ fun r -> r.kex);
-        (f_hk_len $ fun r -> Slice.length r.host_key);
+        (f_hk_len $ fun r -> Optint.of_int (Slice.length r.host_key));
         (name_list "HostKey" f_hk_len $ fun r -> r.host_key);
-        (f_ec_len $ fun r -> Slice.length r.enc_c2s);
+        (f_ec_len $ fun r -> Optint.of_int (Slice.length r.enc_c2s));
         (name_list "EncC2S" f_ec_len $ fun r -> r.enc_c2s);
-        (f_es_len $ fun r -> Slice.length r.enc_s2c);
+        (f_es_len $ fun r -> Optint.of_int (Slice.length r.enc_s2c));
         (name_list "EncS2C" f_es_len $ fun r -> r.enc_s2c);
-        (f_mc_len $ fun r -> Slice.length r.mac_c2s);
+        (f_mc_len $ fun r -> Optint.of_int (Slice.length r.mac_c2s));
         (name_list "MacC2S" f_mc_len $ fun r -> r.mac_c2s);
-        (f_ms_len $ fun r -> Slice.length r.mac_s2c);
+        (f_ms_len $ fun r -> Optint.of_int (Slice.length r.mac_s2c));
         (name_list "MacS2C" f_ms_len $ fun r -> r.mac_s2c);
-        (f_cc_len $ fun r -> Slice.length r.comp_c2s);
+        (f_cc_len $ fun r -> Optint.of_int (Slice.length r.comp_c2s));
         (name_list "CompC2S" f_cc_len $ fun r -> r.comp_c2s);
-        (f_cs_len $ fun r -> Slice.length r.comp_s2c);
+        (f_cs_len $ fun r -> Optint.of_int (Slice.length r.comp_s2c));
         (name_list "CompS2C" f_cs_len $ fun r -> r.comp_s2c);
-        (f_lc_len $ fun r -> Slice.length r.lang_c2s);
+        (f_lc_len $ fun r -> Optint.of_int (Slice.length r.lang_c2s));
         (name_list "LangC2S" f_lc_len $ fun r -> r.lang_c2s);
-        (f_ls_len $ fun r -> Slice.length r.lang_s2c);
+        (f_ls_len $ fun r -> Optint.of_int (Slice.length r.lang_s2c));
         (name_list "LangS2C" f_ls_len $ fun r -> r.lang_s2c);
         (Wire.Field.v "FirstFollows" Wire.uint8 $ fun r -> r.first_follows);
         (Wire.Field.v "Reserved" Wire.uint32be $ fun r -> r.reserved);

--- a/dune-project
+++ b/dune-project
@@ -26,6 +26,7 @@
   (bytesrw (>= 0.1))
   (eio (>= 1.0))
   (fmt (>= 0.9))
+  (optint (>= 0.3))
   (memtrace :with-test)
   (alcotest :with-test)
   (alcobar :with-test)

--- a/examples/demo/demo.ml
+++ b/examples/demo/demo.ml
@@ -37,8 +37,8 @@ type all_ints = {
   u8 : int;
   u16 : int;
   u16be : int;
-  u32 : int;
-  u32be : int;
+  u32 : Optint.t;
+  u32be : Optint.t;
   u64be : int64;
 }
 
@@ -66,8 +66,8 @@ let all_ints_default =
     u8 = 0xFF;
     u16 = 0x1234;
     u16be = 0x5678;
-    u32 = 0xDEADBEEF;
-    u32be = 0xCAFEBABE;
+    u32 = Optint.of_int 0xDEADBEEF;
+    u32be = Optint.of_int 0xCAFEBABE;
     u64be = 0x0102030405060708L;
   }
 
@@ -202,7 +202,7 @@ let bool_fields_data n =
 (* -- 7. Large mixed: u32be+u8+u8+u16be+u8+u8+u16be+u16be+u32be+u64be = 26 bytes -- *)
 
 type large_mixed = {
-  sync : int;
+  sync : Optint.t;
   version : int;
   type_ : int;
   spacecraft : int;
@@ -210,7 +210,7 @@ type large_mixed = {
   count : int;
   offset : int;
   length : int;
-  crc : int;
+  crc : Optint.t;
   timestamp : int64;
 }
 
@@ -251,7 +251,7 @@ let large_mixed_size = Codec.wire_size large_mixed_codec
 
 let large_mixed_default =
   {
-    sync = 0x1ACFFC1D;
+    sync = Optint.of_int 0x1ACFFC1D;
     version = 2;
     type_ = 0;
     spacecraft = 0x01FF;
@@ -259,7 +259,7 @@ let large_mixed_default =
     count = 66;
     offset = 16;
     length = 1024;
-    crc = 0xDEADBEEF;
+    crc = Optint.of_int 0xDEADBEEF;
     timestamp = 0x0102030405060708L;
   }
 
@@ -524,13 +524,13 @@ let byte_array_struct =
    [UINT8[:byte-size (total_ - sizeof(this))]] -- [total] is an F*
    keyword and gets escaped automatically. *)
 let all_bytes_struct =
-  let total = Wire.Param.input "total" Wire.uint32be in
+  let total = Wire.Param.input "total" Wire.int32be in
   param_struct "TrailingData"
     [ Wire.Param.decl total ]
     [ field "Header" uint32be; field "Rest" (Wire.rest_bytes total) ]
 
 let all_zeros_struct =
-  let total = Wire.Param.input "total" Wire.uint32be in
+  let total = Wire.Param.input "total" Wire.int32be in
   param_struct "PaddedMsg"
     [ Wire.Param.decl total ]
     [ field "Value" uint16be; field "Padding" (Wire.rest_bytes total) ]

--- a/examples/demo/demo.mli
+++ b/examples/demo/demo.mli
@@ -31,8 +31,8 @@ type all_ints = {
   u8 : int;
   u16 : int;
   u16be : int;
-  u32 : int;
-  u32be : int;
+  u32 : Optint.t;
+  u32be : Optint.t;
   u64be : int64;
 }
 
@@ -162,7 +162,7 @@ val bool_fields_data : int -> bytes array
 (** {1 LargeMixed (26 bytes)} *)
 
 type large_mixed = {
-  sync : int;
+  sync : Optint.t;
   version : int;
   type_ : int;
   spacecraft : int;
@@ -170,7 +170,7 @@ type large_mixed = {
   count : int;
   offset : int;
   length : int;
-  crc : int;
+  crc : Optint.t;
   timestamp : int64;
 }
 

--- a/examples/net/example.ml
+++ b/examples/net/example.ml
@@ -28,8 +28,12 @@ let () =
   let protocol =
     (Staged.unstage (Codec.get ipv4_codec bf_ip_protocol)) buf ip_off
   in
-  let src = (Staged.unstage (Codec.get ipv4_codec bf_ip_src)) buf ip_off in
-  let dst = (Staged.unstage (Codec.get ipv4_codec bf_ip_dst)) buf ip_off in
+  let src =
+    Optint.to_int ((Staged.unstage (Codec.get ipv4_codec bf_ip_src)) buf ip_off)
+  in
+  let dst =
+    Optint.to_int ((Staged.unstage (Codec.get ipv4_codec bf_ip_dst)) buf ip_off)
+  in
   let tcp_off =
     Slice.first
       ((Staged.unstage (Codec.get ipv4_codec bf_ip_payload)) buf ip_off)

--- a/examples/net/net.ml
+++ b/examples/net/net.ml
@@ -59,8 +59,8 @@ type ipv4 = {
   ttl : int;
   protocol : int;
   checksum : int;
-  src : int;
-  dst : int;
+  src : Optint.t;
+  dst : Optint.t;
   payload : Slice.t;
 }
 
@@ -180,8 +180,8 @@ let ipv4_size = Codec.wire_size ipv4_codec
 type tcp = {
   src_port : int;
   dst_port : int;
-  seq : int;
-  ack_num : int;
+  seq : Optint.t;
+  ack_num : Optint.t;
   data_offset : int;
   reserved : int;
   ns : bool;

--- a/examples/net/net.mli
+++ b/examples/net/net.mli
@@ -51,10 +51,10 @@ val ipv4_payload_size : int
 val f_ip_protocol : int Wire.Field.t
 (** Zero-copy field accessor for the IPv4 Protocol field. *)
 
-val f_ip_src : int Wire.Field.t
+val f_ip_src : Optint.t Wire.Field.t
 (** Zero-copy field accessor for the IPv4 source address field. *)
 
-val f_ip_dst : int Wire.Field.t
+val f_ip_dst : Optint.t Wire.Field.t
 (** Zero-copy field accessor for the IPv4 destination address field. *)
 
 val f_ip_payload : Bytesrw.Bytes.Slice.t Wire.Field.t
@@ -63,10 +63,10 @@ val f_ip_payload : Bytesrw.Bytes.Slice.t Wire.Field.t
 val bf_ip_protocol : (int, ipv4) Wire.Codec.field
 (** Bound field handle for the IPv4 Protocol field. *)
 
-val bf_ip_src : (int, ipv4) Wire.Codec.field
+val bf_ip_src : (Optint.t, ipv4) Wire.Codec.field
 (** Bound field handle for the IPv4 source address field. *)
 
-val bf_ip_dst : (int, ipv4) Wire.Codec.field
+val bf_ip_dst : (Optint.t, ipv4) Wire.Codec.field
 (** Bound field handle for the IPv4 destination address field. *)
 
 val bf_ip_payload : (Bytesrw.Bytes.Slice.t, ipv4) Wire.Codec.field

--- a/examples/space/space.ml
+++ b/examples/space/space.ml
@@ -314,7 +314,7 @@ type tm_with_ocf = {
   mc_count : int;
   vc_count : int;
   first_hdr : int;
-  ocf : int option;
+  ocf : Optint.t option;
 }
 
 let f_tmo_ocf_flag = Field.v "OCFFlag" (bit (bits ~width:1 U16be))

--- a/fuzz/gen/fuzz_gen.ml
+++ b/fuzz/gen/fuzz_gen.ml
@@ -128,13 +128,23 @@ let scalar_int64 typ size value_gen boundaries =
   leaf ~equal:Int64.equal ~typ ~value_gen ~random:(bytes_fixed size)
     ~adversarial:(Alcobar.choose (List.map Alcobar.const boundaries))
 
+let scalar_optint typ size value_gen boundaries =
+  leaf ~equal:Optint.equal ~typ ~value_gen ~random:(bytes_fixed size)
+    ~adversarial:(Alcobar.choose (List.map Alcobar.const boundaries))
+
+let scalar_optint63 typ size value_gen boundaries =
+  leaf ~equal:Optint.Int63.equal ~typ ~value_gen ~random:(bytes_fixed size)
+    ~adversarial:(Alcobar.choose (List.map Alcobar.const boundaries))
+
 let u8_boundaries = [ 0; 1; 0x7F; 0x80; 0xFE; 0xFF ]
 let u16_boundaries = [ 0; 1; 0x7F; 0x80; 0x7FFF; 0x8000; 0xFFFE; 0xFFFF ]
 
 let u32_boundaries =
-  [ 0; 1; 0xFFFF; 0x7FFF_FFFF; 0x8000_0000; 0xFFFF_FFFE; 0xFFFF_FFFF ]
+  List.map Optint.of_int
+    [ 0; 1; 0xFFFF; 0x7FFF_FFFF; 0x8000_0000; 0xFFFF_FFFE; 0xFFFF_FFFF ]
 
-let u63_boundaries = [ 0; 1; 0xFFFF_FFFF; max_int - 1; max_int ]
+let u63_boundaries =
+  List.map Optint.Int63.of_int [ 0; 1; 0xFFFF_FFFF; max_int - 1; max_int ]
 
 let u64_boundaries_i64 =
   Int64.[ zero; one; of_int 0xFFFF_FFFF; max_int; min_int; -1L; sub max_int 1L ]
@@ -148,13 +158,19 @@ let uint16 = scalar_int Wire.uint16 2 Alcobar.uint16 u16_boundaries
 let uint16be = scalar_int Wire.uint16be 2 Alcobar.uint16 u16_boundaries
 
 let masked_u32 =
-  Alcobar.map Alcobar.[ Alcobar.int ] (fun n -> n land 0xFFFF_FFFF)
+  Alcobar.map
+    Alcobar.[ Alcobar.int ]
+    (fun n -> Optint.of_int (n land 0xFFFF_FFFF))
 
-let masked_u63 = Alcobar.map Alcobar.[ Alcobar.int ] (fun n -> n land max_int)
-let uint32 = scalar_int Wire.uint32 4 masked_u32 u32_boundaries
-let uint32be = scalar_int Wire.uint32be 4 masked_u32 u32_boundaries
-let uint63 = scalar_int Wire.uint63 8 masked_u63 u63_boundaries
-let uint63be = scalar_int Wire.uint63be 8 masked_u63 u63_boundaries
+let masked_u63 =
+  Alcobar.map
+    Alcobar.[ Alcobar.int ]
+    (fun n -> Optint.Int63.of_int (n land max_int))
+
+let uint32 = scalar_optint Wire.uint32 4 masked_u32 u32_boundaries
+let uint32be = scalar_optint Wire.uint32be 4 masked_u32 u32_boundaries
+let uint63 = scalar_optint63 Wire.uint63 8 masked_u63 u63_boundaries
+let uint63be = scalar_optint63 Wire.uint63be 8 masked_u63 u63_boundaries
 let uint64 = scalar_int64 Wire.uint64 8 Alcobar.int64 u64_boundaries_i64
 let uint64be = scalar_int64 Wire.uint64be 8 Alcobar.int64 u64_boundaries_i64
 let int8 = scalar_int Wire.int8 1 Alcobar.int8 s8_boundaries
@@ -568,6 +584,7 @@ let exact_cases ~typ ~equal cases =
 
 let exact_int typ cases = exact_cases ~typ ~equal:Int.equal cases
 let exact_int64 typ cases = exact_cases ~typ ~equal:Int64.equal cases
+let exact_optint typ cases = exact_cases ~typ ~equal:Optint.equal cases
 
 let uint16_endian_edges =
   exact_int Wire.uint16
@@ -588,19 +605,19 @@ let uint16be_endian_edges =
     ]
 
 let uint32_endian_edges =
-  exact_int Wire.uint32
+  exact_optint Wire.uint32
     [
-      (0x01234567, bytes_of_octets [ 0x67; 0x45; 0x23; 0x01 ]);
-      (0x80000000, bytes_of_octets [ 0x00; 0x00; 0x00; 0x80 ]);
-      (0xFFFFFFFF, bytes_of_octets [ 0xFF; 0xFF; 0xFF; 0xFF ]);
+      (Optint.of_int 0x01234567, bytes_of_octets [ 0x67; 0x45; 0x23; 0x01 ]);
+      (Optint.of_int 0x80000000, bytes_of_octets [ 0x00; 0x00; 0x00; 0x80 ]);
+      (Optint.of_int 0xFFFFFFFF, bytes_of_octets [ 0xFF; 0xFF; 0xFF; 0xFF ]);
     ]
 
 let uint32be_endian_edges =
-  exact_int Wire.uint32be
+  exact_optint Wire.uint32be
     [
-      (0x01234567, bytes_of_octets [ 0x01; 0x23; 0x45; 0x67 ]);
-      (0x80000000, bytes_of_octets [ 0x80; 0x00; 0x00; 0x00 ]);
-      (0xFFFFFFFF, bytes_of_octets [ 0xFF; 0xFF; 0xFF; 0xFF ]);
+      (Optint.of_int 0x01234567, bytes_of_octets [ 0x01; 0x23; 0x45; 0x67 ]);
+      (Optint.of_int 0x80000000, bytes_of_octets [ 0x80; 0x00; 0x00; 0x00 ]);
+      (Optint.of_int 0xFFFFFFFF, bytes_of_octets [ 0xFF; 0xFF; 0xFF; 0xFF ]);
     ]
 
 let uint64_endian_edges =
@@ -1074,7 +1091,7 @@ let bounded_u8 ~min ~max =
    with a range [self_constraint]. [set] writes a boundary value as raw bytes and
    [max_val] is the type's maximum (so out-of-type boundary samples are dropped).
    Covers the constraint path on wider and big-endian scalars, not just uint8. *)
-let bounded_int ~inner_typ ~size ~set ~max_val ~min ~max =
+let bounded_int ~inner_typ ~size ~set ~max_val ~min ~max ~of_int ~equal =
   let f =
     Wire.Field.v "v" inner_typ ~self_constraint:(fun r ->
         Wire.Expr.(r >= Wire.int min && r <= Wire.int max))
@@ -1083,7 +1100,7 @@ let bounded_int ~inner_typ ~size ~set ~max_val ~min ~max =
     Wire.Codec.v "_bounded_int" (fun v -> v) Wire.Codec.[ (f $ fun v -> v) ]
   in
   let value_gen =
-    Alcobar.map Alcobar.[ Alcobar.range ~min (max - min + 1) ] Fun.id
+    Alcobar.map Alcobar.[ Alcobar.range ~min (max - min + 1) ] of_int
   in
   let encode v =
     let buf = Bytes.create size in
@@ -1110,18 +1127,19 @@ let bounded_int ~inner_typ ~size ~set ~max_val ~min ~max =
     positive;
     random = bytes_fixed size;
     adversarial = boundary_bytes;
-    equal = Int.equal;
+    equal;
     env = None;
   }
 
 let bounded_u16be =
   bounded_int ~inner_typ:Wire.uint16be ~size:2 ~set:Bytes.set_uint16_be
-    ~max_val:0xFFFF ~min:1000 ~max:60000
+    ~max_val:0xFFFF ~min:1000 ~max:60000 ~of_int:Fun.id ~equal:Int.equal
 
 let bounded_u32be =
   bounded_int ~inner_typ:Wire.uint32be ~size:4
     ~set:(fun b o n -> Bytes.set_int32_be b o (Int32.of_int n))
-    ~max_val:0x7FFF_FFFF ~min:1000 ~max:1_000_000
+    ~max_val:0x7FFF_FFFF ~min:1000 ~max:1_000_000 ~of_int:Optint.of_int
+    ~equal:Optint.equal
 
 (* Two-uint8 record with [Codec.v ~where:(a < b)]. Positives keep a < b;
    adversarials sit at the boundary (a = b, a = b+1) so the where clause

--- a/fuzz/gen/fuzz_gen.mli
+++ b/fuzz/gen/fuzz_gen.mli
@@ -202,16 +202,16 @@ val uint16 : int t
 val uint16be : int t
 (** [uint16be] generates for {!Wire.uint16be}. *)
 
-val uint32 : int t
+val uint32 : Optint.t t
 (** [uint32] generates for {!Wire.uint32}. *)
 
-val uint32be : int t
+val uint32be : Optint.t t
 (** [uint32be] generates for {!Wire.uint32be}. *)
 
-val uint63 : int t
+val uint63 : Optint.Int63.t t
 (** [uint63] generates for {!Wire.uint63}. *)
 
-val uint63be : int t
+val uint63be : Optint.Int63.t t
 (** [uint63be] generates for {!Wire.uint63be}. *)
 
 val uint64 : int64 t

--- a/lib/bitfield.ml
+++ b/lib/bitfield.ml
@@ -34,6 +34,18 @@ let[@inline always] u32_be buf off =
   lor (Char.code (Bytes.unsafe_get buf (off + 2)) lsl 8)
   lor Char.code (Bytes.unsafe_get buf (off + 3))
 
+(* A bitfield word is a bag of bits manipulated in the native [int], never a
+   uint32 field value, so these stay [int]-based rather than going through
+   [UInt32]/[Optint]. On a host whose native [int] is narrower than 32 bits a
+   U32-base bitfield does not fit the word and is unsupported regardless. *)
+let[@inline always] set_u32_le buf off v =
+  Bytes.set_uint16_le buf off (v land 0xFFFF);
+  Bytes.set_uint16_le buf (off + 2) ((v lsr 16) land 0xFFFF)
+
+let[@inline always] set_u32_be buf off v =
+  Bytes.set_uint16_be buf off ((v lsr 16) land 0xFFFF);
+  Bytes.set_uint16_be buf (off + 2) (v land 0xFFFF)
+
 let read_word base buf off =
   match base with
   | U8 -> Bytes.get_uint8 buf off
@@ -47,8 +59,8 @@ let write_word base buf off v =
   | U8 -> Bytes.set_uint8 buf off v
   | U16 Little -> Bytes.set_uint16_le buf off v
   | U16 Big -> Bytes.set_uint16_be buf off v
-  | U32 Little -> UInt32.set_le buf off v
-  | U32 Big -> UInt32.set_be buf off v
+  | U32 Little -> set_u32_le buf off v
+  | U32 Big -> set_u32_be buf off v
 
 (** EverParse's native bit order for a base: LE bases default to LSB-first (MSVC
     C bit-field packing), BE bases to MSB-first (network byte order). *)

--- a/lib/bitfield.mli
+++ b/lib/bitfield.mli
@@ -25,6 +25,12 @@ val u32_le : bytes -> int -> int
 val u32_be : bytes -> int -> int
 (** Inline big-endian 32-bit word read. *)
 
+val set_u32_le : bytes -> int -> int -> unit
+(** Inline little-endian 32-bit word write of a native-[int] bitfield word. *)
+
+val set_u32_be : bytes -> int -> int -> unit
+(** Inline big-endian 32-bit word write of a native-[int] bitfield word. *)
+
 val write_word : Types.bitfield_base -> bytes -> int -> int -> unit
 (** Write the base word to bytes at offset. *)
 

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -975,9 +975,9 @@ let build_bf_reader base byte_off shift width =
       fun buf off ->
         (Bytes.get_uint16_be buf (off + byte_off) lsr shift) land mask
   | U32 Little ->
-      fun buf off -> (UInt32.le buf (off + byte_off) lsr shift) land mask
+      fun buf off -> (Bitfield.u32_le buf (off + byte_off) lsr shift) land mask
   | U32 Big ->
-      fun buf off -> (UInt32.be buf (off + byte_off) lsr shift) land mask
+      fun buf off -> (Bitfield.u32_be buf (off + byte_off) lsr shift) land mask
 
 let err_bf_overflow width value =
   Fmt.invalid_arg "Codec.encode: value 0x%X exceeds %d-bit field width" value
@@ -1010,14 +1010,14 @@ let build_bf_writer base byte_off shift width =
   | U32 Little ->
       fun buf off value ->
         check_bf_overflow width value;
-        let cur = UInt32.le buf (off + byte_off) in
-        UInt32.set_le buf (off + byte_off)
+        let cur = Bitfield.u32_le buf (off + byte_off) in
+        Bitfield.set_u32_le buf (off + byte_off)
           (cur lor ((value land mask) lsl shift))
   | U32 Big ->
       fun buf off value ->
         check_bf_overflow width value;
-        let cur = UInt32.be buf (off + byte_off) in
-        UInt32.set_be buf (off + byte_off)
+        let cur = Bitfield.u32_be buf (off + byte_off) in
+        Bitfield.set_u32_be buf (off + byte_off)
           (cur lor ((value land mask) lsl shift))
 
 let build_bf_accessor_writer base byte_off shift width =
@@ -1041,13 +1041,13 @@ let build_bf_accessor_writer base byte_off shift width =
           (cur land clear_mask lor ((value land mask) lsl shift))
   | U32 Little ->
       fun buf off value ->
-        let cur = UInt32.le buf (off + byte_off) in
-        UInt32.set_le buf (off + byte_off)
+        let cur = Bitfield.u32_le buf (off + byte_off) in
+        Bitfield.set_u32_le buf (off + byte_off)
           (cur land clear_mask lor ((value land mask) lsl shift))
   | U32 Big ->
       fun buf off value ->
-        let cur = UInt32.be buf (off + byte_off) in
-        UInt32.set_be buf (off + byte_off)
+        let cur = Bitfield.u32_be buf (off + byte_off) in
+        Bitfield.set_u32_be buf (off + byte_off)
           (cur land clear_mask lor ((value land mask) lsl shift))
 
 let build_bf_clear base byte_off =

--- a/lib/dune
+++ b/lib/dune
@@ -1,7 +1,7 @@
 (library
  (name wire)
  (public_name wire)
- (libraries bytesrw fmt))
+ (libraries bytesrw fmt optint))
 
 (mdx
  (files codec.mli field.mli wire.mli)

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -1090,8 +1090,8 @@ let case_index_to_expr : type k. k typ -> k -> packed_expr =
   match tag_typ with
   | Uint8 -> Pack_expr (Int k)
   | Uint16 _ -> Pack_expr (Int k)
-  | Uint32 _ -> Pack_expr (Int k)
-  | Uint63 _ -> Pack_expr (Int k)
+  | Uint32 _ -> Pack_expr (Int (UInt32.to_int k))
+  | Uint63 _ -> Pack_expr (Int (UInt63.to_int k))
   | Uint_var _ -> Pack_expr (Int k)
   | Int8 -> Pack_expr (Int k)
   | Int16 _ -> Pack_expr (Int k)

--- a/lib/uInt32.ml
+++ b/lib/uInt32.ml
@@ -1,28 +1,37 @@
-type t = int
+type t = Optint.t
 
-let pp = Fmt.int
+let pp = Optint.pp
 
-(* Compose two unboxed 16-bit reads/writes rather than going through
-   [Int32.to_int] / [Int32.of_int], which box an [int32] per call. The
-   result stays in the native [int]. *)
+(* Compose two unboxed 16-bit reads/writes through [Optint]. On a 64-bit host
+   [Optint.t] is an unboxed native [int], so the shifts and [logor] stay in
+   registers exactly like the old [int] code (measured identical, zero alloc);
+   where the native [int] is narrower than 32 bits [Optint.t] falls back to a
+   boxed [int32], which is what keeps a value with bit 31 set (a TCP sequence
+   number) from being truncated. *)
+
+let mask16 = Optint.of_int 0xFFFF
 
 let le buf off =
   let lo = Bytes.get_uint16_le buf off in
   let hi = Bytes.get_uint16_le buf (off + 2) in
-  lo lor (hi lsl 16)
+  Optint.(logor (of_int lo) (shift_left (of_int hi) 16))
 
 let be buf off =
   let hi = Bytes.get_uint16_be buf off in
   let lo = Bytes.get_uint16_be buf (off + 2) in
-  (hi lsl 16) lor lo
+  Optint.(logor (shift_left (of_int hi) 16) (of_int lo))
+
+let low16 v = Optint.to_int (Optint.logand v mask16)
 
 let set_le buf off v =
-  Bytes.set_uint16_le buf off (v land 0xFFFF);
-  Bytes.set_uint16_le buf (off + 2) ((v lsr 16) land 0xFFFF)
+  Bytes.set_uint16_le buf off (low16 v);
+  Bytes.set_uint16_le buf (off + 2) (low16 (Optint.shift_right_logical v 16))
 
 let set_be buf off v =
-  Bytes.set_uint16_be buf off ((v lsr 16) land 0xFFFF);
-  Bytes.set_uint16_be buf (off + 2) (v land 0xFFFF)
+  Bytes.set_uint16_be buf off (low16 (Optint.shift_right_logical v 16));
+  Bytes.set_uint16_be buf (off + 2) (low16 v)
 
-let to_int t = t
-let of_int t = t land 0xFFFF_FFFF
+let to_int = Optint.to_int
+let of_int v = Optint.of_int (v land 0xFFFF_FFFF)
+let to_int32 = Optint.to_int32
+let of_int32 = Optint.of_int32

--- a/lib/uInt32.mli
+++ b/lib/uInt32.mli
@@ -1,9 +1,14 @@
-(** Unsigned 32-bit integer. Unboxed on 64-bit (fits in 63-bit OCaml int). *)
+(** Unsigned 32-bit integer.
 
-type t = int
+    Backed by {!Optint.t}: an unboxed native [int] on a 64-bit host, a boxed
+    [int32] where the native [int] is narrower. This is what lets a value with
+    bit 31 set survive decoding on js_of_ocaml / wasm_of_ocaml, where a plain
+    [int] would drop it. *)
+
+type t = Optint.t
 
 val pp : Format.formatter -> t -> unit
-(** Pretty-printer for unsigned 32-bit values represented as OCaml integers. *)
+(** Pretty-printer for unsigned 32-bit values. *)
 
 val le : bytes -> int -> t
 (** [le buf off] reads a little-endian value from [buf] at offset [off]. *)
@@ -19,7 +24,16 @@ val set_be : bytes -> int -> t -> unit
 (** [set_be buf off v] writes [v] as big-endian into [buf] at offset [off]. *)
 
 val to_int : t -> int
-(** Identity coercion. *)
+(** [to_int t] is the value as a native [int]. Exact on a 64-bit host; on a
+    narrower one a value with bit 31 set does not fit and is truncated, so
+    prefer {!to_int32} across such a boundary. *)
 
 val of_int : int -> t
-(** Identity coercion. *)
+(** [of_int n] is the low 32 bits of [n]. *)
+
+val to_int32 : t -> int32
+(** [to_int32 t] is the value as an [int32] (its bit pattern, exact on every
+    platform). *)
+
+val of_int32 : int32 -> t
+(** [of_int32 n] is the [int32] bit pattern as a 32-bit value. *)

--- a/lib/uInt63.ml
+++ b/lib/uInt63.ml
@@ -1,43 +1,53 @@
-(* Unsigned 63-bit integer. Reads 8 bytes, masks to 63 bits (OCaml int). *)
+(* Unsigned 63-bit integer. Reads 8 bytes and masks to 63 bits.
 
-type t = int
+   Backed by Optint.Int63: an unboxed native int on a 64-bit host (identical to
+   the old code there), a boxed int64 where the native int is narrower. On such
+   a target the old plain-int composition shifted past the word ([w2 lsl 32],
+   [w3 lsl 48]) and lost the high half entirely. *)
 
-let pp = Fmt.int
+module I = Optint.Int63
 
-(* Compose four unboxed 16-bit reads/writes rather than going through
-   [Int64.to_int] / [Int64.of_int], which box an [int64] per call. The
-   result stays in the native [int]; reads still mask to [max_int] (the
-   top bit does not fit a 63-bit [int]), and the most-significant write
-   chunk uses [asr] so it carries the same sign extension [Int64.of_int]
-   produced. *)
+type t = I.t
+
+let pp = I.pp
+let mask16 = I.of_int 0xFFFF
+
+let compose w0 w1 w2 w3 =
+  I.(
+    logand
+      (logor (of_int w0)
+         (logor
+            (shift_left (of_int w1) 16)
+            (logor (shift_left (of_int w2) 32) (shift_left (of_int w3) 48))))
+      max_int)
 
 let le buf off =
-  let w0 = Bytes.get_uint16_le buf off in
-  let w1 = Bytes.get_uint16_le buf (off + 2) in
-  let w2 = Bytes.get_uint16_le buf (off + 4) in
-  let w3 = Bytes.get_uint16_le buf (off + 6) in
-  let v = w0 lor (w1 lsl 16) lor (w2 lsl 32) lor (w3 lsl 48) in
-  v land max_int
+  compose
+    (Bytes.get_uint16_le buf off)
+    (Bytes.get_uint16_le buf (off + 2))
+    (Bytes.get_uint16_le buf (off + 4))
+    (Bytes.get_uint16_le buf (off + 6))
 
 let be buf off =
-  let w0 = Bytes.get_uint16_be buf off in
-  let w1 = Bytes.get_uint16_be buf (off + 2) in
-  let w2 = Bytes.get_uint16_be buf (off + 4) in
-  let w3 = Bytes.get_uint16_be buf (off + 6) in
-  let v = (w0 lsl 48) lor (w1 lsl 32) lor (w2 lsl 16) lor w3 in
-  v land max_int
+  compose
+    (Bytes.get_uint16_be buf (off + 6))
+    (Bytes.get_uint16_be buf (off + 4))
+    (Bytes.get_uint16_be buf (off + 2))
+    (Bytes.get_uint16_be buf off)
+
+let chunk v shift = I.to_int (I.logand (I.shift_right_logical v shift) mask16)
 
 let set_le buf off v =
-  Bytes.set_uint16_le buf off (v land 0xFFFF);
-  Bytes.set_uint16_le buf (off + 2) ((v lsr 16) land 0xFFFF);
-  Bytes.set_uint16_le buf (off + 4) ((v lsr 32) land 0xFFFF);
-  Bytes.set_uint16_le buf (off + 6) ((v asr 48) land 0xFFFF)
+  Bytes.set_uint16_le buf off (chunk v 0);
+  Bytes.set_uint16_le buf (off + 2) (chunk v 16);
+  Bytes.set_uint16_le buf (off + 4) (chunk v 32);
+  Bytes.set_uint16_le buf (off + 6) (chunk v 48)
 
 let set_be buf off v =
-  Bytes.set_uint16_be buf off ((v asr 48) land 0xFFFF);
-  Bytes.set_uint16_be buf (off + 2) ((v lsr 32) land 0xFFFF);
-  Bytes.set_uint16_be buf (off + 4) ((v lsr 16) land 0xFFFF);
-  Bytes.set_uint16_be buf (off + 6) (v land 0xFFFF)
+  Bytes.set_uint16_be buf off (chunk v 48);
+  Bytes.set_uint16_be buf (off + 2) (chunk v 32);
+  Bytes.set_uint16_be buf (off + 4) (chunk v 16);
+  Bytes.set_uint16_be buf (off + 6) (chunk v 0)
 
-let to_int t = t
-let of_int t = t
+let to_int = I.to_int
+let of_int = I.of_int

--- a/lib/uInt63.mli
+++ b/lib/uInt63.mli
@@ -1,9 +1,13 @@
-(** Unsigned 63-bit integer. Reads 8 bytes, masks to 63 bits (OCaml int). *)
+(** Unsigned 63-bit integer. Reads 8 bytes, masks to 63 bits.
 
-type t = int
+    Backed by {!Optint.Int63}: an unboxed native [int] on a 64-bit host, a boxed
+    [int64] where the native [int] is narrower (there a plain-[int] composition
+    would shift past the word and lose the high half). *)
+
+type t = Optint.Int63.t
 
 val pp : Format.formatter -> t -> unit
-(** Pretty-printer for unsigned 63-bit values represented as OCaml integers. *)
+(** Pretty-printer for unsigned 63-bit values. *)
 
 val le : bytes -> int -> t
 (** [le buf off] reads a little-endian value from [buf] at offset [off]. *)
@@ -19,7 +23,7 @@ val set_be : bytes -> int -> t -> unit
 (** [set_be buf off v] writes [v] as big-endian into [buf] at offset [off]. *)
 
 val to_int : t -> int
-(** Identity coercion. *)
+(** [to_int t] is the value as a native [int]. Exact on a 64-bit host. *)
 
 val of_int : int -> t
-(** Identity coercion. *)
+(** [of_int n] is [n] as a 63-bit value. *)

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -489,17 +489,20 @@ val uint16 : int typ
 val uint16be : int typ
 (** Unsigned 16-bit big-endian integer. *)
 
-val uint32 : int typ
-(** Unsigned 32-bit little-endian integer. *)
+val uint32 : Optint.t typ
+(** Unsigned 32-bit little-endian integer. Decodes to an {!Optint.t} so a value
+    with bit 31 set survives on a narrow-[int] target (js/wasm). *)
 
-val uint32be : int typ
-(** Unsigned 32-bit big-endian integer. *)
+val uint32be : Optint.t typ
+(** Unsigned 32-bit big-endian integer. Decodes to an {!Optint.t}. *)
 
-val uint63 : int typ
-(** Unsigned 63-bit little-endian integer carried on 8 bytes. *)
+val uint63 : Optint.Int63.t typ
+(** Unsigned 63-bit little-endian integer carried on 8 bytes. Decodes to an
+    {!Optint.Int63.t}. *)
 
-val uint63be : int typ
-(** Unsigned 63-bit big-endian integer carried on 8 bytes. *)
+val uint63be : Optint.Int63.t typ
+(** Unsigned 63-bit big-endian integer carried on 8 bytes. Decodes to an
+    {!Optint.Int63.t}. *)
 
 val uint64 : int64 typ
 (** [uint64] is an unsigned 64-bit little-endian integer represented as an OCaml

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -31,7 +31,7 @@ let decode_record codec s =
 
 (* -- Record codec tests -- *)
 
-type simple_record = { a : int; b : int; c : int }
+type simple_record = { a : int; b : int; c : Optint.t }
 
 let simple_record_codec =
   let open Codec in
@@ -44,7 +44,7 @@ let simple_record_codec =
     ]
 
 let test_record_encode () =
-  let v = { a = 0x42; b = 0x1234; c = 0x56789ABC } in
+  let v = { a = 0x42; b = 0x1234; c = Optint.of_int 0x56789ABC } in
   match encode_record simple_record_codec v with
   | Error e -> Alcotest.failf "%a" pp_parse_error e
   | Ok encoded ->
@@ -61,11 +61,11 @@ let test_record_decode () =
   | Ok v ->
       Alcotest.(check int) "a" 0x42 v.a;
       Alcotest.(check int) "b" 0x1234 v.b;
-      Alcotest.(check int) "c" 0x56789ABC v.c
+      Alcotest.(check int) "c" 0x56789ABC (Optint.to_int v.c)
   | Error e -> Alcotest.failf "%a" pp_parse_error e
 
 let test_record_roundtrip () =
-  let original = { a = 0xAB; b = 0xCDEF; c = 0x12345678 } in
+  let original = { a = 0xAB; b = 0xCDEF; c = Optint.of_int 0x12345678 } in
   match encode_record simple_record_codec original with
   | Error e -> Alcotest.failf "encode: %a" pp_parse_error e
   | Ok encoded -> (
@@ -73,7 +73,8 @@ let test_record_roundtrip () =
       | Ok decoded ->
           Alcotest.(check int) "a roundtrip" original.a decoded.a;
           Alcotest.(check int) "b roundtrip" original.b decoded.b;
-          Alcotest.(check int) "c roundtrip" original.c decoded.c
+          Alcotest.(check int)
+            "c roundtrip" (Optint.to_int original.c) (Optint.to_int decoded.c)
       | Error e -> Alcotest.failf "%a" pp_parse_error e)
 
 let test_struct_of_record () =
@@ -524,7 +525,7 @@ let test_record_with_multi () =
       | Error e -> Alcotest.failf "%a" pp_parse_error e)
 
 (* Record with byte_array field *)
-type ba_record = { id : int; uuid : string; tag : int }
+type ba_record = { id : Optint.t; uuid : string; tag : int }
 
 let ba_record_codec =
   let open Codec in
@@ -537,21 +538,26 @@ let ba_record_codec =
     ]
 
 let test_record_byte_array_roundtrip () =
-  let original = { id = 0x12345678; uuid = "0123456789abcdef"; tag = 0xABCD } in
+  let original =
+    { id = Optint.of_int 0x12345678; uuid = "0123456789abcdef"; tag = 0xABCD }
+  in
   match encode_record ba_record_codec original with
   | Error e -> Alcotest.failf "encode: %a" pp_parse_error e
   | Ok encoded -> (
       Alcotest.(check int) "wire size" 22 (String.length encoded);
       match decode_record ba_record_codec encoded with
       | Ok decoded ->
-          Alcotest.(check int) "id" original.id decoded.id;
+          Alcotest.(check int)
+            "id"
+            (Optint.to_int original.id)
+            (Optint.to_int decoded.id);
           Alcotest.(check string) "uuid" original.uuid decoded.uuid;
           Alcotest.(check int) "tag" original.tag decoded.tag
       | Error e -> Alcotest.failf "%a" pp_parse_error e)
 
 let test_record_byte_array_padding () =
   (* Short string should be zero-padded *)
-  let original = { id = 1; uuid = "short"; tag = 2 } in
+  let original = { id = Optint.of_int 1; uuid = "short"; tag = 2 } in
   match encode_record ba_record_codec original with
   | Error e -> Alcotest.failf "encode: %a" pp_parse_error e
   | Ok encoded -> (
@@ -2746,10 +2752,10 @@ let test_raw_with_offset () =
   let codec = Codec.v "RawOff" (fun v -> v) [ cf_v ] in
   let buf = Bytes.create 20 in
   Bytes.fill buf 0 20 '\x00';
-  (Staged.unstage (Codec.set codec cf_v)) buf 10 0xDEADBEEF;
+  (Staged.unstage (Codec.set codec cf_v)) buf 10 (Optint.of_int 0xDEADBEEF);
   Alcotest.(check int)
     "get at offset 10" 0xDEADBEEF
-    ((Staged.unstage (Codec.get codec cf_v)) buf 10)
+    (Optint.to_int ((Staged.unstage (Codec.get codec cf_v)) buf 10))
 
 (* -- Dependent-size byte_slice tests -- *)
 
@@ -3791,7 +3797,7 @@ let test_optional_codec_absent () =
 
 (* Multiple optional fields (TM frame pattern) *)
 
-type multi_opt = { data : int; ocf : int option; fecf : int option }
+type multi_opt = { data : int; ocf : Optint.t option; fecf : int option }
 
 let multi_opt_codec ~ocf ~fecf =
   Codec.v "MultiOpt"
@@ -3815,7 +3821,9 @@ let test_optional_both_present () =
   Bytes.set_uint16_be buf 6 0x3333;
   let r = decode_ok (Codec.decode c buf 0) in
   Alcotest.(check int) "data" 0x1111 r.data;
-  Alcotest.(check (option int)) "ocf" (Some 0x22222222) r.ocf;
+  Alcotest.(check (option int))
+    "ocf" (Some 0x22222222)
+    (Option.map Optint.to_int r.ocf);
   Alcotest.(check (option int)) "fecf" (Some 0x3333) r.fecf
 
 let test_optional_both_absent () =
@@ -3825,7 +3833,7 @@ let test_optional_both_absent () =
   Bytes.set_uint16_be buf 0 0x1111;
   let r = decode_ok (Codec.decode c buf 0) in
   Alcotest.(check int) "data" 0x1111 r.data;
-  Alcotest.(check (option int)) "ocf" None r.ocf;
+  Alcotest.(check (option int)) "ocf" None (Option.map Optint.to_int r.ocf);
   Alcotest.(check (option int)) "fecf" None r.fecf
 
 let test_optional_mixed () =
@@ -3836,7 +3844,9 @@ let test_optional_mixed () =
   Bytes.set_int32_be buf 2 0x22222222l;
   let r = decode_ok (Codec.decode c buf 0) in
   Alcotest.(check int) "data" 0x1111 r.data;
-  Alcotest.(check (option int)) "ocf" (Some 0x22222222) r.ocf;
+  Alcotest.(check (option int))
+    "ocf" (Some 0x22222222)
+    (Option.map Optint.to_int r.ocf);
   Alcotest.(check (option int)) "fecf" None r.fecf
 
 (* Dynamic optional: presence determined by a previously-parsed field. *)
@@ -3949,7 +3959,12 @@ let test_encode_totality () =
    Field.ref now accepts 'a t, so a bool field created with [bit] can be
    referenced directly in expressions. *)
 
-type tm_opt = { ocf_flag : bool; data : int; ocf : int option; trail : int }
+type tm_opt = {
+  ocf_flag : bool;
+  data : int;
+  ocf : Optint.t option;
+  trail : int;
+}
 
 let f_to_ocf_flag = Field.v "OCFFlag" (bit (bits ~width:1 U8))
 
@@ -3977,7 +3992,9 @@ let test_dyn_opt_anyref_present () =
   let r = decode_ok (Codec.decode tm_opt_codec buf 0) in
   Alcotest.(check bool) "ocf_flag" true r.ocf_flag;
   Alcotest.(check int) "data" 0x1234 r.data;
-  Alcotest.(check (option int)) "ocf" (Some 0xDEADBEEF) r.ocf;
+  Alcotest.(check (option int))
+    "ocf" (Some 0xDEADBEEF)
+    (Option.map Optint.to_int r.ocf);
   Alcotest.(check int) "trail" 0xFF r.trail
 
 let test_dyn_opt_anyref_absent () =
@@ -3988,7 +4005,7 @@ let test_dyn_opt_anyref_absent () =
   let r = decode_ok (Codec.decode tm_opt_codec buf 0) in
   Alcotest.(check bool) "ocf_flag" false r.ocf_flag;
   Alcotest.(check int) "data" 0x1234 r.data;
-  Alcotest.(check (option int)) "ocf" None r.ocf;
+  Alcotest.(check (option int)) "ocf" None (Option.map Optint.to_int r.ocf);
   Alcotest.(check int) "trail" 0xFF r.trail
 
 (* -- Predicates with bitwise/shift/mod operators in [optional] --
@@ -4296,7 +4313,7 @@ let test_repeat_variable_size_elements () =
 
 (* -- Casetype as a trailing variable-size codec field -- *)
 
-type ev_payload = [ `Login of int | `Logout of int | `Other of int ]
+type ev_payload = [ `Login of int | `Logout of Optint.t | `Other of int ]
 
 let casetype_field_event_typ : ev_payload Wire.typ =
   Wire.casetype "EvPayload" Wire.uint8
@@ -4338,7 +4355,9 @@ let test_casetype_field_logout () =
   Bytes.set_uint8 buf 8 2;
   Bytes.set_int32_be buf 9 0x55667788l;
   let r = decode_ok (Codec.decode casetype_field_codec buf 0) in
-  Alcotest.(check bool) "Logout" true (r.data = `Logout 0x55667788)
+  Alcotest.(check bool)
+    "Logout" true
+    (r.data = `Logout (Optint.of_int 0x55667788))
 
 let test_casetype_field_default () =
   let buf = Bytes.create 10 in
@@ -4461,7 +4480,7 @@ type tm_like = {
   hdr : int;
   data_len : int;
   packets : packet list;
-  ocf : int option;
+  ocf : Optint.t option;
   fecf : int option;
 }
 
@@ -4507,7 +4526,9 @@ let test_tm_like_full () =
   Alcotest.(check int) "packet count" 2 (List.length r.packets);
   Alcotest.(check int) "pkt0.id" 0x01 (List.nth r.packets 0).id;
   Alcotest.(check int) "pkt1.id" 0x02 (List.nth r.packets 1).id;
-  Alcotest.(check (option int)) "ocf" (Some 0x33333333) r.ocf;
+  Alcotest.(check (option int))
+    "ocf" (Some 0x33333333)
+    (Option.map Optint.to_int r.ocf);
   Alcotest.(check (option int)) "fecf" (Some 0x4444) r.fecf
 
 let test_tm_like_no_trailing () =
@@ -4520,7 +4541,7 @@ let test_tm_like_no_trailing () =
   Bytes.set_uint16_be buf 4 0x1111;
   let r = decode_ok (Codec.decode c buf 0) in
   Alcotest.(check int) "packet count" 1 (List.length r.packets);
-  Alcotest.(check (option int)) "ocf" None r.ocf;
+  Alcotest.(check (option int)) "ocf" None (Option.map Optint.to_int r.ocf);
   Alcotest.(check (option int)) "fecf" None r.fecf
 
 let test_tm_like_roundtrip () =
@@ -4535,7 +4556,7 @@ let test_tm_like_roundtrip () =
           ({ id = 0x0B; data = 0x000B } : packet);
           ({ id = 0x0C; data = 0x000C } : packet);
         ];
-      ocf = Some 0xDEADBEEF;
+      ocf = Some (Optint.of_int 0xDEADBEEF);
       fecf = Some 0xCAFE;
     }
   in
@@ -4549,7 +4570,10 @@ let test_tm_like_roundtrip () =
       Alcotest.(check int) "pkt.id" o.id d.id;
       Alcotest.(check int) "pkt.data" o.data d.data)
     original.packets decoded.packets;
-  Alcotest.(check (option int)) "ocf" original.ocf decoded.ocf;
+  Alcotest.(check (option int))
+    "ocf"
+    (Option.map Optint.to_int original.ocf)
+    (Option.map Optint.to_int decoded.ocf);
   Alcotest.(check (option int)) "fecf" original.fecf decoded.fecf
 
 (* -- Multiple consecutive variable-size fields (CFDP-style) --
@@ -4684,7 +4708,7 @@ let test_multi_var_fixed_after () =
 
 module Slice = Bytesrw.Bytes.Slice
 
-type ssh_string = { len : int; data : Slice.t }
+type ssh_string = { len : Optint.t; data : Slice.t }
 
 let ssh_f_len = Field.v "len" uint32be
 let ssh_f_data = Field.v "data" (byte_slice ~size:(Field.ref ssh_f_len))
@@ -4697,7 +4721,7 @@ let ssh_string_codec =
 let mk_ssh_string s =
   let b = Bytes.of_string s in
   {
-    len = String.length s;
+    len = Optint.of_int (String.length s);
     data = Slice.make b ~first:0 ~length:(Bytes.length b);
   }
 
@@ -4714,17 +4738,19 @@ let test_ssh_two_var_slices () =
       (fun reason _ desc _ lang -> (reason, desc, lang))
       [
         (f_reason $ fun (r, _, _) -> r);
-        (f_desc_len $ fun (_, d, _) -> Slice.length d);
+        (f_desc_len $ fun (_, d, _) -> Optint.of_int (Slice.length d));
         (f_desc $ fun (_, d, _) -> d);
-        (f_lang_len $ fun (_, _, l) -> Slice.length l);
+        (f_lang_len $ fun (_, _, l) -> Optint.of_int (Slice.length l));
         (f_lang $ fun (_, _, l) -> l);
       ]
   in
-  let v = (11, (mk_ssh_string "bye").data, (mk_ssh_string "en-US").data) in
+  let v =
+    (Optint.of_int 11, (mk_ssh_string "bye").data, (mk_ssh_string "en-US").data)
+  in
   let buf = Bytes.create 200 in
   Codec.encode codec v buf 0;
   let r, d, l = decode_ok (Codec.decode codec buf 0) in
-  Alcotest.(check int) "reason" 11 r;
+  Alcotest.(check int) "reason" 11 (Optint.to_int r);
   Alcotest.(check string) "desc" "bye" (Slice.to_string d);
   Alcotest.(check string) "lang" "en-US" (Slice.to_string l)
 
@@ -4741,9 +4767,9 @@ let test_two_var_codecs_embedded () =
   let buf = Bytes.create 200 in
   Codec.encode pair_codec v buf 0;
   let a, b = decode_ok (Codec.decode pair_codec buf 0) in
-  Alcotest.(check int) "a.len" 4 a.len;
+  Alcotest.(check int) "a.len" 4 (Optint.to_int a.len);
   Alcotest.(check string) "a.data" "abcd" (Slice.to_string a.data);
-  Alcotest.(check int) "b.len" 2 b.len;
+  Alcotest.(check int) "b.len" 2 (Optint.to_int b.len);
   Alcotest.(check string) "b.data" "xy" (Slice.to_string b.data)
 
 let test_three_var_codecs_embedded () =

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -812,7 +812,7 @@ type tm_like = {
   hdr : int;
   data_len : int;
   packets : packet list;
-  ocf : int option;
+  ocf : Optint.t option;
   fecf : int option;
 }
 

--- a/test/test_uint32.ml
+++ b/test/test_uint32.ml
@@ -4,8 +4,8 @@ open Wire.Private
 
 let check_roundtrip name ~set ~get v =
   let buf = Bytes.create 4 in
-  set buf 0 v;
-  Alcotest.(check int) name (v land 0xFFFF_FFFF) (get buf 0)
+  set buf 0 (UInt32.of_int v);
+  Alcotest.(check int) name (v land 0xFFFF_FFFF) (UInt32.to_int (get buf 0))
 
 let test_roundtrip_le () =
   check_roundtrip "le roundtrip" ~set:UInt32.set_le ~get:UInt32.le 0xDEAD_BEEF
@@ -14,19 +14,28 @@ let test_roundtrip_be () =
   check_roundtrip "be roundtrip" ~set:UInt32.set_be ~get:UInt32.be 0xCAFE_BABE
 
 let test_of_int_masks () =
-  Alcotest.(check int) "mask" 0xFF (UInt32.of_int 0xFF);
+  Alcotest.(check int) "mask" 0xFF (UInt32.to_int (UInt32.of_int 0xFF));
   Alcotest.(check int) "identity" 42 (UInt32.to_int (UInt32.of_int 42))
 
 (* Pin the wire byte order so the read/write paths cannot drift. *)
 let test_byte_layout () =
   let buf = Bytes.of_string "\x01\x02\x03\x04" in
-  Alcotest.(check int) "le read" 0x04030201 (UInt32.le buf 0);
-  Alcotest.(check int) "be read" 0x01020304 (UInt32.be buf 0);
+  Alcotest.(check int) "le read" 0x04030201 (UInt32.to_int (UInt32.le buf 0));
+  Alcotest.(check int) "be read" 0x01020304 (UInt32.to_int (UInt32.be buf 0));
   let out = Bytes.create 4 in
-  UInt32.set_le out 0 0x04030201;
+  UInt32.set_le out 0 (UInt32.of_int 0x04030201);
   Alcotest.(check string) "le write" "\x01\x02\x03\x04" (Bytes.to_string out);
-  UInt32.set_be out 0 0x01020304;
+  UInt32.set_be out 0 (UInt32.of_int 0x01020304);
   Alcotest.(check string) "be write" "\x01\x02\x03\x04" (Bytes.to_string out)
+
+(* A value with bit 31 set keeps it: its int32 bit pattern survives even where a
+   native int could not hold it. This is the TCP sequence number that regressed. *)
+let test_high_bit () =
+  let buf = Bytes.create 4 in
+  UInt32.set_be buf 0 (UInt32.of_int 0xA695_853B);
+  Alcotest.(check int32)
+    "seq bit 31" 0xA695_853Bl
+    (UInt32.to_int32 (UInt32.be buf 0))
 
 let test_boundaries () =
   List.iter
@@ -42,5 +51,6 @@ let suite =
       Alcotest.test_case "roundtrip be" `Quick test_roundtrip_be;
       Alcotest.test_case "of_int masks" `Quick test_of_int_masks;
       Alcotest.test_case "byte layout" `Quick test_byte_layout;
+      Alcotest.test_case "high bit preserved" `Quick test_high_bit;
       Alcotest.test_case "boundaries" `Quick test_boundaries;
     ] )

--- a/test/test_uint63.ml
+++ b/test/test_uint63.ml
@@ -4,8 +4,8 @@ open Wire.Private
 
 let check_roundtrip name ~set ~get v =
   let buf = Bytes.create 8 in
-  set buf 0 v;
-  Alcotest.(check int) name v (get buf 0)
+  set buf 0 (UInt63.of_int v);
+  Alcotest.(check int) name v (UInt63.to_int (get buf 0))
 
 let test_roundtrip_le () =
   check_roundtrip "le roundtrip" ~set:UInt63.set_le ~get:UInt63.le
@@ -22,13 +22,17 @@ let test_of_int_identity () =
    cannot drift. *)
 let test_byte_layout () =
   let buf = Bytes.of_string "\x01\x02\x03\x04\x05\x06\x07\x08" in
-  Alcotest.(check int) "le read" 0x0807_0605_0403_0201 (UInt63.le buf 0);
-  Alcotest.(check int) "be read" 0x0102_0304_0506_0708 (UInt63.be buf 0);
+  Alcotest.(check int)
+    "le read" 0x0807_0605_0403_0201
+    (UInt63.to_int (UInt63.le buf 0));
+  Alcotest.(check int)
+    "be read" 0x0102_0304_0506_0708
+    (UInt63.to_int (UInt63.be buf 0));
   let out = Bytes.create 8 in
-  UInt63.set_le out 0 0x0807_0605_0403_0201;
+  UInt63.set_le out 0 (UInt63.of_int 0x0807_0605_0403_0201);
   Alcotest.(check string)
     "le write" "\x01\x02\x03\x04\x05\x06\x07\x08" (Bytes.to_string out);
-  UInt63.set_be out 0 0x0102_0304_0506_0708;
+  UInt63.set_be out 0 (UInt63.of_int 0x0102_0304_0506_0708);
   Alcotest.(check string)
     "be write" "\x01\x02\x03\x04\x05\x06\x07\x08" (Bytes.to_string out)
 

--- a/test/test_wire.ml
+++ b/test/test_wire.ml
@@ -63,13 +63,13 @@ let test_parse_uint16_be () =
 let test_parse_uint32_le () =
   let input = "\x01\x02\x03\x04" in
   match of_string uint32 input with
-  | Ok v -> Alcotest.(check int) "uint32 le value" 0x04030201 v
+  | Ok v -> Alcotest.(check int) "uint32 le value" 0x04030201 (Optint.to_int v)
   | Error e -> Alcotest.failf "%a" pp_parse_error e
 
 let test_parse_uint32_be () =
   let input = "\x01\x02\x03\x04" in
   match of_string uint32be input with
-  | Ok v -> Alcotest.(check int) "uint32 be value" 0x01020304 v
+  | Ok v -> Alcotest.(check int) "uint32 be value" 0x01020304 (Optint.to_int v)
   | Error e -> Alcotest.failf "%a" pp_parse_error e
 
 let test_parse_uint64_le () =
@@ -179,7 +179,7 @@ let test_finite_rejects_inf () =
 let test_rest_of_buffer_codec () =
   (* "Header then rest-of-buffer payload" idiom -- both formulations
      should work in a Codec field and round-trip OCaml decode/encode. *)
-  let total = Param.input "total" uint32be in
+  let total = Param.input "total" int32be in
   let f_h = Field.v "Header" uint8 in
   let f_d = Field.v "Data" (rest_bytes total) in
   let codec =
@@ -696,11 +696,11 @@ let test_encode_uint16_be () =
   Alcotest.(check string) "uint16 be encoding" "\x01\x02" encoded
 
 let test_encode_uint32_le () =
-  let encoded = to_string uint32 0x04030201 in
+  let encoded = to_string uint32 (Optint.of_int 0x04030201) in
   Alcotest.(check string) "uint32 le encoding" "\x01\x02\x03\x04" encoded
 
 let test_encode_uint32_be () =
-  let encoded = to_string uint32be 0x01020304 in
+  let encoded = to_string uint32be (Optint.of_int 0x01020304) in
   Alcotest.(check string) "uint32 be encoding" "\x01\x02\x03\x04" encoded
 
 let test_encode_array () =
@@ -777,7 +777,9 @@ let test_roundtrip_uint16 () =
   roundtrip "roundtrip uint16" uint16 Alcotest.int 0x1234
 
 let test_roundtrip_uint32 () =
-  roundtrip "roundtrip uint32" uint32 Alcotest.int 0x12345678
+  roundtrip "roundtrip uint32" uint32
+    (Alcotest.testable Optint.pp Optint.equal)
+    (Optint.of_int 0x12345678)
 
 let test_roundtrip_array () =
   roundtrip "roundtrip array"
@@ -813,16 +815,16 @@ let test_stream_uint16_chunk3 () =
   | Error e -> Alcotest.failf "uint16be chunk=3: %a" pp_parse_error e
 
 let test_stream_uint32_chunk1 () =
-  let encoded = to_string uint32 0xDEADBEEF in
+  let encoded = to_string uint32 (Optint.of_int 0xDEADBEEF) in
   match parse_chunked ~chunk_size:1 uint32 encoded with
-  | Ok v -> Alcotest.(check int) "uint32 chunk=1" 0xDEADBEEF v
+  | Ok v -> Alcotest.(check int) "uint32 chunk=1" 0xDEADBEEF (Optint.to_int v)
   | Error e -> Alcotest.failf "uint32 chunk=1: %a" pp_parse_error e
 
 let test_stream_uint32_chunk3 () =
   (* chunk=3: 4-byte value straddles at byte 3 *)
-  let encoded = to_string uint32be 0x12345678 in
+  let encoded = to_string uint32be (Optint.of_int 0x12345678) in
   match parse_chunked ~chunk_size:3 uint32be encoded with
-  | Ok v -> Alcotest.(check int) "uint32be chunk=3" 0x12345678 v
+  | Ok v -> Alcotest.(check int) "uint32be chunk=3" 0x12345678 (Optint.to_int v)
   | Error e -> Alcotest.failf "uint32be chunk=3: %a" pp_parse_error e
 
 let test_stream_uint64_chunk1 () =
@@ -884,7 +886,7 @@ let test_stream_rewind_partial_fixed () =
   let reader = Bytesrw.Bytes.Reader.of_string ~slice_length:1 "\x01\x02\x03" in
   (match Wire.of_reader uint32be reader with
   | Error { kind = Unexpected_eof _; _ } -> ()
-  | Ok v -> Alcotest.failf "expected eof, got %d" v
+  | Ok v -> Alcotest.failf "expected eof, got %d" (Optint.to_int v)
   | Error e -> Alcotest.failf "expected Unexpected_eof: %a" pp_parse_error e);
   Alcotest.(check int) "rewound" 0x0102 (reader_decode_ok uint16be reader);
   Alcotest.(check int) "rest intact" 0x03 (reader_decode_ok uint8 reader)
@@ -919,16 +921,18 @@ let test_stream_bitfield_chunk1 () =
 (* Encode roundtrip through chunked writer *)
 let test_stream_encode_chunk1 () =
   let v = 0xDEADBEEF in
-  let encoded = encode_chunked ~chunk_size:1 uint32be v in
+  let encoded = encode_chunked ~chunk_size:1 uint32be (Optint.of_int v) in
   match of_string uint32be encoded with
-  | Ok decoded -> Alcotest.(check int) "encode chunk=1" v decoded
+  | Ok decoded ->
+      Alcotest.(check int) "encode chunk=1" v (Optint.to_int decoded)
   | Error e -> Alcotest.failf "encode chunk=1: %a" pp_parse_error e
 
 let test_stream_encode_chunk3 () =
   let v = 0x12345678 in
-  let encoded = encode_chunked ~chunk_size:3 uint32be v in
+  let encoded = encode_chunked ~chunk_size:3 uint32be (Optint.of_int v) in
   match of_string uint32be encoded with
-  | Ok decoded -> Alcotest.(check int) "encode chunk=3" v decoded
+  | Ok decoded ->
+      Alcotest.(check int) "encode chunk=3" v (Optint.to_int decoded)
   | Error e -> Alcotest.failf "encode chunk=3: %a" pp_parse_error e
 
 (* An open enum accepts any value, named or not. The typ-level [of_string] path

--- a/wire.opam
+++ b/wire.opam
@@ -15,6 +15,7 @@ depends: [
   "bytesrw" {>= "0.1"}
   "eio" {>= "1.0"}
   "fmt" {>= "0.9"}
+  "optint" {>= "0.3"}
   "memtrace" {with-test}
   "alcotest" {with-test}
   "alcobar" {with-test}


### PR DESCRIPTION
`Wire.uint32`/`uint32be` now decode to `Optint.t`, and `uint63`/`uint63be` to `Optint.Int63.t`, instead of a native `int`.

They used to be composed in the native `int` (`(hi lsl 16) lor lo` for uint32, up to `lsl 48` for uint63). On a target whose `int` is narrower than 63 bits (js_of_ocaml, wasm_of_ocaml) those shifts overflow and drop the high bits, so a uint32 with bit 31 set (a TCP sequence number) decoded with the top bit silently lost. `Optint.t` holds the full width on every target, and is an unboxed native `int` on a 64-bit host, so the read path there is unchanged: field access stays zero-allocation and the timing is within noise.

    IPv4.src (uint32be), Codec.get:  before 3.2 ns/op 0w,  after 3.2 ns/op 0w

Bitfield word manipulation, which twiddles native-int bits rather than reading a field value, moves off `UInt32` onto `Bitfield`'s own u32 helpers.

Migration: a uint32 field or record slot is now `Optint.t`, read it with `Optint.to_int` / `Optint.to_int32`; a uint32 used as a size parameter must become `int32be`.
