### PR TITLE
test: make browser toolchains optional

### DIFF
--- a/test/wasm/dune
+++ b/test/wasm/dune
@@ -24,8 +24,8 @@
  (name test)
  (modes js wasm)
  (libraries wire test_helpers alcotest re bytesrw fmt optint)
- (enabled_if
-  (and
-   %{bin-available:wasm_of_ocaml}
-   %{bin-available:js_of_ocaml}
-   %{bin-available:node})))
+ (enabled_if %{bin-available:node})
+ (js_of_ocaml
+  (enabled_if %{bin-available:js_of_ocaml}))
+ (wasm_of_ocaml
+  (enabled_if %{bin-available:wasm_of_ocaml})))


### PR DESCRIPTION
Gate the JavaScript and WebAssembly build modes independently so a normal build only requires the optional compiler that is actually installed. Keep Node as the shared runtime gate.