### PR TITLE
docs: cover conditional groups and bare uint64

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ### Added
 
+- A bare `uint64` field now has end-to-end coverage through EverParse C
+  generation, so a regression in that projection fails the test suite
+  (#236, @samoht)
+
 - `Field.optional` over a sub-codec now documents how to make a whole field
   group conditional, keeping the group's byte-length prefix and dependent
   `Field.repeat` local to the group while later fields stay in the parent

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ### Added
 
+- `Field.optional` over a sub-codec now documents how to make a whole field
+  group conditional, keeping the group's byte-length prefix and dependent
+  `Field.repeat` local to the group while later fields stay in the parent
+  codec (#236, @samoht)
+
 - The full test suite now also runs under wasm_of_ocaml (31-bit int) and
   js_of_ocaml (32-bit int) on node in CI, so every codec keeps working on a
   narrow-int target, and the build fails if a new integer literal would be

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -401,7 +401,36 @@ module Field : sig
     'a typ ->
     'a option t
   (** [optional name ~present t] is a field present iff [present] evaluates to
-      [true]. Absent fields decode as [None] and consume zero bytes. *)
+      [true]. Absent fields decode as [None] and consume zero bytes.
+
+      To make a whole field group conditional, define the group as a sub-codec
+      and pass [codec group] as [t]. Expressions inside the group can refer to
+      its earlier fields, so the group may start with a byte-length prefix
+      followed by {!repeat}; fields after the optional group remain in the
+      parent codec. This shape projects to 3D as a gate-selected sub-codec.
+
+      {[
+      type ext = { len : int; items : int list }
+
+      let f_ext_len = Field.v "ExtLen" uint8
+
+      let ext_codec =
+        Codec.v "Ext"
+          (fun len items -> { len; items })
+          Codec.
+            [
+              (f_ext_len $ fun e -> e.len);
+              ( Field.repeat "ExtItems" ~size:(Field.ref f_ext_len) uint8
+              $ fun e -> e.items );
+            ]
+
+      let f_gate = Field.v "Gate" uint8
+
+      let f_ext =
+        Field.optional "Ext"
+          ~present:Expr.(Field.ref f_gate <> int 0)
+          (codec ext_codec)
+      ]} *)
 
   val optional_or :
     string ->

--- a/test/3d/test_wire_3d.ml
+++ b/test/3d/test_wire_3d.ml
@@ -1361,6 +1361,27 @@ let test_optional_length_prefixed_group_projects () =
       (Sys.file_exists (Filename.concat dir "ProjectedTransferSegment.c"))
   end
 
+(* A bare UINT64 field was once reported as failing EverParse extraction.
+   [generate_c] runs the whole pipeline (F* verification, then C extraction)
+   and raises if EverParse rejects the module, so this pins the shape rather
+   than only its rendering. *)
+let test_bare_uint64_projects () =
+  if not (Wire_3d.has_3d_exe ()) then ()
+  else begin
+    let codec =
+      Codec.v "BareUint64"
+        (fun value -> value)
+        Codec.[ Field.v "value" uint64 $ Fun.id ]
+    in
+    let dir = Filename.temp_dir "wire_3d_bare_uint64" "" in
+    let schema = Everparse.project ~mode:`Ffi codec in
+    Wire_3d.generate_3d ~outdir:dir [ schema ];
+    Wire_3d.generate_c ~outdir:dir [ schema ];
+    Alcotest.(check bool)
+      "C generated for bare uint64" true
+      (Sys.file_exists (Filename.concat dir "BareUint64.c"))
+  end
+
 (* A [nested ~size] / [nested_at_most] field projects through EverParse:
    byte-span and enum inners go through a synthesised wrapper struct, and scalar
    and sub-record inners render inline (rather than as an extern setter param
@@ -1468,6 +1489,7 @@ let suite =
         test_field_optional_byte_array;
       Alcotest.test_case "optional length-prefixed group projects" `Slow
         test_optional_length_prefixed_group_projects;
+      Alcotest.test_case "bare uint64 projects" `Slow test_bare_uint64_projects;
       Alcotest.test_case "nested field projects through EverParse" `Slow
         test_nested_field_projects;
       Alcotest.test_case "e2e: compile + run across naming conventions" `Slow

--- a/test/3d/test_wire_3d.ml
+++ b/test/3d/test_wire_3d.ml
@@ -1318,6 +1318,49 @@ let test_field_optional_byte_array () =
   Alcotest.(check bool)
     "byte-size suffix uses inner size" true (contains out "8")
 
+(* A gate-selected sub-codec may contain a group-local length followed by a
+   repeat and still leave later fields in the parent. Run the full EverParse
+   extraction here: rendering alone would not catch an invalid casetype or
+   dependent repeat in the generated F*. *)
+let test_optional_length_prefixed_group_projects () =
+  if not (Wire_3d.has_3d_exe ()) then ()
+  else begin
+    let f_ext_len = Field.v "ext_items_len" uint8 in
+    let extensions =
+      Codec.v "ProjectedTransferExtensions"
+        (fun len items -> (len, items))
+        Codec.
+          [
+            f_ext_len $ fst;
+            Field.repeat "ext_items" ~size:(Field.ref f_ext_len) uint8 $ snd;
+          ]
+    in
+    let f_start = Field.v "start" uint8 in
+    let f_data_len = Field.v "data_len" uint8 in
+    let codec =
+      Codec.v "ProjectedTransferSegment"
+        (fun start ext data_len data -> (start, ext, data_len, data))
+        Codec.
+          [
+            (f_start $ fun (start, _, _, _) -> start);
+            ( Field.optional "extensions"
+                ~present:Expr.(Field.ref f_start <> int 0)
+                (codec extensions)
+            $ fun (_, ext, _, _) -> ext );
+            (f_data_len $ fun (_, _, data_len, _) -> data_len);
+            ( Field.v "data" (byte_array ~size:(Field.ref f_data_len))
+            $ fun (_, _, _, data) -> data );
+          ]
+    in
+    let dir = Filename.temp_dir "wire_3d_optional_group" "" in
+    let schema = Everparse.project ~mode:`Ffi codec in
+    Wire_3d.generate_3d ~outdir:dir [ schema ];
+    Wire_3d.generate_c ~outdir:dir [ schema ];
+    Alcotest.(check bool)
+      "C generated for conditional group" true
+      (Sys.file_exists (Filename.concat dir "ProjectedTransferSegment.c"))
+  end
+
 (* A [nested ~size] / [nested_at_most] field projects through EverParse:
    byte-span and enum inners go through a synthesised wrapper struct, and scalar
    and sub-record inners render inline (rather than as an extern setter param
@@ -1423,6 +1466,8 @@ let suite =
         test_array_rejects_unsized_elem;
       Alcotest.test_case "Field.optional: byte_array inner projects" `Quick
         test_field_optional_byte_array;
+      Alcotest.test_case "optional length-prefixed group projects" `Slow
+        test_optional_length_prefixed_group_projects;
       Alcotest.test_case "nested field projects through EverParse" `Slow
         test_nested_field_projects;
       Alcotest.test_case "e2e: compile + run across naming conventions" `Slow

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -683,6 +683,81 @@ let test_optional_self_delimiting_codec () =
   Alcotest.(check int) "absent size" 1 n;
   Alcotest.(check (option string)) "absent desc" None d.desc
 
+(* A conditional group can carry its own length prefix and dependent list.
+   Keeping those fields in a sub-codec lets their expressions stay local to
+   the group, while a following payload remains in the parent codec. This is
+   the shape of an optional secondary header that declares its own length. *)
+type transfer_extensions = { items_len : int; items : int list }
+
+let transfer_extensions_codec =
+  let f_len = Field.v "ext_items_len" uint8 in
+  let f_items = Field.repeat "ext_items" ~size:(Field.ref f_len) uint8 in
+  Codec.v "TransferExtensions"
+    (fun items_len items -> { items_len; items })
+    Codec.[ (f_len $ fun r -> r.items_len); (f_items $ fun r -> r.items) ]
+
+type transfer_segment = {
+  start : int;
+  extensions : transfer_extensions option;
+  data_len : int;
+  data : string;
+}
+
+let transfer_segment_codec =
+  let f_start = Field.v "start" uint8 in
+  let f_extensions =
+    Field.optional "extensions"
+      ~present:Expr.(Field.ref f_start <> int 0)
+      (codec transfer_extensions_codec)
+  in
+  let f_data_len = Field.v "data_len" uint8 in
+  let f_data = Field.v "data" (byte_array ~size:(Field.ref f_data_len)) in
+  Codec.v "TransferSegment"
+    (fun start extensions data_len data ->
+      { start; extensions; data_len; data })
+    Codec.
+      [
+        (f_start $ fun r -> r.start);
+        (f_extensions $ fun r -> r.extensions);
+        (f_data_len $ fun r -> r.data_len);
+        (f_data $ fun r -> r.data);
+      ]
+
+let test_optional_length_prefixed_group () =
+  let present =
+    {
+      start = 1;
+      extensions = Some { items_len = 2; items = [ 0xA1; 0xB2 ] };
+      data_len = 3;
+      data = "xyz";
+    }
+  in
+  let n, decoded = roundtrip transfer_segment_codec present in
+  Alcotest.(check int) "present size" 8 n;
+  Alcotest.(check (list int))
+    "extension items" [ 0xA1; 0xB2 ] (Option.get decoded.extensions).items;
+  Alcotest.(check string) "following data" "xyz" decoded.data;
+  let absent = { start = 0; extensions = None; data_len = 2; data = "ok" } in
+  let n, decoded = roundtrip transfer_segment_codec absent in
+  Alcotest.(check int) "absent size" 4 n;
+  Alcotest.(check bool)
+    "extensions absent" true
+    (Option.is_none decoded.extensions);
+  Alcotest.(check string) "following data" "ok" decoded.data;
+  let out = render_3d transfer_segment_codec in
+  Alcotest.(check bool)
+    "group is its own struct" true
+    (contains ~sub:"typedef struct WireTransferExtensions" out);
+  Alcotest.(check bool)
+    "group-local dependent repeat" true
+    (contains ~sub:"UINT8 ext_items[:byte-size ext_items_len]" out);
+  Alcotest.(check bool)
+    "group is gate-selected" true
+    (contains ~sub:"Opt_TransferExtensions(" out);
+  Alcotest.(check bool)
+    "later fields stay in the parent" true
+    (contains ~sub:"UINT8 data[:byte-size data_len]" out)
+
 (* Wire.array over a fixed byte_array element: a fixed-count list of n-byte
    chunks (e.g. an array of IPv4 addresses). Used to project a double
    [:byte-size]; the element is now emitted as bare bytes under the budget. *)
@@ -5949,6 +6024,8 @@ let suite =
         test_optional_var_byte_array;
       Alcotest.test_case "optional: self-delimiting codec inner roundtrip"
         `Quick test_optional_self_delimiting_codec;
+      Alcotest.test_case "optional: length-prefixed group roundtrip" `Quick
+        test_optional_length_prefixed_group;
       Alcotest.test_case "repeat: byte_array element roundtrip" `Quick
         test_repeat_byte_array_element;
       Alcotest.test_case "repeat: byte_array element projection" `Quick


### PR DESCRIPTION
Document the supported optional length-prefixed group pattern and exercise it through OCaml round-tripping and EverParse extraction. Also pin bare uint64 extraction with a non-batch regression.