### PR TITLE
3d: install only the checked wrapper, not the raw validator header

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,6 +42,14 @@
 
 ### Fixed
 
+- A standalone `Wire_3d` schema installs only its checked wrapper header
+  (`<Base>Wrapper.h`), not the raw `<Base>.h`. The raw `<Base>Validate*`
+  entrypoints skip a `StartPosition <= InputLength` bound check, so a direct C
+  caller passing `StartPosition > InputLength` underflowed the read span and
+  went out of bounds; the wrapper validates from position 0 and is the safe
+  public API. The validators stay in the installed archive, just not as a header
+  (#228, @samoht)
+
 - Codec values are now safe to share across domains: their validation scratch
   and parameter backing are per-domain, so encoding, decoding, or validating one
   codec concurrently no longer corrupts the result (#223, #224, @samoht)

--- a/lib/3d/wire_3d.ml
+++ b/lib/3d/wire_3d.ml
@@ -1171,10 +1171,21 @@ let emit_standalone_build_rules ppf ~base ~archive ~c_files =
     \  (run %%{dep:agree} corpus)))\n\n"
     archive base base strict_cc_flags everparse_type_defines archive
 
-let emit_standalone_install ppf ~package ~three_d ~archive ~c_files =
+(* Install only the checked wrapper header, not the raw validator header. The
+   [<Base>Validate*] entrypoints in [<Base>.h] take a [StartPosition] and their
+   EverParse-emitted preamble bounds a read as [N <= InputLength - StartPosition]
+   with no prior [StartPosition <= InputLength] check, so a direct C caller
+   passing [StartPosition > InputLength] underflows the span (unsigned) and reads
+   out of bounds. The generated wrapper [<Base>Check<Codec>(base, len)] always
+   validates from position 0 and is the safe public C API; the raw validators
+   stay build-internal, linked into the archive but not shipped as a header.
+   [<Base>Wrapper.h] does not include [<Base>.h], so this compiles standalone. *)
+let emit_standalone_install ppf ~package ~three_d ~archive ~public_header =
   let pr fmt = Fmt.pf ppf fmt in
   pr "(install\n (package %s)\n (section lib)\n (files\n" package;
-  List.iter (fun f -> pr "  (%s as c/%s)\n" f f) (three_d :: archive :: c_files);
+  List.iter
+    (fun f -> pr "  (%s as c/%s)\n" f f)
+    [ three_d; archive; public_header ];
   pr "  (EverParse.h as c/EverParse.h)\n";
   pr "  (EverParseEndianness.h as c/EverParseEndianness.h)))\n"
 
@@ -1189,7 +1200,8 @@ let generate_dune_standalone ?name ~outdir ~package _codecs =
   let ppf = Format.formatter_of_out_channel oc in
   emit_standalone_gen_rules ppf ~three_d ~c_files;
   emit_standalone_build_rules ppf ~base ~archive ~c_files;
-  emit_standalone_install ppf ~package ~three_d ~archive ~c_files;
+  emit_standalone_install ppf ~package ~three_d ~archive
+    ~public_header:(base ^ "Wrapper.h");
   Format.pp_print_flush ppf ();
   close_out oc
 

--- a/lib/3d/wire_3d.mli
+++ b/lib/3d/wire_3d.mli
@@ -175,7 +175,10 @@ val generate_standalone :
     is [name] when given, else [package], normalised to a CamelCase identifier
     (["my-pkg"] becomes [MyPkg]); [package] always names the opam package. The
     generated [<Name>Check<Codec>] wrappers validate the whole buffer, rejecting
-    trailing bytes (see {!generate_c}). *)
+    trailing bytes (see {!generate_c}). Only the checked wrapper header
+    [<Name>Wrapper.h] is installed as the public C API; the raw
+    [<Name>Validate*] entrypoints (which take an unguarded [StartPosition]) stay
+    build-internal, linked into the archive but not shipped as a header. *)
 
 val generate_dune_standalone :
   ?name:string -> outdir:string -> package:string -> packed list -> unit


### PR DESCRIPTION
A standalone `Wire_3d` schema installed the raw validator header `<Base>.h` alongside the checked wrapper. `<Base>.h` declares the raw `<Base>Validate*` entrypoints, which take a `StartPosition`; the EverParse-emitted preamble bounds a read as `N <= InputLength - StartPosition` with no prior `StartPosition <= InputLength` check, so a direct C caller passing `StartPosition > InputLength` underflows the span in unsigned arithmetic and reads out of bounds. Same class as #222, one layer up.

The OCaml path never reaches it: the generated `<Base>Check<Codec>` wrapper always validates from position 0. It is also the only entrypoint a consumer needs, and `<Base>Wrapper.h` does not include `<Base>.h`, so the install now ships only the wrapper header (plus the archive and the `.3d`). The raw validators stay linked into the archive but are no longer advertised as a public C API.
