### PR TITLE
bench, diff: drop dead deps, link the C archive explicitly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+### Removed
+
+- The wire package no longer depends on eio: nothing in the library used it,
+  it was only ever linked, unused, into `wire.diff` (#233, @samoht)
+
 ## 1.1.0
 
 ### Added

--- a/bench/clcw/dune
+++ b/bench/clcw/dune
@@ -1,7 +1,7 @@
 (library
  (name clcw_bench)
  (modules clcw_bench)
- (libraries space wire bench_lib c_tier c_stubs memtrace unix fmt))
+ (libraries space wire bench_lib memtrace unix fmt))
 
 (library
  (name clcw_bench_c)

--- a/bench/gateway/dune
+++ b/bench/gateway/dune
@@ -1,7 +1,7 @@
 (library
  (name gateway_bench)
  (modules gateway_bench)
- (libraries space wire bench_lib c_tier c_stubs memtrace unix fmt))
+ (libraries space wire bench_lib memtrace unix fmt))
 
 (library
  (name gateway_bench_c)

--- a/bench/routing/dune
+++ b/bench/routing/dune
@@ -1,7 +1,7 @@
 (library
  (name routing_bench)
  (modules routing_bench)
- (libraries space wire bench_lib c_tier c_stubs memtrace unix fmt))
+ (libraries space wire bench_lib memtrace unix fmt))
 
 (library
  (name routing_bench_c)

--- a/dune-project
+++ b/dune-project
@@ -24,7 +24,6 @@
  (depends
   (ocaml (>= 5.2))
   (bytesrw (>= 0.1))
-  (eio (>= 1.0))
   (fmt (>= 0.9))
   (optint (>= 0.3))
   (memtrace :with-test)

--- a/lib/diff/dune
+++ b/lib/diff/dune
@@ -1,4 +1,4 @@
 (library
  (name wire_diff)
  (public_name wire.diff)
- (libraries wire eio fmt))
+ (libraries wire fmt))

--- a/test/bench/dune
+++ b/test/bench/dune
@@ -15,6 +15,7 @@
   clcw_bench_c
   gateway_bench
   gateway_bench_c
+  c_stubs_c
   alcotest
   unix))
 

--- a/wire.opam
+++ b/wire.opam
@@ -13,7 +13,6 @@ depends: [
   "dune" {>= "3.21"}
   "ocaml" {>= "5.2"}
   "bytesrw" {>= "0.1"}
-  "eio" {>= "1.0"}
   "fmt" {>= "0.9"}
   "optint" {>= "0.3"}
   "memtrace" {with-test}


### PR DESCRIPTION
merlint's dead-dependency rule flags c_tier and c_stubs in the clcw, gateway and routing bench libraries and eio in wire.diff: no unit of theirs appears in any .cmt import, and eio also leaves the wire package dependencies. Dropping them surfaced that test/bench never linked the EverParse validator archive under BUILD_EVERPARSE=1; it now links c_stubs_c explicitly, like the bench executables already do.