### PR TITLE
dev: enforce dependency, formatting, and merlint checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,21 @@ jobs:
       - run: opam exec -- dune fmt 2>/dev/null || true
       - run: git diff --exit-code
 
+  merlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: '5.4'
+          dune-version: '3.21'
+
+      - run: opam repository add tangled git+https://tangled.org/gazagnaire.org/opam-overlay.git --rank=-1
+      - run: opam install . --deps-only --with-test
+      - run: opam install merlint
+      - run: opam exec -- merlint --build
+
   # One AFL job per fuzzer: fuzz/ fuzzes the [wire] library (round-trip and
   # validation) and fuzz/3d/ fuzzes [wire_3d] (the EverParse / 3D projection),
   # mirroring the lib/ layout. The [afl] profile (dune-workspace) instruments

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ test:
 # modules truncate to the bit patterns they intend on a 31-bit target, and
 # the runtime checks prove the values survive. Warnings only surface for
 # freshly compiled units, so the grep is meaningful on a cold build (CI).
+# Remove the filter once https://github.com/mirage/optint/pull/31 is released.
 test-wasm:
 	@command -v wasm_of_ocaml >/dev/null || \
 	  { echo "wasm_of_ocaml not found: opam install wasm_of_ocaml-compiler"; exit 1; }

--- a/bench/demo/dune
+++ b/bench/demo/dune
@@ -3,7 +3,7 @@
 (library
  (name demo_bench_cases)
  (modules demo_bench_cases)
- (libraries demo space net wire bench_lib bytesrw fmt))
+ (libraries demo space net wire bench_lib bytesrw fmt optint))
 
 (library
  (name demo_bench_diff)
@@ -28,6 +28,7 @@
   wire.stubs
   c_tier
   bench_lib
+  fmt
   wire
   memtrace
   unix))

--- a/bench/dune
+++ b/bench/dune
@@ -24,16 +24,7 @@
 (executable
  (name gen_stubs)
  (modules gen_stubs)
- (libraries
-  demo_bench_cases
-  demo
-  space
-  net
-  wire
-  wire.3d
-  wire.stubs
-  bench_lib
-  unix))
+ (libraries demo_bench_cases demo space wire wire.3d wire.stubs fmt unix))
 
 ; Generate c_stubs.ml (OCaml external declarations) -- always
 

--- a/bench/memtrace/dune
+++ b/bench/memtrace/dune
@@ -1,3 +1,3 @@
 (executable
  (name bench)
- (libraries demo space wire bytesrw memtrace))
+ (libraries demo space wire bytesrw memtrace optint fmt))

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,5 @@
 (lang dune 3.21)
+(implicit_transitive_deps false)
 (using directory-targets 0.1)
 (using mdx 0.4)
 (cram enable)

--- a/examples/demo/dune
+++ b/examples/demo/dune
@@ -1,4 +1,4 @@
 (library
  (name demo)
  (wrapped false)
- (libraries wire))
+ (libraries wire optint))

--- a/examples/net/dune
+++ b/examples/net/dune
@@ -2,12 +2,12 @@
  (name net)
  (modules net)
  (wrapped false)
- (libraries wire))
+ (libraries wire bytesrw optint fmt))
 
 (executable
  (name example)
  (modules example)
- (libraries net wire))
+ (libraries net wire bytesrw fmt))
 
 ; The committed Net.3d is the RFC-documented projection of the net codecs.
 ; gen_spec renders it; the runtest diff fails if it drifts from net.ml, and

--- a/examples/space/dune
+++ b/examples/space/dune
@@ -1,4 +1,4 @@
 (library
  (name space)
  (wrapped false)
- (libraries wire))
+ (libraries wire bytesrw optint))

--- a/fuzz/3d/dune
+++ b/fuzz/3d/dune
@@ -1,6 +1,6 @@
 (executable
  (name fuzz)
- (libraries wire wire.3d unix alcobar fuzz_gen))
+ (libraries wire wire.3d unix alcobar fuzz_gen fmt))
 
 (rule
  (alias runtest)

--- a/fuzz/diff/gen/dune
+++ b/fuzz/diff/gen/dune
@@ -6,4 +6,4 @@
 (executable
  (name gen_diff)
  (modules gen_diff)
- (libraries diff_codecs fuzz_gen wire wire.3d wire.stubs unix))
+ (libraries diff_codecs fuzz_gen wire wire.3d wire.stubs unix fmt))

--- a/fuzz/gen/dune
+++ b/fuzz/gen/dune
@@ -1,3 +1,3 @@
 (library
  (name fuzz_gen)
- (libraries wire alcobar bytesrw))
+ (libraries wire alcobar bytesrw optint fmt))

--- a/fuzz/gen/fuzz_gen.mli
+++ b/fuzz/gen/fuzz_gen.mli
@@ -90,10 +90,8 @@ val validate_cases : string -> 'a t -> Alcobar.test_case list
     pass; random and adversarial inputs may pass or fail but must not crash.
     Threads the env via {!Wire.Codec.validate}'s [?env] when [g] needs one. *)
 
-type packed =
-  | Pack : 'a t -> packed
-      (** A gen with its value type hidden, for uniform iteration over
-          {!registry}. *)
+(** A gen with its value type hidden, for uniform iteration over {!registry}. *)
+type packed = Pack : 'a t -> packed
 
 val codec : 'a t -> 'a Wire.Codec.t
 (** [codec g] is the codec [g] generates for. *)

--- a/lib/3d/wire_3d.ml
+++ b/lib/3d/wire_3d.ml
@@ -232,7 +232,7 @@ let run_process ?(output = Inherit) ~cwd exe args =
             Unix.close fd)
           output_fd;
         Unix.execv exe (Array.of_list (exe :: args))
-      with _ -> Unix._exit 127)
+      with Unix.Unix_error _ -> Unix._exit 127)
   | pid ->
       Option.iter Unix.close output_fd;
       snd (Unix.waitpid [] pid)

--- a/lib/3d/wire_3d.ml
+++ b/lib/3d/wire_3d.ml
@@ -1544,6 +1544,10 @@ let emit_standalone_build_rules ppf ~base ~archive ~c_files ~wrappers =
    standalone. *)
 let emit_standalone_install ppf ~package ~three_d ~archive ~public_header
     ~provenance =
+  (* Dune currently adds files from a disabled install stanza to the directory's
+     [all] alias. Keep the stanza unconditional until
+     https://github.com/ocaml/dune/issues/15825 is fixed; the archive itself is
+     intentionally built for every context above. *)
   let pr fmt = Fmt.pf ppf fmt in
   pr "(install\n (package %s)\n (section lib)\n (files\n" package;
   List.iter

--- a/lib/3d/wire_3d.ml
+++ b/lib/3d/wire_3d.ml
@@ -535,8 +535,10 @@ let fields_c_files schemas =
    parameterized and plain entrypoints, [print_c_entry] in the upstream
    [src/3d/Target.fst]): if a future EverParse emits neither the known tail
    nor its own consumption check, fail loudly rather than silently shipping a
-   prefix recognizer. The behavioural backstop is the differential runtest,
-   whose corpus includes over-length inputs the oracle rejects. *)
+   prefix recognizer. Tracked upstream as
+   https://github.com/project-everest/everparse/issues/312. The behavioural
+   backstop is the differential runtest, whose corpus includes over-length
+   inputs the oracle rejects. *)
 let wrapper_success_tail = "\t\treturn FALSE;\n\t}\n\treturn TRUE;\n}"
 let wrapper_consumption_check = "result != (uint64_t) len"
 

--- a/lib/3d/wire_3d.mli
+++ b/lib/3d/wire_3d.mli
@@ -190,8 +190,8 @@ val generate_standalone :
   packed list ->
   unit
 (** [generate_standalone ?quiet ?name ~outdir ~package codecs] runs the
-    documentation pipeline: project each codec with {!Wire.Everparse.doc}, merge
-    them into one [<Name>.3d], and (when [3d.exe] is available) compile it to a
+    documentation pipeline: project each codec in documentation mode, merge them
+    into one [<Name>.3d], and (when [3d.exe] is available) compile it to a
     single validator-only [<Name>.c] (no [_Fields] plug, no FFI). The file base
     is [name] when given, else [package], normalised to a CamelCase identifier
     (["my-pkg"] becomes [MyPkg]); [package] always names the opam package. The
@@ -264,7 +264,7 @@ val generate_agree :
     EverParse-generated validators and exits nonzero on any input where the
     validator's accept/reject decision differs from the recorded verdict. It
     reads the [<Name>CheckWire<Codec>] helper names from the generated
-    [<Name>Wrapper.h], so {!generate_c_standalone} (or [3d.exe]) must have run
+    [<Name>Wrapper.h], so {!generate_standalone} (or [3d.exe]) must have run
     first. *)
 
 val main :

--- a/lib/bitfield.ml
+++ b/lib/bitfield.ml
@@ -8,8 +8,8 @@ let total_bits = function U8 -> 8 | U16 _ -> 16 | U32 _ -> 32
 let equal a b =
   match (a, b) with
   | U8, U8 -> true
-  | U16 e1, U16 e2 -> e1 = e2
-  | U32 e1, U32 e2 -> e1 = e2
+  | U16 e1, U16 e2 -> Types.equal_endian e1 e2
+  | U32 e1, U32 e2 -> Types.equal_endian e1 e2
   | _ -> false
 
 (* Fast word reads -- avoid Bytes.get_int32_be which goes through Int32

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -146,26 +146,12 @@ and build_field_encoder_ctx : type a.
         off + 4
   | Int64 Little -> fun _runtime -> setter_off 8 Bytes.set_int64_le
   | Int64 Big -> fun _runtime -> setter_off 8 Bytes.set_int64_be
-  | Float32 Little ->
-      fun _runtime buf off v ->
-        Bytes.set_int32_le buf off (Int32.bits_of_float v);
-        off + 4
-  | Float32 Big ->
-      fun _runtime buf off v ->
-        Bytes.set_int32_be buf off (Int32.bits_of_float v);
-        off + 4
-  | Float64 Little ->
-      fun _runtime buf off v ->
-        Bytes.set_int64_le buf off (Int64.bits_of_float v);
-        off + 8
-  | Float64 Big ->
-      fun _runtime buf off v ->
-        Bytes.set_int64_be buf off (Int64.bits_of_float v);
-        off + 8
+  | Float32 Little -> fun _runtime -> float32_field_encoder Bytes.set_int32_le
+  | Float32 Big -> fun _runtime -> float32_field_encoder Bytes.set_int32_be
+  | Float64 Little -> fun _runtime -> float64_field_encoder Bytes.set_int64_le
+  | Float64 Big -> fun _runtime -> float64_field_encoder Bytes.set_int64_be
   | Uint_var { size = Int n; endian } ->
-      fun _runtime buf off v ->
-        Uint_var.write endian buf off n v;
-        off + n
+      fun _runtime -> uint_var_field_encoder endian n
   | Byte_array { size = Int n } -> fun _runtime -> blit_string_padded n
   | Byte_array_where { size = Int n; _ } -> fun _runtime -> blit_string_padded n
   | Byte_slice { size = Int n } ->
@@ -3046,6 +3032,32 @@ let validate_or_eof buf f =
     let len = Bytes.length buf in
     raise_eof ~at:len ~expected:(len + 1) ~got:len
 
+let has_validation_checks compiled_where struct_fields =
+  compiled_where <> None
+  || List.exists
+       (fun (Types.Field f) ->
+         f.constraint_ <> None || f.action <> None
+         || field_reader_validates f.field_typ)
+       struct_fields
+
+let seed_param_slots arr n_total = function
+  | None -> ()
+  | Some slots ->
+      let n = Array.length slots in
+      Array.blit slots 0 arr.ints (n_total - n) n
+
+let validation_runtime param_slots arr buf =
+  Types.eval_ctx
+    ~set_param:(fun name value ->
+      match Hashtbl.find_opt param_slots name with
+      | Some idx -> arr.ints.(idx) <- value
+      | None -> ())
+    buf
+    (fun name ->
+      match Hashtbl.find_opt param_slots name with
+      | Some idx -> arr.ints.(idx)
+      | None -> 0)
+
 let build_validators validators_rev checkers_rev compiled_where struct_fields
     param_slots n_total =
   let validator_fns = Array.of_list (List.map snd validators_rev) in
@@ -3070,14 +3082,7 @@ let build_validators validators_rev checkers_rev compiled_where struct_fields
      [validate_with_bounds]. A codec of plain scalars and byte spans then
      validates with no allocation, so validating it on a hot read path (a
      [Codec.get] preceded by [validate]) stays cheap. *)
-  let has_checks =
-    compiled_where <> None
-    || List.exists
-         (fun (Types.Field f) ->
-           f.constraint_ <> None || f.action <> None
-           || field_reader_validates f.field_typ)
-         struct_fields
-  in
+  let has_checks = has_validation_checks compiled_where struct_fields in
   let validate =
     if not has_checks then fun ?env_slots:_ _buf _off -> ()
     else
@@ -3085,25 +3090,10 @@ let build_validators validators_rev checkers_rev compiled_where struct_fields
       fun ?env_slots buf off ->
         let arr = get_arr () in
         clear_slots arr n_total;
-        (match env_slots with
-        | Some slots ->
-            (* Seed param slots so [where] clauses referencing [Param.input]
-               evaluate correctly. *)
-            let n = Array.length slots in
-            Array.blit slots 0 arr.ints (n_total - n) n
-        | None -> ());
-        let runtime =
-          Types.eval_ctx
-            ~set_param:(fun name value ->
-              match Hashtbl.find_opt param_slots name with
-              | Some idx -> arr.ints.(idx) <- value
-              | None -> ())
-            buf
-            (fun name ->
-              match Hashtbl.find_opt param_slots name with
-              | Some idx -> arr.ints.(idx)
-              | None -> 0)
-        in
+        (* Seed param slots so [where] clauses referencing [Param.input]
+           evaluate correctly. *)
+        seed_param_slots arr n_total env_slots;
+        let runtime = validation_runtime param_slots arr buf in
         validate_or_eof buf (fun () -> validate_arr arr runtime off)
   in
   (validate_arr, populate, validate)
@@ -3117,7 +3107,7 @@ let collect_param_handles codec_name struct_fields where =
         Hashtbl.add seen p.name packed;
         handles := packed :: !handles
     | Some (Param.Pack existing) ->
-        if not (Obj.repr p == Obj.repr existing) then
+        if p.Types.id <> existing.Types.id then
           Fmt.invalid_arg "Codec.v %S: duplicate parameter name %S" codec_name
             p.name
   in
@@ -3396,6 +3386,30 @@ let reject_invalid_codec_shape name fields =
   reject_nested_where name fields;
   reject_certain_byte_size_mul name fields
 
+let build_size_of_value size_funcs =
+  let n = Array.length size_funcs in
+  fun value ->
+    let total = Stdlib.ref 0 in
+    for i = 0 to n - 1 do
+      total := !total + size_funcs.(i) value
+    done;
+    !total
+
+let build_record_encoder name writers size_of_value =
+  let n = Array.length writers in
+  fun value runtime off ->
+    let buf = Types.eval_bytes runtime in
+    let need = size_of_value value in
+    if off + need > Bytes.length buf then
+      Fmt.invalid_arg "Codec.encode %s: buffer too short (need %d, got %d)" name
+        need
+        (Bytes.length buf - off);
+    let write_off = Stdlib.ref off in
+    for i = 0 to n - 1 do
+      write_off := writers.(i) value runtime off !write_off
+    done;
+    !write_off
+
 let seal : type r. (r, r) record -> r t =
  fun (Record r) ->
   let codec_id = Atomic.fetch_and_add id_counter 1 in
@@ -3407,7 +3421,6 @@ let seal : type r. (r, r) record -> r t =
   in
   let min_size = r.min_wire_size in
   let writers = Array.of_list (List.rev r.writers_rev) in
-  let n_writers = Array.length writers in
   let raw_decode = build_decode r.make r.readers in
   let validators = List.rev r.validators_rev in
   let param_base = r.n_array_slots in
@@ -3428,14 +3441,7 @@ let seal : type r. (r, r) record -> r t =
   (* Per-field action runners *)
   let field_actions = List.rev r.field_actions_rev in
   let size_funcs = Array.of_list (List.rev r.size_of_value_rev) in
-  let n_size_funcs = Array.length size_funcs in
-  let size_of_value v =
-    let total = Stdlib.ref 0 in
-    for i = 0 to n_size_funcs - 1 do
-      total := !total + size_funcs.(i) v
-    done;
-    !total
-  in
+  let size_of_value = build_size_of_value size_funcs in
   {
     id = codec_id;
     name = r.name;
@@ -3444,19 +3450,7 @@ let seal : type r. (r, r) record -> r t =
     field_readers = List.rev r.field_readers;
     field_actions;
     decode = build_checked_decode raw_decode wire_size_info min_size;
-    encode =
-      (fun v runtime off ->
-        let buf = Types.eval_bytes runtime in
-        let need = size_of_value v in
-        if off + need > Bytes.length buf then
-          Fmt.invalid_arg "Codec.encode %s: buffer too short (need %d, got %d)"
-            r.name need
-            (Bytes.length buf - off);
-        let write_off = Stdlib.ref off in
-        for i = 0 to n_writers - 1 do
-          write_off := writers.(i) v runtime off !write_off
-        done;
-        !write_off);
+    encode = build_record_encoder r.name writers size_of_value;
     wire_size = wire_size_info;
     struct_fields;
     validate =

--- a/lib/everparse.ml
+++ b/lib/everparse.ml
@@ -272,7 +272,8 @@ let rec unwrap_bits : type a.
 
 let is_same_bit_group base bit_order (Types.Field f) =
   match unwrap_bits f.field_typ with
-  | Some (b2, bo2, _) -> b2 = base && bo2 = bit_order
+  | Some (b2, bo2, _) ->
+      Bitfield.equal b2 base && Types.equal_bit_order bo2 bit_order
   | None -> false
 
 let bit_width (Types.Field f) =
@@ -310,7 +311,7 @@ let reorder_bit_group base bit_order f0 rest =
   let native = Bitfield.native_bit_order base in
   let used, group, rest' = collect_bit_group base bit_order total f0 rest in
   let emitted =
-    if bit_order = native then group
+    if Types.equal_bit_order bit_order native then group
     else
       (* Backward references in reversed order would break: fields now
          come before the values their constraints read. Collapse all
@@ -482,7 +483,9 @@ let coalesced_wire_size fields =
           | Some (base, order, width) -> (
               match open_base with
               | Some b
-                when b = base && bit_order = Some order
+                when Bitfield.equal b base
+                     && Option.equal Types.equal_bit_order bit_order
+                          (Some order)
                      && bits_used + width <= Bitfield.total_bits base ->
                   (total, open_base, bits_used + width, bit_order)
               | _ ->

--- a/lib/field.mli
+++ b/lib/field.mli
@@ -131,10 +131,8 @@ val action : 'a t -> Types.action option
 val doc : 'a t -> string option
 (** Field note attached via {!v}'s [?doc], if any. *)
 
-type packed =
-  | Named : 'a t -> packed
-  | Anon : 'a anon -> packed
-      (** Existentially packed field for heterogeneous lists. *)
+(** Existentially packed field for heterogeneous lists. *)
+type packed = Named : 'a t -> packed | Anon : 'a anon -> packed
 
 val decl_of_packed : packed -> Types.field
 (** [decl_of_packed p] is the {!Types.field} declaration of [p]. *)

--- a/lib/param.ml
+++ b/lib/param.ml
@@ -11,6 +11,8 @@ type 'a int_cvt = { fwd : 'a -> int; bwd : int -> 'a }
 
 exception Unfittable_native_int
 
+let id_counter = Atomic.make 0
+
 let optint_to_int to_int value =
   match to_int value with
   | value -> value
@@ -71,11 +73,13 @@ let check_typ name typ =
 
 let input name typ =
   check_typ "input" typ;
-  { Types.name; typ; packed_typ = Types.Pack_typ typ; mutable_ = false }
+  let id = Atomic.fetch_and_add id_counter 1 in
+  { Types.id; name; typ; packed_typ = Types.Pack_typ typ; mutable_ = false }
 
 let output name typ =
   check_typ "output" typ;
-  { Types.name; typ; packed_typ = Types.Pack_typ typ; mutable_ = true }
+  let id = Atomic.fetch_and_add id_counter 1 in
+  { Types.id; name; typ; packed_typ = Types.Pack_typ typ; mutable_ = true }
 
 let decl (t : ('a, 'k) t) : Types.param =
   { param_name = t.name; param_typ = t.packed_typ; mutable_ = t.mutable_ }

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -1,6 +1,16 @@
 type endian = Little | Big
 type bit_order = Msb_first | Lsb_first
 
+let equal_endian a b =
+  match (a, b) with
+  | Little, Little | Big, Big -> true
+  | Little, Big | Big, Little -> false
+
+let equal_bit_order a b =
+  match (a, b) with
+  | Msb_first, Msb_first | Lsb_first, Lsb_first -> true
+  | Msb_first, Lsb_first | Lsb_first, Msb_first -> false
+
 (* Sequence builder for Array/Repeat -- Jsont-style accumulator pattern.
    Existentially hides the builder type so callers control the output container. *)
 type ('elt, 'seq) seq_map =
@@ -99,6 +109,7 @@ let raise_constraint ~at ~which ?value () =
   raise_error ~at (Constraint_failed { which; value })
 
 type ('a, 'k) param_handle = {
+  id : int;
   name : string;
   typ : 'a typ;
   packed_typ : packed_typ;

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -1,6 +1,10 @@
 (** Core type definitions for the Wire DSL. *)
 
-type endian = Little | Big  (** Byte order. *)
+(** Byte order. *)
+type endian = Little | Big
+
+val equal_endian : endian -> endian -> bool
+(** [equal_endian a b] is [true] when [a] and [b] are the same byte order. *)
 
 type eval_ctx
 (** Explicit runtime context for buffer and parameter expression evaluation.
@@ -31,6 +35,9 @@ val eval_set_param : eval_ctx -> string -> int -> unit
 (** Which predicate a {!Constraint_failed} came from. *)
 type predicate = Where | Field | Action | Per_byte
 
+(** Parse failure categories. For {!constructor-Constraint_failed}, [value] is
+    the offending field's value for a single-field self-constraint and [None]
+    for a cross-field or where predicate. *)
 type error_kind =
   | Unexpected_eof of { expected : int; got : int }
   | Invalid_enum of { value : int; valid : int list }
@@ -39,8 +46,6 @@ type error_kind =
   | Non_zero_padding
   | Value_out_of_range of { value : int64 }
   | Constraint_failed of { which : predicate; value : int64 option }
-      (** [value] is the offending field's value for a single-field
-          self-constraint, [None] for a cross-field or where predicate. *)
 
 type parse_error = { at : int; field : string list; kind : error_kind }
 (** [at] is the absolute byte offset of the failing field. Alongside it the
@@ -63,24 +68,26 @@ val eof :
 (** [eof ~expected ~got ()] is [parse_error (Unexpected_eof { expected; got })]:
     the input ended with [got] bytes where [expected] were needed. *)
 
-type bit_order =
-  | Msb_first
-  | Lsb_first
-      (** Which end of a packed base word the first declared bitfield occupies.
+(** Which end of a packed base word the first declared bitfield occupies.
 
-          [Msb_first] places the first declared field at the most significant
-          bit, matching how RFC, CCSDS, and IETF specs draw their bit diagrams.
-          [Lsb_first] places it at bit 0, matching MSVC C bit-field packing.
+    {!constructor-Msb_first} places the first declared field at the most
+    significant bit, matching how RFC, CCSDS, and IETF specs draw their bit
+    diagrams. {!constructor-Lsb_first} places it at bit 0, matching MSVC C
+    bit-field packing.
 
-          Bit order is independent of byte order. Every combination of base word
-          and bit order is a valid wire description. When projecting to
-          EverParse 3D, the export layer reverses field declaration order within
-          a bit group if the user's bit order differs from EverParse's native
-          choice for the base; this preserves byte layout in memory and is
-          invisible to the user. *)
+    Bit order is independent of byte order. Every combination of base word and
+    bit order is a valid wire description. When projecting to EverParse 3D, the
+    export layer reverses field declaration order within a bit group if the
+    user's bit order differs from EverParse's native choice for the base; this
+    preserves byte layout in memory and is invisible to the user. *)
+type bit_order = Msb_first | Lsb_first
+
+val equal_bit_order : bit_order -> bit_order -> bool
+(** [equal_bit_order a b] is [true] when [a] and [b] are the same bit order. *)
 
 (** {1 Sequence builders} *)
 
+(** Builder for sequence accumulation. Existentially hides the builder type. *)
 type ('elt, 'seq) seq_map =
   | Seq_map : {
       empty : 'b;
@@ -89,8 +96,6 @@ type ('elt, 'seq) seq_map =
       iter : ('elt -> unit) -> 'seq -> unit;
     }
       -> ('elt, 'seq) seq_map
-      (** Builder for sequence accumulation. Existentially hides the builder
-          type. *)
 
 val seq_list : ('a, 'a list) seq_map
 (** Default builder: accumulate into a list. *)
@@ -118,6 +123,7 @@ type param_input
 type param_output
 
 type ('a, 'k) param_handle = {
+  id : int;
   name : string;
   typ : 'a typ;
   packed_typ : packed_typ;
@@ -133,6 +139,7 @@ and packed_typ = Pack_typ : 'a typ -> packed_typ
 
 and _ ref_kind = I : int ref_kind | I64 : int64 ref_kind
 
+(** Typed expressions used in constraints, actions, and sizes. *)
 and _ expr =
   | Int : int -> int expr
   | Int64 : int64 -> int64 expr
@@ -166,14 +173,11 @@ and _ expr =
   | Not : bool expr -> bool expr
   | Cast : [ `U8 | `U16 | `U32 | `U64 ] * int expr -> int expr
   | If_then_else : bool expr * int expr * int expr -> int expr
-      (** Ternary [(cond ? then_ : else_)] for conditional byte-size. *)
 
 (** {1 Types} *)
 
-and bitfield_base =
-  | U8
-  | U16 of endian
-  | U32 of endian  (** Base storage for bitfield extractions. *)
+(** Base storage for bitfield extractions. *)
+and bitfield_base = U8 | U16 of endian | U32 of endian
 
 and _ typ =
   | Uint8 : int typ  (** 8-bit unsigned. *)
@@ -292,8 +296,8 @@ and ('a, 'k) case_branch =
     }
       -> ('a, 'k) case_branch
 
-and packed_expr =
-  | Pack_expr : 'a expr -> packed_expr  (** Existentially packed expression. *)
+(** Existentially packed expression. *)
+and packed_expr = Pack_expr : 'a expr -> packed_expr
 
 and struct_ = {
   name : string;
@@ -303,6 +307,7 @@ and struct_ = {
 }
 (** Struct declaration. *)
 
+(** A single struct field. *)
 and field =
   | Field : {
       field_name : string option;
@@ -311,15 +316,15 @@ and field =
       action : action option;
       field_doc : string option;
     }
-      -> field  (** A single struct field. *)
+      -> field
 
 and param = { param_name : string; param_typ : packed_typ; mutable_ : bool }
 (** Formal parameter. *)
 
-and action =
-  | Success of action_stmt list
-  | Act of action_stmt list  (** Action attached to a field. *)
+(** Action attached to a field. *)
+and action = Success of action_stmt list | Act of action_stmt list
 
+(** Statements available in field actions. *)
 and action_stmt =
   | Assign : ('a, param_output) param_handle * int expr -> action_stmt
   | Field_assign of string * string * int expr
@@ -327,17 +332,17 @@ and action_stmt =
   | Return of bool expr
   | Abort
   | If of bool expr * action_stmt list * action_stmt list option
-  | Var of string * int expr  (** Action statement. *)
+  | Var of string * int expr
 
 type param_env = {
   codec_id : int;
   names : string array;
-      (** Parallel to [slots]: the param name at each slot, so a handle resolves
-          to its slot by name (per-env, hence per-codec). *)
+      (** Parallel to {!field-slots}: the param name at each slot, so a handle
+          resolves to its slot by name (per-env, hence per-codec). *)
   slots : int array;
   bound : bool array;
-      (** Parallel to [slots]; set by [Param.bind] so consumers can detect
-          unbound input params. *)
+      (** Parallel to {!field-slots}; set by [Param.bind] so consumers can
+          detect unbound input params. *)
 }
 
 (** {1 Expression Constructors} *)

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -209,69 +209,40 @@ let parse_struct_typ s buf off len =
   Codec.validate_struct v buf off;
   ((), off + sz)
 
+let parse_fixed size get buf off len =
+  check_eof len (off + size);
+  (get buf off, off + size)
+
+let int32_le buf off = Int32.to_int (Bytes.get_int32_le buf off)
+let int32_be buf off = Int32.to_int (Bytes.get_int32_be buf off)
+let float32_le buf off = Int32.float_of_bits (Bytes.get_int32_le buf off)
+let float32_be buf off = Int32.float_of_bits (Bytes.get_int32_be buf off)
+let float64_le buf off = Int64.float_of_bits (Bytes.get_int64_le buf off)
+let float64_be buf off = Int64.float_of_bits (Bytes.get_int64_be buf off)
+
 let rec parse_direct : type a. a typ -> bytes -> int -> int -> a * int =
  fun typ buf off len ->
   match typ with
-  | Uint8 ->
-      check_eof len (off + 1);
-      (Bytes.get_uint8 buf off, off + 1)
-  | Uint16 Little ->
-      check_eof len (off + 2);
-      (Bytes.get_uint16_le buf off, off + 2)
-  | Uint16 Big ->
-      check_eof len (off + 2);
-      (Bytes.get_uint16_be buf off, off + 2)
-  | Uint32 Little ->
-      check_eof len (off + 4);
-      (UInt32.le buf off, off + 4)
-  | Uint32 Big ->
-      check_eof len (off + 4);
-      (UInt32.be buf off, off + 4)
-  | Uint63 Little ->
-      check_eof len (off + 8);
-      (UInt63.le buf off, off + 8)
-  | Uint63 Big ->
-      check_eof len (off + 8);
-      (UInt63.be buf off, off + 8)
-  | Uint64 Little ->
-      check_eof len (off + 8);
-      (Bytes.get_int64_le buf off, off + 8)
-  | Uint64 Big ->
-      check_eof len (off + 8);
-      (Bytes.get_int64_be buf off, off + 8)
-  | Int8 ->
-      check_eof len (off + 1);
-      (Bytes.get_int8 buf off, off + 1)
-  | Int16 Little ->
-      check_eof len (off + 2);
-      (Bytes.get_int16_le buf off, off + 2)
-  | Int16 Big ->
-      check_eof len (off + 2);
-      (Bytes.get_int16_be buf off, off + 2)
-  | Int32 Little ->
-      check_eof len (off + 4);
-      (Int32.to_int (Bytes.get_int32_le buf off), off + 4)
-  | Int32 Big ->
-      check_eof len (off + 4);
-      (Int32.to_int (Bytes.get_int32_be buf off), off + 4)
-  | Int64 Little ->
-      check_eof len (off + 8);
-      (Bytes.get_int64_le buf off, off + 8)
-  | Int64 Big ->
-      check_eof len (off + 8);
-      (Bytes.get_int64_be buf off, off + 8)
-  | Float32 Little ->
-      check_eof len (off + 4);
-      (Int32.float_of_bits (Bytes.get_int32_le buf off), off + 4)
-  | Float32 Big ->
-      check_eof len (off + 4);
-      (Int32.float_of_bits (Bytes.get_int32_be buf off), off + 4)
-  | Float64 Little ->
-      check_eof len (off + 8);
-      (Int64.float_of_bits (Bytes.get_int64_le buf off), off + 8)
-  | Float64 Big ->
-      check_eof len (off + 8);
-      (Int64.float_of_bits (Bytes.get_int64_be buf off), off + 8)
+  | Uint8 -> parse_fixed 1 Bytes.get_uint8 buf off len
+  | Uint16 Little -> parse_fixed 2 Bytes.get_uint16_le buf off len
+  | Uint16 Big -> parse_fixed 2 Bytes.get_uint16_be buf off len
+  | Uint32 Little -> parse_fixed 4 UInt32.le buf off len
+  | Uint32 Big -> parse_fixed 4 UInt32.be buf off len
+  | Uint63 Little -> parse_fixed 8 UInt63.le buf off len
+  | Uint63 Big -> parse_fixed 8 UInt63.be buf off len
+  | Uint64 Little -> parse_fixed 8 Bytes.get_int64_le buf off len
+  | Uint64 Big -> parse_fixed 8 Bytes.get_int64_be buf off len
+  | Int8 -> parse_fixed 1 Bytes.get_int8 buf off len
+  | Int16 Little -> parse_fixed 2 Bytes.get_int16_le buf off len
+  | Int16 Big -> parse_fixed 2 Bytes.get_int16_be buf off len
+  | Int32 Little -> parse_fixed 4 int32_le buf off len
+  | Int32 Big -> parse_fixed 4 int32_be buf off len
+  | Int64 Little -> parse_fixed 8 Bytes.get_int64_le buf off len
+  | Int64 Big -> parse_fixed 8 Bytes.get_int64_be buf off len
+  | Float32 Little -> parse_fixed 4 float32_le buf off len
+  | Float32 Big -> parse_fixed 4 float32_be buf off len
+  | Float64 Little -> parse_fixed 8 float64_le buf off len
+  | Float64 Big -> parse_fixed 8 float64_be buf off len
   | Uint_var { size; endian } ->
       let n = Eval.expr Eval.empty size in
       check_eof len (off + n);

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -1,8 +1,8 @@
 (** Binary wire format descriptions.
 
-    A wire format is a sequence of typed {!Field}s -- integers, bitfields,
-    enumerations, byte arrays -- laid out at fixed bit offsets in a buffer. A
-    {!Codec} binds those fields to an OCaml record, giving you:
+    A wire format is a sequence of typed {!module-Field} values -- integers,
+    bitfields, enumerations, byte arrays -- laid out at fixed bit offsets in a
+    buffer. A {!Codec} binds those fields to an OCaml record, giving you:
 
     - Zero-copy field access via staged getters and setters.
     - Full-record [decode] / [encode] between bytes and OCaml values.
@@ -60,29 +60,25 @@ end
 type 'a expr = 'a Types.expr
 type bitfield = U8 | U16 | U16be | U32 | U32be
 
-type bit_order = Types.bit_order =
-  | Msb_first
-  | Lsb_first
-      (** Which end of a packed base word the first declared bitfield occupies.
+(** Which end of a packed base word the first declared bitfield occupies.
 
-          - [Msb_first] (default): the first declared field lands at the most
-            significant bit of the base word, matching how RFC, CCSDS, and IETF
-            specs draw their bit diagrams. Copy-pasting a spec into field
-            declarations just works.
+    - {!constructor-Msb_first} (default): the first declared field lands at the
+      most significant bit of the base word, matching how RFC, CCSDS, and IETF
+      specs draw their bit diagrams. Copy-pasting a spec into field declarations
+      just works.
 
-          - [Lsb_first]: the first declared field lands at bit 0 of the base
-            word, matching MSVC's C bit-field packing. Useful when mirroring a C
-            struct.
+    - {!constructor-Lsb_first}: the first declared field lands at bit 0 of the
+      base word, matching MSVC's C bit-field packing. Useful when mirroring a C
+      struct.
 
-          Bit order is independent of byte order: any combination of base word
-          and bit order is a valid wire description, and the EverParse 3D
-          projection reverses declaration order within a bit group when
-          necessary so that every pairing emits a valid 3D schema with identical
-          byte layout. *)
+    Bit order is independent of byte order: any combination of base word and bit
+    order is a valid wire description, and the EverParse 3D projection reverses
+    declaration order within a bit group when necessary so that every pairing
+    emits a valid 3D schema with identical byte layout. *)
+type bit_order = Types.bit_order = Msb_first | Lsb_first
 
-type endian = Types.endian =
-  | Little
-  | Big  (** Byte order for multi-byte integers. *)
+(** Byte order for multi-byte integers. *)
+type endian = Types.endian = Little | Big
 
 type 'a typ = 'a Types.typ
 
@@ -516,7 +512,7 @@ module Field : sig
   (** Field note attached via {!v}'s [?doc], if any. *)
 
   val decl_of_packed : packed -> Types.field
-  (** The {!Types.field} declaration of a packed field. *)
+  (** The underlying field declaration of a packed field. *)
 end
 
 (** {1 Type Descriptions}
@@ -538,19 +534,19 @@ val uint16be : int typ
 (** Unsigned 16-bit big-endian integer. *)
 
 val uint32 : Optint.t typ
-(** Unsigned 32-bit little-endian integer. Decodes to an {!Optint.t} so a value
+(** Unsigned 32-bit little-endian integer. Decodes to an [Optint.t] so a value
     with bit 31 set survives on a narrow-int target (js/wasm). *)
 
 val uint32be : Optint.t typ
-(** Unsigned 32-bit big-endian integer. Decodes to an {!Optint.t}. *)
+(** Unsigned 32-bit big-endian integer. Decodes to an [Optint.t]. *)
 
 val uint63 : Optint.Int63.t typ
 (** Unsigned 63-bit little-endian integer carried on 8 bytes. Decodes to an
-    {!Optint.Int63.t}. *)
+    [Optint.Int63.t]. *)
 
 val uint63be : Optint.Int63.t typ
 (** Unsigned 63-bit big-endian integer carried on 8 bytes. Decodes to an
-    {!Optint.Int63.t}. *)
+    [Optint.Int63.t]. *)
 
 val uint64 : int64 typ
 (** [uint64] is an unsigned 64-bit little-endian integer represented as an OCaml
@@ -612,7 +608,7 @@ val is_nan : float Field.t -> bool expr
 val uint : ?endian:endian -> int expr -> UInt63.t typ
 (** [uint size] is an unsigned integer of [size] bytes (1-7) with the given byte
     order (default {!Big}). The size may be a dynamic expression for
-    parameter-driven widths. Decodes to a {!UInt63.t}: a 7-byte value needs 56
+    parameter-driven widths. Decodes to a [UInt63.t]: a 7-byte value needs 56
     bits, which does not fit an int on a narrow-int target (js/wasm). *)
 
 val bits : ?bit_order:bit_order -> width:int -> bitfield -> int typ
@@ -680,6 +676,7 @@ val zeroterm_at_most : size:int expr -> string typ
 val where : bool expr -> 'a typ -> 'a typ
 (** Refine a description with a boolean constraint. *)
 
+(** Builder for sequence accumulation (Jsont-style). *)
 type ('elt, 'seq) seq_map = ('elt, 'seq) Types.seq_map =
   | Seq_map : {
       empty : 'b;
@@ -688,7 +685,6 @@ type ('elt, 'seq) seq_map = ('elt, 'seq) Types.seq_map =
       iter : ('elt -> unit) -> 'seq -> unit;
     }
       -> ('elt, 'seq) seq_map
-      (** Builder for sequence accumulation (Jsont-style). *)
 
 val seq_list : ('a, 'a list) seq_map
 (** Default builder: accumulate into a list. *)
@@ -813,14 +809,17 @@ val size : 'a typ -> int option
 
 (** {1 Parsing Errors}
 
-    Direct decoding reports failures as values of type {!parse_error}. The cases
-    distinguish structural failure on input, such as unexpected end of input or
-    a constraint violation, from semantic failure such as an invalid enum or
-    tag. *)
+    Direct decoding reports failures as values of type {!type-parse_error}. The
+    cases distinguish structural failure on input, such as unexpected end of
+    input or a constraint violation, from semantic failure such as an invalid
+    enum or tag. *)
 
 (** Which predicate a {!Constraint_failed} came from. *)
 type predicate = Where | Field | Action | Per_byte
 
+(** Parse failure categories. For {!constructor-Constraint_failed}, [value] is
+    the offending field's value for a single-field self-constraint and [None]
+    for a cross-field or where predicate. *)
 type error_kind =
   | Unexpected_eof of { expected : int; got : int }
   | Invalid_enum of { value : int; valid : int list }
@@ -829,8 +828,6 @@ type error_kind =
   | Non_zero_padding
   | Value_out_of_range of { value : int64 }
   | Constraint_failed of { which : predicate; value : int64 option }
-      (** [value] is the offending field's value for a single-field
-          self-constraint, [None] for a cross-field or where predicate. *)
 
 type parse_error = { at : int; field : string list; kind : error_kind }
 (** [at] is the absolute byte offset of the failing field. Alongside it the
@@ -876,7 +873,7 @@ val eof :
     values with bytes.
 
     Use them when you want a value now: one-shot decoding, streaming code built
-    around {!Bytesrw}, tests, small tools, and formats that are naturally
+    around [Bytesrw], tests, small tools, and formats that are naturally
     consumed as values.
 
     Use {!Codec} instead when the format is record-shaped and the main goal is
@@ -937,7 +934,7 @@ val of_bytes_exn : 'a typ -> bytes -> 'a
     data-dependent and should not be silently ignored. *)
 
 val to_writer : 'a typ -> 'a -> Bytesrw.Bytes.Writer.t -> unit
-(** Encodes one value to a {!Bytesrw.Bytes.Writer.t}.
+(** Encodes one value to a [Bytesrw.Bytes.Writer.t].
 
     This function is exception-based. Unsupported description forms, such as
     unresolved type references, raise an exception rather than returning an
@@ -951,8 +948,8 @@ val to_string : 'a typ -> 'a -> string
 
 (** {1 Codecs}
 
-    A codec is the primary way to work with a wire format. It binds {!Field}s to
-    an OCaml record type and provides:
+    A codec is the primary way to work with a wire format. It binds
+    {!module-Field} values to an OCaml record type and provides:
 
     - {b Zero-copy field access}: {!Codec.get} and {!Codec.set} read and write
       individual fields directly in a buffer -- no intermediate record
@@ -1063,7 +1060,7 @@ module Codec : sig
       bindings for any {!val:Param.input} referenced in those clauses.
 
       Raises [Invalid_argument] when [?env] belongs to another codec or leaves
-      an input parameter unbound, and {!Validation_error} on failure. *)
+      an input parameter unbound, and {!exception-Parse_error} on failure. *)
 
   val get :
     ?env:Param.env -> 'r t -> ('a, 'r) field -> (bytes -> int -> 'a) Staged.t
@@ -1087,7 +1084,7 @@ module Codec : sig
 
       Zero-copy access to the offset/length of a [byte_slice] field. The naive
       nesting [Slice.first (Codec.get c f buf base)] forces [Codec.get] to
-      allocate a fresh {!Bytesrw.Bytes.Slice.t} -- 4 words -- only for
+      allocate a fresh [Bytesrw.Bytes.Slice.t] -- 4 words -- only for
       [Slice.first] to extract one int and discard the rest. {!slice_offset}
       skips the make and returns the int directly. *)
 
@@ -1143,7 +1140,7 @@ module Codec : sig
   (** [validator_of_struct s] compiles [s] into a validator. *)
 
   val validate_struct : validator -> bytes -> int -> unit
-  (** Run the validator. Raises {!Validation_error} on failure. *)
+  (** Run the validator. Raises {!exception-Parse_error} on failure. *)
 
   val struct_size_of : validator -> bytes -> int -> int
   (** Byte size of the struct starting at [off]. *)
@@ -1185,7 +1182,8 @@ val codec : 'r Codec.t -> 'r typ
 
     {!Everparse} is the pure export layer. The normal workflow is:
 
-    - build a record-shaped description with {!Field} and {!Codec};
+    - build a record-shaped description with {!module-Field} and
+      {!module-Codec};
     - project it with {!Everparse.project};
     - emit one [.3d] file per schema with {!Everparse.write};
     - run EverParse/C tooling with [Wire_3d];
@@ -1285,7 +1283,8 @@ module Everparse : sig
 
         These constructors exist for EverParse features that currently have no
         codec-level equivalent, plus the struct-level projection knobs. Most
-        users should stay on the {!Field}/{!Codec} path and use {!project}. *)
+        users should stay on the {!module-Field}/{!module-Codec} path and use
+        {!project}. *)
 
     type nonrec struct_ = struct_
     type field = Field.packed
@@ -1364,16 +1363,8 @@ module Everparse : sig
     val field_names : struct_ -> string list
     (** Named field names in declaration order. *)
 
-    type ocaml_kind =
-      | Int
-      | Int64
-      | Float32
-      | Float64
-      | Bool
-      | String
-      | Unit
-          (** The OCaml representation kind of a field (for FFI stub
-              generation). *)
+    (** The OCaml representation kind of a field (for FFI stub generation). *)
+    type ocaml_kind = Int | Int64 | Float32 | Float64 | Bool | String | Unit
 
     val field_kinds : struct_ -> (string * ocaml_kind) list
     (** Named field names with their OCaml type kind. *)

--- a/scripts/install-git-hooks
+++ b/scripts/install-git-hooks
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -eu
+
+repo=$(git rev-parse --show-toplevel)
+git config core.hooksPath scripts
+echo "Git hooks now use $repo/scripts"

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+set -eu
+
+if git diff --cached --quiet -- '*.ml' '*.mli' '*.mll' '*.mly'; then
+  exit 0
+fi
+
+# Keep this file-local: a repo-wide [dune fmt] discovers symlinked workspace
+# subtrees and can hit https://github.com/ocaml/dune/issues/10635.
+if ! git diff --cached --name-only --diff-filter=ACM -z -- \
+  '*.ml' '*.mli' '*.mll' '*.mly' \
+  | xargs -0 opam exec -- ocamlformat --check --
+then
+  echo "Staged OCaml files are not formatted; run opam exec -- dune fmt." >&2
+  exit 1
+fi
+
+git diff --cached --name-only --diff-filter=ACM -z -- \
+  '*.ml' '*.mli' '*.mll' '*.mly' \
+  | xargs -0 merlint --no-build >/tmp/git-merlint-hook.log 2>&1 \
+  || {
+    echo "merlint failed; see /tmp/git-merlint-hook.log for details" >&2
+    exit 1
+  }

--- a/test/3d/dune
+++ b/test/3d/dune
@@ -6,7 +6,7 @@
 (test
  (name test)
  (modules test test_wire_3d)
- (libraries wire wire.3d alcotest re unix))
+ (libraries wire wire.3d alcotest re unix fmt))
 
 (rule
  (targets

--- a/test/3d/test_wire_3d.ml
+++ b/test/3d/test_wire_3d.ml
@@ -542,12 +542,15 @@ let test_archive_hides_raw_validators () =
            ~objcopy:"objcopy" ~ar:"ar" ~archive ~base ~wrappers
     in
     let run cmd =
-      let ic = Unix.open_process_in (Fmt.str "cd %s && %s 2>&1" tmpdir cmd) in
-      let out = In_channel.input_all ic in
-      (out, Unix.close_process_in ic)
+      Fmt.kstr
+        (fun command ->
+          let ic = Unix.open_process_in command in
+          let out = In_channel.input_all ic in
+          (out, Unix.close_process_in ic))
+        "cd %s && %s 2>&1" tmpdir cmd
     in
     let build_out, build_status = run (String.concat " && " steps) in
-    let nm_out, _ = run (Fmt.str "nm %s" archive) in
+    let nm_out, _ = Fmt.kstr run "nm %s" archive in
     ignore (Fmt.kstr Sys.command "rm -rf %s" tmpdir);
     (match build_status with
     | Unix.WEXITED 0 -> ()

--- a/test/bench/dune
+++ b/test/bench/dune
@@ -1,7 +1,7 @@
 (test
  (name test)
  (modules test test_bench_lib test_demo_bench_cases)
- (libraries bench_lib demo_bench_cases alcotest unix))
+ (libraries bench_lib demo_bench_cases alcotest unix fmt))
 
 (executable
  (name bench)

--- a/test/diff/dune
+++ b/test/diff/dune
@@ -26,7 +26,7 @@
 (executable
  (name gen_schemas)
  (modules gen_schemas)
- (libraries schema))
+ (libraries schema wire))
 
 (rule
  (alias gen_schemas)
@@ -46,7 +46,7 @@
 (executable
  (name gen_c)
  (modules gen_c)
- (libraries wire wire.3d wire.stubs unix))
+ (libraries wire wire.3d unix fmt))
 
 (rule
  (alias gen_c)
@@ -94,7 +94,7 @@
 (executable
  (name fuzz_schema)
  (modules fuzz_schema)
- (libraries schema alcobar))
+ (libraries schema alcobar wire))
 
 (rule
  (alias fuzz)

--- a/test/dune
+++ b/test/dune
@@ -1,3 +1,3 @@
 (test
  (name test)
- (libraries wire wire.3d test_helpers alcotest re))
+ (libraries wire test_helpers alcotest re bytesrw fmt optint))

--- a/test/stubs/dune
+++ b/test/stubs/dune
@@ -2,4 +2,4 @@
  (name test)
  (enabled_if
   (= %{env:BUILD_EVERPARSE=} "1"))
- (libraries wire wire.3d wire.stubs net alcotest re unix))
+ (libraries wire wire.3d wire.stubs net alcotest re unix fmt))

--- a/test/test_wire.ml
+++ b/test/test_wire.ml
@@ -785,6 +785,12 @@ let test_nested_exact_region_direct () =
 
 type invariant_encoding = Rejected | Encoded of string
 
+let equal_invariant_encoding a b =
+  match (a, b) with
+  | Rejected, Rejected -> true
+  | Encoded a, Encoded b -> String.equal a b
+  | Rejected, Encoded _ | Encoded _, Rejected -> false
+
 let direct_encoding typ value =
   try Encoded (to_string typ value) with Invalid_argument _ -> Rejected
 
@@ -795,12 +801,13 @@ let compiled_encoding codec value =
     Encoded (Bytes.unsafe_to_string buf)
   with Invalid_argument _ -> Rejected
 
-let check_invariant_encoding label typ codec value =
+let check_invariant_encoding ~equal label typ codec value =
   let direct = direct_encoding typ value in
   let compiled = compiled_encoding codec value in
   Alcotest.(check bool)
     (label ^ ": direct and compiled acceptance")
-    true (direct = compiled);
+    true
+    (equal_invariant_encoding direct compiled);
   match direct with
   | Rejected ->
       Alcotest.(check bool)
@@ -821,11 +828,15 @@ let check_invariant_encoding label typ codec value =
       Alcotest.(check bool)
         (label ^ ": direct round-trip")
         true
-        (of_string typ bytes = Ok value);
+        (match of_string typ bytes with
+        | Ok decoded -> equal decoded value
+        | Error _ -> false);
       Alcotest.(check bool)
         (label ^ ": compiled round-trip")
         true
-        (Codec.decode codec (Bytes.of_string bytes) 0 = Ok value)
+        (match Codec.decode codec (Bytes.of_string bytes) 0 with
+        | Ok decoded -> equal decoded value
+        | Error _ -> false)
 
 let test_region_cardinality_contract () =
   let array_typ = array ~len:(int 3) uint8 in
@@ -834,7 +845,7 @@ let test_region_cardinality_contract () =
   in
   for n = 0 to 5 do
     let values = List.init n Fun.id in
-    check_invariant_encoding
+    check_invariant_encoding ~equal:(List.equal Int.equal)
       (Fmt.str "array count %d" n)
       array_typ array_codec values
   done;
@@ -845,7 +856,7 @@ let test_region_cardinality_contract () =
   in
   for n = 0 to 4 do
     let values = List.init n Fun.id in
-    check_invariant_encoding
+    check_invariant_encoding ~equal:(List.equal Int.equal)
       (Fmt.str "repeat count %d" n)
       repeat_typ repeat_codec values
   done;
@@ -856,7 +867,7 @@ let test_region_cardinality_contract () =
   in
   List.iter
     (fun value ->
-      check_invariant_encoding
+      check_invariant_encoding ~equal:String.equal
         (Fmt.str "nested value length %d" (String.length value))
         nested_typ nested_codec value)
     [ ""; "A"; "AB"; "ABC"; "ABCD" ]

--- a/test/wasm/dune
+++ b/test/wasm/dune
@@ -22,7 +22,7 @@
 (test
  (name test)
  (modes js wasm)
- (libraries wire wire.3d test_helpers alcotest re)
+ (libraries wire test_helpers alcotest re bytesrw fmt optint)
  (enabled_if
   (and
    %{bin-available:wasm_of_ocaml}

--- a/test/wasm/dune
+++ b/test/wasm/dune
@@ -11,7 +11,8 @@
 
 ; Verbose keeps alcotest away from its per-test output capture, whose
 ; primitives (alcotest_before_test) exist only for native and js_of_ocaml;
-; ALCOTEST_COLUMNS short-circuits the terminal-dimensions one.
+; ALCOTEST_COLUMNS short-circuits the terminal-dimensions one. Remove this
+; override once https://github.com/mirage/alcotest/pull/436 is released.
 
 (env
  (_


### PR DESCRIPTION
Enable explicit transitive-dependency checking and declare direct dependencies
across the tree. Run merlint in CI and directly from the staged-file pre-commit
hook, remove opaque polymorphic comparisons, tighten generated-code
documentation, and retain documented upstream workarounds.
