### PR TITLE
3d: hide the raw validators from the installed archive

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,13 +42,14 @@
 
 ### Fixed
 
-- A standalone `Wire_3d` schema installs only its checked wrapper header
-  (`<Base>Wrapper.h`), not the raw `<Base>.h`. The raw `<Base>Validate*`
-  entrypoints skip a `StartPosition <= InputLength` bound check, so a direct C
-  caller passing `StartPosition > InputLength` underflowed the read span and
-  went out of bounds; the wrapper validates from position 0 and is the safe
-  public API. The validators stay in the installed archive, just not as a header
-  (#228, @samoht)
+- A standalone `Wire_3d` archive no longer exposes its raw `<Base>Validate*`
+  validators to C callers. Those entrypoints skip a `StartPosition <=
+  InputLength` bound check, so a direct caller passing `StartPosition >
+  InputLength` underflowed the read span and went out of bounds. The install now
+  ships only the checked `<Base>Wrapper.h` header (not `<Base>.h`), and the
+  archive build localizes every symbol except the `<Base>Check<Codec>` wrappers,
+  so the raw validators are neither declared nor linkable; the wrapper validates
+  from position 0 and is the safe public API (#228, #229, @samoht)
 
 - Codec values are now safe to share across domains: their validation scratch
   and parameter backing are per-domain, so encoding, decoding, or validating one

--- a/lib/3d/wire_3d.ml
+++ b/lib/3d/wire_3d.ml
@@ -1131,29 +1131,50 @@ let emit_standalone_gen_rules ppf ~three_d ~c_files =
     (String.concat " " c_files)
     three_d
 
-let emit_standalone_build_rules ppf ~base ~archive ~c_files =
-  (* Build the validator into an archive, installed with the package, so
-     consumers get a ready-to-link library and a downstream build fails loudly
-     if the spec stops projecting to compilable C. *)
-  Fmt.pf ppf
-    "(rule\n\
-    \ (targets %s)\n\
-    \ (deps EverParse.h EverParseEndianness.h %s)\n\
-    \ (action\n\
-    \  (progn\n\
-    \   (run cc %s %s -c %s.c %sWrapper.c)\n\
-    \   (run ar rcs %s %s.o %sWrapper.o))))\n\n"
-    archive
-    (String.concat " " c_files)
-    strict_cc_flags everparse_type_defines base base archive base base;
-  (* Differential self-check: the OCaml codec's accept/reject verdict over a
-     fuzzed corpus must match the committed C validator's, or the doc projection
-     is unsound (or the committed C is stale). The corpus and the [agree] driver
-     are built as targets and run directly, so no shell is involved: the
-     generator is referenced through [%{exe:gen.exe}], which records the
-     dependency and resolves the sandbox path (a bare [./gen.exe] is not
-     reliably present in the action's cwd). Uses only gen.exe and cc, no
-     3d.exe. *)
+(* The C symbols a standalone archive exports: the [<Base>Check<Codec>] wrapper
+   for each codec, named exactly as EverParse names it (and as [agree.c] links
+   it, see [generate_agree]), so the export allowlist matches the real symbol. *)
+let wrapper_symbols base codecs =
+  List.map
+    (fun (Pack c) ->
+      pascal_case (base ^ "_check_" ^ (project ~mode:`Standalone c).name))
+    codecs
+
+(* Post-compile steps that fold the compiled objects into one archive member
+   exporting only [wrappers], localizing the raw [<Base>Validate*] entry points
+   so their unguarded [StartPosition] (see [emit_standalone_install]) is not
+   reachable through the installed archive. macOS localizes during the partial
+   link ([ld -r -exported_symbol]); GNU [ld] cannot, so [objcopy] does it after.
+   Shared by the emitted dune rule and the symbol-hiding test so they cannot
+   drift. *)
+let archive_link_steps ~macos ~archive ~base ~wrappers =
+  let libo = base ^ "_lib.o" in
+  let objs = Fmt.str "%s.o %sWrapper.o" base base in
+  if macos then
+    [
+      Fmt.str "ld -r -o %s %s%s" libo objs
+        (List.fold_left (fun a w -> a ^ " -exported_symbol _" ^ w) "" wrappers);
+      Fmt.str "ar rcs %s %s" archive libo;
+    ]
+  else
+    [
+      Fmt.str "ld -r -o %s %s" libo objs;
+      Fmt.str "objcopy%s %s"
+        (List.fold_left
+           (fun a w -> a ^ " --keep-global-symbol " ^ w)
+           "" wrappers)
+        libo;
+      Fmt.str "ar rcs %s %s" archive libo;
+    ]
+
+(* Differential self-check: the OCaml codec's accept/reject verdict over a
+   fuzzed corpus must match the committed C validator's, or the doc projection
+   is unsound (or the committed C is stale). The corpus and the [agree] driver
+   are built as targets and run directly, so no shell is involved: the generator
+   is referenced through [%{exe:gen.exe}], which records the dependency and
+   resolves the sandbox path (a bare [./gen.exe] is not reliably present in the
+   action's cwd). Uses only gen.exe and cc, no 3d.exe. *)
+let emit_standalone_check_rules ppf ~base ~archive =
   Fmt.pf ppf
     "(rule\n\
     \ (targets corpus)\n\
@@ -1170,6 +1191,35 @@ let emit_standalone_build_rules ppf ~base ~archive ~c_files =
     \ (action\n\
     \  (run %%{dep:agree} corpus)))\n\n"
     archive base base strict_cc_flags everparse_type_defines archive
+
+let emit_standalone_build_rules ppf ~base ~archive ~c_files ~wrappers =
+  (* Build the validator into an archive, installed with the package, so
+     consumers get a ready-to-link library and a downstream build fails loudly
+     if the spec stops projecting to compilable C. The archive exports only the
+     checked [<Base>Check<Codec>] wrappers and localizes the raw validators; the
+     localizing step is platform-specific, so there is one rule per
+     [ocaml-config:system]. *)
+  let compile =
+    Fmt.str "cc %s %s -c %s.c %sWrapper.c" strict_cc_flags
+      everparse_type_defines base base
+  in
+  let emit_rule ~cond ~macos =
+    let steps = compile :: archive_link_steps ~macos ~archive ~base ~wrappers in
+    Fmt.pf ppf
+      "(rule\n\
+      \ (targets %s)\n\
+      \ (enabled_if %s)\n\
+      \ (deps EverParse.h EverParseEndianness.h %s)\n\
+      \ (action\n\
+      \  (progn\n"
+      archive cond
+      (String.concat " " c_files);
+    List.iter (fun s -> Fmt.pf ppf "   (run %s)\n" s) steps;
+    Fmt.pf ppf "   )))\n\n"
+  in
+  emit_rule ~cond:"(= %{ocaml-config:system} macosx)" ~macos:true;
+  emit_rule ~cond:"(<> %{ocaml-config:system} macosx)" ~macos:false;
+  emit_standalone_check_rules ppf ~base ~archive
 
 (* Install only the checked wrapper header, not the raw validator header. The
    [<Base>Validate*] entrypoints in [<Base>.h] take a [StartPosition] and their
@@ -1189,17 +1239,18 @@ let emit_standalone_install ppf ~package ~three_d ~archive ~public_header =
   pr "  (EverParse.h as c/EverParse.h)\n";
   pr "  (EverParseEndianness.h as c/EverParseEndianness.h)))\n"
 
-let generate_dune_standalone ?name ~outdir ~package _codecs =
+let generate_dune_standalone ?name ~outdir ~package codecs =
   let base = standalone_base ?name ~package () in
   let three_d = base ^ ".3d" in
   let c_files =
     [ base ^ ".c"; base ^ ".h"; base ^ "Wrapper.c"; base ^ "Wrapper.h" ]
   in
   let archive = "lib" ^ String.lowercase_ascii base ^ ".a" in
+  let wrappers = wrapper_symbols base codecs in
   let oc = open_out (Filename.concat outdir "dune.inc") in
   let ppf = Format.formatter_of_out_channel oc in
   emit_standalone_gen_rules ppf ~three_d ~c_files;
-  emit_standalone_build_rules ppf ~base ~archive ~c_files;
+  emit_standalone_build_rules ppf ~base ~archive ~c_files ~wrappers;
   emit_standalone_install ppf ~package ~three_d ~archive
     ~public_header:(base ^ "Wrapper.h");
   Format.pp_print_flush ppf ();

--- a/lib/3d/wire_3d.mli
+++ b/lib/3d/wire_3d.mli
@@ -190,6 +190,25 @@ val generate_dune_standalone :
     stanza (under opam [package]) for the spec, parser, and archive. [name]
     defaults to [package]; see {!generate_standalone}. *)
 
+val wrapper_symbols : string -> packed list -> string list
+(** [wrapper_symbols base codecs] is the [<Base>Check<Codec>] wrapper C symbol
+    for each codec, computed exactly as EverParse names them. These are the only
+    symbols a standalone archive exports; the raw [<Base>Validate*] validators
+    are localized (see {!archive_link_steps}). *)
+
+val archive_link_steps :
+  macos:bool ->
+  archive:string ->
+  base:string ->
+  wrappers:string list ->
+  string list
+(** [archive_link_steps ~macos ~archive ~base ~wrappers] is the post-compile
+    shell commands that fold [<base>.o] and [<base>Wrapper.o] into [archive]
+    exporting only [wrappers] and localizing the raw validators. Platform
+    specific ([macos] localizes during the partial link; elsewhere [objcopy]
+    does it after). Shared by the emitted dune rule and the symbol-hiding test.
+*)
+
 val generate_corpus : ?count:int -> Format.formatter -> packed list -> unit
 (** [generate_corpus ?count ppf codecs] prints, for each codec, [count] fuzzed
     inputs as [<codec> <hex> <verdict>] lines, where [verdict] is [1] when the

--- a/test/3d/test_wire_3d.ml
+++ b/test/3d/test_wire_3d.ml
@@ -280,6 +280,64 @@ let test_doc_differential_no_params () =
     differential_ok ~name:"plainspec" ~package:"plain-doc" ~corpus:(`Fuzz 100)
       [ Wire_3d.pack diff_enum_codec; Wire_3d.pack diff_range_codec ]
 
+(* The installed standalone archive must export only the checked
+   [<Base>Check<Codec>] wrappers, not the raw [<Base>Validate*] entry points
+   whose EverParse-emitted preamble underflows on [StartPosition > InputLength].
+   Build the archive exactly as the generated dune rule does for this platform
+   (via {!Wire_3d.archive_link_steps}) and assert [nm] shows no global [Validate]
+   symbol. This runs the platform's real link step on CI (macOS and Linux). Needs
+   3d.exe for the C. *)
+let test_archive_hides_raw_validators () =
+  if not (Wire_3d.has_3d_exe ()) then ()
+  else begin
+    let name = "symspec" and package = "sym-doc" in
+    let codec =
+      Codec.v "Sample"
+        (fun v -> v)
+        [ Codec.( $ ) (Field.v "X" uint32be) (fun v -> v) ]
+    in
+    let codecs = [ Wire_3d.pack codec ] in
+    let tmpdir = Filename.temp_dir "wire_3d_sym_" "" in
+    Wire_3d.generate_standalone ~outdir:tmpdir ~name ~package codecs;
+    let base = String.capitalize_ascii name in
+    let archive = "lib" ^ String.lowercase_ascii base ^ ".a" in
+    let wrappers = Wire_3d.wrapper_symbols base codecs in
+    let macos =
+      let ic = Unix.open_process_in "uname -s" in
+      let s = try input_line ic with End_of_file -> "" in
+      ignore (Unix.close_process_in ic);
+      String.equal s "Darwin"
+    in
+    let compile =
+      Fmt.str "cc %s %s -c %s.c %sWrapper.c" Wire_3d.strict_cc_flags
+        Wire_3d.everparse_type_defines base base
+    in
+    let steps =
+      compile :: Wire_3d.archive_link_steps ~macos ~archive ~base ~wrappers
+    in
+    let run cmd =
+      let ic = Unix.open_process_in (Fmt.str "cd %s && %s 2>&1" tmpdir cmd) in
+      let out = In_channel.input_all ic in
+      (out, Unix.close_process_in ic)
+    in
+    let build_out, build_status = run (String.concat " && " steps) in
+    let nm_out, _ = run (Fmt.str "nm %s" archive) in
+    ignore (Fmt.kstr Sys.command "rm -rf %s" tmpdir);
+    (match build_status with
+    | Unix.WEXITED 0 -> ()
+    | _ -> Alcotest.failf "localized archive build failed:\n%s" build_out);
+    (* Global text symbols are the uppercase-[T] [nm] lines. *)
+    let globals =
+      String.split_on_char '\n' nm_out
+      |> List.filter (fun l -> Re.execp (Re.compile (Re.str " T ")) l)
+    in
+    let any sub =
+      List.exists (fun l -> Re.execp (Re.compile (Re.str sub)) l) globals
+    in
+    Alcotest.(check bool) "raw Validate not exported" false (any "Validate");
+    Alcotest.(check bool) "Check wrapper exported" true (any "Check")
+  end
+
 (* A signed field with an ordering constraint: it projects to an unsigned UINT,
    so the refinement must be the two's-complement form or the C validator and the
    OCaml decoder disagree on bytes whose top bit is set (200 = signed -56). The
@@ -1160,6 +1218,8 @@ let suite =
         test_generate_dune_standalone_name_override;
       Alcotest.test_case "generate_standalone (needs 3d.exe)" `Quick
         test_generate_standalone;
+      Alcotest.test_case "archive hides raw validators (needs 3d.exe)" `Quick
+        test_archive_hides_raw_validators;
       Alcotest.test_case "doc differential (needs 3d.exe)" `Quick
         test_doc_differential;
       Alcotest.test_case "doc differential no params (needs 3d.exe)" `Quick


### PR DESCRIPTION
Follow-up to #228. That PR removed the raw validator header from the install, but the archive still exported the `<Base>Validate*` symbols globally, so a C caller who declared them (they are in no installed header) could still link the archive and reach their unguarded `StartPosition`: the EverParse preamble bounds a read as `N <= InputLength - StartPosition` with no `StartPosition <= InputLength` check, so `StartPosition > InputLength` underflows in unsigned arithmetic and reads out of bounds. The wrapper lives in a separate translation unit from the validators, so they cannot be made `static`.

The archive build now folds the objects into one member exporting only the `<Base>Check<Codec>` wrappers and localizes everything else: macOS localizes during the partial link (`ld -r -exported_symbol`), GNU `ld` cannot so `objcopy --keep-global-symbol` does it after, so there is one dune rule per `ocaml-config:system`. After it, `nm` on the archive shows only the `Check` wrappers; the raw validators are `t` (local), not `T`.

A new test builds a standalone archive the same way (via the shared `Wire_3d.archive_link_steps`) and asserts `nm` shows no global `Validate` symbol. It runs the real link step on both CI runners: the `everparse-3d` job (ubuntu, with 3d.exe) exercises the `objcopy` path, and the macOS build exercises `-exported_symbol`.
