### PR TITLE
ci: make configuration failures visible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,6 @@ jobs:
       - uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
-          dune-version: '3.21'
 
       - run: opam install . --deps-only --with-test
       - run: opam exec -- dune build @install
@@ -44,7 +43,6 @@ jobs:
       - uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: 'ocaml-variants.5.4.1+options,ocaml-option-tsan'
-          dune-version: '3.21'
 
       - run: opam install . --deps-only --with-test
 
@@ -61,10 +59,9 @@ jobs:
       - uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: '5.3'
-          dune-version: '3.21'
 
       - run: opam install ocamlformat.0.29.0
-      - run: opam exec -- dune fmt 2>/dev/null || true
+      - run: opam exec -- dune fmt
       - run: git diff --exit-code
 
   merlint:
@@ -96,7 +93,6 @@ jobs:
       - uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: '5.3'
-          dune-version: '3.21'
 
       - run: opam install . --deps-only --with-test
 
@@ -152,7 +148,6 @@ jobs:
       - uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: '5.3'
-          dune-version: '3.21'
 
       - run: opam install . --deps-only --with-test
 
@@ -214,7 +209,6 @@ jobs:
       - uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: '5.3'
-          dune-version: '3.21'
 
       - run: opam install . --deps-only --with-test
 
@@ -246,7 +240,6 @@ jobs:
       - uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: '5.3'
-          dune-version: '3.21'
 
       - run: opam install . --deps-only --with-test
 


### PR DESCRIPTION
Remove unsupported setup-ocaml inputs and stop suppressing formatter failures, so CI reports configuration drift instead of silently accepting it.