### PR TITLE
3d: detect stale generated files, rename struct tags

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,11 @@
 
 ### Fixed
 
+- `dune runtest` now diffs a package's committed `.3d` specs and `dune.inc`
+  against freshly generated ones, so editing a codec without refreshing them
+  fails with a promotable report instead of leaving a stale spec committed
+  (#235, @samoht)
+
 - 32-bit bitfields are now exact on a narrow-int target: a field touching
   bit 31 of its base word used to decode and encode with that bit silently
   dropped there (#232, @samoht)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,10 @@
 
 ### Changed
 
+- Generated `.3d` C struct tags are now named `Wire<Name>` rather than
+  `_<Name>`. Public typedef names are unchanged, and standalone entrypoints
+  follow as `<Base>CheckWire<Name>` (#235, @samoht)
+
 - `uint` now decodes to `Optint.Int63.t` rather than a native `int`, like
   `uint63` before it: a 7-byte value needs 56 bits, which does not fit an
   int on a narrow-int target (js_of_ocaml, wasm_of_ocaml) and used to

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,11 @@
   fails with a promotable report instead of leaving a stale spec committed
   (#235, @samoht)
 
+- EverParse C generation now installs a `<Name>.provenance` stamp recording the
+  stdlib BLAKE2b-256 digest of the `.3d` it was built from, and `dune runtest`
+  rechecks it without EverParse, so a changed spec can no longer keep stale C
+  (#235, @samoht)
+
 - 32-bit bitfields are now exact on a narrow-int target: a field touching
   bit 31 of its base word used to decode and encode with that bit silently
   dropped there (#232, @samoht)

--- a/bench/clcw/clcw_c.c
+++ b/bench/clcw/clcw_c.c
@@ -1,6 +1,6 @@
 /* CLCW polling loop -- application logic with EverParse field extraction.
 
-   Uses EverParse-generated CLCWValidateCLCW to extract bitfields into a typed
+   Uses EverParse-generated ClcwValidateWireClcw to extract bitfields into a typed
    ClcwFields struct via the default plug. Application logic (anomaly
    detection) reads named members of the struct. No hand-written bitfield
    manipulation, no index arithmetic. */
@@ -25,7 +25,7 @@ static int count_anomalies(uint8_t *buf, int n_words, int n_iters) {
 
   for (int i = 0; i < n_iters; i++) {
     uint8_t *p = buf + (i % n_words) * WORD_SIZE;
-    ClcwValidateClcw((WIRECTX *)&fields, NULL, bench_err, p, WORD_SIZE, 0);
+    ClcwValidateWireClcw((WIRECTX *)&fields, NULL, bench_err, p, WORD_SIZE, 0);
 
     int expected_report = expected_seq & 0xFF;
     if (fields.Lockout || fields.Wait || fields.Retransmit

--- a/bench/gateway/gateway_c.c
+++ b/bench/gateway/gateway_c.c
@@ -1,7 +1,7 @@
 /* TM frame reassembly -- application logic with EverParse field extraction.
 
-   Uses EverParse-generated TmframeValidateTmframe and
-   SpacePacketValidateSpacePacket to extract fields into typed struct plugs.
+   Uses EverParse-generated TmframeValidateWireTmframe and
+   SpacePacketValidateWireSpacePacket to extract fields into typed struct plugs.
    Application logic (checksum computation) reads named struct members.
    No hand-written bitfield manipulation. */
 
@@ -34,7 +34,7 @@ static inline uint64_t hash_int(uint64_t state, int value) {
 static void walk_frame(uint8_t *frame, int tm_hdr, int pkt_size,
                         int data_field_size, uint64_t *checksum) {
   TmframeFields tf = {0};
-  TmframeValidateTmframe((WIRECTX *)&tf, NULL, bench_err, frame, tm_hdr, 0);
+  TmframeValidateWireTmframe((WIRECTX *)&tf, NULL, bench_err, frame, tm_hdr, 0);
 
   int vcid = (int)tf.VCID;
   int fhp = (int)tf.FirstHdrPtr;
@@ -49,7 +49,7 @@ static void walk_frame(uint8_t *frame, int tm_hdr, int pkt_size,
   int sp_hdr = 6;
   int off = tm_hdr + fhp;
   while (off + pkt_size <= tm_hdr + data_field_size) {
-    SpacePacketValidateSpacePacket((WIRECTX *)&sp, NULL, bench_err,
+    SpacePacketValidateWireSpacePacket((WIRECTX *)&sp, NULL, bench_err,
         frame + off, sp_hdr, 0);
     int apid = (int)sp.APID;
     int seq = (int)sp.SeqCount;

--- a/bench/gen_stubs.ml
+++ b/bench/gen_stubs.ml
@@ -124,6 +124,7 @@ let generate_c oc =
     (fun s ->
       let name = Wire.Everparse.Raw.struct_name s in
       let ep = Wire_3d.everparse_name name in
+      let validator = Wire_stubs.validator_name name in
       let lower = String.lowercase_ascii name in
       let n_fields = List.length (Wire.Everparse.Raw.field_names s) in
       ignore n_fields;
@@ -132,10 +133,8 @@ let generate_c oc =
       pr "  uint8_t *data = (uint8_t *)Bytes_val(v_buf);\n";
       pr "  uint32_t len = caml_string_length(v_buf);\n";
       pr "  %sFields ctx = {0};\n" ep;
-      pr
-        "  uint64_t r = %sValidate%s((WIRECTX *) &ctx, NULL, bench_err, data, \
-         len, 0);\n"
-        ep ep;
+      pr "  uint64_t r = %s((WIRECTX *) &ctx, NULL, bench_err, data, len, 0);\n"
+        validator;
       pr "  CAMLreturn(Val_bool(EverParseIsSuccess(r)));\n";
       pr "}\n\n";
       let item_size = struct_size s in
@@ -154,9 +153,8 @@ let generate_c oc =
       pr "  for (int i = 0; i < count; i++) {\n";
       pr "    uint8_t *item = buf + ((uint32_t)i %% n_items) * item_size;\n";
       pr
-        "    result = %sValidate%s((WIRECTX *) &ctx, NULL, bench_err, item, \
-         item_size, 0);\n"
-        ep ep;
+        "    result = %s((WIRECTX *) &ctx, NULL, bench_err, item, item_size, 0);\n"
+        validator;
       pr "  }\n";
       pr "  (void)result;\n";
       pr "  int64_t t1 = now_ns();\n";

--- a/bench/routing/routing_c.c
+++ b/bench/routing/routing_c.c
@@ -1,6 +1,6 @@
 /* APID routing -- application logic with EverParse field extraction.
 
-   Uses EverParse-generated SpacePacketValidateSpacePacket to extract fields
+   Uses EverParse-generated SpacePacketValidateWireSpacePacket to extract fields
    into a typed SpacePacketFields struct via the default plug. Application
    logic (routing dispatch) reads named members. No hand-written bitfield
    manipulation. */
@@ -35,7 +35,7 @@ static void route_counts(uint8_t *buf, int total_bytes, int n, int counts[4]) {
 
   for (int i = 0; i < n; i++) {
     if (off + hdr > total_bytes) off = 0;
-    SpacePacketValidateSpacePacket((WIRECTX *)&fields, NULL, bench_err,
+    SpacePacketValidateWireSpacePacket((WIRECTX *)&fields, NULL, bench_err,
         buf + off, hdr, 0);
     counts[routing_table[fields.APID]]++;
     off += hdr + (int)fields.DataLength + 1;

--- a/examples/net/Net.3d
+++ b/examples/net/Net.3d
@@ -1,6 +1,6 @@
 /*++ Ethernet II (DIX) frame header; IEEE 802.3 --*/
 entrypoint
-typedef struct _Ethernet
+typedef struct WireEthernet
 {
    UINT8 DstMAC[:byte-size 6];
    UINT8 SrcMAC[:byte-size 6];
@@ -10,7 +10,7 @@ typedef struct _Ethernet
 
 /*++ IPv4 header, RFC 791 section 3.1 --*/
 entrypoint
-typedef struct _IPv4
+typedef struct WireIPv4
 {
    /* RFC 791 3.1: header length in 32-bit words */
    UINT8 IHL : 4;
@@ -43,7 +43,7 @@ typedef struct _IPv4
 
 /*++ TCP header, RFC 9293 section 3.1 --*/
 entrypoint
-typedef struct _TCP
+typedef struct WireTCP
 {
    UINT16BE SrcPort;
    UINT16BE DstPort;
@@ -67,7 +67,7 @@ typedef struct _TCP
 
 /*++ UDP header, RFC 768 --*/
 entrypoint
-typedef struct _UDP
+typedef struct WireUDP
 {
    /* RFC 768: source port */
    UINT16BE SrcPort;

--- a/lib/3d/wire_3d.ml
+++ b/lib/3d/wire_3d.ml
@@ -121,11 +121,9 @@ let read_extern_names ~outdir s =
   close_in ic;
   List.rev !names
 
-(* EverParse's top-level validator function follows its own normalization
-   rule (different from extern callbacks: it preserves underscores when the
-   name doesn't start with 2+ uppercase, strips them when it does). Rather
-   than duplicate EverParse's logic, extract the actual name from the
-   generated [<Name>.h]: [uint64_t <Name>Validate<Name>(...)]. *)
+(* EverParse's top-level validator function follows its own normalization rule
+   and includes the 3D struct tag after [Validate]. Rather than duplicate that
+   logic, extract the complete function name from the generated [<Name>.h]. *)
 let read_validate_name ~outdir s =
   let path = Filename.concat outdir (file_base s ^ ".h") in
   let ic = open_in path in
@@ -138,13 +136,10 @@ let read_validate_name ~outdir s =
     || (c >= '0' && c <= '9')
     || c = '_'
   in
-  (* EverParse declares the validator as [<Name>Validate<Name>(...)]. Find the
-     [Validate] keyword and return the C identifier immediately before it -- the
-     base [<Name>]. Scanning every position (not just the first 'V') lets the
-     name itself contain a 'V' (e.g. "VeritySuperblock"); anchoring on the
-     identifier before [Validate] also drops a leading return type should
-     EverParse ever emit it on the same line. *)
-  let base_before_validate line =
+  (* Find [Validate] inside the declaration and return its complete surrounding
+     C identifier. Scanning every position lets the module name itself contain a
+     [V]; the identifier boundaries also discard the return type and arguments. *)
+  let identifier_containing_validate line =
     let len = String.length line in
     let rec scan i =
       if i + nlen > len then None
@@ -154,7 +149,11 @@ let read_validate_name ~outdir s =
         while !j > 0 && is_ident line.[!j - 1] do
           decr j
         done;
-        Some (String.sub line !j (i - !j))
+        let k = ref (i + nlen) in
+        while !k < len && is_ident line.[!k] do
+          incr k
+        done;
+        Some (String.sub line !j (!k - !j))
       end
       else scan (i + 1)
     in
@@ -163,7 +162,7 @@ let read_validate_name ~outdir s =
   (try
      while !found = None do
        let line = String.trim (input_line ic) in
-       found := base_before_validate line
+       found := identifier_containing_validate line
      done
    with End_of_file -> ());
   close_in ic;
@@ -474,7 +473,7 @@ let fields_c_files schemas =
       else None)
     schemas
 
-(* EverParse's [<Base>Check<Codec>] wrapper returns TRUE on any successful
+(* EverParse's [<Base>CheckWire<Codec>] wrapper returns TRUE on any successful
    validator result, but a success result is the consumed position: a valid
    record followed by trailing bytes still returns TRUE, making the wrapper a
    prefix recognizer rather than a validator. Wire's contract is whole-buffer
@@ -566,14 +565,14 @@ let parse_3d ?(batch = false) ~outdir file =
     in
     Error (if msg = "" then Fmt.str "exit %d" ret else msg)
 
-let emit_sanity_check ppf ~name ~ep ~ctx_arg wire_size =
+let emit_sanity_check ppf ~name ~validator ~ctx_arg wire_size =
   let pr fmt = Fmt.pf ppf fmt in
   (* Sanity: the OCaml codec's wire_size must match what the EverParse
      validator consumes. A mismatch means the .3d projection of the codec
      packs to a different size than the codec declares -- almost always a
      bug in the codec's bitfield declarations. Later checks are meaningless
      if this fails, so abort the whole test binary with a clear message. *)
-  pr "    r = %sValidate%s(%sNULL, counting_error_handler, buf, %d, 0);\n" ep ep
+  pr "    r = %s(%sNULL, counting_error_handler, buf, %d, 0);\n" validator
     ctx_arg wire_size;
   pr "    if (!EverParseIsSuccess(r) || r != %d) {\n" wire_size;
   pr "      fprintf(stderr,\n";
@@ -585,9 +584,9 @@ let emit_sanity_check ppf ~name ~ep ~ctx_arg wire_size =
   pr "      return 2;\n";
   pr "    }\n"
 
-let emit_truncation_checks ppf ~ep ~ctx_arg wire_size =
+let emit_truncation_checks ppf ~validator ~ctx_arg wire_size =
   let pr fmt = Fmt.pf ppf fmt in
-  pr "    r = %sValidate%s(%sNULL, counting_error_handler, buf, %d, 0);\n" ep ep
+  pr "    r = %s(%sNULL, counting_error_handler, buf, %d, 0);\n" validator
     ctx_arg (wire_size * 2);
   pr "    CHECK(\"larger buffer validates\", EverParseIsSuccess(r));\n";
   pr "    CHECK(\"position is %d not %d\", r == %d);\n" wire_size
@@ -595,38 +594,34 @@ let emit_truncation_checks ppf ~ep ~ctx_arg wire_size =
   pr "\n";
   pr "    for (uint64_t len = 0; len < %d; len++) {\n" wire_size;
   pr "      error_count = 0;\n";
-  pr "      r = %sValidate%s(%sNULL, counting_error_handler, buf, len, 0);\n" ep
-    ep ctx_arg;
+  pr "      r = %s(%sNULL, counting_error_handler, buf, len, 0);\n" validator
+    ctx_arg;
   pr "      CHECK(\"truncated to len fails\", EverParseIsError(r));\n";
   pr "    }\n";
   pr "\n";
-  pr "    r = %sValidate%s(%sNULL, counting_error_handler, buf, 0, 0);\n" ep ep
+  pr "    r = %s(%sNULL, counting_error_handler, buf, 0, 0);\n" validator
     ctx_arg;
   pr "    CHECK(\"empty input fails\", EverParseIsError(r));\n"
 
-let emit_random_checks ppf ~ep ~ctx_arg wire_size =
+let emit_random_checks ppf ~validator ~ctx_arg wire_size =
   let pr fmt = Fmt.pf ppf fmt in
   pr "    srand(42);\n";
   pr "    for (int i = 0; i < 1000; i++) {\n";
   pr "      for (int j = 0; j < %d; j++)\n" wire_size;
   pr "        buf[j] = (uint8_t)(rand() & 0xff);\n";
-  pr "      r = %sValidate%s(%sNULL, counting_error_handler, buf, %d, 0);\n" ep
-    ep ctx_arg wire_size;
+  pr "      r = %s(%sNULL, counting_error_handler, buf, %d, 0);\n" validator
+    ctx_arg wire_size;
   pr "      CHECK(\"random buffer validates\", EverParseIsSuccess(r));\n";
   pr "      CHECK(\"random position correct\", r == %d);\n" wire_size;
   pr "    }\n"
 
-let emit_schema_test ?outdir ppf s wire_size =
+let emit_schema_test ~outdir ppf s wire_size =
   let pr fmt = Fmt.pf ppf fmt in
   (* Read the validator name straight out of EverParse's generated [.h]
      -- the one authoritative source. EverParse applies its own naming
      rules (different for the top-level Validate function vs. the extern
      callbacks); any attempt to re-implement them here has drifted before. *)
-  let ep =
-    match outdir with
-    | Some dir -> read_validate_name ~outdir:dir s
-    | None -> file_base s
-  in
+  let validator = read_validate_name ~outdir s in
   let lower = String.lowercase_ascii s.name in
   let uses_ctx = Wire.Everparse.uses_wire_ctx s in
   let ctx_arg = if uses_ctx then "(WIRECTX *) &ctx, " else "" in
@@ -638,13 +633,13 @@ let emit_schema_test ?outdir ppf s wire_size =
   if uses_ctx then pr "    %sFields ctx = {0};\n" (c_ident s);
   pr "\n";
   pr "    memset(buf, 0, %d);\n" wire_size;
-  emit_sanity_check ppf ~name:s.name ~ep ~ctx_arg wire_size;
+  emit_sanity_check ppf ~name:s.name ~validator ~ctx_arg wire_size;
   pr "    CHECK(\"zero buffer validates\", EverParseIsSuccess(r));\n";
   pr "    CHECK(\"position advanced to %d\", r == %d);\n" wire_size wire_size;
   pr "\n";
-  emit_truncation_checks ppf ~ep ~ctx_arg wire_size;
+  emit_truncation_checks ppf ~validator ~ctx_arg wire_size;
   pr "\n";
-  emit_random_checks ppf ~ep ~ctx_arg wire_size;
+  emit_random_checks ppf ~validator ~ctx_arg wire_size;
   pr "\n";
   if uses_ctx then pr "    (void) ctx;\n";
   pr "    printf(\"%s: %%d passed, %%d failed\\n\", pass, fail);\n" lower;
@@ -1031,7 +1026,7 @@ let hex_of_bytes b =
 (* The accept/reject decision the validator must reproduce: the OCaml codec
    decodes (structure plus constraints), validates (constraints and
    where-clauses), and the record spans the whole buffer -- the hardened
-   [<Base>Check<Codec>] wrapper rejects trailing bytes (see [harden_wrapper]),
+   [<Base>CheckWire<Codec>] wrapper rejects trailing bytes (see [harden_wrapper]),
    so the oracle must too. *)
 let codec_accepts ?env c buf =
   match Wire.Codec.decode ?env c buf 0 with
@@ -1218,9 +1213,19 @@ let emit_agree_main ppf =
   pr "  return mismatch == 0 ? 0 : 1;";
   pr "}"
 
-(* EverParse names each entrypoint wrapper [<Base>Check<Codec>] and gives it the
-   input parameters before the trailing [base, len], so both the helper name and
-   its parameter C types follow from the codec alone. Deriving them here keeps
+(* The 3D struct tag [pp_struct] emits, which is what EverParse mangles into the
+   entrypoint name. A raw-module schema has no source struct to read it from, so
+   say so rather than guess a symbol that would only fail at link time. *)
+let schema_entrypoint_name s =
+  match s.source with
+  | Some source -> "Wire" ^ Raw.struct_name source
+  | None ->
+      Fmt.failwith "%s: raw-module schema has no entrypoint struct tag" s.name
+
+(* EverParse names each entrypoint wrapper [<Base>CheckWire<Codec>] and gives
+   it the input parameters before the trailing [base, len], so both the helper
+   name and its parameter C types follow from the codec alone. Deriving them
+   here keeps
    [agree.c] pure OCaml (no reading of the generated [<Base>Wrapper.h]); a wrong
    name would surface as a link error when the differential test compiles
    [agree.c] against the real wrapper. *)
@@ -1239,7 +1244,9 @@ let generate_agree ?name ~outdir ~package codecs =
            [pascal_case (module ^ "_check_" ^ codec)], so compute it the same way
            rather than gluing pre-normalized parts: only the whole-string
            [pascal_case] gets the casing right for names like [TPM2B -> Tpm2b]. *)
-        (s.name, pascal_case (base ^ "_check_" ^ s.name), ptypes))
+        ( s.name,
+          pascal_case (base ^ "_check_" ^ schema_entrypoint_name s),
+          ptypes ))
       codecs
   in
   let has_params = List.exists (fun (_, _, ptypes) -> ptypes <> []) triples in
@@ -1341,13 +1348,15 @@ let emit_standalone_gen_rules ppf ~three_d ~c_files ~provenance =
     (String.concat " " c_files)
     provenance three_d
 
-(* The C symbols a standalone archive exports: the [<Base>Check<Codec>] wrapper
-   for each codec, named exactly as EverParse names it (and as [agree.c] links
-   it, see [generate_agree]), so the export allowlist matches the real symbol. *)
+(* The C symbols a standalone archive exports: the [<Base>CheckWire<Codec>]
+   wrapper for each codec, named exactly as EverParse names it (and as
+   [agree.c] links it, see [generate_agree]), so the export allowlist matches
+   the real symbol. *)
 let wrapper_symbols base codecs =
   List.map
     (fun (Pack c) ->
-      pascal_case (base ^ "_check_" ^ (project ~mode:`Standalone c).name))
+      let s = project ~mode:`Standalone c in
+      pascal_case (base ^ "_check_" ^ schema_entrypoint_name s))
     codecs
 
 (* Post-compile steps that fold the compiled objects into one archive member
@@ -1413,7 +1422,7 @@ let emit_standalone_check_rules ppf ~base ~archive =
 (* Build the validator into an archive, installed with the package, so consumers
    get a ready-to-link library and a downstream build fails loudly if the spec
    stops projecting to compilable C. The archive exports only the checked
-   [<Base>Check<Codec>] wrappers and localizes the raw validators.
+   [<Base>CheckWire<Codec>] wrappers and localizes the raw validators.
 
    The build runs in every context through that context's own toolchain, so a
    cross build produces a target archive: [CC] is the context C compiler
@@ -1467,10 +1476,11 @@ let emit_standalone_build_rules ppf ~base ~archive ~c_files ~wrappers =
    EverParse-emitted preamble bounds a read as [N <= InputLength - StartPosition]
    with no prior [StartPosition <= InputLength] check, so a direct C caller
    passing [StartPosition > InputLength] underflows the span (unsigned) and reads
-   out of bounds. The generated wrapper [<Base>Check<Codec>(base, len)] always
-   validates from position 0 and is the safe public C API; the raw validators
-   stay build-internal, linked into the archive but not shipped as a header.
-   [<Base>Wrapper.h] does not include [<Base>.h], so this compiles standalone. *)
+   out of bounds. The generated wrapper [<Base>CheckWire<Codec>(base, len)]
+   always validates from position 0 and is the safe public C API; the raw
+   validators stay build-internal, linked into the archive but not shipped as a
+   header. [<Base>Wrapper.h] does not include [<Base>.h], so this compiles
+   standalone. *)
 let emit_standalone_install ppf ~package ~three_d ~archive ~public_header
     ~provenance =
   let pr fmt = Fmt.pf ppf fmt in

--- a/lib/3d/wire_3d.ml
+++ b/lib/3d/wire_3d.ml
@@ -185,6 +185,64 @@ let locate_3d_exe () =
       in
       if Sys.file_exists local then Some local else None
 
+let everparse_version exe =
+  let ic = Unix.open_process_args_in exe [| exe; "--version" |] in
+  let output = In_channel.input_all ic in
+  match Unix.close_process_in ic with
+  | Unix.WEXITED 0 -> (
+      match String.split_on_char '\n' output with
+      | version :: _ when version <> "" -> version
+      | _ -> Fmt.failwith "%s --version returned no version" exe)
+  | Unix.WEXITED n -> Fmt.failwith "%s --version exited with code %d" exe n
+  | Unix.WSIGNALED n ->
+      Fmt.failwith "%s --version was killed by signal %d" exe n
+  | Unix.WSTOPPED n ->
+      Fmt.failwith "%s --version was stopped by signal %d" exe n
+
+let provenance_file three_d =
+  Filename.remove_extension (Filename.basename three_d) ^ ".provenance"
+
+let schema_digest ~outdir three_d =
+  Digest.BLAKE256.(to_hex (file (Filename.concat outdir three_d)))
+
+let write_provenance ~outdir ~version three_d =
+  let digest = schema_digest ~outdir three_d in
+  let path = Filename.concat outdir (provenance_file three_d) in
+  Out_channel.with_open_bin path (fun oc ->
+      Fmt.pf
+        (Format.formatter_of_out_channel oc)
+        "schema-blake2b-256: %s\neverparse: %s\n%!" digest version)
+
+let recorded_digest path =
+  let prefix = "schema-blake2b-256: " in
+  In_channel.with_open_bin path In_channel.input_lines
+  |> List.find_map (fun line ->
+      if String.starts_with ~prefix line then
+        Some
+          (String.sub line (String.length prefix)
+             (String.length line - String.length prefix))
+      else None)
+  |> function
+  | Some digest -> digest
+  | None -> Fmt.failwith "%s: missing schema-blake2b-256" path
+
+(* A stamp is only ever written beside the C that EverParse produced from that
+   exact [.3d], so a recorded hash that no longer matches means the committed C
+   is stale. Fail instead of emitting a promotable diff: promoting a recomputed
+   stamp would relabel the stale C as current and hide the drift for good. *)
+let check_provenance ~outdir three_d_files =
+  List.iter
+    (fun three_d ->
+      let stamp = Filename.concat outdir (provenance_file three_d) in
+      let recorded = recorded_digest stamp in
+      let actual = schema_digest ~outdir three_d in
+      if recorded <> actual then
+        Fmt.failwith
+          "stale generated C: %s records schema-blake2b-256 %s but %s hashes \
+           to %s; regenerate with BUILD_EVERPARSE=1 dune build @3d"
+          stamp recorded three_d actual)
+    three_d_files
+
 let everparse_dir () =
   match locate_3d_exe () with
   | Some exe -> Filename.dirname exe |> Filename.dirname
@@ -463,13 +521,15 @@ let run_everparse_files ?(quiet = true) ~outdir files =
     | Some e -> e
     | None -> failwith "3d.exe not found in PATH or ~/.local/everparse/bin/"
   in
+  let version = everparse_version exe in
   List.iter
     (fun f ->
       let redirect = if quiet then " > /dev/null 2>&1" else "" in
       let cmd = Fmt.str "cd %s && %s --batch %s%s" outdir exe f redirect in
       let ret = Sys.command cmd in
       if ret <> 0 then Fmt.failwith "EverParse failed on %s with code %d" f ret;
-      harden_wrapper ~outdir (Filename.remove_extension (Filename.basename f)))
+      harden_wrapper ~outdir (Filename.remove_extension (Filename.basename f));
+      write_provenance ~outdir ~version f)
     files;
   copy_everparse_endianness ~outdir
 
@@ -812,7 +872,7 @@ let everparse_type_defines =
   "-DUINT8=uint8_t -DUINT16=uint16_t -DUINT16BE=uint16_t -DUINT32=uint32_t \
    -DUINT32BE=uint32_t -DUINT64=uint64_t -DUINT64BE=uint64_t"
 
-let emit_gen_rules ppf three_d_files c_files ctx_files =
+let emit_gen_rules ppf three_d_files c_files ctx_files provenance_files =
   Fmt.pf ppf
     "(rule\n\
     \ (alias 3d)\n\
@@ -825,12 +885,13 @@ let emit_gen_rules ppf three_d_files c_files ctx_files =
     \ (enabled_if\n\
     \  (= %%{env:BUILD_EVERPARSE=} \"1\"))\n\
     \ (mode promote)\n\
-    \ (targets EverParse.h EverParseEndianness.h %s test.c)\n\
+    \ (targets EverParse.h EverParseEndianness.h %s test.c %s)\n\
     \ (deps %s)\n\
     \ (action\n\
     \  (run %%{exe:gen.exe} c)))\n\n"
     (String.concat " " three_d_files)
     (String.concat " " (c_files @ ctx_files))
+    (String.concat " " provenance_files)
     (String.concat " " three_d_files)
 
 (* One [runtest] rule per file rather than one [progn] over all of them: a
@@ -855,6 +916,17 @@ let emit_drift_check_rules ppf three_d_files =
     \ (action\n\
     \  (diff dune.inc dune.inc.gen)))\n\n"
 
+let emit_provenance_check_rules ppf three_d_files =
+  let stamps = List.map provenance_file three_d_files in
+  Fmt.pf ppf
+    "(rule\n\
+    \ (alias runtest)\n\
+    \ (deps %s %s)\n\
+    \ (action\n\
+    \  (run %%{exe:gen.exe} provenance-check)))\n\n"
+    (String.concat " " three_d_files)
+    (String.concat " " stamps)
+
 let emit_runtest_rule ppf ~test_bin ~all_deps ~c_srcs =
   Fmt.pf ppf
     "(rule\n\
@@ -871,12 +943,14 @@ let emit_runtest_rule ppf ~test_bin ~all_deps ~c_srcs =
     (String.concat " " all_deps)
     strict_cc_flags test_bin (String.concat " " c_srcs) test_bin test_bin
 
-let emit_install_stanza ppf ~package ~three_d_files ~c_files ~ctx_files =
+let emit_install_stanza ppf ~package ~three_d_files ~c_files ~ctx_files
+    ~provenance_files =
   let pr fmt = Fmt.pf ppf fmt in
   pr "(install\n (package %s)\n (section lib)\n (files\n" package;
   List.iter (fun f -> pr "  (%s as c/%s)\n" f f) three_d_files;
   List.iter (fun f -> pr "  (%s as c/%s)\n" f f) c_files;
   List.iter (fun f -> pr "  (%s as c/%s)\n" f f) ctx_files;
+  List.iter (fun f -> pr "  (%s as c/%s)\n" f f) provenance_files;
   pr "  (EverParse.h as c/EverParse.h)\n";
   pr "  (EverParseEndianness.h as c/EverParseEndianness.h)))\n"
 
@@ -888,6 +962,7 @@ let generate_dune_file ~filename ~outdir ~package schemas =
   let ctx_files = wire_ctx_files schemas in
   let fields_srcs = fields_c_files schemas in
   let three_d_files = List.map (fun n -> n ^ ".3d") names in
+  let provenance_files = List.map provenance_file three_d_files in
   let test_bin =
     "test_" ^ String.map (fun c -> if c = '-' then '_' else c) package
   in
@@ -895,10 +970,12 @@ let generate_dune_file ~filename ~outdir ~package schemas =
     [ "test.c"; "EverParse.h"; "EverParseEndianness.h" ] @ c_files @ ctx_files
   in
   let c_srcs = List.map (fun n -> n ^ ".c") names @ fields_srcs in
-  emit_gen_rules ppf three_d_files c_files ctx_files;
+  emit_gen_rules ppf three_d_files c_files ctx_files provenance_files;
   emit_drift_check_rules ppf three_d_files;
+  emit_provenance_check_rules ppf three_d_files;
   emit_runtest_rule ppf ~test_bin ~all_deps ~c_srcs;
-  emit_install_stanza ppf ~package ~three_d_files ~c_files ~ctx_files;
+  emit_install_stanza ppf ~package ~three_d_files ~c_files ~ctx_files
+    ~provenance_files;
   Format.pp_print_flush ppf ();
   close_out oc
 
@@ -1234,7 +1311,7 @@ let host_context_and cond = Fmt.str "(and\n   %s\n   %s)" host_context cond
    committed C goes stale -- the runtest differential below catches that, since
    it regenerates the corpus and [agree.c] from the current codec and runs them
    against the committed validator. *)
-let emit_standalone_gen_rules ppf ~three_d ~c_files =
+let emit_standalone_gen_rules ppf ~three_d ~c_files ~provenance =
   Fmt.pf ppf
     "(rule\n\
     \ (alias 3d)\n\
@@ -1255,14 +1332,14 @@ let emit_standalone_gen_rules ppf ~three_d ~c_files =
     \ (enabled_if\n\
     \  %s)\n\
     \ (mode promote)\n\
-    \ (targets EverParse.h EverParseEndianness.h %s)\n\
+    \ (targets EverParse.h EverParseEndianness.h %s %s)\n\
     \ (deps %s)\n\
     \ (action\n\
     \  (run %%{exe:gen.exe} c)))\n\n"
     host_context three_d host_context
     (host_context_and "(= %{env:BUILD_EVERPARSE=} \"1\")")
     (String.concat " " c_files)
-    three_d
+    provenance three_d
 
 (* The C symbols a standalone archive exports: the [<Base>Check<Codec>] wrapper
    for each codec, named exactly as EverParse names it (and as [agree.c] links
@@ -1394,12 +1471,13 @@ let emit_standalone_build_rules ppf ~base ~archive ~c_files ~wrappers =
    validates from position 0 and is the safe public C API; the raw validators
    stay build-internal, linked into the archive but not shipped as a header.
    [<Base>Wrapper.h] does not include [<Base>.h], so this compiles standalone. *)
-let emit_standalone_install ppf ~package ~three_d ~archive ~public_header =
+let emit_standalone_install ppf ~package ~three_d ~archive ~public_header
+    ~provenance =
   let pr fmt = Fmt.pf ppf fmt in
   pr "(install\n (package %s)\n (section lib)\n (files\n" package;
   List.iter
     (fun f -> pr "  (%s as c/%s)\n" f f)
-    [ three_d; archive; public_header ];
+    [ three_d; archive; public_header; provenance ];
   pr "  (EverParse.h as c/EverParse.h)\n";
   pr "  (EverParseEndianness.h as c/EverParseEndianness.h)))\n"
 
@@ -1411,13 +1489,15 @@ let generate_dune_standalone_file ~filename ?name ~outdir ~package codecs =
   in
   let archive = "lib" ^ String.lowercase_ascii base ^ ".a" in
   let wrappers = wrapper_symbols base codecs in
+  let provenance = provenance_file three_d in
   let oc = open_out (Filename.concat outdir filename) in
   let ppf = Format.formatter_of_out_channel oc in
-  emit_standalone_gen_rules ppf ~three_d ~c_files;
+  emit_standalone_gen_rules ppf ~three_d ~c_files ~provenance;
   emit_drift_check_rules ppf [ three_d ];
+  emit_provenance_check_rules ppf [ three_d ];
   emit_standalone_build_rules ppf ~base ~archive ~c_files ~wrappers;
   emit_standalone_install ppf ~package ~three_d ~archive
-    ~public_header:(base ^ "Wrapper.h");
+    ~public_header:(base ^ "Wrapper.h") ~provenance;
   Format.pp_print_flush ppf ();
   close_out oc
 
@@ -1438,6 +1518,9 @@ let main ?name ~mode ~package codecs =
       | [ _; "dune-gen" ] ->
           generate_dune_file ~filename:"dune.inc.gen" ~outdir:"." ~package
             schemas
+      | [ _; "provenance-check" ] ->
+          check_provenance ~outdir:"."
+            (List.map Wire.Everparse.filename schemas)
       | _ -> run ~outdir:"." schemas)
   | `Standalone -> (
       match argv with
@@ -1451,5 +1534,8 @@ let main ?name ~mode ~package codecs =
       | [ _; "dune-gen" ] ->
           generate_dune_standalone_file ~filename:"dune.inc.gen" ?name
             ~outdir:"." ~package codecs
+      | [ _; "provenance-check" ] ->
+          check_provenance ~outdir:"."
+            [ standalone_base ?name ~package () ^ ".3d" ]
       | [ _; "corpus" ] -> generate_corpus Format.std_formatter codecs
       | _ -> generate_standalone ?name ~outdir:"." ~package codecs)

--- a/lib/3d/wire_3d.ml
+++ b/lib/3d/wire_3d.ml
@@ -648,11 +648,34 @@ let generate_3d ~outdir schemas =
   ensure_dir outdir;
   write_3d ~outdir schemas
 
+let copy_file ~src ~dst =
+  let contents = In_channel.with_open_bin src In_channel.input_all in
+  Out_channel.with_open_bin dst (fun oc ->
+      Out_channel.output_string oc contents)
+
 let rm_rf dir =
   (try Sys.readdir dir with Sys_error _ -> [||])
   |> Array.iter (fun f ->
       try Sys.remove (Filename.concat dir f) with Sys_error _ -> ());
   try Sys.rmdir dir with Sys_error _ -> ()
+
+(* Regenerate into a scratch directory through the same writer the committed
+   [.3d] came from, so the drift check compares against the real generator
+   rather than against a second copy of it that could itself drift. *)
+let generate_3d_check ~outdir schemas =
+  ensure_dir outdir;
+  let tmpdir = Filename.temp_dir "wire_3d_check" "" in
+  Fun.protect
+    ~finally:(fun () -> rm_rf tmpdir)
+    (fun () ->
+      write_3d ~outdir:tmpdir schemas;
+      List.iter
+        (fun s ->
+          let file = Wire.Everparse.filename s in
+          copy_file
+            ~src:(Filename.concat tmpdir file)
+            ~dst:(Filename.concat outdir (file ^ ".gen")))
+        schemas)
 
 let default_job_count () = max 1 (min 4 (Domain.recommended_domain_count ()))
 
@@ -810,6 +833,28 @@ let emit_gen_rules ppf three_d_files c_files ctx_files =
     (String.concat " " (c_files @ ctx_files))
     (String.concat " " three_d_files)
 
+(* One [runtest] rule per file rather than one [progn] over all of them: a
+   [progn] stops at the first mismatch, so a single pass would report and offer
+   to promote only the first drifted spec. *)
+let emit_drift_check_rules ppf three_d_files =
+  let generated = List.map (fun f -> f ^ ".gen") three_d_files in
+  let pr fmt = Fmt.pf ppf fmt in
+  pr "(rule\n (targets %s)\n (action\n  (run %%{exe:gen.exe} 3d-gen)))\n\n"
+    (String.concat " " generated);
+  List.iter
+    (fun f ->
+      pr "(rule\n (alias runtest)\n (action\n  (diff %s %s.gen)))\n\n" f f)
+    three_d_files;
+  pr
+    "(rule\n\
+    \ (targets dune.inc.gen)\n\
+    \ (action\n\
+    \  (run %%{exe:gen.exe} dune-gen)))\n\n\
+     (rule\n\
+    \ (alias runtest)\n\
+    \ (action\n\
+    \  (diff dune.inc dune.inc.gen)))\n\n"
+
 let emit_runtest_rule ppf ~test_bin ~all_deps ~c_srcs =
   Fmt.pf ppf
     "(rule\n\
@@ -835,8 +880,8 @@ let emit_install_stanza ppf ~package ~three_d_files ~c_files ~ctx_files =
   pr "  (EverParse.h as c/EverParse.h)\n";
   pr "  (EverParseEndianness.h as c/EverParseEndianness.h)))\n"
 
-let generate_dune ~outdir ~package schemas =
-  let oc = open_out (Filename.concat outdir "dune.inc") in
+let generate_dune_file ~filename ~outdir ~package schemas =
+  let oc = open_out (Filename.concat outdir filename) in
   let ppf = Format.formatter_of_out_channel oc in
   let names = List.map file_base schemas in
   let c_files = List.concat_map (fun n -> [ n ^ ".h"; n ^ ".c" ]) names in
@@ -851,10 +896,14 @@ let generate_dune ~outdir ~package schemas =
   in
   let c_srcs = List.map (fun n -> n ^ ".c") names @ fields_srcs in
   emit_gen_rules ppf three_d_files c_files ctx_files;
+  emit_drift_check_rules ppf three_d_files;
   emit_runtest_rule ppf ~test_bin ~all_deps ~c_srcs;
   emit_install_stanza ppf ~package ~three_d_files ~c_files ~ctx_files;
   Format.pp_print_flush ppf ();
   close_out oc
+
+let generate_dune ~outdir ~package schemas =
+  generate_dune_file ~filename:"dune.inc" ~outdir ~package schemas
 
 (* A codec awaiting projection. [main] and the standalone helpers take these
    rather than an already-projected [Wire.Everparse.t] so the caller never has
@@ -1131,6 +1180,17 @@ let generate_3d_standalone ?name ~outdir ~package codecs =
     ~name:(standalone_base ?name ~package ())
     (List.map (fun (Pack c) -> project ~mode:`Standalone c) codecs)
 
+let generate_3d_standalone_check ?name ~outdir ~package codecs =
+  let tmpdir = Filename.temp_dir "wire_3d_check" "" in
+  Fun.protect
+    ~finally:(fun () -> rm_rf tmpdir)
+    (fun () ->
+      generate_3d_standalone ?name ~outdir:tmpdir ~package codecs;
+      let file = standalone_base ?name ~package () ^ ".3d" in
+      copy_file
+        ~src:(Filename.concat tmpdir file)
+        ~dst:(Filename.concat outdir (file ^ ".gen")))
+
 let generate_c_standalone ?(quiet = true) ?name ~outdir ~package () =
   ensure_dir outdir;
   if has_3d_exe () then
@@ -1343,7 +1403,7 @@ let emit_standalone_install ppf ~package ~three_d ~archive ~public_header =
   pr "  (EverParse.h as c/EverParse.h)\n";
   pr "  (EverParseEndianness.h as c/EverParseEndianness.h)))\n"
 
-let generate_dune_standalone ?name ~outdir ~package codecs =
+let generate_dune_standalone_file ~filename ?name ~outdir ~package codecs =
   let base = standalone_base ?name ~package () in
   let three_d = base ^ ".3d" in
   let c_files =
@@ -1351,14 +1411,19 @@ let generate_dune_standalone ?name ~outdir ~package codecs =
   in
   let archive = "lib" ^ String.lowercase_ascii base ^ ".a" in
   let wrappers = wrapper_symbols base codecs in
-  let oc = open_out (Filename.concat outdir "dune.inc") in
+  let oc = open_out (Filename.concat outdir filename) in
   let ppf = Format.formatter_of_out_channel oc in
   emit_standalone_gen_rules ppf ~three_d ~c_files;
+  emit_drift_check_rules ppf [ three_d ];
   emit_standalone_build_rules ppf ~base ~archive ~c_files ~wrappers;
   emit_standalone_install ppf ~package ~three_d ~archive
     ~public_header:(base ^ "Wrapper.h");
   Format.pp_print_flush ppf ();
   close_out oc
+
+let generate_dune_standalone ?name ~outdir ~package codecs =
+  generate_dune_standalone_file ~filename:"dune.inc" ?name ~outdir ~package
+    codecs
 
 let main ?name ~mode ~package codecs =
   let argv = Array.to_list Sys.argv in
@@ -1367,15 +1432,24 @@ let main ?name ~mode ~package codecs =
       let schemas = List.map (fun (Pack c) -> project ~mode:`Ffi c) codecs in
       match argv with
       | [ _; "3d" ] -> generate_3d ~outdir:"." schemas
+      | [ _; "3d-gen" ] -> generate_3d_check ~outdir:"." schemas
       | [ _; "c" ] -> generate_c ~outdir:"." schemas
       | [ _; "dune" ] -> generate_dune ~outdir:"." ~package schemas
+      | [ _; "dune-gen" ] ->
+          generate_dune_file ~filename:"dune.inc.gen" ~outdir:"." ~package
+            schemas
       | _ -> run ~outdir:"." schemas)
   | `Standalone -> (
       match argv with
       | [ _; "3d" ] -> generate_3d_standalone ?name ~outdir:"." ~package codecs
+      | [ _; "3d-gen" ] ->
+          generate_3d_standalone_check ?name ~outdir:"." ~package codecs
       | [ _; "c" ] -> generate_c_standalone ?name ~outdir:"." ~package ()
       | [ _; "agree" ] -> generate_agree ?name ~outdir:"." ~package codecs
       | [ _; "dune" ] ->
           generate_dune_standalone ?name ~outdir:"." ~package codecs
+      | [ _; "dune-gen" ] ->
+          generate_dune_standalone_file ~filename:"dune.inc.gen" ?name
+            ~outdir:"." ~package codecs
       | [ _; "corpus" ] -> generate_corpus Format.std_formatter codecs
       | _ -> generate_standalone ?name ~outdir:"." ~package codecs)

--- a/lib/3d/wire_3d.mli
+++ b/lib/3d/wire_3d.mli
@@ -64,7 +64,10 @@ val generate_3d : outdir:string -> Wire.Everparse.t list -> unit
 val generate_dune :
   outdir:string -> package:string -> Wire.Everparse.t list -> unit
 (** [generate_dune ~outdir ~package schemas] writes [dune.inc] listing the
-    build, runtest, and install rules for the generated C artifacts. *)
+    build, runtest, and install rules for the generated C artifacts. The
+    [runtest] rules regenerate every committed [.3d] file and [dune.inc] into
+    [.gen] targets and diff them, so source changes cannot leave those hermetic
+    artifacts stale. *)
 
 val run_everparse :
   ?quiet:bool -> outdir:string -> Wire.Everparse.t list -> unit
@@ -187,8 +190,10 @@ val generate_dune_standalone :
     compile it to [<Name>.c], a rule that builds the validator into an installed
     [lib<name>.a] archive, a [runtest] rule that runs the differential
     self-check (see {!generate_corpus} / {!generate_agree}), and an install
-    stanza (under opam [package]) for the spec, parser, and archive. [name]
-    defaults to [package]; see {!generate_standalone}.
+    stanza (under opam [package]) for the spec, parser, and archive. The
+    [runtest] rules also regenerate the committed [.3d] and [dune.inc] into
+    [.gen] targets and diff them. [name] defaults to [package]; see
+    {!generate_standalone}.
 
     The [c/] archive builds and installs in every dune context through that
     context's own toolchain ([%{ocaml-config:c_compiler}], the [ocaml-config]
@@ -254,6 +259,7 @@ val main :
     - [3d] writes the [.3d] file(s)
     - [c] produces the C parser(s)
     - [dune] generates [dune.inc] with build rules, test, and install stanzas
+    - [3d-gen] / [dune-gen] write the corresponding [.gen] drift-check targets
     - otherwise runs the full pipeline.
 
     [mode] is mandatory, so every [gen.ml] states what it emits. With

--- a/lib/3d/wire_3d.mli
+++ b/lib/3d/wire_3d.mli
@@ -152,10 +152,10 @@ val generate_c : ?quiet:bool -> outdir:string -> Wire.Everparse.t list -> unit
 (** [generate_c ?quiet ~outdir schemas] invokes EverParse on existing [.3d]
     files to produce C parsers and generates [test.c].
 
-    The EverParse-emitted [<Name>Check<Codec>] wrapper is hardened after
+    The EverParse-emitted [<Name>CheckWire<Codec>] wrapper is hardened after
     generation: it returns [FALSE] unless the validator consumed the whole
     buffer, so a valid record followed by trailing bytes is rejected. The raw
-    [<Name>Validate<Codec>] function keeps EverParse's prefix semantics and
+    [<Name>ValidateWire<Codec>] function keeps EverParse's prefix semantics and
     returns the consumed position.
 
     If [quiet] is [true] (the default), EverParse output is suppressed. If
@@ -190,9 +190,9 @@ val generate_standalone :
     single validator-only [<Name>.c] (no [_Fields] plug, no FFI). The file base
     is [name] when given, else [package], normalised to a CamelCase identifier
     (["my-pkg"] becomes [MyPkg]); [package] always names the opam package. The
-    generated [<Name>Check<Codec>] wrappers validate the whole buffer, rejecting
-    trailing bytes (see {!generate_c}). Only the checked wrapper header
-    [<Name>Wrapper.h] is installed as the public C API; the raw
+    generated [<Name>CheckWire<Codec>] wrappers validate the whole buffer,
+    rejecting trailing bytes (see {!generate_c}). Only the checked wrapper
+    header [<Name>Wrapper.h] is installed as the public C API; the raw
     [<Name>Validate*] entrypoints (which take an unguarded [StartPosition]) stay
     build-internal, linked into the archive but not shipped as a header. *)
 
@@ -217,10 +217,10 @@ val generate_dune_standalone :
     which runs a built validator on the build machine. *)
 
 val wrapper_symbols : string -> packed list -> string list
-(** [wrapper_symbols base codecs] is the [<Base>Check<Codec>] wrapper C symbol
-    for each codec, computed exactly as EverParse names them. These are the only
-    symbols a standalone archive exports; the raw [<Base>Validate*] validators
-    are localized (see {!archive_link_steps}). *)
+(** [wrapper_symbols base codecs] is the [<Base>CheckWire<Codec>] wrapper C
+    symbol for each codec, computed exactly as EverParse names them. These are
+    the only symbols a standalone archive exports; the raw [<Base>Validate*]
+    validators are localized (see {!archive_link_steps}). *)
 
 val archive_link_steps :
   macos:bool ->
@@ -258,7 +258,7 @@ val generate_agree :
     [outdir]: a C program that replays a {!generate_corpus} corpus through the
     EverParse-generated validators and exits nonzero on any input where the
     validator's accept/reject decision differs from the recorded verdict. It
-    reads the [<Name>Check<Codec>] helper names from the generated
+    reads the [<Name>CheckWire<Codec>] helper names from the generated
     [<Name>Wrapper.h], so {!generate_c_standalone} (or [3d.exe]) must have run
     first. *)
 

--- a/lib/3d/wire_3d.mli
+++ b/lib/3d/wire_3d.mli
@@ -5,7 +5,8 @@
     generates C parser artifacts around the result.
 
     The output directory contains a self-contained C library: [EverParse.h],
-    [<Name>.h], [<Name>.c], and a [test.c] that exercises the validators.
+    [<Name>.h], [<Name>.c], a [<Name>.provenance] stamp, and a [test.c] that
+    exercises the validators.
 
     {b Typical usage} ([gen.ml]):
     {[
@@ -77,7 +78,19 @@ val run_everparse :
     If [quiet] is [true] (the default), EverParse output is suppressed. If
     [quiet] is [false], EverParse stdout/stderr are left visible.
 
+    A [<Name>.provenance] file records the BLAKE2b-256 digest of [<Name>.3d] and
+    the EverParse version that generated the C. Generated [dune.inc] rules
+    recompute that digest during [runtest] and fail on a mismatch, so C
+    staleness is detected without running EverParse. The failure is deliberately
+    not promotable: only regenerating the C may refresh the stamp.
+
     Requires [3d.exe] in PATH. *)
+
+val check_provenance : outdir:string -> string list -> unit
+(** [check_provenance ~outdir three_d_files] recomputes the BLAKE2b-256 digest
+    of each [.3d] in [outdir] and raises [Failure] if it differs from the digest
+    recorded in the matching [<Name>.provenance] stamp, which means the
+    committed C came from a different spec. Needs no [3d.exe]. *)
 
 val parse_3d : ?batch:bool -> outdir:string -> string -> (unit, string) result
 (** [parse_3d ~outdir file] runs [3d.exe] on a single [.3d] file in [outdir].
@@ -260,6 +273,7 @@ val main :
     - [c] produces the C parser(s)
     - [dune] generates [dune.inc] with build rules, test, and install stanzas
     - [3d-gen] / [dune-gen] write the corresponding [.gen] drift-check targets
+    - [provenance-check] verifies the committed provenance stamps, no EverParse
     - otherwise runs the full pipeline.
 
     [mode] is mandatory, so every [gen.ml] states what it emits. With

--- a/lib/stubs/wire_stubs.ml
+++ b/lib/stubs/wire_stubs.ml
@@ -3,6 +3,10 @@
 let ml_type_of = Wire.Private.ml_type_of
 let everparse_name = Wire_3d.everparse_name
 
+let validator_name name =
+  let ep = everparse_name name in
+  Fmt.str "%sValidateWire%s" ep ep
+
 let pp_c_stub_error_handler ppf lower =
   Fmt.pf ppf
     "static void %s_err(const char *t, const char *f, const char *r,@\n" lower;
@@ -12,12 +16,11 @@ let pp_c_stub_error_handler ppf lower =
     "  (void)t; (void)f; (void)r; (void)c; (void)ctx; (void)i; (void)p;@\n";
   Fmt.pf ppf "}@\n"
 
-let c_stub_validate ppf ~lower ~ep =
+let c_stub_validate ppf ~lower ~ep ~validator =
   Fmt.pf ppf "  %sFields fields = {0};@\n" ep;
   Fmt.pf ppf
-    "  uint64_t r = %sValidate%s((WIRECTX *) &fields, NULL, %s_err, data, len, \
-     0);@\n"
-    ep ep lower;
+    "  uint64_t r = %s((WIRECTX *) &fields, NULL, %s_err, data, len, 0);@\n"
+    validator lower;
   Fmt.pf ppf
     "  if (!EverParseIsSuccess(r)) caml_failwith(\"%s: validation failed\");@\n"
     lower
@@ -45,7 +48,8 @@ let pp_field_value ppf (fname, kind) =
       Fmt.pf ppf "caml_copy_double((double) fields.%s)" fname
   | _ -> Fmt.pf ppf "Val_long(fields.%s)" fname
 
-let pp_c_stub_output ppf ~lower ~ep (s : Wire.Everparse.Raw.struct_) =
+let pp_c_stub_output ppf ~lower ~ep ~validator (s : Wire.Everparse.Raw.struct_)
+    =
   let kinds = Wire.Everparse.Raw.field_kinds s in
   let n_fields = List.length kinds in
   (* Single C entry point per schema: [caml_wire_<name>_parse_k] takes a
@@ -61,7 +65,7 @@ let pp_c_stub_output ppf ~lower ~ep (s : Wire.Everparse.Raw.struct_) =
     Fmt.pf ppf "  CAMLparam3(v_k, v_buf, v_off);@\n";
     Fmt.pf ppf "  CAMLlocal1(v_result);@\n";
     pp_c_stub_bounds ppf ~lower;
-    c_stub_validate ppf ~lower ~ep;
+    c_stub_validate ppf ~lower ~ep ~validator;
     Fmt.pf ppf "  value args[%d];@\n" n_fields;
     List.iteri
       (fun i kind -> Fmt.pf ppf "  args[%d] = %a;@\n" i pp_field_value kind)
@@ -76,7 +80,7 @@ let pp_c_stub_output ppf ~lower ~ep (s : Wire.Everparse.Raw.struct_) =
       "CAMLprim value caml_wire_%s_parse(value v_buf, value v_off) {@\n" lower;
     Fmt.pf ppf "  CAMLparam2(v_buf, v_off);@\n";
     pp_c_stub_bounds ppf ~lower;
-    c_stub_validate ppf ~lower ~ep;
+    c_stub_validate ppf ~lower ~ep ~validator;
     Fmt.pf ppf "  CAMLreturn(Val_unit);@\n";
     Fmt.pf ppf "}@\n@\n"
   end
@@ -84,9 +88,10 @@ let pp_c_stub_output ppf ~lower ~ep (s : Wire.Everparse.Raw.struct_) =
 let pp_c_stub ppf (s : Wire.Everparse.Raw.struct_) =
   let name = Wire.Everparse.Raw.struct_name s in
   let ep = everparse_name name in
+  let validator = validator_name name in
   let lower = String.lowercase_ascii name in
   pp_c_stub_error_handler ppf lower;
-  pp_c_stub_output ppf ~lower ~ep s
+  pp_c_stub_output ppf ~lower ~ep ~validator s
 
 let to_c_stubs (structs : Wire.Everparse.Raw.struct_ list) =
   let buf = Buffer.create 4096 in

--- a/lib/stubs/wire_stubs.mli
+++ b/lib/stubs/wire_stubs.mli
@@ -68,5 +68,9 @@ val to_ml_stub_name : Wire.Everparse.Raw.struct_ -> string
 val everparse_name : string -> string
 (** Convert a Wire struct name to the EverParse CamelCase convention. *)
 
+val validator_name : string -> string
+(** [validator_name name] is the generated C validator entry point for the Wire
+    struct [name]. *)
+
 val ml_type_of : 'a Wire.typ -> string
 (** Return the OCaml type name corresponding to a Wire type. *)

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -1467,6 +1467,7 @@ let reserved_3d =
 let escape_3d name =
   if Reserved_3d.mem name reserved_3d then name ^ "_" else name
 
+let struct_tag_name (s : struct_) = "Wire" ^ escape_3d s.name
 let pp_endian ppf = function Little -> () | Big -> Fmt.string ppf "BE"
 
 let pp_bitfield_base ppf = function
@@ -2615,6 +2616,7 @@ let guard_subtraction_sizes fields =
 let pp_struct ppf (s : struct_) =
   anon_counter := 0;
   let name = escape_3d s.name in
+  let tag = struct_tag_name s in
   let where, fields = lower_where_to_field_constraint s.where s.fields in
   let fields = guard_subtraction_sizes fields in
   let widenable =
@@ -2625,7 +2627,7 @@ let pp_struct ppf (s : struct_) =
         | _ -> None)
       fields
   in
-  Fmt.pf ppf "typedef struct _%s%a" name pp_params s.params;
+  Fmt.pf ppf "typedef struct %s%a" tag pp_params s.params;
   Option.iter (Fmt.pf ppf "@,where (%a)" pp_expr) where;
   Fmt.pf ppf "@,{@[<v 2>";
   List.iter (pp_field widenable ppf) fields;
@@ -2677,9 +2679,10 @@ let pp_decl ppf = function
           Fmt.pf ppf "@,")
         doc;
       if extern_ then
-        (* extern typedef struct _Name Name *)
+        (* The tag occupies C's distinct tag namespace; a readable [Wire]
+           prefix keeps it separate from the public typedef name. *)
         let n = escape_3d st.name in
-        Fmt.pf ppf "extern typedef struct _%s %s@,@," n n
+        Fmt.pf ppf "extern typedef struct %s %s@,@," (struct_tag_name st) n
       else begin
         if output then Fmt.pf ppf "output@,";
         if export then Fmt.pf ppf "export@,";

--- a/test/3d/test_wire_3d.ml
+++ b/test/3d/test_wire_3d.ml
@@ -186,6 +186,9 @@ let test_generate_dune_standalone () =
     "installs under the package" true (has "(package my-pkg)");
   Alcotest.(check bool) "builds a validator archive" true (has "libmypkg.a");
   Alcotest.(check bool)
+    "exports the wrapper derived from the struct tag" true
+    (has "MyPkgCheckWirePkt");
+  Alcotest.(check bool)
     "runtest runs the differential check" true
     (has "%{dep:agree} corpus");
   Alcotest.(check bool) "corpus oracle" true (has "%{exe:gen.exe} corpus");
@@ -416,7 +419,7 @@ let test_doc_differential_no_params () =
       [ Wire_3d.pack diff_enum_codec; Wire_3d.pack diff_range_codec ]
 
 (* The installed standalone archive must export only the checked
-   [<Base>Check<Codec>] wrappers, not the raw [<Base>Validate*] entry points
+   [<Base>CheckWire<Codec>] wrappers, not the raw [<Base>Validate*] entry points
    whose EverParse-emitted preamble underflows on [StartPosition > InputLength].
    Build the archive exactly as the generated dune rule does for this platform
    (via {!Wire_3d.archive_link_steps}) and assert [nm] shows no global [Validate]

--- a/test/3d/test_wire_3d.ml
+++ b/test/3d/test_wire_3d.ml
@@ -100,6 +100,14 @@ let test_ensure_dir () =
   Alcotest.(check bool) "dir created" true (Sys.file_exists tmpdir);
   Unix.rmdir tmpdir
 
+let read_file path =
+  let ic = open_in path in
+  let n = in_channel_length ic in
+  let buf = Bytes.create n in
+  really_input ic buf 0 n;
+  close_in ic;
+  Bytes.unsafe_to_string buf
+
 let test_generate_c () =
   (* generate_c requires 3d.exe; skip when not available *)
   if Wire_3d.has_3d_exe () then begin
@@ -111,16 +119,53 @@ let test_generate_c () =
     Alcotest.(check bool) "C file generated" true (Sys.file_exists c_path);
     let ext_path = Filename.concat tmpdir "TestSimple_ExternalTypedefs.h" in
     Alcotest.(check bool)
-      "ExternalTypedefs.h generated" true (Sys.file_exists ext_path)
+      "ExternalTypedefs.h generated" true (Sys.file_exists ext_path);
+    let provenance = Filename.concat tmpdir "TestSimple.provenance" in
+    Alcotest.(check bool)
+      "provenance generated" true
+      (Sys.file_exists provenance);
+    let contents = read_file provenance in
+    Alcotest.(check bool)
+      "provenance records schema BLAKE2b-256" true
+      (Re.execp
+         (Re.compile
+            (Re.Perl.re
+               "schema-blake2b-256: [0-9a-f]{64}\\neverparse: EverParse/3d "))
+         contents)
   end
 
-let read_file path =
-  let ic = open_in path in
-  let n = in_channel_length ic in
-  let buf = Bytes.create n in
-  really_input ic buf 0 n;
-  close_in ic;
-  Bytes.unsafe_to_string buf
+let raises_failure f =
+  match f () with () -> false | exception Failure _ -> true
+
+(* The stamp is what stops a committed validator outliving the spec it was
+   generated from, so cover both verdicts here rather than only the rule text.
+   No 3d.exe needed: the check is deliberately hermetic. *)
+let test_check_provenance () =
+  let tmpdir = Filename.temp_dir "wire_3d_provenance" "" in
+  let three_d = "Foo.3d" in
+  let schema = Filename.concat tmpdir three_d in
+  let stamp = Filename.concat tmpdir "Foo.provenance" in
+  let write path contents =
+    Out_channel.with_open_bin path (fun oc ->
+        Out_channel.output_string oc contents)
+  in
+  write schema "entrypoint\ntypedef struct WireFoo\n{\n   UINT8 A;\n} Foo;\n";
+  let stamp_of digest =
+    Fmt.str "schema-blake2b-256: %s\neverparse: EverParse/3d vtest\n" digest
+  in
+  write stamp (stamp_of Digest.BLAKE256.(to_hex (file schema)));
+  Wire_3d.check_provenance ~outdir:tmpdir [ three_d ];
+  write schema "entrypoint\ntypedef struct WireFoo\n{\n   UINT16 A;\n} Foo;\n";
+  Alcotest.(check bool)
+    "spec edited after generation is rejected" true
+    (raises_failure (fun () ->
+         Wire_3d.check_provenance ~outdir:tmpdir [ three_d ]));
+  write stamp "everparse: EverParse/3d vtest\n";
+  Alcotest.(check bool)
+    "stamp without a recorded hash is rejected" true
+    (raises_failure (fun () ->
+         Wire_3d.check_provenance ~outdir:tmpdir [ three_d ]));
+  ignore (Fmt.kstr Sys.command "rm -rf %s" tmpdir)
 
 let doc_codec name =
   Codec.v name (fun v -> v) Codec.[ (Field.v "v" uint8 $ fun v -> v) ]
@@ -156,6 +201,14 @@ let test_generate_dune_standalone () =
   Alcotest.(check bool)
     "runtest diffs the committed dune.inc" true
     (has "(diff dune.inc dune.inc.gen)");
+  Alcotest.(check bool)
+    "C regeneration writes provenance" true (has "MyPkg.provenance");
+  Alcotest.(check bool)
+    "runtest checks provenance" true
+    (has "%{exe:gen.exe} provenance-check");
+  Alcotest.(check bool)
+    "stale provenance is not promotable" false
+    (has "MyPkg.provenance.gen");
   Alcotest.(check bool)
     "generator invoked via exe macro, not ./gen.exe" false (has "./gen.exe");
   Alcotest.(check bool) "no shell action in the runtest" false (has "(system");
@@ -1061,7 +1114,16 @@ let test_projection_filenames () =
     (contains_exact "targets dune.inc.gen");
   Alcotest.(check bool)
     "runtest diffs the committed dune.inc" true
-    (contains_exact "(diff dune.inc dune.inc.gen)")
+    (contains_exact "(diff dune.inc dune.inc.gen)");
+  Alcotest.(check bool)
+    "C regeneration writes provenance" true
+    (contains_exact "Rpmsg_endpoint_info.provenance");
+  Alcotest.(check bool)
+    "runtest checks provenance" true
+    (contains_exact "%{exe:gen.exe} provenance-check");
+  Alcotest.(check bool)
+    "stale provenance is not promotable" false
+    (contains_exact "Rpmsg_endpoint_info.provenance.gen")
 
 (* -- Adversarial projection tests for 3D-shape transformations -- *)
 
@@ -1308,6 +1370,7 @@ let suite =
       Alcotest.test_case "schema_of_struct" `Quick test_schema_of_struct;
       Alcotest.test_case "ensure_dir" `Quick test_ensure_dir;
       Alcotest.test_case "generate_c (needs 3d.exe)" `Quick test_generate_c;
+      Alcotest.test_case "check_provenance" `Quick test_check_provenance;
       Alcotest.test_case "generate_dune_standalone" `Quick
         test_generate_dune_standalone;
       Alcotest.test_case "generate_dune_standalone name override" `Quick

--- a/test/3d/test_wire_3d.ml
+++ b/test/3d/test_wire_3d.ml
@@ -145,6 +145,18 @@ let test_generate_dune_standalone () =
     (has "%{dep:agree} corpus");
   Alcotest.(check bool) "corpus oracle" true (has "%{exe:gen.exe} corpus");
   Alcotest.(check bool)
+    "runtest regenerates the spec" true
+    (has "targets MyPkg.3d.gen");
+  Alcotest.(check bool)
+    "runtest diffs the committed spec" true
+    (has "(diff MyPkg.3d MyPkg.3d.gen)");
+  Alcotest.(check bool)
+    "runtest regenerates dune.inc" true
+    (has "targets dune.inc.gen");
+  Alcotest.(check bool)
+    "runtest diffs the committed dune.inc" true
+    (has "(diff dune.inc dune.inc.gen)");
+  Alcotest.(check bool)
     "generator invoked via exe macro, not ./gen.exe" false (has "./gen.exe");
   Alcotest.(check bool) "no shell action in the runtest" false (has "(system");
   Alcotest.(check bool)
@@ -1037,7 +1049,19 @@ let test_projection_filenames () =
     (contains_exact "%{env:BUILD_EVERPARSE=}");
   Alcotest.(check bool)
     "C rule never auto-regenerates" false
-    (contains_exact "mode fallback")
+    (contains_exact "mode fallback");
+  Alcotest.(check bool)
+    "runtest regenerates every .3d" true
+    (contains_exact "targets Rpmsg_endpoint_info.3d.gen");
+  Alcotest.(check bool)
+    "runtest diffs every committed .3d" true
+    (contains_exact "(diff Rpmsg_endpoint_info.3d Rpmsg_endpoint_info.3d.gen)");
+  Alcotest.(check bool)
+    "runtest regenerates dune.inc" true
+    (contains_exact "targets dune.inc.gen");
+  Alcotest.(check bool)
+    "runtest diffs the committed dune.inc" true
+    (contains_exact "(diff dune.inc dune.inc.gen)")
 
 (* -- Adversarial projection tests for 3D-shape transformations -- *)
 

--- a/test/diff/gen_c.ml
+++ b/test/diff/gen_c.ml
@@ -170,7 +170,7 @@ let generate_c_stubs ~schema_dir outdir schemas =
         List.filter (fun p -> not (param_is_mutable p)) params
       in
       let output_params = List.filter (fun p -> param_is_mutable p) params in
-      (* Distinct from EverParse's generated [<Name>Check<Name>], which for an
+      (* Distinct from EverParse's generated [<Name>CheckWire<Name>], which for an
          output-parameter codec takes an extra out-pointer and would otherwise
          collide with this hand-rolled accept/reject wrapper. *)
       pr "BOOLEAN %s_diff_check(uint8_t *base, uint32_t len) {\n" name;

--- a/test/stubs/test_wire_stubs.ml
+++ b/test/stubs/test_wire_stubs.ml
@@ -193,6 +193,9 @@ let test_c_stubs_no_params () =
   Alcotest.(check bool)
     "has error handler" true
     (contains ~sub:"simpleheader_err" c);
+  Alcotest.(check bool)
+    "uses generated Wire-prefixed validator" true
+    (contains ~sub:"ValidateWire" c);
   Alcotest.(check bool) "has EverParse.h" true (contains ~sub:"EverParse.h" c)
 
 let test_c_stubs_with_params () =
@@ -268,6 +271,11 @@ let test_name_single () =
   Alcotest.(check string)
     "single" "foo"
     (Wire_stubs.to_ml_stub_name (struct_ "Foo" [ field "x" uint8 ]))
+
+let test_validator_name () =
+  Alcotest.(check string)
+    "Wire-prefixed validator" "ClcwValidateWireClcw"
+    (Wire_stubs.validator_name "CLCW")
 
 (* -- End-to-end: generate -> EverParse -> compile C+ML -> call -- *)
 
@@ -709,10 +717,7 @@ let test_e2e_full_stack () =
         Wire_3d.write_external_typedefs ~outdir:dir [ schema ];
         Wire_3d.write_fields ~outdir:dir [ schema ])
       schemas;
-    let validator name =
-      let n = Wire_3d.everparse_name name in
-      n ^ "Validate" ^ n
-    in
+    let validator = Wire_stubs.validator_name in
     let fields name = Wire_3d.everparse_name name ^ "Fields" in
     let ip_off = Net.ethernet_size - Net.ethernet_payload_size in
     let tcp_off = ip_off + (Net.ipv4_size - Net.ipv4_payload_size) in
@@ -809,6 +814,8 @@ let suite =
       Alcotest.test_case "name: camelCase" `Quick test_name_camel;
       Alcotest.test_case "name: ALLCAPS" `Quick test_name_allcaps;
       Alcotest.test_case "name: single word" `Quick test_name_single;
+      Alcotest.test_case "name: validator entry point" `Quick
+        test_validator_name;
       (* end-to-end: generate -> EverParse -> compile -> call *)
       Alcotest.test_case "e2e: no params" `Slow test_e2e_no_params;
       Alcotest.test_case "e2e: offset bounds" `Slow test_e2e_offset_bounds;

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -863,7 +863,7 @@ let test_3d_codec_embed () =
   (* Inner struct must be defined *)
   Alcotest.(check bool)
     "inner struct defined" true
-    (contains ~sub:"typedef struct _Inner" output);
+    (contains ~sub:"typedef struct WireInner" output);
   (* Outer struct references Inner by name *)
   Alcotest.(check bool)
     "outer references Inner" true
@@ -944,7 +944,7 @@ let test_3d_tm_like () =
   (* Sub-codec should be referenced by name *)
   Alcotest.(check bool)
     "contains Packet typedef" true
-    (contains ~sub:"typedef struct _Packet" output);
+    (contains ~sub:"typedef struct WirePacket" output);
   (* Packet should be referenced in the TmLike struct *)
   Alcotest.(check bool)
     "Packet type referenced" true
@@ -1147,7 +1147,7 @@ let test_3d_param_embed () =
   in
   Alcotest.(check bool)
     "sub typedef carries the formal" true
-    (contains ~sub:"_PSub(UINT8 lim)" s);
+    (contains ~sub:"WirePSub(UINT8 lim)" s);
   Alcotest.(check bool)
     "use site applies the formal" true
     (contains ~sub:"PSub(lim) s" s)
@@ -1233,7 +1233,7 @@ let test_3d_byte_array_where () =
   let s = Wire.Everparse.Raw.to_3d schema.module_ in
   Alcotest.(check bool)
     "synth typedef present" true
-    (contains ~sub:"struct __RefByte_" s);
+    (contains ~sub:"struct Wire_RefByte_" s);
   Alcotest.(check bool)
     "field references synth" true
     (contains ~sub:"_RefByte_" s);


### PR DESCRIPTION
Committed .3d specs, dune.inc rules and EverParse C can no longer fall behind the codec they were generated from. Generated struct tags read as Wire<Name> instead of _<Name>, and both library and benchmark stubs follow the resulting validator symbol names.