### PR TITLE
3d: build the standalone verified C archive per context

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,16 @@
 
 ### Changed
 
+- The standalone `c/` archive (`3d` mode) now builds and installs in every dune
+  context through that context's own toolchain, so a cross build produces and
+  installs a target-native verified parser instead of skipping the C. The build
+  uses `%{ocaml-config:c_compiler}`, the `ocaml-config` partial linker, and the
+  binutils that compiler resolves (`-print-prog-name`), so a cross `cc` finds
+  the target's `objcopy`/`ar`. `EverParseEndianness.h` gains a freestanding
+  `__BYTE_ORDER__`/`__builtin_bswap*` branch so it compiles for an OS-less
+  target (a unikernel defines neither `__linux__` nor `__APPLE__`). Only C
+  regeneration and the `agree` differential test stay host-gated (#231, @samoht)
+
 - `uint32`/`uint32be` now decode to `Optint.t` and `uint63`/`uint63be` to
   `Optint.Int63.t` rather than a native `int`, so a value with bit 31 (or the
   high half) set is no longer silently truncated on a target whose `int` is

--- a/lib/3d/wire_3d.ml
+++ b/lib/3d/wire_3d.ml
@@ -173,16 +173,6 @@ let read_validate_name ~outdir s =
 
 let write_3d ~outdir schemas = Wire.Everparse.write ~mode:`Ffi ~outdir schemas
 
-let copy_file ~src ~dst =
-  let ic = open_in_bin src in
-  let n = in_channel_length ic in
-  let buf = Bytes.create n in
-  really_input ic buf 0 n;
-  close_in ic;
-  let oc = open_out_bin dst in
-  output_bytes oc buf;
-  close_out oc
-
 let locate_3d_exe () =
   let ic = Unix.open_process_in "command -v 3d.exe 2>/dev/null" in
   let path = try Some (input_line ic) with End_of_file -> None in
@@ -200,13 +190,71 @@ let everparse_dir () =
   | Some exe -> Filename.dirname exe |> Filename.dirname
   | None -> failwith "3d.exe not found"
 
+(* A freestanding endianness branch for EverParseEndianness.h. The shipped
+   header keys byte order off an OS (<endian.h> on Linux, OSSwap on macOS, ...)
+   and [#error]s when none matches, so it does not compile for a no-OS target
+   like a unikernel (which defines neither [__linux__] nor [__APPLE__]). Any GCC
+   or Clang exposes byte order as [__BYTE_ORDER__] and byte-swaps with
+   [__builtin_bswap*] without an OS, so this branch, spliced in before the
+   [#error], makes the header portable to a cross target. *)
+let endianness_freestanding_branch =
+  {|#elif (defined(__GNUC__) || defined(__clang__)) && defined(__BYTE_ORDER__)
+/* Freestanding target with no OS <endian.h> (e.g. a unikernel): take byte
+   order from the compiler and byte-swap with its builtins. */
+#  if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#    define htobe16(x) __builtin_bswap16(x)
+#    define htole16(x) (x)
+#    define be16toh(x) __builtin_bswap16(x)
+#    define le16toh(x) (x)
+#    define htobe32(x) __builtin_bswap32(x)
+#    define htole32(x) (x)
+#    define be32toh(x) __builtin_bswap32(x)
+#    define le32toh(x) (x)
+#    define htobe64(x) __builtin_bswap64(x)
+#    define htole64(x) (x)
+#    define be64toh(x) __builtin_bswap64(x)
+#    define le64toh(x) (x)
+#  else
+#    define htobe16(x) (x)
+#    define htole16(x) __builtin_bswap16(x)
+#    define be16toh(x) (x)
+#    define le16toh(x) __builtin_bswap16(x)
+#    define htobe32(x) (x)
+#    define htole32(x) __builtin_bswap32(x)
+#    define be32toh(x) (x)
+#    define le32toh(x) __builtin_bswap32(x)
+#    define htobe64(x) (x)
+#    define htole64(x) __builtin_bswap64(x)
+#    define be64toh(x) (x)
+#    define le64toh(x) __builtin_bswap64(x)
+#  endif
+
+|}
+
+(* The EverParse anchor the freestanding branch is spliced before: the fallthrough
+   that rejects an unrecognized platform. *)
+let endianness_unsupported_anchor = "#else\n\n#error \"Unsupported platform\""
+
+let with_freestanding_endianness content =
+  let anchor = Re.compile (Re.str endianness_unsupported_anchor) in
+  Re.replace_string ~all:false anchor
+    ~by:(endianness_freestanding_branch ^ endianness_unsupported_anchor)
+    content
+
 let copy_everparse_endianness ~outdir =
   let dst = Filename.concat outdir "EverParseEndianness.h" in
   if not (Sys.file_exists dst) then begin
     let ep_dir = everparse_dir () in
     let src = Filename.concat ep_dir "src/3d/EverParseEndianness.h" in
-    if Sys.file_exists src then copy_file ~src ~dst
-    else Fmt.failwith "Cannot find EverParseEndianness.h at %s" src
+    if not (Sys.file_exists src) then
+      Fmt.failwith "Cannot find EverParseEndianness.h at %s" src;
+    let ic = open_in_bin src in
+    let n = in_channel_length ic in
+    let buf = really_input_string ic n in
+    close_in ic;
+    let oc = open_out_bin dst in
+    output_string oc (with_freestanding_endianness buf);
+    close_out oc
   end
 
 let has_3d_exe () = locate_3d_exe () <> None
@@ -1097,6 +1145,26 @@ let generate_standalone ?(quiet = true) ?name ~outdir ~package codecs =
   generate_c_standalone ~quiet ?name ~outdir ~package ();
   generate_agree ?name ~outdir ~package codecs
 
+(* The standalone [c/] archive is a per-target artefact: a consumer links it
+   into a program for the target it was built for, so a cross build must produce
+   a target archive and install it into the cross toolchain, exactly as it does
+   the host archive for the host toolchain. [emit_standalone_build_rules] gets
+   this by building through the context's own toolchain -- [%{cc}], the
+   [ocaml-config] partial linker, and the binutils that compiler resolves -- so
+   the tools follow the build context rather than a fixed host.
+
+   Two things stay host-only, gated on [%{context_name}] (a cross context is
+   named [<host-context>.<target>], so the host is the one still called
+   [default]): regenerating the committed [.3d]/C from [3d.exe] (a host
+   developer action; the committed C is what a cross build compiles), and the
+   [agree] differential test (it runs the built validator, which a cross build
+   produces for the target, not the host). *)
+let host_context = "(= %{context_name} default)"
+
+(* [(and)] of the host-context gate and [cond], laid out as [dune fmt] prints
+   it (the one-line form runs past the margin). *)
+let host_context_and cond = Fmt.str "(and\n   %s\n   %s)" host_context cond
+
 (* The [.3d] and [agree.c] are pure OCaml ([gen.exe 3d] / [gen.exe agree]), so
    they regenerate on demand and never go stale. The C needs [3d.exe], so its
    rule exists only under [BUILD_EVERPARSE=1] ([mode promote] writes it back into
@@ -1110,24 +1178,29 @@ let emit_standalone_gen_rules ppf ~three_d ~c_files =
   Fmt.pf ppf
     "(rule\n\
     \ (alias 3d)\n\
+    \ (enabled_if\n\
+    \  %s)\n\
     \ (mode promote)\n\
     \ (targets %s)\n\
     \ (action\n\
     \  (run %%{exe:gen.exe} 3d)))\n\n\
      (rule\n\
+    \ (enabled_if\n\
+    \  %s)\n\
     \ (targets agree.c)\n\
     \ (action\n\
     \  (run %%{exe:gen.exe} agree)))\n\n\
      (rule\n\
     \ (alias 3d)\n\
     \ (enabled_if\n\
-    \  (= %%{env:BUILD_EVERPARSE=} \"1\"))\n\
+    \  %s)\n\
     \ (mode promote)\n\
     \ (targets EverParse.h EverParseEndianness.h %s)\n\
     \ (deps %s)\n\
     \ (action\n\
     \  (run %%{exe:gen.exe} c)))\n\n"
-    three_d
+    host_context three_d host_context
+    (host_context_and "(= %{env:BUILD_EVERPARSE=} \"1\")")
     (String.concat " " c_files)
     three_d
 
@@ -1147,24 +1220,25 @@ let wrapper_symbols base codecs =
    link ([ld -r -exported_symbol]); GNU [ld] cannot, so [objcopy] does it after.
    Shared by the emitted dune rule and the symbol-hiding test so they cannot
    drift. *)
-let archive_link_steps ~macos ~archive ~base ~wrappers =
+let archive_link_steps ~macos ~pack_linker ~objcopy ~ar ~archive ~base ~wrappers
+    =
   let libo = base ^ "_lib.o" in
   let objs = Fmt.str "%s.o %sWrapper.o" base base in
   if macos then
     [
-      Fmt.str "ld -r -o %s %s%s" libo objs
+      Fmt.str "%s %s %s%s" pack_linker libo objs
         (List.fold_left (fun a w -> a ^ " -exported_symbol _" ^ w) "" wrappers);
-      Fmt.str "ar rcs %s %s" archive libo;
+      Fmt.str "%s rcs %s %s" ar archive libo;
     ]
   else
     [
-      Fmt.str "ld -r -o %s %s" libo objs;
-      Fmt.str "objcopy%s %s"
+      Fmt.str "%s %s %s" pack_linker libo objs;
+      Fmt.str "%s%s %s" objcopy
         (List.fold_left
            (fun a w -> a ^ " --keep-global-symbol " ^ w)
            "" wrappers)
         libo;
-      Fmt.str "ar rcs %s %s" archive libo;
+      Fmt.str "%s rcs %s %s" ar archive libo;
     ]
 
 (* Differential self-check: the OCaml codec's accept/reject verdict over a
@@ -1177,45 +1251,75 @@ let archive_link_steps ~macos ~archive ~base ~wrappers =
 let emit_standalone_check_rules ppf ~base ~archive =
   Fmt.pf ppf
     "(rule\n\
+    \ (enabled_if\n\
+    \  %s)\n\
     \ (targets corpus)\n\
     \ (action\n\
     \  (with-stdout-to corpus (run %%{exe:gen.exe} corpus))))\n\n\
      (rule\n\
+    \ (enabled_if\n\
+    \  %s)\n\
     \ (targets agree)\n\
     \ (deps agree.c %s EverParse.h EverParseEndianness.h %s.h %sWrapper.h)\n\
     \ (action\n\
     \  (run cc %s %s agree.c %s -o agree)))\n\n\
      (rule\n\
     \ (alias runtest)\n\
+    \ (enabled_if\n\
+    \  %s)\n\
     \ (deps corpus agree)\n\
     \ (action\n\
     \  (run %%{dep:agree} corpus)))\n\n"
-    archive base base strict_cc_flags everparse_type_defines archive
+    host_context host_context archive base base strict_cc_flags
+    everparse_type_defines archive host_context
 
+(* Build the validator into an archive, installed with the package, so consumers
+   get a ready-to-link library and a downstream build fails loudly if the spec
+   stops projecting to compilable C. The archive exports only the checked
+   [<Base>Check<Codec>] wrappers and localizes the raw validators.
+
+   The build runs in every context through that context's own toolchain, so a
+   cross build produces a target archive: [CC] is the context C compiler
+   ([ocaml-config:c_compiler]), the partial link is the [ocaml-config] pack
+   linker, and the symbol-hiding [objcopy]/[ar] are the ones that compiler
+   resolves ([-print-prog-name]) -- a cross [cc] finds the target's binutils. A
+   shell runs the whole thing so that command substitution can resolve the
+   binutils; there is no dune variable for [objcopy] or [ar]. The localizing step
+   is still platform-specific ([macos] localizes during the partial link,
+   elsewhere [objcopy] does it after), keyed on [ocaml-config:system]: for the
+   host context it names the host, for a cross context the target, which is what
+   selects the right localize path either way. *)
 let emit_standalone_build_rules ppf ~base ~archive ~c_files ~wrappers =
-  (* Build the validator into an archive, installed with the package, so
-     consumers get a ready-to-link library and a downstream build fails loudly
-     if the spec stops projecting to compilable C. The archive exports only the
-     checked [<Base>Check<Codec>] wrappers and localizes the raw validators; the
-     localizing step is platform-specific, so there is one rule per
-     [ocaml-config:system]. *)
-  let compile =
-    Fmt.str "cc %s %s -c %s.c %sWrapper.c" strict_cc_flags
+  let compile cc =
+    Fmt.str "%s %s %s -c %s.c %sWrapper.c" cc strict_cc_flags
       everparse_type_defines base base
   in
   let emit_rule ~cond ~macos =
-    let steps = compile :: archive_link_steps ~macos ~archive ~base ~wrappers in
+    let steps =
+      compile "\"$CC\""
+      :: archive_link_steps ~macos
+           ~pack_linker:"%{ocaml-config:native_pack_linker}"
+           ~objcopy:"\"$(\"$CC\" -print-prog-name=objcopy)\""
+           ~ar:"\"$(\"$CC\" -print-prog-name=ar)\"" ~archive ~base ~wrappers
+    in
+    let script =
+      "set -e; CC=%{ocaml-config:c_compiler}; " ^ String.concat "; " steps
+    in
+    (* The script is one dune-quoted string argument to [sh -c]; its own double
+       quotes (around [$CC] and the [$(...)] tool lookups) are escaped so they
+       do not close the dune string. *)
+    let quoted = String.concat "\\\"" (String.split_on_char '"' script) in
     Fmt.pf ppf
       "(rule\n\
       \ (targets %s)\n\
-      \ (enabled_if %s)\n\
+      \ (enabled_if\n\
+      \  %s)\n\
       \ (deps EverParse.h EverParseEndianness.h %s)\n\
       \ (action\n\
-      \  (progn\n"
+      \  (run sh -c \"%s\")))\n\n"
       archive cond
-      (String.concat " " c_files);
-    List.iter (fun s -> Fmt.pf ppf "   (run %s)\n" s) steps;
-    Fmt.pf ppf "   )))\n\n"
+      (String.concat " " c_files)
+      quoted
   in
   emit_rule ~cond:"(= %{ocaml-config:system} macosx)" ~macos:true;
   emit_rule ~cond:"(<> %{ocaml-config:system} macosx)" ~macos:false;

--- a/lib/3d/wire_3d.mli
+++ b/lib/3d/wire_3d.mli
@@ -188,7 +188,15 @@ val generate_dune_standalone :
     [lib<name>.a] archive, a [runtest] rule that runs the differential
     self-check (see {!generate_corpus} / {!generate_agree}), and an install
     stanza (under opam [package]) for the spec, parser, and archive. [name]
-    defaults to [package]; see {!generate_standalone}. *)
+    defaults to [package]; see {!generate_standalone}.
+
+    The [c/] archive builds and installs in every dune context through that
+    context's own toolchain ([%{ocaml-config:c_compiler}], the [ocaml-config]
+    partial linker, and the binutils that compiler resolves), so a cross build
+    produces and installs a target-native archive rather than the host's. Only
+    the host-side steps are gated on [(= %{context_name} default)]: regenerating
+    the committed [.3d]/C from [3d.exe], and the [agree] differential test,
+    which runs a built validator on the build machine. *)
 
 val wrapper_symbols : string -> packed list -> string list
 (** [wrapper_symbols base codecs] is the [<Base>Check<Codec>] wrapper C symbol
@@ -198,16 +206,22 @@ val wrapper_symbols : string -> packed list -> string list
 
 val archive_link_steps :
   macos:bool ->
+  pack_linker:string ->
+  objcopy:string ->
+  ar:string ->
   archive:string ->
   base:string ->
   wrappers:string list ->
   string list
-(** [archive_link_steps ~macos ~archive ~base ~wrappers] is the post-compile
-    shell commands that fold [<base>.o] and [<base>Wrapper.o] into [archive]
-    exporting only [wrappers] and localizing the raw validators. Platform
-    specific ([macos] localizes during the partial link; elsewhere [objcopy]
-    does it after). Shared by the emitted dune rule and the symbol-hiding test.
-*)
+(** [archive_link_steps ~macos ~pack_linker ~objcopy ~ar ~archive ~base
+     ~wrappers] is the post-compile shell commands that fold [<base>.o] and
+    [<base>Wrapper.o] into [archive] exporting only [wrappers] and localizing
+    the raw validators. Platform specific ([macos] localizes during the partial
+    link with [pack_linker], elsewhere [objcopy] does it after). The tool
+    commands are parameters so the emitted dune rule can pass the build
+    context's toolchain (cross tools in a cross context) while the symbol-hiding
+    test passes the host's; both share this one definition of the localize
+    logic. *)
 
 val generate_corpus : ?count:int -> Format.formatter -> packed list -> unit
 (** [generate_corpus ?count ppf codecs] prints, for each codec, [count] fuzzed

--- a/test/3d/test_wire_3d.ml
+++ b/test/3d/test_wire_3d.ml
@@ -170,6 +170,76 @@ let test_generate_dune_standalone_name_override () =
   Alcotest.(check bool)
     "install still uses the opam package" true (has "(package my-pkg)")
 
+(* Split [s] into its top-level parenthesized stanzas. *)
+let top_level_stanzas s =
+  let stanzas = ref [] and buf = Buffer.create 256 in
+  let depth = ref 0 and in_string = ref false in
+  String.iter
+    (fun c ->
+      if !depth > 0 then Buffer.add_char buf c;
+      if !in_string then (if c = '"' then in_string := false)
+      else
+        match c with
+        | '"' -> in_string := true
+        | '(' ->
+            incr depth;
+            if !depth = 1 then Buffer.add_char buf c
+        | ')' ->
+            decr depth;
+            if !depth = 0 then begin
+              stanzas := Buffer.contents buf :: !stanzas;
+              Buffer.clear buf
+            end
+        | _ -> ())
+    s;
+  List.rev !stanzas
+
+let test_generate_dune_standalone_context_policy () =
+  (* The archive is a per-target artefact: a consumer links it into a program
+     for the target it was built for. So its build and install run in every
+     context through that context's own toolchain -- neither is gated on
+     [%{context_name}], and there is no placeholder. Only the host-side steps
+     are gated: regenerating the committed C from [3d.exe] and the [agree]
+     differential test, which runs a built validator on the build machine. *)
+  let tmpdir = Filename.temp_dir "wire_3d_dune_ctx" "" in
+  Wire_3d.generate_dune_standalone ~outdir:tmpdir ~package:"my-pkg"
+    [ Wire_3d.pack (doc_codec "Pkt") ];
+  let dune_inc = read_file (Filename.concat tmpdir "dune.inc") in
+  ignore (Fmt.kstr Sys.command "rm -rf %s" tmpdir);
+  let has sub s = Re.execp (Re.compile (Re.str sub)) s in
+  let stanzas = top_level_stanzas dune_inc in
+  Alcotest.(check bool) "dune.inc has stanzas" true (stanzas <> []);
+  (* The two archive build rules -- one per [%{ocaml-config:system}] branch --
+     run in all contexts, so a cross build produces a target archive. *)
+  let archive_rules = List.filter (has "%{ocaml-config:system}") stanzas in
+  Alcotest.(check int) "two archive build rules" 2 (List.length archive_rules);
+  List.iter
+    (fun rule ->
+      Alcotest.(check bool)
+        "archive build is not host-gated" false
+        (has "%{context_name}" rule);
+      Alcotest.(check bool)
+        "archive build uses the context compiler" true
+        (has "%{ocaml-config:c_compiler}" rule))
+    archive_rules;
+  (* One install stanza, ungated: the archive installs into whichever toolchain
+     the build targeted. *)
+  let installs = List.filter (has "(install") stanzas in
+  Alcotest.(check int) "one install stanza" 1 (List.length installs);
+  Alcotest.(check bool)
+    "install runs in all contexts" false
+    (has "%{context_name}" (List.hd installs));
+  (* No empty placeholder: the real archive builds in every context now. *)
+  Alcotest.(check bool)
+    "no placeholder archive" false
+    (has "(write-file libmypkg.a" dune_inc);
+  (* The host-only steps -- C regeneration and the differential test -- stay
+     gated on the host context. *)
+  let host_gated = List.filter (has "(= %{context_name} default)") stanzas in
+  Alcotest.(check bool)
+    "host-side steps stay host-gated" true
+    (List.length host_gated >= 1)
+
 let test_generate_standalone () =
   (* generate_standalone needs 3d.exe; skip when not available. *)
   if Wire_3d.has_3d_exe () then begin
@@ -313,7 +383,9 @@ let test_archive_hides_raw_validators () =
         Wire_3d.everparse_type_defines base base
     in
     let steps =
-      compile :: Wire_3d.archive_link_steps ~macos ~archive ~base ~wrappers
+      compile
+      :: Wire_3d.archive_link_steps ~macos ~pack_linker:"ld -r -o"
+           ~objcopy:"objcopy" ~ar:"ar" ~archive ~base ~wrappers
     in
     let run cmd =
       let ic = Unix.open_process_in (Fmt.str "cd %s && %s 2>&1" tmpdir cmd) in
@@ -1216,6 +1288,8 @@ let suite =
         test_generate_dune_standalone;
       Alcotest.test_case "generate_dune_standalone name override" `Quick
         test_generate_dune_standalone_name_override;
+      Alcotest.test_case "generate_dune_standalone context policy" `Quick
+        test_generate_dune_standalone_context_policy;
       Alcotest.test_case "generate_standalone (needs 3d.exe)" `Quick
         test_generate_standalone;
       Alcotest.test_case "archive hides raw validators (needs 3d.exe)" `Quick


### PR DESCRIPTION
An EverParse-verified parser is the shipped artefact: a consumer links `libX.a` into a program for the target it was built for. The generated `dune.inc` built it with host `cc`/`ld`/`objcopy`/`ar` and chose the symbol-hiding tool from the target's object format, so a cross build on macOS handed a Mach-O object to the target's `objcopy`, and a successful one would have installed a host archive into the cross toolchain. It now builds in every context through that context's own toolchain (`%{ocaml-config:c_compiler}`, the `ocaml-config` pack linker, and `objcopy`/`ar` from `cc -print-prog-name`), so a cross `cc` resolves the target's binutils; `EverParseEndianness.h` gains a freestanding `__BYTE_ORDER__` branch so it compiles for an OS-less target such as a unikernel.

Supersedes the host-only gating this branch first proposed. Should land before the 1.1.0 release (#230).
