### PR TITLE
codec: project int64 mask constraints, keep the slot through map

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 ## unreleased
 
+### Added
+
+- `Wire.Expr.land64` is an int64 bitwise AND for masking a full-width `uint64`
+  field inside a constraint, and `~self_int64` / `Field.int64` now accept a
+  `map`-decoded uint64 field. A sign-magnitude offset bound such as a bsdiff
+  seek (`land64 self mask <= max`) is now expressible and projects to a 3D
+  refinement EverParse verifies (#227, @samoht)
+
 ### Changed
 
 - Decode errors are redesigned. `parse_error` is now a `{ at; field; kind }`

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -503,16 +503,25 @@ type ('c1, 'c2) leaves = {
   field_pos : 'c1 -> 'c2 -> int;
 }
 
-let compile_int64 : type c1 c2.
+let rec compile_int64 : type c1 c2.
     (c1, c2) leaves -> int64 expr -> c1 -> c2 -> int64 =
  fun l e ->
-  match e with Int64 n -> fun _ _ -> n | Ref (I64, name) -> l.i64 name
+  match e with
+  | Int64 n -> fun _ _ -> n
+  | Ref (I64, name) -> l.i64 name
+  | Land64 (a, b) ->
+      let fa = compile_int64 l a and fb = compile_int64 l b in
+      fun c1 c2 -> Int64.logand (fa c1 c2) (fb c1 c2)
 
 let try_int64 : type a c1 c2.
     (c1, c2) leaves -> a expr -> (c1 -> c2 -> int64) option =
  fun l e ->
   let go e = Some (compile_int64 l e) in
-  match e with Int64 _ as e -> go e | Ref (I64, _) as e -> go e | _ -> None
+  match e with
+  | Int64 _ as e -> go e
+  | Ref (I64, _) as e -> go e
+  | Land64 _ as e -> go e
+  | _ -> None
 
 let rec compile_int : type c1 c2. (c1, c2) leaves -> int expr -> c1 -> c2 -> int
     =
@@ -1086,6 +1095,9 @@ let rec iter_param_refs : type a. (Param.packed -> unit) -> a expr -> unit =
   | Lxor (a, b)
   | Lsl (a, b)
   | Lsr (a, b) ->
+      iter_param_refs f a;
+      iter_param_refs f b
+  | Land64 (a, b) ->
       iter_param_refs f a;
       iter_param_refs f b
   | Lt (a, b) ->

--- a/lib/eval.ml
+++ b/lib/eval.ml
@@ -111,6 +111,7 @@ let rec expr : type a. ctx -> a expr -> a =
   | Div (a, b) -> expr ctx a / expr ctx b
   | Mod (a, b) -> expr ctx a mod expr ctx b
   | Land (a, b) -> expr ctx a land expr ctx b
+  | Land64 (a, b) -> Int64.logand (expr ctx a) (expr ctx b)
   | Lor (a, b) -> expr ctx a lor expr ctx b
   | Lxor (a, b) -> expr ctx a lxor expr ctx b
   | Lnot a -> lnot (expr ctx a)

--- a/lib/field.ml
+++ b/lib/field.ml
@@ -23,6 +23,11 @@ let rec has_int64_slot : type a. a Types.typ -> bool =
   | Where { inner; _ } -> has_int64_slot inner
   | Optional { inner; _ } -> has_int64_slot inner
   | Optional_or { inner; _ } -> has_int64_slot inner
+  (* [build_populate] fills the int64 slot with the raw pre-map wire value
+     (via [encode]) and recurses [Enum] through its base, so a constraint over
+     the raw uint64 of a [map]-decoded or enum field is well defined. *)
+  | Map { inner; _ } -> has_int64_slot inner
+  | Enum { base; _ } -> has_int64_slot base
   | _ -> false
 
 let reject_no_int64_slot ~combinator name typ =

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -109,6 +109,10 @@ and _ expr =
   | Lnot : int expr -> int expr
   | Lsl : int expr * int expr -> int expr
   | Lsr : int expr * int expr -> int expr
+  | Land64 : int64 expr * int64 expr -> int64 expr
+      (** Bitwise AND on full-width [int64] operands, for masking a [uint64]
+          field before a comparison (the native-[int] [Land] cannot, since it
+          truncates the field). Projects to 3D as [&]. *)
   | Eq : 'a expr * 'a expr -> bool expr
   | Ne : 'a expr * 'a expr -> bool expr
   | Lt : 'a expr * 'a expr -> bool expr
@@ -313,6 +317,7 @@ module Expr = struct
   let ( / ) a b = Div (a, b)
   let ( mod ) a b = Mod (a, b)
   let ( land ) a b = Land (a, b)
+  let land64 a b = Land64 (a, b)
   let ( lor ) a b = Lor (a, b)
   let ( lxor ) a b = Lxor (a, b)
   let lnot a = Lnot a
@@ -1503,6 +1508,7 @@ let rec pp_expr : type a. a expr Fmt.t =
   | Div (a, b) -> Fmt.pf ppf "(%a / %a)" pp_expr a pp_expr b
   | Mod (a, b) -> Fmt.pf ppf "(%a %% %a)" pp_expr a pp_expr b
   | Land (a, b) -> Fmt.pf ppf "(%a & %a)" pp_expr a pp_expr b
+  | Land64 (a, b) -> Fmt.pf ppf "(%a & %a)" pp_expr a pp_expr b
   | Lor (a, b) -> Fmt.pf ppf "(%a | %a)" pp_expr a pp_expr b
   | Lxor (a, b) -> Fmt.pf ppf "(%a ^ %a)" pp_expr a pp_expr b
   | Lnot a -> Fmt.pf ppf "(~%a)" pp_expr a
@@ -1616,6 +1622,7 @@ let rec subst_expr : type a. (string * int expr) list -> a expr -> a expr =
   | Div (a, b) -> Div (r a, r b)
   | Mod (a, b) -> Mod (r a, r b)
   | Land (a, b) -> Land (r a, r b)
+  | Land64 (a, b) -> Land64 (r a, r b)
   | Lor (a, b) -> Lor (r a, r b)
   | Lxor (a, b) -> Lxor (r a, r b)
   | Lnot a -> Lnot (r a)
@@ -2066,6 +2073,7 @@ let rec mentions_field : type a. string -> a expr -> bool =
   | Lsl (a, b)
   | Lsr (a, b) ->
       mentions_field name a || mentions_field name b
+  | Land64 (a, b) -> mentions_field name a || mentions_field name b
   | Lnot a -> mentions_field name a
   | Cast (_, a) -> mentions_field name a
   | Eq (a, b) -> mentions_field name a || mentions_field name b
@@ -2274,6 +2282,7 @@ let rec collect_refs : type a. a expr -> string list = function
   | Lsl (a, b)
   | Lsr (a, b) ->
       collect_refs a @ collect_refs b
+  | Land64 (a, b) -> collect_refs a @ collect_refs b
   | Lnot a -> collect_refs a
   | Lt (a, b) -> collect_refs_packed a @ collect_refs_packed b
   | Le (a, b) -> collect_refs_packed a @ collect_refs_packed b
@@ -2307,6 +2316,7 @@ let rec widen_add : type a. string list -> a expr -> a expr =
   | Div (a, b) -> Div (r a, r b)
   | Mod (a, b) -> Mod (r a, r b)
   | Land (a, b) -> Land (r a, r b)
+  | Land64 (a, b) -> Land64 (r a, r b)
   | Lor (a, b) -> Lor (r a, r b)
   | Lxor (a, b) -> Lxor (r a, r b)
   | Lnot a -> Lnot (r a)
@@ -2357,6 +2367,7 @@ let rec reject_field_sub_mul : type a. string -> a expr -> unit =
   | Lsl (a, b)
   | Lsr (a, b) ->
       both a b
+  | Land64 (a, b) -> both a b
   | Eq (a, b) -> both a b
   | Ne (a, b) -> both a b
   | Lt (a, b) -> both a b

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -116,6 +116,7 @@ and _ expr =
   | Lnot : int expr -> int expr
   | Lsl : int expr * int expr -> int expr
   | Lsr : int expr * int expr -> int expr
+  | Land64 : int64 expr * int64 expr -> int64 expr
   | Eq : 'a expr * 'a expr -> bool expr
   | Ne : 'a expr * 'a expr -> bool expr
   | Lt : 'a expr * 'a expr -> bool expr
@@ -348,6 +349,10 @@ module Expr : sig
 
   val ( land ) : int expr -> int expr -> int expr
   (** Bitwise AND. *)
+
+  val land64 : int64 expr -> int64 expr -> int64 expr
+  (** Bitwise AND on full-width 64-bit operands, for masking a 64-bit field
+      before a comparison. Projects to 3D as [&]. *)
 
   val ( lor ) : int expr -> int expr -> int expr
   (** Bitwise OR. *)

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -257,6 +257,11 @@ module Expr : sig
   val ( land ) : int expr -> int expr -> int expr
   (** Bitwise AND. *)
 
+  val land64 : int64 expr -> int64 expr -> int64 expr
+  (** Bitwise AND on full-width 64-bit operands, for masking a 64-bit field such
+      as a sign-magnitude offset before a comparison. The plain machine-word AND
+      truncates the field, so it cannot be used here. Projects to 3D as [&]. *)
+
   val ( lor ) : int expr -> int expr -> int expr
   (** Bitwise OR. *)
 

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -3147,6 +3147,36 @@ let test_int64_field_constraint_rejects_negative_zero () =
   | Error e ->
       Alcotest.failf "expected Constraint_failed, got %a" pp_parse_error e
 
+(* The bsdiff seek: a sign-magnitude uint64 decoded through a map, whose
+   magnitude must fit a native int. Exercises an int64 mask ([land64]) over a
+   map'd field: the constraint reads the raw pre-map word. *)
+let mask_seek_codec =
+  let f_seek =
+    Field.v "Seek" (map ~decode:Fun.id ~encode:Fun.id uint64be)
+      ~self_int64:(fun self ->
+        Expr.(
+          land64 self (int64 0x7FFF_FFFF_FFFF_FFFFL)
+          <= int64 (Int64.of_int max_int)))
+  in
+  Codec.v "MaskSeek" Fun.id Codec.[ f_seek $ Fun.id ]
+
+let test_int64_mask_constraint_over_map () =
+  let accept v =
+    Alcotest.(check int64)
+      "accept" v
+      (decode_ok (Codec.decode mask_seek_codec (seek_buf v) 0))
+  in
+  let reject v =
+    match Codec.decode mask_seek_codec (seek_buf v) 0 with
+    | Ok _ -> Alcotest.failf "expected 0x%Lx rejected" v
+    | Error { kind = Constraint_failed _; _ } -> ()
+    | Error e -> Alcotest.failf "wrong error: %a" pp_parse_error e
+  in
+  (* magnitude fits: small values and sign-bit-only (negative zero magnitude) *)
+  List.iter accept [ 0L; 5L; Int64.min_int ];
+  (* magnitude too big: bit 62 set, and all-ones *)
+  List.iter reject [ 0x4000_0000_0000_0000L; Int64.max_int ]
+
 (* A plain int-kind [self_constraint] on a uint64 field must still read the
    field value, not an unpopulated zero slot: an out-of-range value has to be
    rejected, or the bound is silently vacuous. *)
@@ -6212,6 +6242,8 @@ let suite =
         test_int64_field_constraint_accepts_signed_magnitude_domain;
       Alcotest.test_case "constraint: int64 rejects negative zero" `Quick
         test_int64_field_constraint_rejects_negative_zero;
+      Alcotest.test_case "constraint: int64 mask over map'd field" `Quick
+        test_int64_mask_constraint_over_map;
       Alcotest.test_case "constraint: int-ref bound on uint64 enforced" `Quick
         test_uint64_int_ref_constraint_enforced;
       (* repeat *)

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -790,6 +790,23 @@ let test_3d_int64_literal_uses_unsigned_decimal () =
     "high-bit int64 literal prints unsigned" true
     (contains ~sub:"9223372036854775808uL" out3d)
 
+let test_3d_int64_mask_projects () =
+  (* The sign-magnitude seek bound (raw & 0x7fff... <= max_int), over a map'd
+     uint64, needs an int64 bitwise AND; it projects as an [&] refinement, in
+     doc mode too, in the form 3d.exe verifies. *)
+  let f =
+    Field.v "Seek" (map ~decode:Fun.id ~encode:Fun.id uint64be)
+      ~self_int64:(fun self ->
+        Expr.(
+          land64 self (int64 0x7FFF_FFFF_FFFF_FFFFL)
+          <= int64 (Int64.of_int max_int)))
+  in
+  let codec = Codec.v "MaskSeek" Fun.id Codec.[ f $ Fun.id ] in
+  let out = to_3d (Everparse.project ~mode:`Standalone codec).module_ in
+  Alcotest.(check bool)
+    "int64 mask renders as &" true
+    (contains ~sub:"(Seek & 9223372036854775807uL)" out)
+
 let test_3d_field_pos_rejected () =
   (* EverParse has no [field_pos] keyword, so a projected expression using it is
      rejected at projection, not emitted as an undefined identifier. *)
@@ -1417,6 +1434,8 @@ let suite =
         test_float_ordering_rejected;
       Alcotest.test_case "3d: int64 literal unsigned decimal" `Quick
         test_3d_int64_literal_uses_unsigned_decimal;
+      Alcotest.test_case "3d: int64 mask projects to refinement" `Quick
+        test_3d_int64_mask_projects;
       Alcotest.test_case "3d: field_pos rejected by projection" `Quick
         test_3d_field_pos_rejected;
     ] )

--- a/test/test_field.ml
+++ b/test/test_field.ml
@@ -109,6 +109,17 @@ let test_int64_rejects_field_without_int64_slot () =
              Types.Expr.(self = int64 0L))
           : int Field.t))
 
+let test_int64_accepts_map_over_uint64 () =
+  (* A map over uint64 keeps its int64 slot: [build_populate] fills it with the
+     raw pre-map wire value, so an int64 self-constraint over the raw word is
+     well defined and is accepted (unlike a map over uint8). *)
+  let mapped = Types.map Int64.neg Int64.neg Types.uint64be in
+  ignore
+    (Field.v "Seek" mapped ~self_int64:(fun self ->
+         Types.Expr.(self <= int64 0L))
+      : int64 Field.t);
+  ignore (Field.int64 (Field.v "Seek2" mapped) : int64 Types.expr)
+
 let suite =
   ( "field",
     [
@@ -123,6 +134,8 @@ let suite =
       Alcotest.test_case "int64 on uint64 field" `Quick test_int64_uint64_field;
       Alcotest.test_case "int64 rejects missing slot" `Quick
         test_int64_rejects_field_without_int64_slot;
+      Alcotest.test_case "int64 accepts map over uint64" `Quick
+        test_int64_accepts_map_over_uint64;
       Alcotest.test_case "pp prints name" `Quick test_pp_prints_name;
       Alcotest.test_case "to_decl named" `Quick test_to_decl_named;
       Alcotest.test_case "to_decl anon" `Quick test_to_decl_anon;


### PR DESCRIPTION
`Wire.Expr.land64` adds an int64 bitwise AND, and `~self_int64` / `Field.int64` now accept a `map`-decoded uint64 field.

A sign-magnitude uint64 field, such as a bsdiff seek, is bounded by masking off the sign bit and checking the magnitude fits a native int: `(raw & 0x7fff...) <= max`. That was not expressible. The expr grammar had no int64 bitwise operator, so the mask was a compile-time type error, and `has_int64_slot` looked through `Where` / `Optional` but not `Map`, so attaching the constraint to the map-decoded field raised "no full-width int64 validation slot".

`land64` is lowered in the OCaml validator, top-level eval, and the 3D printer (where it renders as `&`), and `has_int64_slot` now recurses through `Map` / `Enum`, matching what `build_populate` already fills. The int64 slot holds the raw pre-map wire value, so the OCaml and generated C validators agree on the same word: `((Seek & mask) <= max)` is a refinement EverParse verifies.
