### PR TITLE
codec: harden construction and parameter errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,11 @@
 
 ### Fixed
 
+- Codec operations now reject a `Param.env` created for another codec before
+  reading its positional slots. This applies consistently to encode, decode,
+  validation, and staged getters, including codecs whose parameter counts
+  happen to match.
+
 - Casetype projection and `Param.bind` now translate unfittable `uint32`,
   `uint63`, and `uint` values into contextual `Invalid_argument` exceptions
   naming the case index or parameter, instead of leaking an Optint `Failure` on

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,11 @@
 
 ### Fixed
 
+- `Codec.v` now reports a clear construction error when a byte-size product
+  `field * constant` has a simple `field <= bound` constraint whose maximum can
+  reach EverParse's `2^32` limit. Products without this conclusive shape remain
+  deferred to EverParse, avoiding speculative rejections.
+
 - `dune runtest` now diffs a package's committed `.3d` specs and `dune.inc`
   against freshly generated ones, so editing a codec without refreshing them
   fails with a promotable report instead of leaving a stale spec committed

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,11 @@
 
 ### Fixed
 
+- Casetype projection and `Param.bind` now translate unfittable `uint32`,
+  `uint63`, and `uint` values into contextual `Invalid_argument` exceptions
+  naming the case index or parameter, instead of leaking an Optint `Failure` on
+  narrow-int targets.
+
 - `Codec.v` now reports a clear construction error when a byte-size product
   `field * constant` has a simple `field <= bound` constraint whose maximum can
   reach EverParse's `2^32` limit. Products without this conclusive shape remain

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -3489,6 +3489,11 @@ let unbound_params (t : 'r t) (env : Param.env) : string list =
 let has_input_params (t : 'r t) =
   List.exists (fun (Param.Pack p) -> not p.Types.mutable_) t.param_handles
 
+let check_env_owner ~op t (env : Param.env) =
+  if env.codec_id <> t.id then
+    Fmt.invalid_arg "Codec.%s: env was not created by Codec.env for %S" op
+      t.name
+
 let require_env ~op t = function
   | None when not (has_input_params t) -> ()
   | None ->
@@ -3497,6 +3502,7 @@ let require_env ~op t = function
          Param.bind p N])."
         op t.name
   | Some env -> (
+      check_env_owner ~op t env;
       match unbound_params t env with
       | [] -> ()
       | missing ->
@@ -3609,8 +3615,9 @@ let to_struct t =
   | [], None -> struct' t.name t.struct_fields
   | _ -> param_struct t.name formals ?where:t.where t.struct_fields
 
-let validate ?env (t : _ t) buf off =
-  let env_slots = Option.map (fun (e : Param.env) -> e.slots) env in
+let validate ?env:e (t : _ t) buf off =
+  require_env ~op:"validate" t e;
+  let env_slots = Option.map (fun (env : Param.env) -> env.slots) e in
   t.validate ?env_slots buf off
 
 (* Build a staged reader from field type and access info.
@@ -3734,6 +3741,7 @@ let field_access (codec : _ t) name =
 
 let[@inline] get (type a r) ?env (codec : r t) (f : (a, r) field) :
     (bytes -> int -> a) Staged.t =
+  Option.iter (check_env_owner ~op:"get" codec) env;
   let access = field_access codec f.name in
   let read = build_staged_reader f.typ access in
   match List.assoc_opt f.name codec.field_actions with
@@ -3752,9 +3760,6 @@ let[@inline] get (type a r) ?env (codec : r t) (f : (a, r) field) :
         match env with
         | None -> ((fun _arr -> ()), fun _arr -> ())
         | Some (e : Param.env) ->
-            if e.codec_id <> codec.id then
-              Fmt.invalid_arg
-                "Codec.get: env was not created by Codec.env for %S" codec.name;
             let param_handles = codec.param_handles in
             let param_base = codec.param_base in
             ( (fun arr ->

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -3011,6 +3011,106 @@ let reject_nested_where name fields =
       check_typ (Option.value ~default:"<anon>" f.field_name) f.field_typ)
     fields
 
+(* EverParse represents byte sizes as [u32]. Its verifier rejects a product
+   [count * width] when the declared upper bound permits 2^32 or more, but the
+   resulting F* diagnostic points into generated code. Recognise only the
+   deliberately narrow, certain case: a literal coefficient multiplied by a
+   field with a simple [field <= K] constraint. Everything else stays with
+   EverParse so this diagnostic cannot create false positives. *)
+let min_known_bound a b =
+  match (a, b) with
+  | None, x | x, None -> x
+  | Some a, Some b -> Some (Int.min a b)
+
+let rec simple_upper_bound field : bool expr -> int option = function
+  | Le (Ref (I, candidate), Int bound) when String.equal field candidate ->
+      Some bound
+  | And (a, b) ->
+      min_known_bound (simple_upper_bound field a) (simple_upper_bound field b)
+  | _ -> None
+
+let byte_size_bound_for fields field =
+  List.fold_left
+    (fun bound (Types.Field f) ->
+      match (f.field_name, f.constraint_) with
+      | Some candidate, Some constraint_ when String.equal field candidate ->
+          min_known_bound bound (simple_upper_bound field constraint_)
+      | _ -> bound)
+    None fields
+
+let reject_byte_size_product name fields sized_field field coefficient =
+  match byte_size_bound_for fields field with
+  | Some bound when bound >= 0 && coefficient > 0 ->
+      let limit = 0x1_0000_0000L in
+      let coefficient64 = Int64.of_int coefficient in
+      let first_overflowing_bound =
+        let quotient = Int64.div limit coefficient64 in
+        if Int64.rem limit coefficient64 = 0L then quotient
+        else Int64.succ quotient
+      in
+      if Int64.compare (Int64.of_int bound) first_overflowing_bound >= 0 then
+        Fmt.invalid_arg
+          "Codec.v %S: byte-size for field %S multiplies %S (bounded by <= %d) \
+           by %d, which permits at least 2^32 bytes; tighten the field bound \
+           for EverParse's u32 byte-size limit"
+          name sized_field field bound coefficient
+  | _ -> ()
+
+let rec check_byte_size_expr name fields sized_field : int expr -> unit =
+  function
+  | Mul (Ref (I, field), Int coefficient) | Mul (Int coefficient, Ref (I, field))
+    ->
+      reject_byte_size_product name fields sized_field field coefficient
+  | Add (a, b)
+  | Sub (a, b)
+  | Mul (a, b)
+  | Div (a, b)
+  | Mod (a, b)
+  | Land (a, b)
+  | Lor (a, b)
+  | Lxor (a, b)
+  | Lsl (a, b)
+  | Lsr (a, b) ->
+      check_byte_size_expr name fields sized_field a;
+      check_byte_size_expr name fields sized_field b
+  | Lnot a | Cast (_, a) -> check_byte_size_expr name fields sized_field a
+  | If_then_else (_, a, b) ->
+      check_byte_size_expr name fields sized_field a;
+      check_byte_size_expr name fields sized_field b
+  | Int _ | Ref _ | Param_ref _ | Sizeof _ | Sizeof_this | Field_pos -> ()
+
+let rec check_byte_size_typ : type a.
+    string -> Types.field list -> string -> a Types.typ -> unit =
+ fun name fields sized_field -> function
+  | Uint_var { size; _ }
+  | Byte_array { size }
+  | Byte_array_where { size; _ }
+  | Byte_slice { size }
+  | Single_elem { size; _ }
+  | Zeroterm_at_most { size }
+  | Repeat { size; _ } ->
+      check_byte_size_expr name fields sized_field size
+  | Map { inner; _ } -> check_byte_size_typ name fields sized_field inner
+  | Where { inner; _ } -> check_byte_size_typ name fields sized_field inner
+  | Apply { typ; _ } -> check_byte_size_typ name fields sized_field typ
+  | Optional { inner; _ } -> check_byte_size_typ name fields sized_field inner
+  | Optional_or { inner; _ } ->
+      check_byte_size_typ name fields sized_field inner
+  | _ -> ()
+
+let reject_certain_byte_size_mul name fields =
+  List.iter
+    (fun (Types.Field f) ->
+      check_byte_size_typ name fields
+        (Option.value ~default:"<anon>" f.field_name)
+        f.field_typ)
+    fields
+
+let reject_invalid_codec_shape name fields =
+  reject_greedy_not_last name fields;
+  reject_nested_where name fields;
+  reject_certain_byte_size_mul name fields
+
 let seal : type r. (r, r) record -> r t =
  fun (Record r) ->
   let codec_id = Atomic.fetch_and_add id_counter 1 in
@@ -3028,8 +3128,7 @@ let seal : type r. (r, r) record -> r t =
   let param_base = r.n_array_slots in
   (* Collect and index params *)
   let struct_fields = List.rev r.fields_rev in
-  reject_greedy_not_last r.name struct_fields;
-  reject_nested_where r.name struct_fields;
+  reject_invalid_codec_shape r.name struct_fields;
   let param_handles = collect_param_handles struct_fields r.where in
   let n_params = List.length param_handles in
   fill_param_slots r.param_slots param_base param_handles;

--- a/lib/codec.mli
+++ b/lib/codec.mli
@@ -72,11 +72,11 @@ val decode :
     If [?env] is supplied, input params are read from it and output params are
     written back to it after decoding.
 
-    Raises [Invalid_argument] when the codec has input params and no env is
-    supplied, or the env left any input param unbound (the error names the
-    offending param). An unbound input param would resolve a parametric field
-    size to 0 and silently truncate the field, so it is rejected up front the
-    same way {!encode} does. *)
+    Raises [Invalid_argument] when [?env] was created for a different codec,
+    when the codec has input params and no env is supplied, or when the env left
+    any input param unbound (the error names the offending param). An unbound
+    input param would resolve a parametric field size to 0 and silently truncate
+    the field, so it is rejected up front the same way {!encode} does. *)
 
 val decode_exn : ?env:Param.env -> 'r t -> bytes -> int -> 'r
 (** [decode_exn ?env c buf off] is like {!decode} but raises
@@ -115,10 +115,11 @@ val encode : ?env:Param.env -> 'r t -> 'r -> bytes -> int -> unit
     {!decode} when reading the bytes back, but [encode] does not need a prior
     decode to obtain it.
 
-    Raises [Invalid_argument] when the codec has parameters and no env is
-    supplied, when the env left any input param unbound (the error names the
-    offending param), when the destination buffer is too short, or when a
-    parametric byte field's value length does not match its env-bound size. *)
+    Raises [Invalid_argument] when [?env] was created for a different codec,
+    when the codec has parameters and no env is supplied, when the env left any
+    input param unbound (the error names the offending param), when the
+    destination buffer is too short, or when a parametric byte field's value
+    length does not match its env-bound size. *)
 
 val to_struct : 'r t -> Types.struct_
 (** Project to a {!Types.struct_} declaration. *)
@@ -128,15 +129,18 @@ val validate : ?env:Param.env -> 'r t -> bytes -> int -> unit
     without constructing a record and without firing actions. [?env] supplies
     bindings for any [Param.input] referenced in those clauses.
 
-    Raises {!Types.Parse_error} on constraint/where-clause failure. *)
+    Raises [Invalid_argument] if [?env] belongs to another codec or leaves an
+    input parameter unbound, and {!Types.Parse_error} on constraint/where-clause
+    failure. *)
 
 val get :
   ?env:Param.env -> 'r t -> ('a, 'r) field -> (bytes -> int -> 'a) Staged.t
 (** [get ?env c f] is a staged zero-copy getter for field [f] in codec [c]. If
     [f] has an action, it fires on every read. [env] syncs output parameters
     after each action; fields without actions have zero overhead regardless of
-    [env]. Does not check record-level where-clauses or other fields'
-    constraints -- call {!validate} first on untrusted input. *)
+    [env]. An environment created for another codec raises [Invalid_argument].
+    Does not check record-level where-clauses or other fields' constraints --
+    call {!validate} first on untrusted input. *)
 
 val set : 'r t -> ('a, 'r) field -> (bytes -> int -> 'a -> unit) Staged.t
 (** Staged zero-copy field setter. Does not check constraints or fire actions --

--- a/lib/param.ml
+++ b/lib/param.ml
@@ -9,15 +9,22 @@ let pp ppf (p : (_, _) t) = Fmt.string ppf p.Types.name
    the relevant field. Avoids drift between the parallel cases. *)
 type 'a int_cvt = { fwd : 'a -> int; bwd : int -> 'a }
 
+exception Unfittable_native_int
+
+let optint_to_int to_int value =
+  match to_int value with
+  | value -> value
+  | exception (Failure _ | Invalid_argument _) -> raise Unfittable_native_int
+
 let rec int_cvt : type a. a Types.typ -> a int_cvt =
  fun typ ->
   let id : 'a int_cvt = { fwd = (fun v -> v); bwd = (fun v -> v) } in
   match typ with
   | Uint8 -> id
   | Uint16 _ -> id
-  | Uint_var _ -> { fwd = UInt63.to_int; bwd = UInt63.of_int }
-  | Uint32 _ -> { fwd = UInt32.to_int; bwd = UInt32.of_int }
-  | Uint63 _ -> { fwd = UInt63.to_int; bwd = UInt63.of_int }
+  | Uint_var _ -> { fwd = optint_to_int UInt63.to_int; bwd = UInt63.of_int }
+  | Uint32 _ -> { fwd = optint_to_int UInt32.to_int; bwd = UInt32.of_int }
+  | Uint63 _ -> { fwd = optint_to_int UInt63.to_int; bwd = UInt63.of_int }
   | Uint64 _ ->
       {
         fwd =
@@ -111,7 +118,14 @@ let env_idx (env : env) name =
   find 0
 
 let bind (p : ('a, input) t) (v : 'a) (env : env) : env =
-  let iv = to_int p.Types.typ v in
+  let iv =
+    match to_int p.Types.typ v with
+    | value -> value
+    | exception Unfittable_native_int ->
+        Fmt.invalid_arg
+          "Param.bind %S: value does not fit this platform's native int"
+          p.Types.name
+  in
   let slots = Array.copy env.slots in
   let bound = Array.copy env.bound in
   let i = env_idx env p.Types.name in

--- a/lib/param.mli
+++ b/lib/param.mli
@@ -29,7 +29,8 @@ val expr : ('a, 'k) t -> int Types.expr
 
 type env = Types.param_env
 (** Immutable parameter environment backed by a flat [int array]. Create one
-    with {!Codec.env}, bind inputs with {!bind}, read outputs with {!get}. *)
+    with {!Codec.env}, bind inputs with {!bind}, read outputs with {!get}. An
+    environment belongs to that codec and cannot be used with another one. *)
 
 val bind : ('a, input) t -> 'a -> env -> env
 (** [bind p v env] returns an environment with input [p] set to [v].

--- a/lib/param.mli
+++ b/lib/param.mli
@@ -32,7 +32,10 @@ type env = Types.param_env
     with {!Codec.env}, bind inputs with {!bind}, read outputs with {!get}. *)
 
 val bind : ('a, input) t -> 'a -> env -> env
-(** [bind p v env] returns an environment with input [p] set to [v]. *)
+(** [bind p v env] returns an environment with input [p] set to [v].
+
+    Raises [Invalid_argument] naming [p] if [v] cannot fit the platform's native
+    integer representation used by parameter environments. *)
 
 val bind_by_name : string -> int -> env -> env
 (** [bind_by_name name v env] binds the input parameter called [name] to the

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -1098,6 +1098,25 @@ let is_int_dispatch_typ : type a. a typ -> bool = function
       true
   | _ -> false
 
+let uint32_case_index k =
+  match UInt32.to_int k with
+  | index -> index
+  | exception (Failure _ | Invalid_argument _) ->
+      let index =
+        UInt32.to_int32 k |> Int64.of_int32 |> Int64.logand 0xFFFF_FFFFL
+      in
+      Fmt.invalid_arg
+        "Wire.casetype: case index %Ld does not fit this platform's native int"
+        index
+
+let uint63_case_index k =
+  match UInt63.to_int k with
+  | index -> index
+  | exception (Failure _ | Invalid_argument _) ->
+      Fmt.invalid_arg
+        "Wire.casetype: case index %a does not fit this platform's native int"
+        UInt63.pp k
+
 (* Project a case-branch discriminator value of type ['k] to a 3D constant
    expression. Only called for int-shaped tags; non-int tags don't reach
    here because their casetype field is rewritten away before
@@ -1107,9 +1126,9 @@ let case_index_to_expr : type k. k typ -> k -> packed_expr =
   match tag_typ with
   | Uint8 -> Pack_expr (Int k)
   | Uint16 _ -> Pack_expr (Int k)
-  | Uint32 _ -> Pack_expr (Int (UInt32.to_int k))
-  | Uint63 _ -> Pack_expr (Int (UInt63.to_int k))
-  | Uint_var _ -> Pack_expr (Int (UInt63.to_int k))
+  | Uint32 _ -> Pack_expr (Int (uint32_case_index k))
+  | Uint63 _ -> Pack_expr (Int (uint63_case_index k))
+  | Uint_var _ -> Pack_expr (Int (uint63_case_index k))
   | Int8 -> Pack_expr (Int k)
   | Int16 _ -> Pack_expr (Int k)
   | Int32 _ -> Pack_expr (Int k)

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -153,7 +153,10 @@ module Param : sig
       read outputs with {!get}. *)
 
   val bind : ('a, input) t -> 'a -> env -> env
-  (** [bind p v env] returns an environment with input [p] set to [v]. *)
+  (** [bind p v env] returns an environment with input [p] set to [v].
+
+      Raises [Invalid_argument] naming [p] if [v] cannot fit the platform's
+      native integer representation used by parameter environments. *)
 
   val bind_by_name : string -> int -> env -> env
   (** [bind_by_name name v env] binds the input parameter called [name] to the
@@ -787,7 +790,9 @@ val default :
 val casetype : string -> 'k typ -> ('a, 'k) case_def list -> 'a typ
 (** [casetype name tag defs] is a tag-dispatched union. The discriminator typ
     ['k] can be an integer, a string, or any other typ with decidable equality;
-    every case must supply an explicit [~index]. *)
+    every case must supply an explicit [~index]. Projecting an integer-tagged
+    casetype raises [Invalid_argument] naming the case index when it cannot fit
+    the platform's native integer representation. *)
 
 val size : 'a typ -> int option
 (** [size t] is the fixed wire size of a description, if known statically. *)

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -697,7 +697,13 @@ val array_seq : ('a, 'seq) seq_map -> len:int expr -> 'a typ -> 'seq typ
 *)
 
 val byte_array : size:int expr -> string typ
-(** Fixed-size byte sequence copied as a string. *)
+(** Fixed-size byte sequence copied as a string.
+
+    When [size] contains the simple product of a field and a literal, and that
+    field has a simple [field <= bound] constraint, {!Codec.v} rejects the codec
+    if [bound * literal] can reach [2^32]. EverParse represents byte sizes as
+    [u32] and cannot verify such a schema; tighten the field bound. More complex
+    bounds are left to EverParse. *)
 
 val byte_array_where :
   size:int expr -> per_byte:(int expr -> bool expr) -> string typ

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -150,7 +150,8 @@ module Param : sig
 
   type env = Param.env
   (** Parameter environment. Create with {!Codec.env}, bind inputs with {!bind},
-      read outputs with {!get}. *)
+      read outputs with {!get}. An environment belongs to that codec and cannot
+      be used with another one. *)
 
   val bind : ('a, input) t -> 'a -> env -> env
   (** [bind p v env] returns an environment with input [p] set to [v].
@@ -1019,10 +1020,11 @@ module Codec : sig
       If [?env] is supplied, input params are read from it and output params are
       written back to it on success.
 
-      Raises [Invalid_argument] when the codec has input params and the env is
-      missing or leaves one unbound, the same precondition {!encode} enforces:
-      an unbound input param would resolve a parametric field size to 0 and
-      silently truncate the field. *)
+      Raises [Invalid_argument] when [?env] was created for a different codec,
+      or when the codec has input params and the env is missing or leaves one
+      unbound, the same precondition {!encode} enforces: an unbound input param
+      would resolve a parametric field size to 0 and silently truncate the
+      field. *)
 
   val decode_exn : ?env:Param.env -> 'r t -> bytes -> int -> 'r
   (** Like {!decode} but raises {!exception:Parse_error} on failure. *)
@@ -1036,23 +1038,26 @@ module Codec : sig
       [?env] (built with [Codec.env c |> Param.bind p N]). The bound widths must
       match the field values in [r]; the encoder cross-checks them.
 
-      Raises [Invalid_argument] when the codec has parameters and no env is
-      supplied, when the env left any input param unbound (the error names it),
-      when the destination buffer is too short, or when a parametric byte
-      field's value length does not match its env-bound size. *)
+      Raises [Invalid_argument] when [?env] was created for a different codec,
+      when the codec has parameters and no env is supplied, when the env left
+      any input param unbound (the error names it), when the destination buffer
+      is too short, or when a parametric byte field's value length does not
+      match its env-bound size. *)
 
   val validate : ?env:Param.env -> 'r t -> bytes -> int -> unit
   (** [validate ?env c buf off] checks field [~constraint_] and [~where] clauses
       without constructing a record and without firing actions. [?env] supplies
       bindings for any {!val:Param.input} referenced in those clauses.
 
-      Raises {!Validation_error} on failure. *)
+      Raises [Invalid_argument] when [?env] belongs to another codec or leaves
+      an input parameter unbound, and {!Validation_error} on failure. *)
 
   val get :
     ?env:Param.env -> 'r t -> ('a, 'r) field -> (bytes -> int -> 'a) Staged.t
   (** Staged field reader. If the field has an [~action], the action fires on
-      every read. Pass [~env] to sync output parameters after each action.
-      Fields without actions have zero overhead regardless of [~env].
+      every read. Pass [~env] to sync output parameters after each action. An
+      environment created for another codec raises [Invalid_argument]. Fields
+      without actions have zero per-read overhead regardless of [~env].
 
       Does not check [~where] clauses or other fields' constraints -- call
       {!validate} first on untrusted input. *)

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -2418,6 +2418,55 @@ let test_bitfield_on_non_bitfield () =
   | _ -> Alcotest.fail "expected error for non-bitfield"
   | exception Invalid_argument _ -> ()
 
+let expect_foreign_env ~op ~codec f =
+  match f () with
+  | _ -> Alcotest.failf "expected Invalid_argument from %s" op
+  | exception Invalid_argument msg ->
+      Alcotest.(check bool) "names the operation" true (contains ~sub:op msg);
+      Alcotest.(check bool) "names the codec" true (contains ~sub:codec msg)
+
+let test_foreign_env_codec_operations () =
+  let p_a = Param.input "limit_a" uint8 in
+  let f_a = Field.v "v" uint8 in
+  let codec_a =
+    Codec.v "EnvA"
+      ~where:Expr.(Field.ref f_a <= Param.expr p_a)
+      Fun.id
+      Codec.[ f_a $ Fun.id ]
+  in
+  let p_b = Param.input "limit_b" uint8 in
+  let f_b = Field.v "v" uint8 in
+  let codec_b =
+    Codec.v "EnvB"
+      ~where:Expr.(Field.ref f_b <= Param.expr p_b)
+      Fun.id
+      Codec.[ f_b $ Fun.id ]
+  in
+  let env_b = Codec.env codec_b |> Param.bind p_b 0xff in
+  let buf = Bytes.of_string "\x01" in
+  expect_foreign_env ~op:"Codec.encode" ~codec:"EnvA" (fun () ->
+      Codec.encode ~env:env_b codec_a 1 buf 0);
+  expect_foreign_env ~op:"Codec.decode" ~codec:"EnvA" (fun () ->
+      Codec.decode ~env:env_b codec_a buf 0);
+  expect_foreign_env ~op:"Codec.validate" ~codec:"EnvA" (fun () ->
+      Codec.validate ~env:env_b codec_a buf 0);
+  let p_c = Param.input "limit_c" uint8 in
+  let p_d = Param.input "floor_d" uint8 in
+  let f_c = Field.v "v" uint8 in
+  let codec_c =
+    Codec.v "EnvC"
+      ~where:
+        Expr.(
+          Field.ref f_c <= Param.expr p_c && Field.ref f_c >= Param.expr p_d)
+      Fun.id
+      Codec.[ f_c $ Fun.id ]
+  in
+  let env_a = Codec.env codec_a |> Param.bind p_a 0xff in
+  expect_foreign_env ~op:"Codec.encode" ~codec:"EnvC" (fun () ->
+      Codec.encode ~env:env_a codec_c 1 buf 0);
+  expect_foreign_env ~op:"Codec.decode" ~codec:"EnvC" (fun () ->
+      Codec.decode ~env:env_a codec_c buf 0)
+
 let test_env_from_wrong_codec () =
   (* Using env from codec1 with get ~env on codec2 *)
   let out1 = Param.output "out_wrong" uint8 in
@@ -2433,12 +2482,8 @@ let test_env_from_wrong_codec () =
   let cf_v2 = Codec.(Field.v "v" uint8 $ fun v -> v) in
   let codec2 = Codec.v "Wrong2" (fun v -> v) [ cf_v2 ] in
   let env1 = Codec.env codec1 in
-  (* Use env1 (from codec1) with codec2's get -- should not crash *)
-  let get_v2 = Staged.unstage (Codec.get ~env:env1 codec2 cf_v2) in
-  (* No action on cf_v2, so env is ignored -- should work fine *)
-  Alcotest.(check int)
-    "wrong env ignored" 0x42
-    (get_v2 (Bytes.of_string "\x42") 0)
+  expect_foreign_env ~op:"Codec.get" ~codec:"Wrong2" (fun () ->
+      Codec.get ~env:env1 codec2 cf_v2)
 
 let test_env_wrongcodec_with_action () =
   (* Using env from a different codec with an action field.
@@ -6167,6 +6212,8 @@ let suite =
         test_set_field_notin_codec;
       Alcotest.test_case "misuse: bitfield on non-bitfield" `Quick
         test_bitfield_on_non_bitfield;
+      Alcotest.test_case "misuse: foreign env codec operations" `Quick
+        test_foreign_env_codec_operations;
       Alcotest.test_case "misuse: env from wrong codec" `Quick
         test_env_from_wrong_codec;
       Alcotest.test_case "misuse: wrong env with action" `Quick

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -671,6 +671,47 @@ let test_3d_field_sub_mul_rejected () =
     "constant arithmetic still projects" false
     (projects_or_raises constc)
 
+let test_3d_byte_size_mul_bound_rejected () =
+  let construct ~bound ~coeff =
+    let f_count =
+      Field.v "count" uint32 ~self_constraint:(fun count ->
+          Expr.(count <= int bound))
+    in
+    Codec.v "SizedProduct"
+      (fun count data -> (count, data))
+      Codec.
+        [
+          f_count $ fst;
+          Field.v "data" (byte_array ~size:Expr.(Field.ref f_count * int coeff))
+          $ snd;
+        ]
+  in
+  let rejected =
+    match construct ~bound:536_870_912 ~coeff:8 with
+    | _ -> false
+    | exception Invalid_argument msg ->
+        contains ~sub:"byte-size" msg && contains ~sub:"2^32" msg
+  in
+  Alcotest.(check bool) "2^32 maximum rejected clearly" true rejected;
+  Alcotest.(check bool)
+    "maximum below 2^32 remains projectable" false
+    (projects_or_raises (construct ~bound:536_870_911 ~coeff:8));
+  let f_count = Field.v "count" uint32 in
+  let unbounded =
+    Codec.v "UnboundedProduct"
+      (fun count data -> (count, data))
+      Codec.
+        [
+          f_count $ fst;
+          Field.v "data"
+            (byte_array ~size:Expr.(int max_int * Field.ref f_count))
+          $ snd;
+        ]
+  in
+  Alcotest.(check bool)
+    "unbounded products remain EverParse's decision" false
+    (projects_or_raises unbounded)
+
 let test_schema_authoritative () =
   (* [Everparse.project] is the projectability gate: a non-projectable constraint
      raises when the codec is projected, not only later when it is rendered, so
@@ -1388,6 +1429,8 @@ let suite =
         test_3d_arith_constraint_widens;
       Alcotest.test_case "3d: field sub/mul constraint rejected" `Quick
         test_3d_field_sub_mul_rejected;
+      Alcotest.test_case "3d: certain byte-size multiplication overflow" `Quick
+        test_3d_byte_size_mul_bound_rejected;
       Alcotest.test_case "3d: schema is the projectability gate" `Quick
         test_schema_authoritative;
       Alcotest.test_case "3d: array enum element decl" `Quick

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -119,6 +119,28 @@ let test_casetype_enum_tag_labels () =
     "no raw-integer case label" false
     (contains ~sub:"case 2:" output)
 
+let test_casetype_wide_index_error () =
+  let high = Wire.Private.UInt32.be (Bytes.of_string "\x80\x00\x00\x00") 0 in
+  let body =
+    casetype "WideIndex" uint32
+      [ case ~index:high empty ~inject:Fun.id ~project:Option.some ]
+  in
+  let render () =
+    to_3d
+      (module_ [ typedef (struct_ "WideIndexRecord" [ field "body" body ]) ])
+  in
+  if Sys.int_size > 32 then
+    Alcotest.(check bool)
+      "wide case index rendered" true
+      (contains ~sub:"2147483648" (render ()))
+  else
+    match render () with
+    | _ -> Alcotest.fail "expected an unfittable case-index error"
+    | exception Invalid_argument msg ->
+        Alcotest.(check bool)
+          "names the case index" true
+          (contains ~sub:"case index" msg)
+
 let test_pretty_print () =
   let simple =
     struct_ "Simple" [ field "a" uint8; field "b" uint16be; field "c" uint32 ]
@@ -1393,6 +1415,8 @@ let suite =
       Alcotest.test_case "generation: casetype" `Quick test_casetype;
       Alcotest.test_case "generation: casetype enum-tag labels" `Quick
         test_casetype_enum_tag_labels;
+      Alcotest.test_case "generation: wide casetype index error" `Quick
+        test_casetype_wide_index_error;
       Alcotest.test_case "generation: if_then_else projects" `Quick
         test_if_then_else_projects;
       Alcotest.test_case "generation: pretty print" `Quick test_pretty_print;

--- a/test/test_param.ml
+++ b/test/test_param.ml
@@ -39,6 +39,30 @@ let test_input_binding () =
   let env = Codec.env c |> Param.bind p 42 in
   Alcotest.(check int) "value" 42 (Param.get env p)
 
+let test_wide_input_binding_error () =
+  let p = Param.input "wide_limit" uint32 in
+  let f_x = Field.v "x" uint8 in
+  let c =
+    Codec.v "WideInputBinding"
+      ~where:Expr.(Field.ref f_x <= Param.expr p)
+      (fun x -> x)
+      Codec.[ f_x $ Fun.id ]
+  in
+  let high = Wire.Private.UInt32.be (Bytes.of_string "\x80\x00\x00\x00") 0 in
+  if Sys.int_size > 32 then begin
+    let env = Codec.env c |> Param.bind p high in
+    Alcotest.(check int32)
+      "wide value" Int32.min_int
+      (Wire.Private.UInt32.to_int32 (Param.get env p))
+  end
+  else
+    match Param.bind p high (Codec.env c) with
+    | _ -> Alcotest.fail "expected an unfittable parameter error"
+    | exception Invalid_argument msg ->
+        Alcotest.(check bool)
+          "names the parameter" true
+          (contains ~sub:"wide_limit" msg)
+
 let test_output_binding () =
   let out = Param.output "out" uint8 in
   let f_x = Field.v "x" uint8 in
@@ -403,6 +427,8 @@ let suite =
       Alcotest.test_case "output spec" `Quick test_output_spec;
       (* bindings *)
       Alcotest.test_case "input binding" `Quick test_input_binding;
+      Alcotest.test_case "wide input binding error" `Quick
+        test_wide_input_binding_error;
       Alcotest.test_case "output binding" `Quick test_output_binding;
       (* runtime: input params *)
       Alcotest.test_case "input param constraint" `Quick


### PR DESCRIPTION
Reject conclusive EverParse byte-size overflow during codec construction, attach field/parameter context when an integer cannot fit the native representation, and reject environments created for another codec across every operation.