### PR TITLE
codec: enforce exact container sizes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,10 @@
 
 ### Fixed
 
+- `array` and `array_seq` encoders now require exactly the declared number of
+  elements. Short values no longer leave zero-filled phantom elements, and long
+  values are rejected before any bytes are written.
+
 - Codec operations now reject a `Param.env` created for another codec before
   reading its positional slots. This applies consistently to encode, decode,
   validation, and staged getters, including codecs whose parameter counts

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,10 @@
 
 ### Fixed
 
+- `nested` now requires its inner value to consume exactly the declared region
+  on decode and encode. Use `nested_at_most` when trailing region padding is
+  intentional; it remains permissive and zero-pads on encode.
+
 - `Codec.v` now rejects duplicate field names and distinct parameter handles
   with the same name. Name-based field access and parameter environments can no
   longer silently alias the first declaration.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,21 +34,27 @@
 
 ### Fixed
 
+- `Codec.size_of_value` now reports the declared width of fixed-size
+  `byte_array`, `byte_array_where`, and `byte_slice` fields. Buffers allocated
+  from it now exactly fit the bytes written when short values are zero-padded or
+  long values are truncated (#238, @samoht)
+
 - `nested` now requires its inner value to consume exactly the declared region
   on decode and encode. Use `nested_at_most` when trailing region padding is
-  intentional; it remains permissive and zero-pads on encode.
+  intentional; it remains permissive and zero-pads on encode (#238, @samoht)
 
 - `Codec.v` now rejects duplicate field names and distinct parameter handles
   with the same name. Name-based field access and parameter environments can no
-  longer silently alias the first declaration.
+  longer silently alias the first declaration (#238, @samoht)
 
 - `Field.repeat` now consumes and emits exactly its declared byte budget.
   Fixed-width remainders, variable-width elements that cross the boundary, and
-  encode under/overshoots are rejected instead of being silently accepted.
+  encode under/overshoots are rejected instead of being silently accepted
+  (#238, @samoht)
 
 - `array` and `array_seq` encoders now require exactly the declared number of
   elements. Short values no longer leave zero-filled phantom elements, and long
-  values are rejected before any bytes are written.
+  values are rejected before any bytes are written (#238, @samoht)
 
 - Codec operations now reject a `Param.env` created for another codec before
   reading its positional slots. This applies consistently to encode, decode,

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,10 @@
 
 ### Fixed
 
+- `Field.repeat` now consumes and emits exactly its declared byte budget.
+  Fixed-width remainders, variable-width elements that cross the boundary, and
+  encode under/overshoots are rejected instead of being silently accepted.
+
 - `array` and `array_seq` encoders now require exactly the declared number of
   elements. Short values no longer leave zero-filled phantom elements, and long
   values are rejected before any bytes are written.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,10 @@
 
 ### Fixed
 
+- `Codec.v` now rejects duplicate field names and distinct parameter handles
+  with the same name. Name-based field access and parameter environments can no
+  longer silently alias the first declaration.
+
 - `Field.repeat` now consumes and emits exactly its declared byte budget.
   Fixed-width remainders, variable-width elements that cross the boundary, and
   encode under/overshoots are rejected instead of being silently accepted.

--- a/fuzz/gen/fuzz_gen.ml
+++ b/fuzz/gen/fuzz_gen.ml
@@ -3364,7 +3364,7 @@ let wrapper_gens =
     ("optional_or_dynamic", Pack optional_or_dynamic);
     ("nested(0,empty)", Pack (nested 0 empty));
     ("nested(2,uint16be)", Pack (nested 2 uint16be));
-    ("nested(4,uint16be)", Pack (nested 4 uint16be));
+    ("nested(4,byte_array4)", Pack (nested 4 (byte_array 4)));
     ("nested_at_most(0,empty)", Pack (nested_at_most 0 empty));
     ("nested_at_most(2,uint16be)", Pack (nested_at_most 2 uint16be));
     ("nested_at_most(4,uint16be)", Pack (nested_at_most 4 uint16be));
@@ -3802,7 +3802,7 @@ let expected_registry_labels =
     "optional_or_dynamic";
     "nested(0,empty)";
     "nested(2,uint16be)";
-    "nested(4,uint16be)";
+    "nested(4,byte_array4)";
     "nested_at_most(0,empty)";
     "nested_at_most(2,uint16be)";
     "nested_at_most(4,uint16be)";

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -33,7 +33,9 @@ let setter_off_int32 n set buf off v =
 
 (* Encode a value into a fixed [n]-byte region: write it with [enc], then
    zero-pad the remainder. Used for [nested] regions. *)
-let single_elem_pad n enc buf off v =
+let single_elem_region ~at_most n typ enc buf off v =
+  let actual = Types.size_of_typ_value typ v in
+  Types.check_nested_size ~at_most ~expected:n ~actual;
   let inner_end = enc buf off v in
   if inner_end < off + n then
     Bytes.fill buf inner_end (off + n - inner_end) '\x00';
@@ -190,8 +192,8 @@ and build_field_encoder : type a. a typ -> bytes -> int -> a -> int =
       bits_field_encoder ~width ~base ~bit_order
   (* A nested region (e.g. a casetype case body): encode the inner at the
      region start, then zero-pad the rest of the fixed [n]-byte region. *)
-  | Single_elem { size = Int n; elem; _ } ->
-      single_elem_pad n (build_field_encoder elem)
+  | Single_elem { size = Int n; elem; at_most } ->
+      single_elem_region ~at_most n elem (build_field_encoder elem)
   | _ ->
       (* Fallback for complex types - not specialized *)
       fun _buf _off _v -> failwith "build_field_encoder: unsupported type"
@@ -1982,7 +1984,12 @@ let var_bytes_reader : type a.
         s;
       s
   | Casetype _ -> read_elem typ buf (base + fo)
-  | Single_elem { elem; _ } -> read_elem elem buf (base + fo)
+  | Single_elem { elem; at_most; _ } ->
+      let first = base + fo in
+      let consumed = elem_size_of elem buf first in
+      if consumed > sz || ((not at_most) && consumed <> sz) then
+        raise_eof ~at:(first + min consumed sz) ~expected:sz ~got:consumed;
+      read_elem elem buf first
   | _ -> assert false
 
 (* Kept at top level: as local closures they would be heap-allocated on
@@ -2050,8 +2057,10 @@ let var_bytes_writer : type a r.
       Bytes.fill buf (write_off + len) (region - len) '\x00';
       write_off + region
   | Casetype _ -> build_field_encoder typ buf write_off value
-  | Single_elem { elem; _ } ->
+  | Single_elem { elem; at_most; _ } ->
       let n = size_fn buf base in
+      let actual = Types.size_of_typ_value elem value in
+      Types.check_nested_size ~at_most ~expected:n ~actual;
       let inner_end = build_field_encoder elem buf write_off value in
       if inner_end < write_off + n then
         Bytes.fill buf inner_end (write_off + n - inner_end) '\x00';

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -1824,6 +1824,9 @@ let repeat_raw_fixed : type elt seq.
      crashing [read_elem] with an out-of-range [Bytes.sub]. *)
   if budget < 0 || start + budget > Bytes.length buf then
     raise_eof ~at:start ~expected:(start + budget) ~got:(Bytes.length buf);
+  let remainder = if esz > 0 then budget mod esz else budget in
+  if remainder <> 0 then
+    raise_eof ~at:(start + budget - remainder) ~expected:esz ~got:remainder;
   let n = if esz > 0 then budget / esz else 0 in
   let rec loop acc i =
     if i >= n then seq.finish acc
@@ -1848,8 +1851,10 @@ let repeat_raw_variable : type elt seq.
   let rec loop acc pos remaining =
     if remaining <= 0 then seq.finish acc
     else
-      let v = read_elem elem buf pos in
       let esz = elem_size_of elem buf pos in
+      if esz <= 0 || esz > remaining then
+        raise_eof ~at:pos ~expected:esz ~got:remaining;
+      let v = read_elem elem buf pos in
       loop (seq.add acc v) (pos + esz) (remaining - esz)
   in
   loop seq.empty start budget
@@ -1875,7 +1880,7 @@ let compile_repeat : type elt seq r.
     elt typ ->
     (elt, seq) seq_map ->
     (seq, r) compiled_field =
- fun ctx fld size_expr elem (Seq_map seq) ->
+ fun ctx fld size_expr elem seq ->
   (* Same dynamic-offset dispatch as [compile_var_bytes] / [compile_codec]:
      when a [Repeat] sits after a variable-size field, the running offset is
      [Dynamic] and is resolved at runtime rather than from a static offset. *)
@@ -1899,23 +1904,22 @@ let compile_repeat : type elt seq r.
     | _ -> assert false
   in
   let elem_size = field_wire_size elem in
-  let raw_reader =
-    repeat_raw_reader (Seq_map seq) elem ~elem_size ~off_fn ~size_fn
-  in
+  let raw_reader = repeat_raw_reader seq elem ~elem_size ~off_fn ~size_fn in
   let get = fld.get in
-  let step =
-    match elem_size with
-    | Some esz -> fun _buf _pos -> esz
-    | None -> fun buf pos -> elem_size_of elem buf pos
-  in
-  let raw_writer v buf _base write_off =
+  let raw_writer v buf base write_off =
     let items = get v in
+    let expected = size_fn buf base in
+    let sized_items =
+      Types.exact_repeat_elements seq ~expected
+        ~size_of:(Types.size_of_typ_value elem)
+        items
+    in
     let pos = Stdlib.ref write_off in
-    seq.iter
-      (fun item ->
+    List.iter
+      (fun (item, size) ->
         write_elem elem buf !pos item;
-        pos := !pos + step buf !pos)
-      items;
+        pos := !pos + size)
+      sized_items;
     !pos
   in
   {

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -155,11 +155,12 @@ and build_field_encoder : type a. a typ -> bytes -> int -> a -> int =
   | Unit -> fun _buf off () -> off
   | Codec { codec_encode; _ } -> fun buf off v -> codec_encode v buf off
   | Casetype { tag; cases; _ } -> build_casetype_encoder tag cases
-  | Array { len = Int _; elem; seq = Seq_map s } ->
+  | Array { len = Int expected; elem; seq } ->
       let enc_elem = build_field_encoder elem in
       fun buf start_off vs ->
         let cur = Stdlib.ref start_off in
-        s.iter (fun v -> cur := enc_elem buf !cur v) vs;
+        Types.exact_array_elements seq ~expected vs
+        |> List.iter (fun v -> cur := enc_elem buf !cur v);
         !cur
   (* NUL-terminated string element / casetype case body: the bytes then a NUL.
      [zeroterm_at_most] pads the rest of its fixed [n]-byte region with zeros. *)

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -2860,14 +2860,18 @@ let build_validators validators_rev checkers_rev compiled_where struct_fields
   in
   (validate_arr, populate, validate)
 
-let collect_param_handles struct_fields where =
+let collect_param_handles codec_name struct_fields where =
   let seen = Hashtbl.create 4 in
   let handles = Stdlib.ref ([] : Param.packed list) in
   let visit (Param.Pack p as packed) =
-    if not (Hashtbl.mem seen p.name) then begin
-      Hashtbl.add seen p.name ();
-      handles := packed :: !handles
-    end
+    match Hashtbl.find_opt seen p.name with
+    | None ->
+        Hashtbl.add seen p.name packed;
+        handles := packed :: !handles
+    | Some (Param.Pack existing) ->
+        if not (Obj.repr p == Obj.repr existing) then
+          Fmt.invalid_arg "Codec.v %S: duplicate parameter name %S" codec_name
+            p.name
   in
   iter_param_refs_fields visit struct_fields where;
   List.rev !handles
@@ -3111,7 +3115,19 @@ let reject_certain_byte_size_mul name fields =
         f.field_typ)
     fields
 
+let reject_duplicate_field_names name fields =
+  let seen = Hashtbl.create (List.length fields) in
+  List.iter
+    (fun (Types.Field f) ->
+      match f.field_name with
+      | None -> ()
+      | Some field when Hashtbl.mem seen field ->
+          Fmt.invalid_arg "Codec.v %S: duplicate field name %S" name field
+      | Some field -> Hashtbl.add seen field ())
+    fields
+
 let reject_invalid_codec_shape name fields =
+  reject_duplicate_field_names name fields;
   reject_greedy_not_last name fields;
   reject_nested_where name fields;
   reject_certain_byte_size_mul name fields
@@ -3134,7 +3150,7 @@ let seal : type r. (r, r) record -> r t =
   (* Collect and index params *)
   let struct_fields = List.rev r.fields_rev in
   reject_invalid_codec_shape r.name struct_fields;
-  let param_handles = collect_param_handles struct_fields r.where in
+  let param_handles = collect_param_handles r.name struct_fields r.where in
   let n_params = List.length param_handles in
   fill_param_slots r.param_slots param_base param_handles;
   let n_total = param_base + n_params in
@@ -3381,7 +3397,7 @@ and validator_of_struct (s : Types.struct_) : validator =
     | Static n -> Fixed n
     | Dynamic f -> Variable { min_size = acc.min_size; compute = f }
   in
-  let param_handles = collect_param_handles s.fields s.where in
+  let param_handles = collect_param_handles s.name s.fields s.where in
   let n_params = List.length param_handles in
   let param_base = acc.n_array_slots in
   fill_param_slots acc.param_slots param_base param_handles;
@@ -3609,13 +3625,13 @@ let encode ?env:e t v buf off =
        spans %d -- writer wrote fewer bytes than promised"
       t.name expected actual
 
-let collect_params (fields : Types.field list) where =
-  collect_param_handles fields where
+let collect_params name (fields : Types.field list) where =
+  collect_param_handles name fields where
   |> List.map (fun (Param.Pack p) ->
       { param_name = p.name; param_typ = p.packed_typ; mutable_ = p.mutable_ })
 
 let to_struct t =
-  let formals = collect_params t.struct_fields t.where in
+  let formals = collect_params t.name t.struct_fields t.where in
   match (formals, t.where) with
   | [], None -> struct' t.name t.struct_fields
   | _ -> param_struct t.name formals ?where:t.where t.struct_fields

--- a/lib/codec.mli
+++ b/lib/codec.mli
@@ -59,7 +59,8 @@ val size_of_value : 'r t -> 'r -> int
     write. Computed from [v], not from a buffer: works for variable-size codecs
     whose tail is [all_bytes] / [rest_bytes] / [all_zeros], where the
     buffer-driven {!wire_size_at} cannot distinguish "value's tail" from
-    "remaining buffer space". *)
+    "remaining buffer space". Fixed-size byte arrays and slices contribute their
+    declared region size, including any zero-padding or truncation. *)
 
 val is_fixed : 'r t -> bool
 (** [is_fixed c] is [true] iff the codec [c] has a fixed wire size. *)

--- a/lib/codec.mli
+++ b/lib/codec.mli
@@ -40,7 +40,10 @@ val v :
 (** [v name constructor fields] seals a codec from a field list. [?doc] attaches
     a free-text note (e.g. an RFC citation) that the documentation projection
     renders as a [/*++ ... --*/] comment on the codec's 3D typedef; see
-    {!Everparse.project}. *)
+    {!Everparse.project}.
+
+    Raises [Invalid_argument] if two fields have the same name, or if distinct
+    parameter handles referenced by the codec have the same name. *)
 
 val wire_size : 'r t -> int
 (** Fixed wire size in bytes. Raises if variable-length. *)

--- a/lib/field.mli
+++ b/lib/field.mli
@@ -85,8 +85,9 @@ val repeat :
   size:int Types.expr ->
   'a Types.typ ->
   'a list t
-(** [repeat name ~size t] parses elements of type [t] until [size] bytes have
-    been consumed. *)
+(** [repeat name ~size t] parses elements of type [t] until exactly [size] bytes
+    have been consumed. Encoding rejects values whose encoded size differs from
+    the budget. *)
 
 val repeat_seq :
   string ->
@@ -98,7 +99,7 @@ val repeat_seq :
   size:int Types.expr ->
   'a Types.typ ->
   'seq t
-(** Repeat with a custom sequence builder. *)
+(** Repeat with a custom sequence builder and the same exact byte budget. *)
 
 val anon : 'a Types.typ -> 'a anon
 (** [anon typ] creates an anonymous (padding) field. *)

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -475,6 +475,19 @@ let seq_list : ('a, 'a list) seq_map =
       iter = List.iter;
     }
 
+let exact_array_elements (type a seq) (Seq_map s : (a, seq) seq_map) ~expected
+    (values : seq) =
+  let actual = Stdlib.ref 0 in
+  let elements = Stdlib.ref [] in
+  s.iter
+    (fun value ->
+      incr actual;
+      elements := value :: !elements)
+    values;
+  if !actual <> expected then
+    Fmt.invalid_arg "Wire.array: expected %d elements, got %d" expected !actual;
+  List.rev !elements
+
 (* The 3D projection of [array]/[optional]/[optional_or]/[repeat] turns
    their length / predicate / byte budget into a [byte-size] suffix.
    That works as long as the wrapped element exposes a wire size we can
@@ -2898,6 +2911,11 @@ let rec size_of_typ_value : type a. a typ -> a -> int =
       let total = Stdlib.ref 0 in
       s.iter (fun e -> total := !total + size_of_typ_value elem e) v;
       !total
+  | Array { len = Int expected; elem; seq } ->
+      exact_array_elements seq ~expected v
+      |> List.fold_left
+           (fun total value -> total + size_of_typ_value elem value)
+           0
   | Array { elem; seq = Seq_map s; _ } ->
       let total = Stdlib.ref 0 in
       s.iter (fun e -> total := !total + size_of_typ_value elem e) v;

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -498,6 +498,14 @@ let exact_repeat_elements seq ~expected ~size_of values =
     Fmt.invalid_arg "Wire.repeat: expected %d bytes, got %d" expected actual;
   sized
 
+let check_nested_size ~at_most ~expected ~actual =
+  if actual > expected then
+    Fmt.invalid_arg "Wire.nested%s: region is %d bytes, value needs %d"
+      (if at_most then "_at_most" else "")
+      expected actual;
+  if (not at_most) && actual <> expected then
+    Fmt.invalid_arg "Wire.nested: expected %d bytes, got %d" expected actual
+
 (* The 3D projection of [array]/[optional]/[optional_or]/[repeat] turns
    their length / predicate / byte budget into a [byte-size] suffix.
    That works as long as the wrapped element exposes a wire size we can
@@ -2912,7 +2920,10 @@ let rec size_of_typ_value : type a. a typ -> a -> int =
          the runtime gate would have said at decode. *)
       size_of_typ_value inner v
   | Codec { codec_size_of_value; _ } -> codec_size_of_value v
-  | Single_elem { size = Int n; _ } -> n
+  | Single_elem { size = Int n; elem; at_most } ->
+      let actual = size_of_typ_value elem v in
+      check_nested_size ~at_most ~expected:n ~actual;
+      n
   | Single_elem _ -> 0
   | Repeat { size = Int expected; elem; seq } ->
       exact_repeat_elements seq ~expected ~size_of:(size_of_typ_value elem) v

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -475,18 +475,28 @@ let seq_list : ('a, 'a list) seq_map =
       iter = List.iter;
     }
 
-let exact_array_elements (type a seq) (Seq_map s : (a, seq) seq_map) ~expected
-    (values : seq) =
-  let actual = Stdlib.ref 0 in
+let sequence_elements (type a seq) (Seq_map s : (a, seq) seq_map) (values : seq)
+    =
   let elements = Stdlib.ref [] in
-  s.iter
-    (fun value ->
-      incr actual;
-      elements := value :: !elements)
-    values;
-  if !actual <> expected then
-    Fmt.invalid_arg "Wire.array: expected %d elements, got %d" expected !actual;
+  s.iter (fun value -> elements := value :: !elements) values;
   List.rev !elements
+
+let exact_array_elements seq ~expected values =
+  let elements = sequence_elements seq values in
+  let actual = List.length elements in
+  if actual <> expected then
+    Fmt.invalid_arg "Wire.array: expected %d elements, got %d" expected actual;
+  elements
+
+let exact_repeat_elements seq ~expected ~size_of values =
+  let sized =
+    sequence_elements seq values
+    |> List.map (fun value -> (value, size_of value))
+  in
+  let actual = List.fold_left (fun total (_, size) -> total + size) 0 sized in
+  if actual <> expected then
+    Fmt.invalid_arg "Wire.repeat: expected %d bytes, got %d" expected actual;
+  sized
 
 (* The 3D projection of [array]/[optional]/[optional_or]/[repeat] turns
    their length / predicate / byte budget into a [byte-size] suffix.
@@ -2904,6 +2914,9 @@ let rec size_of_typ_value : type a. a typ -> a -> int =
   | Codec { codec_size_of_value; _ } -> codec_size_of_value v
   | Single_elem { size = Int n; _ } -> n
   | Single_elem _ -> 0
+  | Repeat { size = Int expected; elem; seq } ->
+      exact_repeat_elements seq ~expected ~size_of:(size_of_typ_value elem) v
+      |> List.fold_left (fun total (_, size) -> total + size) 0
   | Repeat { elem; seq = Seq_map s; _ } ->
       (* Sum the actual element sizes from the value, like [Array]. The byte
          budget ([size]) is only a literal when fixed; a dynamic budget left

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -2894,8 +2894,11 @@ let rec size_of_typ_value : type a. a typ -> a -> int =
   | Zeroterm -> String.length v + 1
   | Zeroterm_at_most { size = Int n } -> n
   | Zeroterm_at_most _ -> 0
+  | Byte_array { size = Int n } -> n
   | Byte_array _ -> String.length v
+  | Byte_array_where { size = Int n; _ } -> n
   | Byte_array_where _ -> String.length v
+  | Byte_slice { size = Int n } -> n
   | Byte_slice _ -> Bytesrw.Bytes.Slice.length v
   | Uint_var { size = Int n; _ } -> n
   | Uint_var _ -> 0

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -74,6 +74,10 @@ type ('elt, 'seq) seq_map =
 val seq_list : ('a, 'a list) seq_map
 (** Default builder: accumulate into a list. *)
 
+val exact_array_elements : ('a, 'seq) seq_map -> expected:int -> 'seq -> 'a list
+(** Materialise an array value after checking its declared element count.
+    Internal helper shared by direct and compiled encoders. *)
+
 (** {1 Param handles} *)
 
 type param_input

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -574,7 +574,8 @@ val array_seq : ('a, 'seq) seq_map -> len:int expr -> 'a typ -> 'seq typ
 (** Fixed-count array with custom builder. *)
 
 val byte_array : size:int expr -> string typ
-(** Byte span as a string. *)
+(** Byte span as a string. A fixed-size span zero-pads short values and
+    truncates long values on encode. *)
 
 val byte_array_where :
   size:int expr -> per_byte:(int expr -> bool expr) -> string typ
@@ -582,7 +583,8 @@ val byte_array_where :
     byte must satisfy [per_byte]. The argument to [per_byte] is an expression
     bound to the current byte's integer value. Decode raises
     {!exception:Parse_error} on the first byte that violates the constraint;
-    encode raises [Invalid_argument]. *)
+    encode raises [Invalid_argument]. A fixed-size span otherwise zero-pads
+    short values and truncates long values on encode. *)
 
 val synth_name_of_elt_var : string -> string
 (** [synth_name_of_elt_var ev] is the 3D-side synthesised refinement-typedef
@@ -597,7 +599,8 @@ val index_bound_elt : 'a typ -> (string * bool expr) option
     used by the EverParse projection. *)
 
 val byte_slice : size:int expr -> Bytesrw.Bytes.Slice.t typ
-(** Zero-copy byte span. *)
+(** Zero-copy byte span. A fixed-size span zero-pads short values and truncates
+    long values on encode. *)
 
 val optional : bool expr -> 'a typ -> 'a option typ
 (** Conditionally present field. *)

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -78,6 +78,15 @@ val exact_array_elements : ('a, 'seq) seq_map -> expected:int -> 'seq -> 'a list
 (** Materialise an array value after checking its declared element count.
     Internal helper shared by direct and compiled encoders. *)
 
+val exact_repeat_elements :
+  ('a, 'seq) seq_map ->
+  expected:int ->
+  size_of:('a -> int) ->
+  'seq ->
+  ('a * int) list
+(** Materialise and size a repeat value after checking its byte budget. Internal
+    helper shared by direct and compiled encoders. *)
+
 (** {1 Param handles} *)
 
 type param_input

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -87,6 +87,10 @@ val exact_repeat_elements :
 (** Materialise and size a repeat value after checking its byte budget. Internal
     helper shared by direct and compiled encoders. *)
 
+val check_nested_size : at_most:bool -> expected:int -> actual:int -> unit
+(** Check an inner value against an exact or at-most nested region. Internal
+    helper shared by sizing and encoders. *)
+
 (** {1 Param handles} *)
 
 type param_input

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -406,10 +406,13 @@ and parse_repeat_loop : type elt seq.
     seq * int =
  fun ~elem ~seq:(Seq_map s) buf off len ~budget ->
   let start = off in
+  if budget < 0 then raise_eof ~at:off ~expected:0 ~got:budget;
+  check_eof len (start + budget);
+  let region_end = start + budget in
   let rec loop acc off' =
-    if off' - start >= budget then (s.finish acc, off')
+    if off' = region_end then (s.finish acc, off')
     else
-      let v, off'' = parse_direct elem buf off' len in
+      let v, off'' = parse_direct elem buf off' region_end in
       loop (s.add acc v) off''
   in
   loop s.empty off
@@ -781,8 +784,12 @@ let rec encode_into : type a. a typ -> a -> encoder -> unit =
       if Eval.expr Eval.empty present then encode_into inner (Option.get v) enc
   | Optional_or { present; inner; _ } ->
       if Eval.expr Eval.empty present then encode_into inner v enc
-  | Repeat { elem; seq = Seq_map seq; _ } ->
-      seq.iter (fun elem_v -> encode_into elem elem_v enc) v
+  | Repeat { size; elem; seq } ->
+      let expected = Eval.expr Eval.empty size in
+      Types.exact_repeat_elements seq ~expected
+        ~size_of:(Types.size_of_typ_value elem)
+        v
+      |> List.iter (fun (elem_v, _) -> encode_into elem elem_v enc)
   | Casetype { tag; cases; _ } -> encode_casetype tag cases v enc
   | Struct _ -> failwith "struct encoding: use Codec.encode"
   | Type_ref _ -> failwith "type_ref requires a type registry"

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -746,8 +746,10 @@ let rec encode_into : type a. a typ -> a -> encoder -> unit =
         write_byte enc 0
       done
   | Where { inner; _ } -> encode_into inner v enc
-  | Array { elem; seq = Seq_map seq; _ } ->
-      seq.iter (fun elem_v -> encode_into elem elem_v enc) v
+  | Array { len; elem; seq } ->
+      let expected = Eval.expr Eval.empty len in
+      Types.exact_array_elements seq ~expected v
+      |> List.iter (fun elem_v -> encode_into elem elem_v enc)
   | Byte_array _ -> write_string enc v
   | Byte_array_where { elt_var; cond; _ } ->
       String.iteri

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -319,10 +319,13 @@ let rec parse_direct : type a. a typ -> bytes -> int -> int -> a * int =
       let n = Eval.expr Eval.empty size in
       check_eof len (off + n);
       (Slice.make_or_eod buf ~first:off ~length:n, off + n)
-  | Single_elem { size; elem; at_most = _ } ->
+  | Single_elem { size; elem; at_most } ->
       let n = Eval.expr Eval.empty size in
       check_eof len (off + n);
-      let v, _ = parse_direct elem buf off (off + n) in
+      let v, inner_end = parse_direct elem buf off (off + n) in
+      let consumed = inner_end - off in
+      if (not at_most) && consumed <> n then
+        raise_eof ~at:inner_end ~expected:n ~got:consumed;
       (v, off + n)
   | Map { inner; decode; _ } ->
       let v, off' = parse_direct inner buf off len in
@@ -768,10 +771,11 @@ let rec encode_into : type a. a typ -> a -> encoder -> unit =
       let off = Slice.first v in
       let len = Slice.length v in
       write_string enc (Bytes.sub_string src off len)
-  | Single_elem { size; elem; _ } ->
+  | Single_elem { size; elem; at_most } ->
       let n = Eval.expr Eval.empty size in
-      encode_into elem v enc;
       let inner_sz = Types.size_of_typ_value elem v in
+      Types.check_nested_size ~at_most ~expected:n ~actual:inner_sz;
+      encode_into elem v enc;
       for _ = inner_sz to n - 1 do
         write_byte enc 0
       done
@@ -905,7 +909,9 @@ let rec encode_direct : type a. a typ -> bytes -> int -> a -> int =
       off + n
   | Byte_array { size = Int n } -> Codec.blit_string_padded n buf off v
   | Byte_slice { size = Int n } -> Codec.blit_slice_padded n buf off v
-  | Single_elem { size = Int n; elem; at_most = _ } ->
+  | Single_elem { size = Int n; elem; at_most } ->
+      let inner_sz = Types.size_of_typ_value elem v in
+      Types.check_nested_size ~at_most ~expected:n ~actual:inner_sz;
       let off' = encode_direct elem buf off v in
       if off' < off + n then Bytes.fill buf off' (off + n - off') '\x00';
       off + n

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -694,11 +694,12 @@ val array : len:int expr -> 'a typ -> 'a list typ
     element count, not a byte size. It projects to 3D only when [t] has a fixed
     wire size: 3D arrays are byte-budgeted, so the count is lowered to
     [len * sizeof t] bytes. For variable-size elements use {!Field.repeat},
-    which is bounded by a byte budget instead. *)
+    which is bounded by a byte budget instead. Encoding a list whose cardinality
+    differs from [len] raises [Invalid_argument] before writing. *)
 
 val array_seq : ('a, 'seq) seq_map -> len:int expr -> 'a typ -> 'seq typ
 (** Like {!array} but accumulates into a custom sequence via a {!type-seq_map}.
-*)
+    Encoding enforces the same exact cardinality. *)
 
 val byte_array : size:int expr -> string typ
 (** Fixed-size byte sequence copied as a string.

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -459,12 +459,15 @@ module Field : sig
     'a typ ->
     'a list t
   (** [repeat name ~size t] parses elements of type [t] until [size] bytes are
-      consumed. The bound is a byte budget, not an element count, which is what
-      lets the elements be variable-size (a tagged union, a length-prefixed
-      sub-codec). It projects to 3D as [t name[:byte-size size]]. There is no
-      count-driven form: "a count field, then that many variable-size elements"
-      is expressible neither here nor in 3D (3D arrays are byte-budgeted), so
-      that shape needs caller-side iteration over the element parser. *)
+      consumed exactly. The bound is a byte budget, not an element count, which
+      is what lets the elements be variable-size (a tagged union, a
+      length-prefixed sub-codec). An element cannot cross the region boundary;
+      encoding raises [Invalid_argument] when the supplied values span fewer or
+      more bytes than [size]. It projects to 3D as [t name[:byte-size size]].
+      There is no count-driven form: "a count field, then that many
+      variable-size elements" is expressible neither here nor in 3D (3D arrays
+      are byte-budgeted), so that shape needs caller-side iteration over the
+      element parser. *)
 
   val repeat_seq :
     string ->
@@ -476,7 +479,8 @@ module Field : sig
     size:int expr ->
     'a typ ->
     'seq t
-  (** Like {!repeat} but accumulates into a custom sequence via [seq]. *)
+  (** Like {!repeat} but accumulates into a custom sequence via [seq], with the
+      same exact byte-budget requirement. *)
 
   val anon : 'a typ -> 'a anon
   (** [anon typ] creates an anonymous (padding) field. *)

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -741,14 +741,17 @@ val nested : size:int expr -> 'a typ -> 'a typ
 
     This is for layouts where a length expression denotes the size of a region,
     but that region is known to contain exactly one value, such as a single
-    nested message. *)
+    nested message. Decoding rejects an inner value that consumes fewer bytes;
+    encoding raises [Invalid_argument] unless the value's encoded size is
+    exactly [size]. *)
 
 val nested_at_most : size:int expr -> 'a typ -> 'a typ
 (** [nested_at_most ~size t] is like {!nested}, but treats [size] as an upper
     bound rather than an exact size.
 
     This is for length-prefixed regions where the one logical element may
-    consume fewer bytes than the available space. *)
+    consume fewer bytes than the available space. Encoding zero-pads the unused
+    region; a value larger than [size] raises [Invalid_argument]. *)
 
 val enum : string -> (string * int) list -> int typ -> int typ
 (** [enum name cases base] validates that the decoded integer is one of the

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -708,6 +708,9 @@ val array_seq : ('a, 'seq) seq_map -> len:int expr -> 'a typ -> 'seq typ
 val byte_array : size:int expr -> string typ
 (** Fixed-size byte sequence copied as a string.
 
+    Encoding zero-pads a string shorter than [size] and truncates one longer
+    than [size].
+
     When [size] contains the simple product of a field and a literal, and that
     field has a simple [field <= bound] constraint, {!Codec.v} rejects the codec
     if [bound * literal] can reach [2^32]. EverParse represents byte sizes as
@@ -721,12 +724,14 @@ val byte_array_where :
     expression bound to the current byte's integer value.
 
     Decode raises {!exception:Parse_error} on the first byte that violates the
-    constraint; encode raises [Invalid_argument]. The motivating shape is SSH
-    name-list payloads (RFC 4251 sec 5), where every byte must be printable
-    US-ASCII. *)
+    constraint; encode raises [Invalid_argument]. Encoding otherwise follows
+    {!byte_array}: short strings are zero-padded and long strings are truncated.
+    The motivating shape is SSH name-list payloads (RFC 4251 sec 5), where every
+    byte must be printable US-ASCII. *)
 
 val byte_slice : size:int expr -> Bytesrw.Bytes.Slice.t typ
-(** Fixed-size byte sequence exposed as a zero-copy slice. *)
+(** Fixed-size byte sequence exposed as a zero-copy slice. Encoding zero-pads a
+    slice shorter than [size] and truncates one longer than [size]. *)
 
 val rest_bytes : (int, _) Param.t -> string typ
 (** [rest_bytes total] is the trailing payload of a record whose total decoded

--- a/test/3d/test_wire_3d.ml
+++ b/test/3d/test_wire_3d.ml
@@ -357,6 +357,16 @@ let diff_bits_codec =
     (fun a b -> (a, b))
     [ Codec.( $ ) fa fst; Codec.( $ ) fb snd ]
 
+let diff_nested_exact_codec =
+  let open Wire in
+  Codec.v "NestedExact" Fun.id
+    Codec.[ Field.v "value" (nested ~size:(int 4) zeroterm) $ Fun.id ]
+
+let diff_nested_at_most_codec =
+  let open Wire in
+  Codec.v "NestedAtMost" Fun.id
+    Codec.[ Field.v "value" (nested_at_most ~size:(int 4) zeroterm) $ Fun.id ]
+
 (* A parameterized codec: the harness must bind the input param in the OCaml
    oracle and pass the same value to the EverParse validator, or a length-bound
    frame can never be checked (the blocker for CCSDS TC/AOS/TM/USLP). *)
@@ -417,6 +427,23 @@ let test_doc_differential_no_params () =
   else
     differential_ok ~name:"plainspec" ~package:"plain-doc" ~corpus:(`Fuzz 100)
       [ Wire_3d.pack diff_enum_codec; Wire_3d.pack diff_range_codec ]
+
+let test_doc_differential_nested_regions () =
+  if not (Wire_3d.has_3d_exe ()) then ()
+  else
+    differential_ok ~name:"nestedspec" ~package:"nested-doc"
+      ~corpus:
+        (`Lines
+           [
+             "NestedExact - 41000000 0";
+             "NestedExact - 41424300 1";
+             "NestedAtMost - 41000000 1";
+             "NestedAtMost - 41424300 1";
+           ])
+      [
+        Wire_3d.pack diff_nested_exact_codec;
+        Wire_3d.pack diff_nested_at_most_codec;
+      ]
 
 (* The installed standalone archive must export only the checked
    [<Base>CheckWire<Codec>] wrappers, not the raw [<Base>Validate*] entry points
@@ -1452,6 +1479,8 @@ let suite =
         test_doc_differential;
       Alcotest.test_case "doc differential no params (needs 3d.exe)" `Quick
         test_doc_differential_no_params;
+      Alcotest.test_case "doc differential nested regions (needs 3d.exe)" `Quick
+        test_doc_differential_nested_regions;
       Alcotest.test_case "doc differential signed (needs 3d.exe)" `Quick
         test_doc_differential_signed;
       Alcotest.test_case "doc differential large payload (needs 3d.exe)" `Quick

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -587,6 +587,50 @@ let test_record_byte_array_padding () =
             (String.sub decoded.uuid 0 5)
       | Error e -> Alcotest.failf "%a" pp_parse_error e)
 
+let codec_seq_array : ('a, 'a array) seq_map =
+  Seq_map
+    {
+      empty = [];
+      add = (fun acc value -> value :: acc);
+      finish = (fun values -> Array.of_list (List.rev values));
+      iter = Array.iter;
+    }
+
+let expect_codec_array_cardinality label codec value expected actual =
+  let buf = Bytes.make 8 '\x7f' in
+  match Codec.encode codec value buf 0 with
+  | () -> Alcotest.failf "%s: expected an array cardinality error" label
+  | exception Invalid_argument msg ->
+      Alcotest.(check bool)
+        (label ^ ": expected count")
+        true
+        (contains ~sub:(Fmt.str "expected %d" expected) msg);
+      Alcotest.(check bool)
+        (label ^ ": actual count") true
+        (contains ~sub:(Fmt.str "got %d" actual) msg);
+      Alcotest.(check string)
+        (label ^ ": buffer unchanged")
+        (String.make 8 '\x7f') (Bytes.to_string buf)
+
+let test_codec_array_cardinality () =
+  let list =
+    Codec.v "ArrayList" Fun.id
+      Codec.[ Field.v "values" (array ~len:(int 3) uint8) $ Fun.id ]
+  in
+  expect_codec_array_cardinality "short list" list [ 1; 2 ] 3 2;
+  expect_codec_array_cardinality "long list" list [ 1; 2; 3; 4 ] 3 4;
+  let custom =
+    Codec.v "ArrayCustom" Fun.id
+      Codec.
+        [
+          Field.v "values" (array_seq codec_seq_array ~len:(int 3) uint8)
+          $ Fun.id;
+        ]
+  in
+  expect_codec_array_cardinality "short custom sequence" custom [| 1; 2 |] 3 2;
+  expect_codec_array_cardinality "long custom sequence" custom [| 1; 2; 3; 4 |]
+    3 4
+
 (* Field.repeat over a zeroterm element: a list of NUL-terminated strings
    within a byte budget. Used to raise Failure at decode; now decodes and
    projects through a synthesised element struct. *)
@@ -6061,6 +6105,8 @@ let suite =
         test_record_byte_array_roundtrip;
       Alcotest.test_case "record: byte_array padding" `Quick
         test_record_byte_array_padding;
+      Alcotest.test_case "array: encode cardinality" `Quick
+        test_codec_array_cardinality;
       Alcotest.test_case "repeat: zeroterm element roundtrip" `Quick
         test_repeat_zeroterm_element;
       Alcotest.test_case "repeat: zeroterm element projection" `Quick

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -77,6 +77,32 @@ let test_record_roundtrip () =
             "c roundtrip" (Optint.to_int original.c) (Optint.to_int decoded.c)
       | Error e -> Alcotest.failf "%a" pp_parse_error e)
 
+let test_duplicate_names_rejected () =
+  let check_invalid ~kind ~name f =
+    match f () with
+    | () -> Alcotest.failf "duplicate %s name was accepted" kind
+    | exception Invalid_argument msg ->
+        Alcotest.(check bool) "codec named" true (contains ~sub:"DupNames" msg);
+        Alcotest.(check bool) "kind named" true (contains ~sub:kind msg);
+        Alcotest.(check bool) "duplicate named" true (contains ~sub:name msg)
+  in
+  check_invalid ~kind:"field" ~name:"dup" (fun () ->
+      ignore
+        (Codec.v "DupNames"
+           (fun a b -> (a, b))
+           Codec.[ Field.v "dup" uint8 $ fst; Field.v "dup" uint8 $ snd ]));
+  let first = Param.input "count" uint8 in
+  let second = Param.input "count" uint8 in
+  check_invalid ~kind:"parameter" ~name:"count" (fun () ->
+      ignore
+        (Codec.v "DupNames"
+           (fun a b -> (a, b))
+           Codec.
+             [
+               Field.v "a" (byte_array ~size:(Param.expr first)) $ fst;
+               Field.v "b" (byte_array ~size:(Param.expr second)) $ snd;
+             ]))
+
 let test_struct_of_record () =
   let output = render_3d simple_record_codec in
   Alcotest.(check bool) "contains UINT8" true (contains ~sub:"UINT8" output);
@@ -6097,6 +6123,8 @@ let suite =
       Alcotest.test_case "record: encode" `Quick test_record_encode;
       Alcotest.test_case "record: decode" `Quick test_record_decode;
       Alcotest.test_case "record: roundtrip" `Quick test_record_roundtrip;
+      Alcotest.test_case "record: duplicate names rejected" `Quick
+        test_duplicate_names_rejected;
       Alcotest.test_case "record: struct_of_codec" `Quick test_struct_of_record;
       Alcotest.test_case "record: metadata decode ok" `Quick
         test_codec_metadata_decode_ok;

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -1089,6 +1089,30 @@ let test_nested_at_most_over_array () =
     "roundtrip" true
     (decode_ok (Codec.decode codec buf 0) = v)
 
+let test_nested_exact_region () =
+  let make name typ =
+    Codec.v name Fun.id Codec.[ Field.v "value" typ $ Fun.id ]
+  in
+  let exact = make "NestedExact" (nested ~size:(int 4) zeroterm) in
+  let at_most = make "NestedAtMost" (nested_at_most ~size:(int 4) zeroterm) in
+  let padded = Bytes.of_string "A\x00\x00\x00" in
+  (match Codec.decode exact padded 0 with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "compiled exact nested accepted trailing padding");
+  Alcotest.(check string)
+    "compiled at-most accepts padding" "A"
+    (decode_ok (Codec.decode at_most padded 0));
+  Alcotest.(check string)
+    "compiled exact accepts full consumption" "ABC"
+    (decode_ok (Codec.decode exact (Bytes.of_string "ABC\x00") 0));
+  (match Codec.size_of_value exact "A" with
+  | _ -> Alcotest.fail "compiled exact nested encode accepted padding"
+  | exception Invalid_argument msg ->
+      Alcotest.(check bool) "nested error" true (contains ~sub:"nested" msg));
+  let buf = Bytes.create 4 in
+  Codec.encode at_most "A" buf 0;
+  Alcotest.(check bytes) "compiled at-most pads" padded buf
+
 (* A casetype whose case body is a [nested] region (a scalar in a fixed span):
    the tag-dispatched case decodes and sizes through the region. *)
 type nest_case = N of int | U of int
@@ -6216,6 +6240,7 @@ let suite =
         test_nested_over_array;
       Alcotest.test_case "nested_at_most over array roundtrip" `Quick
         test_nested_at_most_over_array;
+      Alcotest.test_case "nested exact region" `Quick test_nested_exact_region;
       Alcotest.test_case "casetype nested case body roundtrip" `Quick
         test_casetype_nested_case_body;
       Alcotest.test_case "array rejects non-projectable element" `Quick

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -4377,6 +4377,45 @@ let test_repeat_encode () =
   Alcotest.(check int) "item1.tag" 0x02 (Bytes.get_uint8 buf 4);
   Alcotest.(check int) "item1.value" 0x0002 (Bytes.get_uint16_be buf 5)
 
+let expect_repeat_encode_error label codec value =
+  let buf = Bytes.make 8 '\x7f' in
+  match Codec.encode codec value buf 0 with
+  | () -> Alcotest.failf "%s: expected a repeat byte-budget error" label
+  | exception Invalid_argument msg ->
+      Alcotest.(check bool)
+        (label ^ ": names repeat") true
+        (contains ~sub:"repeat" msg)
+
+let test_repeat_exact_budget () =
+  let f_size = Field.v "size" uint8 in
+  let fixed =
+    Codec.v "RepeatFixedBudget"
+      (fun size items -> (size, items))
+      Codec.
+        [
+          f_size $ fst;
+          Field.repeat "items" ~size:(Field.ref f_size) uint16be $ snd;
+        ]
+  in
+  (match Codec.decode fixed (Bytes.of_string "\x01\xaa") 0 with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "fixed-width repeat accepted a remainder");
+  expect_repeat_encode_error "fixed underrun" fixed (6, [ 1 ]);
+  expect_repeat_encode_error "fixed overshoot" fixed (2, [ 1; 2 ]);
+  let f_var_size = Field.v "size" uint8 in
+  let variable =
+    Codec.v "RepeatVariableBudget"
+      (fun size items -> (size, items))
+      Codec.
+        [
+          f_var_size $ fst;
+          Field.repeat "items" ~size:(Field.ref f_var_size) zeroterm $ snd;
+        ]
+  in
+  match Codec.decode variable (Bytes.of_string "\x01A\x00") 0 with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "variable-width repeat crossed its byte budget"
+
 let test_repeat_roundtrip () =
   let items =
     [
@@ -6474,6 +6513,8 @@ let suite =
       Alcotest.test_case "repeat: decode multiple" `Quick
         test_repeat_decode_multiple;
       Alcotest.test_case "repeat: encode" `Quick test_repeat_encode;
+      Alcotest.test_case "repeat: exact byte budget" `Quick
+        test_repeat_exact_budget;
       Alcotest.test_case "repeat: roundtrip" `Quick test_repeat_roundtrip;
       Alcotest.test_case "repeat: primitive" `Quick test_repeat_primitive;
       Alcotest.test_case "repeat: size_of_value" `Quick

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -1662,23 +1662,47 @@ let test_codec_bitfield_overflow_1bit () =
   Codec.encode codec 0 buf 0;
   Codec.encode codec 1 buf 0
 
-let test_encode_underrun_raises () =
-  (* byte_array ~size:n truncates a value longer than n at write time,
-     while size_of_value reports String.length v. Passing a 5-byte value
-     to a 3-byte field is the simplest underrun: the assertion must fire. *)
-  let codec =
-    Codec.v "Mismatch" Fun.id
-      Codec.[ Field.v "data" (byte_array ~size:(Wire.int 3)) $ Fun.id ]
+let test_fixed_byte_region_size_of_value () =
+  let check_string label typ cases =
+    let codec = Codec.v label Fun.id Codec.[ Field.v "data" typ $ Fun.id ] in
+    List.iter
+      (fun (case, value, expected) ->
+        Alcotest.(check int)
+          (case ^ " size") 3
+          (Codec.size_of_value codec value);
+        let buf = Bytes.create 3 in
+        Codec.encode codec value buf 0;
+        Alcotest.(check bytes) case (Bytes.of_string expected) buf)
+      cases
   in
-  let buf = Bytes.create 5 in
-  match Codec.encode codec "AAAAA" buf 0 with
-  | exception Invalid_argument m
-    when String.length m > 0
-         && contains ~sub:"writer wrote fewer bytes than promised" m ->
-      ()
-  | exception Invalid_argument m ->
-      Alcotest.failf "wrong Invalid_argument message: %s" m
-  | () -> Alcotest.fail "expected underrun assertion to fire"
+  let cases =
+    [
+      ("short", "A", "A\x00\x00");
+      ("exact", "ABC", "ABC");
+      ("long", "ABCDE", "ABC");
+    ]
+  in
+  check_string "FixedBytes" (byte_array ~size:(int 3)) cases;
+  check_string "FixedBytesWhere"
+    (byte_array_where ~size:(int 3) ~per_byte:(fun _ -> Expr.true_))
+    cases;
+  let codec =
+    Codec.v "FixedSlice" Fun.id
+      Codec.[ Field.v "data" (byte_slice ~size:(int 3)) $ Fun.id ]
+  in
+  List.iter
+    (fun (case, value, expected) ->
+      let bytes = Bytes.of_string value in
+      let slice =
+        Bytesrw.Bytes.Slice.make bytes ~first:0 ~length:(Bytes.length bytes)
+      in
+      Alcotest.(check int)
+        (case ^ " slice size") 3
+        (Codec.size_of_value codec slice);
+      let buf = Bytes.create 3 in
+      Codec.encode codec slice buf 0;
+      Alcotest.(check bytes) (case ^ " slice") (Bytes.of_string expected) buf)
+    cases
 
 let test_packed_bf_size () =
   let f_a = Field.v "a" (bits ~width:1 U8) in
@@ -6298,8 +6322,8 @@ let suite =
         test_packed_bf_size;
       Alcotest.test_case "codec bitfield: size_of_value mapped bit" `Quick
         test_packed_mapped_bf_size;
-      Alcotest.test_case "encode: underrun raises" `Quick
-        test_encode_underrun_raises;
+      Alcotest.test_case "fixed byte regions: size_of_value" `Quick
+        test_fixed_byte_region_size_of_value;
       (* action semantics *)
       Alcotest.test_case "action: fires on decode_env" `Quick
         test_action_fires_decode_env;

--- a/test/test_wire.ml
+++ b/test/test_wire.ml
@@ -4,6 +4,8 @@ open Wire
 open Wire.Everparse.Raw
 open Test_helpers
 
+let contains ~sub s = Re.execp (Re.compile (Re.str sub)) s
+
 (* Helper: parse from a string delivered in slices of [chunk_size] bytes.
    Forces multi-byte values to straddle slice boundaries. *)
 let parse_chunked ~chunk_size typ s =
@@ -708,6 +710,36 @@ let test_encode_array () =
   let encoded = to_string t [ 1; 2; 3 ] in
   Alcotest.(check string) "array encoding" "\x01\x02\x03" encoded
 
+let seq_array : ('a, 'a array) seq_map =
+  Seq_map
+    {
+      empty = [];
+      add = (fun acc value -> value :: acc);
+      finish = (fun values -> Array.of_list (List.rev values));
+      iter = Array.iter;
+    }
+
+let expect_direct_array_cardinality label typ value expected actual =
+  match to_string typ value with
+  | _ -> Alcotest.failf "%s: expected an array cardinality error" label
+  | exception Invalid_argument msg ->
+      Alcotest.(check bool)
+        (label ^ ": expected count")
+        true
+        (contains ~sub:(Fmt.str "expected %d" expected) msg);
+      Alcotest.(check bool)
+        (label ^ ": actual count") true
+        (contains ~sub:(Fmt.str "got %d" actual) msg)
+
+let test_encode_array_cardinality () =
+  let list = array ~len:(int 3) uint8 in
+  expect_direct_array_cardinality "short list" list [ 1; 2 ] 3 2;
+  expect_direct_array_cardinality "long list" list [ 1; 2; 3; 4 ] 3 4;
+  let custom = array_seq seq_array ~len:(int 3) uint8 in
+  expect_direct_array_cardinality "short custom sequence" custom [| 1; 2 |] 3 2;
+  expect_direct_array_cardinality "long custom sequence" custom [| 1; 2; 3; 4 |]
+    3 4
+
 let test_encode_byte_array () =
   let t = byte_array ~size:(int 5) in
   let encoded = to_string t "hello" in
@@ -1169,6 +1201,8 @@ let suite =
       Alcotest.test_case "encode: uint32 le" `Quick test_encode_uint32_le;
       Alcotest.test_case "encode: uint32 be" `Quick test_encode_uint32_be;
       Alcotest.test_case "encode: array" `Quick test_encode_array;
+      Alcotest.test_case "encode: array cardinality" `Quick
+        test_encode_array_cardinality;
       Alcotest.test_case "encode: byte_array" `Quick test_encode_byte_array;
       Alcotest.test_case "encode: variants" `Quick test_encode_variants;
       Alcotest.test_case "encode: bitfield" `Quick test_encode_bitfield;

--- a/test/test_wire.ml
+++ b/test/test_wire.ml
@@ -763,6 +763,26 @@ let test_repeat_exact_budget_direct () =
   | Error _ -> ()
   | Ok _ -> Alcotest.fail "variable-width repeat crossed its byte budget"
 
+let test_nested_exact_region_direct () =
+  let exact = nested ~size:(int 4) zeroterm in
+  let at_most = nested_at_most ~size:(int 4) zeroterm in
+  let expect_parse_error label = function
+    | Error _ -> ()
+    | Ok _ -> Alcotest.failf "%s: accepted an under-consumed exact region" label
+  in
+  expect_parse_error "exact decode" (of_string exact "A\x00\x00\x00");
+  Alcotest.(check (result string reject))
+    "at-most decode" (Ok "A")
+    (of_string at_most "A\x00\x00\x00");
+  Alcotest.(check (result string reject))
+    "exact decode fully consumed" (Ok "ABC")
+    (of_string exact "ABC\x00");
+  Alcotest.check_raises "exact encode rejects padding"
+    (Invalid_argument "Wire.nested: expected 4 bytes, got 2") (fun () ->
+      ignore (to_string exact "A"));
+  Alcotest.(check string)
+    "at-most encode pads" "A\x00\x00\x00" (to_string at_most "A")
+
 let test_encode_byte_array () =
   let t = byte_array ~size:(int 5) in
   let encoded = to_string t "hello" in
@@ -1228,6 +1248,8 @@ let suite =
         test_encode_array_cardinality;
       Alcotest.test_case "repeat: exact byte budget" `Quick
         test_repeat_exact_budget_direct;
+      Alcotest.test_case "nested: exact region" `Quick
+        test_nested_exact_region_direct;
       Alcotest.test_case "encode: byte_array" `Quick test_encode_byte_array;
       Alcotest.test_case "encode: variants" `Quick test_encode_variants;
       Alcotest.test_case "encode: bitfield" `Quick test_encode_bitfield;

--- a/test/test_wire.ml
+++ b/test/test_wire.ml
@@ -740,6 +740,29 @@ let test_encode_array_cardinality () =
   expect_direct_array_cardinality "long custom sequence" custom [| 1; 2; 3; 4 |]
     3 4
 
+let expect_direct_repeat_encode_error label typ value =
+  match to_string typ value with
+  | _ -> Alcotest.failf "%s: expected a repeat byte-budget error" label
+  | exception Invalid_argument msg ->
+      Alcotest.(check bool)
+        (label ^ ": names repeat") true
+        (contains ~sub:"repeat" msg)
+
+let test_repeat_exact_budget_direct () =
+  let fixed = Field.typ (Field.repeat "items" ~size:(int 2) uint16be) in
+  expect_direct_repeat_encode_error "fixed underrun" fixed [];
+  expect_direct_repeat_encode_error "fixed overshoot" fixed [ 1; 2 ];
+  let fixed_remainder =
+    Field.typ (Field.repeat "items" ~size:(int 1) uint16be)
+  in
+  (match of_string fixed_remainder "\x01" with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "fixed-width repeat accepted a remainder");
+  let variable = Field.typ (Field.repeat "items" ~size:(int 1) zeroterm) in
+  match of_string variable "A\x00" with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "variable-width repeat crossed its byte budget"
+
 let test_encode_byte_array () =
   let t = byte_array ~size:(int 5) in
   let encoded = to_string t "hello" in
@@ -1203,6 +1226,8 @@ let suite =
       Alcotest.test_case "encode: array" `Quick test_encode_array;
       Alcotest.test_case "encode: array cardinality" `Quick
         test_encode_array_cardinality;
+      Alcotest.test_case "repeat: exact byte budget" `Quick
+        test_repeat_exact_budget_direct;
       Alcotest.test_case "encode: byte_array" `Quick test_encode_byte_array;
       Alcotest.test_case "encode: variants" `Quick test_encode_variants;
       Alcotest.test_case "encode: bitfield" `Quick test_encode_bitfield;


### PR DESCRIPTION
Make array cardinality, repeat byte budgets, and exact nested regions agree across encode and decode; preserve the permissive behavior only under nested_at_most. Reject duplicate declaration names and report fixed byte-region sizes consistently.