### PR TITLE
docs: resolve changelog PR references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,6 @@ jobs:
       - uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
-          dune-version: '3.21'
 
       - run: opam install . --deps-only --with-test
       - run: opam exec -- dune build @install
@@ -44,7 +43,6 @@ jobs:
       - uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: 'ocaml-variants.5.4.1+options,ocaml-option-tsan'
-          dune-version: '3.21'
 
       - run: opam install . --deps-only --with-test
 
@@ -61,10 +59,9 @@ jobs:
       - uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: '5.3'
-          dune-version: '3.21'
 
       - run: opam install ocamlformat.0.29.0
-      - run: opam exec -- dune fmt 2>/dev/null || true
+      - run: opam exec -- dune fmt
       - run: git diff --exit-code
 
   # One AFL job per fuzzer: fuzz/ fuzzes the [wire] library (round-trip and
@@ -81,7 +78,6 @@ jobs:
       - uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: '5.3'
-          dune-version: '3.21'
 
       - run: opam install . --deps-only --with-test
 
@@ -137,7 +133,6 @@ jobs:
       - uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: '5.3'
-          dune-version: '3.21'
 
       - run: opam install . --deps-only --with-test
 
@@ -199,7 +194,6 @@ jobs:
       - uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: '5.3'
-          dune-version: '3.21'
 
       - run: opam install . --deps-only --with-test
 
@@ -231,7 +225,6 @@ jobs:
       - uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: '5.3'
-          dune-version: '3.21'
 
       - run: opam install . --deps-only --with-test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,29 @@ jobs:
       - run: opam exec -- dune build @install
       - run: opam exec -- dune runtest
 
+  # OCaml's TSan runtime does not currently build on the macOS/arm64 runner
+  # (runtime/weak.c), so keep this race-detection lane on Linux. The core test
+  # suite includes a synchronized multi-domain decode of one shared codec.
+  tsan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install ThreadSanitizer link dependencies
+        run: sudo apt-get update && sudo apt-get install -y libunwind-dev
+
+      - uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: 'ocaml-variants.5.4.1+options,ocaml-option-tsan'
+          dune-version: '3.21'
+
+      - run: opam install . --deps-only --with-test
+
+      - name: Run core tests under ThreadSanitizer
+        run: opam exec -- dune exec test/test.exe
+        env:
+          TSAN_OPTIONS: 'halt_on_error=1 history_size=7'
+
   fmt:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,11 @@
 
 ### Fixed
 
+- Codec operations now reject a `Param.env` created for another codec before
+  reading its positional slots. This applies consistently to encode, decode,
+  validation, and staged getters, including codecs whose parameter counts
+  happen to match.
+
 - Casetype projection and `Param.bind` now translate unfittable `uint32`,
   `uint63`, and `uint` values into contextual `Invalid_argument` exceptions
   naming the case index or parameter, instead of leaking an Optint `Failure` on

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,11 @@
 
 ### Fixed
 
+- `Codec.v` now reports a clear construction error when a byte-size product
+  `field * constant` has a simple `field <= bound` constraint whose maximum can
+  reach EverParse's `2^32` limit. Products without this conclusive shape remain
+  deferred to EverParse, avoiding speculative rejections.
+
 - `dune runtest` now diffs a package's committed `.3d` specs and `dune.inc`
   against freshly generated ones, so editing a codec without refreshing them
   fails with a promotable report instead of leaving a stale spec committed

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,11 @@
 
 ### Fixed
 
+- `Codec.size_of_value` now reports the declared width of fixed-size
+  `byte_array`, `byte_array_where`, and `byte_slice` fields. Buffers allocated
+  from it now exactly fit the bytes written when short values are zero-padded or
+  long values are truncated.
+
 - `nested` now requires its inner value to consume exactly the declared region
   on decode and encode. Use `nested_at_most` when trailing region padding is
   intentional; it remains permissive and zero-pads on encode.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ### Added
 
+- `Field.optional` over a sub-codec now documents how to make a whole field
+  group conditional, keeping the group's byte-length prefix and dependent
+  `Field.repeat` local to the group while later fields stay in the parent
+  codec (#NNN, @samoht)
+
 - The full test suite now also runs under wasm_of_ocaml (31-bit int) and
   js_of_ocaml (32-bit int) on node in CI, so every codec keeps working on a
   narrow-int target, and the build fails if a new integer literal would be

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,10 @@
 
 ### Fixed
 
+- `Codec.v` now rejects duplicate field names and distinct parameter handles
+  with the same name. Name-based field access and parameter environments can no
+  longer silently alias the first declaration.
+
 - `Field.repeat` now consumes and emits exactly its declared byte budget.
   Fixed-width remainders, variable-width elements that cross the boundary, and
   encode under/overshoots are rejected instead of being silently accepted.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,10 @@
 
 ### Fixed
 
+- `Field.repeat` now consumes and emits exactly its declared byte budget.
+  Fixed-width remainders, variable-width elements that cross the boundary, and
+  encode under/overshoots are rejected instead of being silently accepted.
+
 - `array` and `array_seq` encoders now require exactly the declared number of
   elements. Short values no longer leave zero-filled phantom elements, and long
   values are rejected before any bytes are written.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,11 @@
 
 ### Fixed
 
+- EverParse is now launched with a literal argument vector and a child-local
+  working directory. Output paths, executable paths, and schema filenames may
+  contain spaces or shell metacharacters without failing or being interpreted
+  as commands.
+
 - `Codec.size_of_value` now reports the declared width of fixed-size
   `byte_array`, `byte_array_where`, and `byte_slice` fields. Buffers allocated
   from it now exactly fit the bytes written when short values are zero-padded or

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,11 @@
 
 ### Fixed
 
+- Casetype projection and `Param.bind` now translate unfittable `uint32`,
+  `uint63`, and `uint` values into contextual `Invalid_argument` exceptions
+  naming the case index or parameter, instead of leaking an Optint `Failure` on
+  narrow-int targets.
+
 - `Codec.v` now reports a clear construction error when a byte-size product
   `field * constant` has a simple `field <= bound` constraint whose maximum can
   reach EverParse's `2^32` limit. Products without this conclusive shape remain

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,10 @@
 
 ### Changed
 
+- Dune now enforces explicit transitive dependencies. Each library, executable,
+  benchmark, fuzz target, and test declares the packages it imports directly,
+  preventing accidental dependency leakage through `wire`.
+
 - Generated `.3d` C struct tags are now named `Wire<Name>` rather than
   `_<Name>`. Public typedef names are unchanged, and standalone entrypoints
   follow as `<Base>CheckWire<Name>` (#235, @samoht)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,10 @@
 
 ### Fixed
 
+- `nested` now requires its inner value to consume exactly the declared region
+  on decode and encode. Use `nested_at_most` when trailing region padding is
+  intentional; it remains permissive and zero-pads on encode.
+
 - `Codec.v` now rejects duplicate field names and distinct parameter handles
   with the same name. Name-based field access and parameter environments can no
   longer silently alias the first declaration.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ### Added
 
+- A bare `uint64` field now has end-to-end coverage through EverParse C
+  generation, so a regression in that projection fails the test suite
+  (#NNN, @samoht)
+
 - `Field.optional` over a sub-codec now documents how to make a whole field
   group conditional, keeping the group's byte-length prefix and dependent
   `Field.repeat` local to the group while later fields stay in the parent

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,17 @@
 
 ### Fixed
 
+- Staged `Codec.get` readers now resolve their field-type dispatch once rather
+  than rebuilding a reader closure on every scalar access. Parameter-free
+  immediate getters and setters, including signed 32-bit setters, now allocate
+  zero words per call on a non-Flambda release build.
+
+- Parameter values are now carried by an explicit encode/decode context rather
+  than ambient domain-local cells. Re-entrant or fiber-interleaved operations
+  on the same parametric codec can therefore use different environments
+  without corrupting each other's field sizes, including embedded codecs,
+  casetype bodies, fixed-size type wrappers, and repeated elements.
+
 - EverParse is now launched with a literal argument vector and a child-local
   working directory. Output paths, executable paths, and schema filenames may
   contain spaces or shell metacharacters without failing or being interpreted

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,10 @@
 
 ### Fixed
 
+- `array` and `array_seq` encoders now require exactly the declared number of
+  elements. Short values no longer leave zero-filled phantom elements, and long
+  values are rejected before any bytes are written.
+
 - Codec operations now reject a `Param.env` created for another codec before
   reading its positional slots. This applies consistently to encode, decode,
   validation, and staged getters, including codecs whose parameter counts

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,6 +44,10 @@
   immediate getters and setters, including signed 32-bit setters, now allocate
   zero words per call on a non-Flambda release build.
 
+- Optional fields that can expose a consume-rest payload are now rejected when
+  followed by another field, rather than allowing that payload to swallow the
+  remainder of the enclosing codec.
+
 - Parameter values are now carried by an explicit encode/decode context rather
   than ambient domain-local cells. Re-entrant or fiber-interleaved operations
   on the same parametric codec can therefore use different environments

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,12 +4,12 @@
 
 - A bare `uint64` field now has end-to-end coverage through EverParse C
   generation, so a regression in that projection fails the test suite
-  (#NNN, @samoht)
+  (#236, @samoht)
 
 - `Field.optional` over a sub-codec now documents how to make a whole field
   group conditional, keeping the group's byte-length prefix and dependent
   `Field.repeat` local to the group while later fields stay in the parent
-  codec (#NNN, @samoht)
+  codec (#236, @samoht)
 
 - The full test suite now also runs under wasm_of_ocaml (31-bit int) and
   js_of_ocaml (32-bit int) on node in CI, so every codec keeps working on a

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ test:
 # modules truncate to the bit patterns they intend on a 31-bit target, and
 # the runtime checks prove the values survive. Warnings only surface for
 # freshly compiled units, so the grep is meaningful on a cold build (CI).
+# Remove the filter once https://github.com/mirage/optint/pull/31 is released.
 test-wasm:
 	@command -v wasm_of_ocaml >/dev/null || \
 	  { echo "wasm_of_ocaml not found: opam install wasm_of_ocaml-compiler"; exit 1; }

--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ and the EverParse `.3d` schema that compiles to a verified C parser. Define
 the format, then:
 
 - **Name reusable fields** with `Field.v` and assemble records with `Codec`
-- **Read and write fields in-place** via `Codec.get` / `Codec.set` -- zero-copy,
-  zero-allocation for immediate types (int, bool)
+- **Read and write fields in-place** via staged `Codec.get` / `Codec.set` --
+  zero-copy, with zero per-call allocation for parameter-free immediate types
+  (int, bool)
 - **Decode and encode records** via `Codec.decode` / `Codec.encode`
 - **Export EverParse `.3d` schemas** via `Everparse.project` / `Everparse.write`
 - **Generate verified C artifacts** via `Wire_3d.run`

--- a/bench/demo/dune
+++ b/bench/demo/dune
@@ -3,7 +3,7 @@
 (library
  (name demo_bench_cases)
  (modules demo_bench_cases)
- (libraries demo space net wire bench_lib bytesrw fmt))
+ (libraries demo space net wire bench_lib bytesrw fmt optint))
 
 (library
  (name demo_bench_diff)

--- a/bench/dune
+++ b/bench/dune
@@ -24,16 +24,7 @@
 (executable
  (name gen_stubs)
  (modules gen_stubs)
- (libraries
-  demo_bench_cases
-  demo
-  space
-  net
-  wire
-  wire.3d
-  wire.stubs
-  bench_lib
-  unix))
+ (libraries demo_bench_cases demo space wire wire.3d wire.stubs fmt unix))
 
 ; Generate c_stubs.ml (OCaml external declarations) -- always
 

--- a/bench/memtrace/dune
+++ b/bench/memtrace/dune
@@ -1,3 +1,3 @@
 (executable
  (name bench)
- (libraries demo space wire bytesrw memtrace))
+ (libraries demo space wire bytesrw memtrace optint fmt))

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,5 @@
 (lang dune 3.21)
+(implicit_transitive_deps false)
 (using directory-targets 0.1)
 (using mdx 0.4)
 (cram enable)

--- a/examples/demo/dune
+++ b/examples/demo/dune
@@ -1,4 +1,4 @@
 (library
  (name demo)
  (wrapped false)
- (libraries wire))
+ (libraries wire optint))

--- a/examples/net/dune
+++ b/examples/net/dune
@@ -2,12 +2,12 @@
  (name net)
  (modules net)
  (wrapped false)
- (libraries wire))
+ (libraries wire bytesrw optint fmt))
 
 (executable
  (name example)
  (modules example)
- (libraries net wire))
+ (libraries net wire bytesrw fmt))
 
 ; The committed Net.3d is the RFC-documented projection of the net codecs.
 ; gen_spec renders it; the runtest diff fails if it drifts from net.ml, and

--- a/examples/space/dune
+++ b/examples/space/dune
@@ -1,4 +1,4 @@
 (library
  (name space)
  (wrapped false)
- (libraries wire))
+ (libraries wire bytesrw optint))

--- a/fuzz/3d/dune
+++ b/fuzz/3d/dune
@@ -1,6 +1,6 @@
 (executable
  (name fuzz)
- (libraries wire wire.3d unix alcobar fuzz_gen))
+ (libraries wire wire.3d unix alcobar fuzz_gen fmt))
 
 (rule
  (alias runtest)

--- a/fuzz/diff/gen/dune
+++ b/fuzz/diff/gen/dune
@@ -6,4 +6,4 @@
 (executable
  (name gen_diff)
  (modules gen_diff)
- (libraries diff_codecs fuzz_gen wire wire.3d wire.stubs unix))
+ (libraries diff_codecs fuzz_gen wire wire.3d wire.stubs unix fmt))

--- a/fuzz/gen/dune
+++ b/fuzz/gen/dune
@@ -1,3 +1,3 @@
 (library
  (name fuzz_gen)
- (libraries wire alcobar bytesrw))
+ (libraries wire alcobar bytesrw optint fmt))

--- a/fuzz/gen/fuzz_gen.ml
+++ b/fuzz/gen/fuzz_gen.ml
@@ -2348,8 +2348,9 @@ end
 
 type any = Any : { g : 'a t; size : int option; label : string } -> any
 
-let add_size a b =
-  match (a, b) with Some x, Some y -> Some (x + y) | _ -> None
+let fixed_size g =
+  if Wire.Codec.is_fixed g.codec then Some (Wire.Codec.wire_size g.codec)
+  else None
 
 (* Fixed-width leaves: usable as [array] / [nested] elements. *)
 let printable_byte b = Wire.Expr.(b >= Wire.int 0x20 && b <= Wire.int 0x7e)
@@ -2554,7 +2555,9 @@ let pair_of (Any a) (Any b) =
   Any
     {
       g;
-      size = add_size a.size b.size;
+      (* Ask the compiled codec: adjacent bitfields can coalesce, so summing
+         their standalone widths overstates the record's actual wire size. *)
+      size = fixed_size g;
       label = "(" ^ a.label ^ "," ^ b.label ^ ")";
     }
 
@@ -2578,7 +2581,7 @@ let rec3_of (Any a) (Any b) (Any c) =
   Any
     {
       g;
-      size = add_size a.size (add_size b.size c.size);
+      size = fixed_size g;
       label = Fmt.str "(%s,%s,%s)" a.label b.label c.label;
     }
 
@@ -2599,7 +2602,7 @@ let rec4_of (Any a) (Any b) (Any c) (Any d) =
   Any
     {
       g;
-      size = add_size a.size (add_size b.size (add_size c.size d.size));
+      size = fixed_size g;
       label = Fmt.str "(%s,%s,%s,%s)" a.label b.label c.label d.label;
     }
 
@@ -2774,7 +2777,9 @@ let check_positive_decode label g value bs env =
   | Ok decoded ->
       if not (g.equal decoded value) then
         Alcobar.failf "%s positive decode mismatch" label
-  | Error _ -> Alcobar.failf "%s positive decode failed" label);
+  | Error error ->
+      Alcobar.failf "%s positive decode failed: %a" label Wire.pp_parse_error
+        error);
   match Wire.Codec.decode_exn ?env g.codec bs 0 with
   | decoded ->
       if not (g.equal decoded value) then

--- a/fuzz/gen/fuzz_gen.ml
+++ b/fuzz/gen/fuzz_gen.ml
@@ -3364,7 +3364,7 @@ let wrapper_gens =
     ("optional_or_dynamic", Pack optional_or_dynamic);
     ("nested(0,empty)", Pack (nested 0 empty));
     ("nested(2,uint16be)", Pack (nested 2 uint16be));
-    ("nested(4,uint16be)", Pack (nested 4 uint16be));
+    ("nested(4,byte_array4)", Pack (nested 4 (byte_array 4)));
     ("nested_at_most(0,empty)", Pack (nested_at_most 0 empty));
     ("nested_at_most(2,uint16be)", Pack (nested_at_most 2 uint16be));
     ("nested_at_most(4,uint16be)", Pack (nested_at_most 4 uint16be));
@@ -3802,7 +3802,7 @@ let expected_registry_labels =
     "optional_or_dynamic";
     "nested(0,empty)";
     "nested(2,uint16be)";
-    "nested(4,uint16be)";
+    "nested(4,byte_array4)";
     "nested_at_most(0,empty)";
     "nested_at_most(2,uint16be)";
     "nested_at_most(4,uint16be)";

--- a/fuzz/gen/fuzz_gen.mli
+++ b/fuzz/gen/fuzz_gen.mli
@@ -90,10 +90,8 @@ val validate_cases : string -> 'a t -> Alcobar.test_case list
     pass; random and adversarial inputs may pass or fail but must not crash.
     Threads the env via {!Wire.Codec.validate}'s [?env] when [g] needs one. *)
 
-type packed =
-  | Pack : 'a t -> packed
-      (** A gen with its value type hidden, for uniform iteration over
-          {!registry}. *)
+(** A gen with its value type hidden, for uniform iteration over {!registry}. *)
+type packed = Pack : 'a t -> packed
 
 val codec : 'a t -> 'a Wire.Codec.t
 (** [codec g] is the codec [g] generates for. *)

--- a/lib/3d/wire_3d.ml
+++ b/lib/3d/wire_3d.ml
@@ -232,7 +232,7 @@ let run_process ?(output = Inherit) ~cwd exe args =
             Unix.close fd)
           output_fd;
         Unix.execv exe (Array.of_list (exe :: args))
-      with _ -> Unix._exit 127)
+      with Unix.Unix_error _ -> Unix._exit 127)
   | pid ->
       Option.iter Unix.close output_fd;
       snd (Unix.waitpid [] pid)

--- a/lib/3d/wire_3d.ml
+++ b/lib/3d/wire_3d.ml
@@ -1544,6 +1544,10 @@ let emit_standalone_build_rules ppf ~base ~archive ~c_files ~wrappers =
    standalone. *)
 let emit_standalone_install ppf ~package ~three_d ~archive ~public_header
     ~provenance =
+  (* Dune currently adds files from a disabled install stanza to the directory's
+     [all] alias. Keep the stanza unconditional until
+     https://github.com/ocaml/dune/issues/15825 is fixed; the archive itself is
+     intentionally built for every context above. *)
   let pr fmt = Fmt.pf ppf fmt in
   pr "(install\n (package %s)\n (section lib)\n (files\n" package;
   List.iter

--- a/lib/3d/wire_3d.ml
+++ b/lib/3d/wire_3d.ml
@@ -172,17 +172,70 @@ let read_validate_name ~outdir s =
 
 let write_3d ~outdir schemas = Wire.Everparse.write ~mode:`Ffi ~outdir schemas
 
+let absolute_path path =
+  if Filename.is_relative path then Filename.concat (Sys.getcwd ()) path
+  else path
+
+let executable path =
+  try
+    Unix.access path [ Unix.X_OK ];
+    not (Sys.is_directory path)
+  with Unix.Unix_error _ | Sys_error _ -> false
+
 let locate_3d_exe () =
-  let ic = Unix.open_process_in "command -v 3d.exe 2>/dev/null" in
-  let path = try Some (input_line ic) with End_of_file -> None in
-  ignore (Unix.close_process_in ic);
+  let path =
+    Sys.getenv_opt "PATH" |> Option.to_list
+    |> List.concat_map (String.split_on_char ':')
+    |> List.find_map (fun dir ->
+        let dir = if dir = "" then "." else dir in
+        let candidate = absolute_path (Filename.concat dir "3d.exe") in
+        if executable candidate then Some candidate else None)
+  in
   match path with
   | Some p -> Some p
   | None ->
       let local =
         Filename.concat (Sys.getenv "HOME") ".local/everparse/bin/3d.exe"
       in
-      if Sys.file_exists local then Some local else None
+      if executable local then Some local else None
+
+type process_output = Inherit | Dev_null | File of string
+
+let process_status_code = function
+  | Unix.WEXITED n -> n
+  | Unix.WSIGNALED n -> 128 + n
+  | Unix.WSTOPPED n -> 128 + n
+
+(* Run [exe] without a shell. Redirection is opened in the parent, then the
+   child changes directory and receives each argument literally through
+   [execv]. This keeps a process-local cwd: changing it in the parent would race
+   with other domains and fibers. *)
+let run_process ?(output = Inherit) ~cwd exe args =
+  let output_fd =
+    match output with
+    | Inherit -> None
+    | Dev_null -> Some (Unix.openfile "/dev/null" [ Unix.O_WRONLY ] 0o600)
+    | File path ->
+        Some
+          (Unix.openfile path
+             [ Unix.O_WRONLY; Unix.O_CREAT; Unix.O_TRUNC ]
+             0o600)
+  in
+  match Unix.fork () with
+  | 0 -> (
+      try
+        Unix.chdir cwd;
+        Option.iter
+          (fun fd ->
+            Unix.dup2 fd Unix.stdout;
+            Unix.dup2 fd Unix.stderr;
+            Unix.close fd)
+          output_fd;
+        Unix.execv exe (Array.of_list (exe :: args))
+      with _ -> Unix._exit 127)
+  | pid ->
+      Option.iter Unix.close output_fd;
+      snd (Unix.waitpid [] pid)
 
 let everparse_version exe =
   let ic = Unix.open_process_args_in exe [| exe; "--version" |] in
@@ -523,9 +576,11 @@ let run_everparse_files ?(quiet = true) ~outdir files =
   let version = everparse_version exe in
   List.iter
     (fun f ->
-      let redirect = if quiet then " > /dev/null 2>&1" else "" in
-      let cmd = Fmt.str "cd %s && %s --batch %s%s" outdir exe f redirect in
-      let ret = Sys.command cmd in
+      let output = if quiet then Dev_null else Inherit in
+      let ret =
+        run_process ~output ~cwd:outdir exe [ "--batch"; f ]
+        |> process_status_code
+      in
       if ret <> 0 then Fmt.failwith "EverParse failed on %s with code %d" f ret;
       harden_wrapper ~outdir (Filename.remove_extension (Filename.basename f));
       write_provenance ~outdir ~version f)
@@ -543,11 +598,11 @@ let parse_3d ?(batch = false) ~outdir file =
   in
   let log_path = Filename.temp_file "wire_parse_3d" ".log" in
   (* 3d.exe emits diagnostics to stdout, so capture both streams. *)
-  let flag = if batch then "--batch " else "" in
-  let cmd =
-    Fmt.str "cd %s && %s %s%s > %s 2>&1" outdir exe flag file log_path
+  let args = if batch then [ "--batch"; file ] else [ file ] in
+  let ret =
+    run_process ~output:(File log_path) ~cwd:outdir exe args
+    |> process_status_code
   in
-  let ret = Sys.command cmd in
   let captured =
     try In_channel.with_open_text log_path In_channel.input_all
     with Sys_error _ -> ""
@@ -735,7 +790,7 @@ let generate_3d_check ~outdir schemas =
 let default_job_count () = max 1 (min 4 (Domain.recommended_domain_count ()))
 
 (* A bounded fork pool: each job runs in its own process, so blocking EverParse
-   runs ([Sys.command]) overlap across cores with full isolation. Returns each
+   runs overlap across cores with full isolation. Returns each
    job's success (exit 0 and no exception) in input order. EverParse runs must
    be isolated because they race on shared intermediate files in a shared
    directory, so jobs that invoke [3d.exe] should each use a private cwd. *)
@@ -805,14 +860,18 @@ let batch_check ?max_jobs ~outdir schemas =
               ~finally:(fun () -> rm_rf work)
               (fun () ->
                 generate_3d ~outdir:work [ schema ];
-                let cmd =
-                  Fmt.str
-                    "cd %s && %s --batch --no_copy_everparse_h %s > %s 2>&1"
-                    work exe
-                    (Wire.Everparse.filename schema)
-                    (Filename.quote (log_of i))
+                let status =
+                  run_process
+                    ~output:(File (log_of i))
+                    ~cwd:work exe
+                    [
+                      "--batch";
+                      "--no_copy_everparse_h";
+                      Wire.Everparse.filename schema;
+                    ]
                 in
-                if Sys.command cmd <> 0 then failwith "EverParse rejected"))
+                if process_status_code status <> 0 then
+                  failwith "EverParse rejected"))
           arr
       in
       let max_jobs = Option.value max_jobs ~default:(default_job_count ()) in

--- a/lib/3d/wire_3d.ml
+++ b/lib/3d/wire_3d.ml
@@ -535,8 +535,10 @@ let fields_c_files schemas =
    parameterized and plain entrypoints, [print_c_entry] in the upstream
    [src/3d/Target.fst]): if a future EverParse emits neither the known tail
    nor its own consumption check, fail loudly rather than silently shipping a
-   prefix recognizer. The behavioural backstop is the differential runtest,
-   whose corpus includes over-length inputs the oracle rejects. *)
+   prefix recognizer. Tracked upstream as
+   https://github.com/project-everest/everparse/issues/312. The behavioural
+   backstop is the differential runtest, whose corpus includes over-length
+   inputs the oracle rejects. *)
 let wrapper_success_tail = "\t\treturn FALSE;\n\t}\n\treturn TRUE;\n}"
 let wrapper_consumption_check = "result != (uint64_t) len"
 

--- a/lib/3d/wire_3d.mli
+++ b/lib/3d/wire_3d.mli
@@ -84,6 +84,9 @@ val run_everparse :
     staleness is detected without running EverParse. The failure is deliberately
     not promotable: only regenerating the C may refresh the stamp.
 
+    The executable, output directory, and schema filenames are passed directly
+    to EverParse without shell interpretation.
+
     Requires [3d.exe] in PATH. *)
 
 val check_provenance : outdir:string -> string list -> unit
@@ -103,7 +106,8 @@ val parse_3d : ?batch:bool -> outdir:string -> string -> (unit, string) result
     it runs the full [--batch] verification (F* and C extraction), catching
     those, and discarding the generated C. Unlike {!run_everparse} it does no
     endianness-header copy, so it works on a bare output directory. Intended for
-    projection coverage tests.
+    projection coverage tests. The output directory and filename are passed
+    without shell interpretation.
 
     Requires [3d.exe] in PATH. *)
 
@@ -134,7 +138,8 @@ val batch_check :
     [3d.exe --batch]. Each run uses a private directory. Returns [Ok ()] iff
     EverParse accepts every schema, else [Error] naming the offending schema(s)
     with their captured diagnostics. Schemas must have distinct names (one [.3d]
-    module each). Requires [3d.exe] in PATH. *)
+    module each). Paths and filenames are passed without shell interpretation.
+    Requires [3d.exe] in PATH. *)
 
 val write_external_typedefs : outdir:string -> Wire.Everparse.t list -> unit
 (** [write_external_typedefs ~outdir schemas] writes the default

--- a/lib/3d/wire_3d.mli
+++ b/lib/3d/wire_3d.mli
@@ -190,8 +190,8 @@ val generate_standalone :
   packed list ->
   unit
 (** [generate_standalone ?quiet ?name ~outdir ~package codecs] runs the
-    documentation pipeline: project each codec with {!Wire.Everparse.doc}, merge
-    them into one [<Name>.3d], and (when [3d.exe] is available) compile it to a
+    documentation pipeline: project each codec in documentation mode, merge them
+    into one [<Name>.3d], and (when [3d.exe] is available) compile it to a
     single validator-only [<Name>.c] (no [_Fields] plug, no FFI). The file base
     is [name] when given, else [package], normalised to a CamelCase identifier
     (["my-pkg"] becomes [MyPkg]); [package] always names the opam package. The
@@ -264,7 +264,7 @@ val generate_agree :
     EverParse-generated validators and exits nonzero on any input where the
     validator's accept/reject decision differs from the recorded verdict. It
     reads the [<Name>CheckWire<Codec>] helper names from the generated
-    [<Name>Wrapper.h], so {!generate_c_standalone} (or [3d.exe]) must have run
+    [<Name>Wrapper.h], so {!generate_standalone} (or [3d.exe]) must have run
     first. *)
 
 val main :

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -33,7 +33,9 @@ let setter_off_int32 n set buf off v =
 
 (* Encode a value into a fixed [n]-byte region: write it with [enc], then
    zero-pad the remainder. Used for [nested] regions. *)
-let single_elem_pad n enc buf off v =
+let single_elem_region ~at_most n typ enc buf off v =
+  let actual = Types.size_of_typ_value typ v in
+  Types.check_nested_size ~at_most ~expected:n ~actual;
   let inner_end = enc buf off v in
   if inner_end < off + n then
     Bytes.fill buf inner_end (off + n - inner_end) '\x00';
@@ -190,8 +192,8 @@ and build_field_encoder : type a. a typ -> bytes -> int -> a -> int =
       bits_field_encoder ~width ~base ~bit_order
   (* A nested region (e.g. a casetype case body): encode the inner at the
      region start, then zero-pad the rest of the fixed [n]-byte region. *)
-  | Single_elem { size = Int n; elem; _ } ->
-      single_elem_pad n (build_field_encoder elem)
+  | Single_elem { size = Int n; elem; at_most } ->
+      single_elem_region ~at_most n elem (build_field_encoder elem)
   | _ ->
       (* Fallback for complex types - not specialized *)
       fun _buf _off _v -> failwith "build_field_encoder: unsupported type"
@@ -1982,7 +1984,12 @@ let var_bytes_reader : type a.
         s;
       s
   | Casetype _ -> read_elem typ buf (base + fo)
-  | Single_elem { elem; _ } -> read_elem elem buf (base + fo)
+  | Single_elem { elem; at_most; _ } ->
+      let first = base + fo in
+      let consumed = elem_size_of elem buf first in
+      if consumed > sz || ((not at_most) && consumed <> sz) then
+        raise_eof ~at:(first + min consumed sz) ~expected:sz ~got:consumed;
+      read_elem elem buf first
   | _ -> assert false
 
 (* Kept at top level: as local closures they would be heap-allocated on
@@ -2050,8 +2057,10 @@ let var_bytes_writer : type a r.
       Bytes.fill buf (write_off + len) (region - len) '\x00';
       write_off + region
   | Casetype _ -> build_field_encoder typ buf write_off value
-  | Single_elem { elem; _ } ->
+  | Single_elem { elem; at_most; _ } ->
       let n = size_fn buf base in
+      let actual = Types.size_of_typ_value elem value in
+      Types.check_nested_size ~at_most ~expected:n ~actual;
       let inner_end = build_field_encoder elem buf write_off value in
       if inner_end < write_off + n then
         Bytes.fill buf inner_end (write_off + n - inner_end) '\x00';

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -27,10 +27,6 @@ let setter_off n set buf off v =
   set buf off v;
   off + n
 
-let setter_off_int32 n set buf off v =
-  set buf off (Int32.of_int v);
-  off + n
-
 (* Encode a value into a fixed [n]-byte region: write it with [enc], then
    zero-pad the remainder. Used for [nested] regions. *)
 let single_elem_region ~at_most n typ enc buf off v =
@@ -58,10 +54,16 @@ let bits_field_encoder ~width ~base ~bit_order buf off v =
   | _ -> Bitfield.write_word base buf off ((v land mask) lsl shift));
   off + Bitfield.byte_size base
 
-let rec build_casetype_encoder : type a k.
-    k typ -> (a, k) case_branch list -> bytes -> int -> a -> int =
- fun tag cases ->
-  let tag_enc = build_field_encoder tag in
+let rec build_casetype_encoder_ctx : type a k.
+    k typ ->
+    (a, k) case_branch list ->
+    Types.eval_ctx ->
+    bytes ->
+    int ->
+    a ->
+    int =
+ fun tag cases runtime ->
+  let tag_enc = build_field_encoder_ctx tag runtime in
   let rec find buf off v = function
     | [] -> failwith "build_field_encoder: casetype: no matching case"
     | Case_branch { cb_inner; cb_project; _ } :: rest -> (
@@ -70,13 +72,14 @@ let rec build_casetype_encoder : type a k.
         match cb_project v with
         | Some (t, body) ->
             let off' = tag_enc buf off t in
-            build_field_encoder cb_inner buf off' body
+            build_field_encoder_ctx cb_inner runtime buf off' body
         | None -> find buf off v rest)
   in
   fun buf off v -> find buf off v cases
 
-and build_field_encoder : type a. a typ -> bytes -> int -> a -> int =
- fun typ ->
+and build_field_encoder_ctx : type a.
+    a typ -> Types.eval_ctx -> bytes -> int -> a -> int =
+ fun typ runtime ->
   match typ with
   | Uint8 ->
       fun buf off v ->
@@ -117,8 +120,17 @@ and build_field_encoder : type a. a typ -> bytes -> int -> a -> int =
   | Int8 -> setter_off 1 Bytes.set_int8
   | Int16 Little -> setter_off 2 Bytes.set_int16_le
   | Int16 Big -> setter_off 2 Bytes.set_int16_be
-  | Int32 Little -> setter_off_int32 4 Bytes.set_int32_le
-  | Int32 Big -> setter_off_int32 4 Bytes.set_int32_be
+  (* Keep the conversion and primitive call visible together. Passing the
+     setter through [setter_off_int32] boxes the temporary [int32] on every
+     staged write when Flambda is disabled. *)
+  | Int32 Little ->
+      fun buf off v ->
+        Bytes.set_int32_le buf off (Int32.of_int v);
+        off + 4
+  | Int32 Big ->
+      fun buf off v ->
+        Bytes.set_int32_be buf off (Int32.of_int v);
+        off + 4
   | Int64 Little -> setter_off 8 Bytes.set_int64_le
   | Int64 Big -> setter_off 8 Bytes.set_int64_be
   | Float32 Little ->
@@ -149,16 +161,16 @@ and build_field_encoder : type a. a typ -> bytes -> int -> a -> int =
         Bytes.blit (Slice.bytes v) (Slice.first v) buf off len;
         if len < n then Bytes.fill buf (off + len) (n - len) '\x00';
         off + n
-  | Where { inner; _ } -> build_field_encoder inner
-  | Enum { base; _ } -> build_field_encoder base
+  | Where { inner; _ } -> build_field_encoder_ctx inner runtime
+  | Enum { base; _ } -> build_field_encoder_ctx base runtime
   | Map { inner; encode; _ } ->
-      let enc = build_field_encoder inner in
+      let enc = build_field_encoder_ctx inner runtime in
       fun buf off v -> enc buf off (encode v)
   | Unit -> fun _buf off () -> off
-  | Codec { codec_encode; _ } -> fun buf off v -> codec_encode v buf off
-  | Casetype { tag; cases; _ } -> build_casetype_encoder tag cases
+  | Codec { codec_encode; _ } -> fun _buf off v -> codec_encode v runtime off
+  | Casetype { tag; cases; _ } -> build_casetype_encoder_ctx tag cases runtime
   | Array { len = Int expected; elem; seq } ->
-      let enc_elem = build_field_encoder elem in
+      let enc_elem = build_field_encoder_ctx elem runtime in
       fun buf start_off vs ->
         let cur = Stdlib.ref start_off in
         Types.exact_array_elements seq ~expected vs
@@ -193,10 +205,13 @@ and build_field_encoder : type a. a typ -> bytes -> int -> a -> int =
   (* A nested region (e.g. a casetype case body): encode the inner at the
      region start, then zero-pad the rest of the fixed [n]-byte region. *)
   | Single_elem { size = Int n; elem; at_most } ->
-      single_elem_region ~at_most n elem (build_field_encoder elem)
+      single_elem_region ~at_most n elem (build_field_encoder_ctx elem runtime)
   | _ ->
       (* Fallback for complex types - not specialized *)
       fun _buf _off _v -> failwith "build_field_encoder: unsupported type"
+
+let build_field_encoder typ buf off v =
+  build_field_encoder_ctx typ (Types.empty_eval_ctx buf) buf off v
 
 (* An [enum] decodes through its base integer type; validate that the value is
    one of the named cases, raising [Invalid_enum] otherwise, so the decoder
@@ -215,79 +230,125 @@ let enum_check cases closed =
 
 (** Build a direct field reader that reads at a fixed offset. No tuples, no refs
     \- just pure value read. Caller must ensure the buffer is large enough. *)
-let rec build_field_reader : type a. a typ -> int -> bytes -> int -> a =
+let rec build_field_reader_ctx : type a.
+    a typ -> int -> Types.eval_ctx -> int -> a =
  fun typ field_off ->
   match typ with
-  | Uint8 -> fun buf base -> Bytes.get_uint8 buf (base + field_off)
-  | Uint16 Little -> fun buf base -> Bytes.get_uint16_le buf (base + field_off)
-  | Uint16 Big -> fun buf base -> Bytes.get_uint16_be buf (base + field_off)
-  | Uint32 Little -> fun buf base -> UInt32.le buf (base + field_off)
-  | Uint32 Big -> fun buf base -> UInt32.be buf (base + field_off)
-  | Uint63 Little -> fun buf base -> UInt63.le buf (base + field_off)
-  | Uint63 Big -> fun buf base -> UInt63.be buf (base + field_off)
-  | Uint64 Little -> fun buf base -> Bytes.get_int64_le buf (base + field_off)
-  | Uint64 Big -> fun buf base -> Bytes.get_int64_be buf (base + field_off)
-  | Int8 -> fun buf base -> Bytes.get_int8 buf (base + field_off)
-  | Int16 Little -> fun buf base -> Bytes.get_int16_le buf (base + field_off)
-  | Int16 Big -> fun buf base -> Bytes.get_int16_be buf (base + field_off)
+  | Uint8 ->
+      fun runtime base ->
+        Bytes.get_uint8 (Types.eval_bytes runtime) (base + field_off)
+  | Uint16 Little ->
+      fun runtime base ->
+        Bytes.get_uint16_le (Types.eval_bytes runtime) (base + field_off)
+  | Uint16 Big ->
+      fun runtime base ->
+        Bytes.get_uint16_be (Types.eval_bytes runtime) (base + field_off)
+  | Uint32 Little ->
+      fun runtime base -> UInt32.le (Types.eval_bytes runtime) (base + field_off)
+  | Uint32 Big ->
+      fun runtime base -> UInt32.be (Types.eval_bytes runtime) (base + field_off)
+  | Uint63 Little ->
+      fun runtime base -> UInt63.le (Types.eval_bytes runtime) (base + field_off)
+  | Uint63 Big ->
+      fun runtime base -> UInt63.be (Types.eval_bytes runtime) (base + field_off)
+  | Uint64 Little ->
+      fun runtime base ->
+        Bytes.get_int64_le (Types.eval_bytes runtime) (base + field_off)
+  | Uint64 Big ->
+      fun runtime base ->
+        Bytes.get_int64_be (Types.eval_bytes runtime) (base + field_off)
+  | Int8 ->
+      fun runtime base ->
+        Bytes.get_int8 (Types.eval_bytes runtime) (base + field_off)
+  | Int16 Little ->
+      fun runtime base ->
+        Bytes.get_int16_le (Types.eval_bytes runtime) (base + field_off)
+  | Int16 Big ->
+      fun runtime base ->
+        Bytes.get_int16_be (Types.eval_bytes runtime) (base + field_off)
   | Int32 Little ->
-      fun buf base -> Int32.to_int (Bytes.get_int32_le buf (base + field_off))
+      fun runtime base ->
+        Int32.to_int
+          (Bytes.get_int32_le (Types.eval_bytes runtime) (base + field_off))
   | Int32 Big ->
-      fun buf base -> Int32.to_int (Bytes.get_int32_be buf (base + field_off))
-  | Int64 Little -> fun buf base -> Bytes.get_int64_le buf (base + field_off)
-  | Int64 Big -> fun buf base -> Bytes.get_int64_be buf (base + field_off)
+      fun runtime base ->
+        Int32.to_int
+          (Bytes.get_int32_be (Types.eval_bytes runtime) (base + field_off))
+  | Int64 Little ->
+      fun runtime base ->
+        Bytes.get_int64_le (Types.eval_bytes runtime) (base + field_off)
+  | Int64 Big ->
+      fun runtime base ->
+        Bytes.get_int64_be (Types.eval_bytes runtime) (base + field_off)
   | Float32 Little ->
-      fun buf base ->
-        Int32.float_of_bits (Bytes.get_int32_le buf (base + field_off))
+      fun runtime base ->
+        Int32.float_of_bits
+          (Bytes.get_int32_le (Types.eval_bytes runtime) (base + field_off))
   | Float32 Big ->
-      fun buf base ->
-        Int32.float_of_bits (Bytes.get_int32_be buf (base + field_off))
+      fun runtime base ->
+        Int32.float_of_bits
+          (Bytes.get_int32_be (Types.eval_bytes runtime) (base + field_off))
   | Float64 Little ->
-      fun buf base ->
-        Int64.float_of_bits (Bytes.get_int64_le buf (base + field_off))
+      fun runtime base ->
+        Int64.float_of_bits
+          (Bytes.get_int64_le (Types.eval_bytes runtime) (base + field_off))
   | Float64 Big ->
-      fun buf base ->
-        Int64.float_of_bits (Bytes.get_int64_be buf (base + field_off))
+      fun runtime base ->
+        Int64.float_of_bits
+          (Bytes.get_int64_be (Types.eval_bytes runtime) (base + field_off))
   | Uint_var { size = Int n; endian } ->
-      fun buf base -> Uint_var.read endian buf (base + field_off) n
+      fun runtime base ->
+        Uint_var.read endian (Types.eval_bytes runtime) (base + field_off) n
   | Byte_array { size = Int n } ->
-      fun buf base -> Bytes.sub_string buf (base + field_off) n
+      fun runtime base ->
+        Bytes.sub_string (Types.eval_bytes runtime) (base + field_off) n
   | Byte_array_where { size = Int n; _ } ->
-      fun buf base -> Bytes.sub_string buf (base + field_off) n
+      fun runtime base ->
+        Bytes.sub_string (Types.eval_bytes runtime) (base + field_off) n
   | Byte_slice { size = Int n } ->
-      fun buf base -> Slice.make_or_eod buf ~first:(base + field_off) ~length:n
-  | Where { inner; _ } -> build_field_reader inner field_off
+      fun runtime base ->
+        Slice.make_or_eod (Types.eval_bytes runtime) ~first:(base + field_off)
+          ~length:n
+  | Where { inner; _ } -> build_field_reader_ctx inner field_off
   | Enum { base; cases; closed; _ } ->
-      let read = build_field_reader base field_off in
+      let read = build_field_reader_ctx base field_off in
       let check = enum_check cases closed in
-      fun buf base -> check ~at:(base + field_off) (read buf base)
+      fun runtime base -> check ~at:(base + field_off) (read runtime base)
   | Map { inner; decode; _ } ->
-      let read = build_field_reader inner field_off in
-      fun buf base -> decode (read buf base)
-  | Unit -> fun _buf _base -> ()
+      let read = build_field_reader_ctx inner field_off in
+      fun runtime base -> decode (read runtime base)
+  | Unit -> fun _runtime _base -> ()
   (* A fixed-size sub-record / sub-codec as an array or nested element: decode
      it at the element offset. The element must be fixed-width (the Array case
      already gates on [field_wire_size]), so the sub-codec is too. *)
   | Codec { codec_decode; _ } ->
-      fun buf base -> codec_decode buf (base + field_off)
+      fun runtime base -> codec_decode runtime (base + field_off)
   | Array { len = Int n; elem; seq = Seq_map s } -> (
       match field_wire_size elem with
       | Some elem_sz ->
-          let read_elem = build_field_reader elem 0 in
-          fun buf base ->
+          let read_elem = build_field_reader_ctx elem 0 in
+          fun runtime base ->
             let acc = Stdlib.ref s.empty in
             for i = 0 to n - 1 do
-              let v = read_elem buf (base + field_off + (i * elem_sz)) in
+              let v = read_elem runtime (base + field_off + (i * elem_sz)) in
               acc := s.add !acc v
             done;
             s.finish !acc
       | None ->
-          fun _buf _base -> failwith "build_field_reader: unsupported type")
-  | _ -> fun _buf _base -> failwith "build_field_reader: unsupported type"
+          fun _runtime _base -> failwith "build_field_reader: unsupported type")
+  | _ -> fun _runtime _base -> failwith "build_field_reader: unsupported type"
+
+let build_field_reader typ field_off =
+  (* Resolve the type dispatch while staging the accessor. If this call stayed
+     inside the returned function, [build_field_reader_ctx] would construct a
+     fresh reader closure for every scalar read. *)
+  let read = build_field_reader_ctx typ field_off in
+  fun buf base -> read (Types.empty_eval_ctx buf) base
 
 let int_of_typ_value = Eval.int_of_exn
 
 type slots = { ints : int array; int64s : int64 array }
+type runtime = Types.eval_ctx
 
 let alloc_slots n = { ints = Array.make n 0; int64s = Array.make n 0L }
 
@@ -343,7 +404,7 @@ let populate_uint63 idx reader =
       (Int64.unsigned_to_int (Optint.Int63.to_int64 (reader buf base)))
 
 let rec build_populate : type a.
-    a typ -> int -> (bytes -> int -> a) -> slots -> bytes -> int -> unit =
+    a typ -> int -> (runtime -> int -> a) -> slots -> runtime -> int -> unit =
  fun typ idx reader ->
   match typ with
   | Uint8 -> fun slots buf base -> set_int_slot slots idx (reader buf base)
@@ -377,19 +438,21 @@ let rec build_populate : type a.
      still returns the [float], reinterpreted via [Int*.float_of_bits]
      elsewhere. *)
   | Float32 Little ->
-      fun slots buf base ->
-        set_int_slot slots idx (Bytes.get_int32_le buf base |> Int32.to_int)
+      fun slots runtime base ->
+        set_int_slot slots idx
+          (Bytes.get_int32_le (Types.eval_bytes runtime) base |> Int32.to_int)
   | Float32 Big ->
-      fun slots buf base ->
-        set_int_slot slots idx (Bytes.get_int32_be buf base |> Int32.to_int)
+      fun slots runtime base ->
+        set_int_slot slots idx
+          (Bytes.get_int32_be (Types.eval_bytes runtime) base |> Int32.to_int)
   | Float64 Little ->
-      fun slots buf base ->
-        let bits = Bytes.get_int64_le buf base in
+      fun slots runtime base ->
+        let bits = Bytes.get_int64_le (Types.eval_bytes runtime) base in
         set_int64_slot slots idx bits;
         set_int_slot slots idx (Int64.to_int bits)
   | Float64 Big ->
-      fun slots buf base ->
-        let bits = Bytes.get_int64_be buf base in
+      fun slots runtime base ->
+        let bits = Bytes.get_int64_be (Types.eval_bytes runtime) base in
         set_int64_slot slots idx bits;
         set_int_slot slots idx (Int64.to_int bits)
   | Where { inner; _ } -> build_populate inner idx reader
@@ -438,6 +501,26 @@ type bf_info = {
   bf_mask : Optint.t;
 }
 
+let no_runtime = Types.empty_eval_ctx
+
+let runtime ?env bytes =
+  match env with
+  | None -> Types.empty_eval_ctx bytes
+  | Some env ->
+      let rec find name i =
+        if i >= Array.length env.Types.names then -1
+        else if env.names.(i) = name then i
+        else find name (i + 1)
+      in
+      Types.eval_ctx
+        ~set_param:(fun name value ->
+          let i = find name 0 in
+          if i >= 0 then env.slots.(i) <- value)
+        bytes
+        (fun name ->
+          let i = find name 0 in
+          if i < 0 then 0 else env.slots.(i))
+
 type field_access =
   | Fixed of int
   | Bitfield of {
@@ -446,11 +529,11 @@ type field_access =
       shift : int;
       width : int;
     }
-  | Dynamic of (bytes -> int -> int)
-  | Variable of { off : int; size_fn : bytes -> int -> int }
+  | Dynamic of (runtime -> int -> int)
+  | Variable of { off : int; size_fn : runtime -> int -> int }
   | Variable_dynamic of {
-      off_fn : bytes -> int -> int;
-      size_fn : bytes -> int -> int;
+      off_fn : runtime -> int -> int;
+      size_fn : runtime -> int -> int;
     }
 
 type ('a, 'r) field = {
@@ -493,7 +576,7 @@ let struct' = struct_
 type (_, _) readers =
   | Nil : ('f, 'f) readers
   | Snoc :
-      ('full, 'a -> 'rest) readers * (bytes -> int -> 'a)
+      ('full, 'a -> 'rest) readers * (runtime -> int -> 'a)
       -> ('full, 'rest) readers
 
 (* Bitfield group state: tracks the current base word being packed. *)
@@ -507,12 +590,12 @@ type bf_codec_state = {
 
 (* Track the byte offset for the next field: static (constant) until we hit
    a variable-size field, then dynamic (computed from the buffer). *)
-type next_off = Static of int | Dynamic of (bytes -> int -> int)
-(* [compute buf base] returns the absolute byte offset where the next
-         field starts. [base] is the record's base offset in [buf]. *)
+type next_off = Static of int | Dynamic of (runtime -> int -> int)
+(* [compute runtime base] returns the absolute byte offset where the next field
+   starts. [base] is the record's base offset in [runtime.buf]. *)
 
-type field_reader = string * (bytes -> int -> int)
-(* Name + buffer-and-base reader for a previously-declared int field. *)
+type field_reader = string * (runtime -> int -> int)
+(* Name + runtime-and-base reader for a previously-declared int field. *)
 
 (* Single GADT walker for [a expr] used by both call surfaces (closure
    over bytes for variable-size sizing; int_array lookup for constraint
@@ -733,11 +816,10 @@ and compile_bool : type c1 c2. (c1, c2) leaves -> bool expr -> c1 -> c2 -> bool
       fun c d -> not (fe c d)
   | Ref _ -> .
 
-(* Closure-based access layer: the context is [buf] and [base], passed as two
-   curried arguments. The compiled offset/size functions are [bytes -> int ->
-   int] directly, so evaluating a size expression allocates nothing per call. *)
-let bytes_leaves ?(sizeof_this : bytes -> int -> int = fun _ _ -> 0)
-    (env : field_reader list) : (bytes, int) leaves =
+(* Runtime access layer: the context carries both the buffer and the immutable
+   parameter environment for this operation. *)
+let bytes_leaves ?(sizeof_this : runtime -> int -> int = fun _ _ -> 0)
+    (env : field_reader list) : (runtime, int) leaves =
   {
     ref_ =
       (fun name ->
@@ -752,7 +834,7 @@ let bytes_leaves ?(sizeof_this : bytes -> int -> int = fun _ _ -> 0)
           "Codec: full-width field ref %S is only available in field \
            constraints"
           name);
-    param_ref = (fun (Pack_param p) _ _ -> !(p.cell ()));
+    param_ref = (fun (Pack_param p) rt _ -> Types.eval_param rt p.name);
     sizeof_typ =
       (fun (Pack_typ t) ->
         match field_wire_size t with
@@ -801,12 +883,10 @@ let array_leaves (cc : compile_ctx) : (slots, unit) leaves =
     param_ref =
       (fun (Pack_param p) a () ->
         (* The per-codec slot map is filled at seal, after these leaves are
-           built, so it must be consulted per call. A param not in this
-           codec's map (e.g. one only reachable via [cell] forwarding from
-           an embedding) falls back to the shared cell. *)
+           built, so it must be consulted per call. *)
         match Hashtbl.find_opt cc.param_slots p.Types.name with
         | Some i -> a.ints.(i)
-        | None -> !(p.cell ()));
+        | None -> Fmt.invalid_arg "Codec: unbound parameter %S" p.Types.name);
     sizeof_typ =
       (fun (Pack_typ t) ->
         let n = field_wire_size t |> Option.value ~default:0 in
@@ -826,7 +906,7 @@ let compile_bool_arr cc e =
   fun arr -> f arr ()
 
 (* Compile action statements to operate on an int array instead of Eval.ctx.
-   Assign writes to cell (mutable param) and updates the array.
+   Assign updates the mutable parameter's array slot.
    Var binds a local by extending the index -- but since we can't grow the
    array, local vars in actions use cell-style mutation or are inlined.
 
@@ -845,7 +925,7 @@ let rec compile_stmt (cc : compile_ctx) (s : Types.action_stmt) :
         let v = fe arr in
         match Hashtbl.find_opt cc.param_slots p.Types.name with
         | Some slot -> set_int_slot arr slot v
-        | None -> p.Types.cell () := v)
+        | None -> Fmt.invalid_arg "Codec: unbound parameter %S" p.Types.name)
   | Field_assign (_, _, _) | Extern_call (_, _) -> fun _ -> ()
   | Return e ->
       let fe = compile_bool_arr cc e in
@@ -895,7 +975,7 @@ type ('f, 'r) record =
       name : string;
       make : 'full;
       readers : ('full, 'f) readers;
-      writers_rev : ('r -> bytes -> int -> int -> int) list;
+      writers_rev : ('r -> runtime -> int -> int -> int) list;
       size_of_value_rev : ('r -> int) list;
           (* Per-field value-driven size functions (one per writer). At
              seal we sum them into [size_of_value]; encode uses that
@@ -907,9 +987,9 @@ type ('f, 'r) record =
       next_off : next_off; (* where the next field starts *)
       fields_rev : Types.field list;
       validators_rev :
-        (int (* byte offset *) * (slots -> bytes -> int -> unit)) list;
+        (int (* byte offset *) * (slots -> runtime -> int -> unit)) list;
       checkers_rev :
-        (int (* byte offset *) * (slots -> bytes -> int -> unit)) list;
+        (int (* byte offset *) * (slots -> runtime -> int -> unit)) list;
       field_actions_rev : (string * compiled_action) list;
       n_fields : int; (* count of named fields (for field indexing) *)
       n_array_slots : int;
@@ -926,7 +1006,7 @@ type ('f, 'r) record =
 
 type wire_size_info =
   | Fixed of int
-  | Variable of { min_size : int; compute : bytes -> int -> int }
+  | Variable of { min_size : int; compute : runtime -> int -> int }
 
 let id_counter = Atomic.make 0
 
@@ -937,16 +1017,16 @@ type 'r t = {
   field_access : (string * field_access) list;
   field_readers : field_reader list;
   field_actions : (string * compiled_action) list;
-  decode : bytes -> int -> 'r;
-  encode : 'r -> bytes -> int -> int;
-      (* Public encode entry. [encode v buf base] writes the record at
+  decode : runtime -> int -> 'r;
+  encode : 'r -> runtime -> int -> int;
+      (* Public encode entry. [encode v runtime base] writes the record at
          [base], threads each per-field writer's return as the next
          writer's [write_off], and returns the final offset. *)
   wire_size : wire_size_info;
   struct_fields : Types.field list;
   validate : ?env_slots:int array -> bytes -> int -> unit;
-  validate_arr : slots -> bytes -> int -> unit;
-  populate : slots -> bytes -> int -> unit;
+  validate_arr : slots -> runtime -> int -> unit;
+  populate : slots -> runtime -> int -> unit;
   n_array_slots : int;
   decode_scratch : unit -> slots;
       (* Validation scratch, one per domain (see [domain_local_slots]) and
@@ -1291,8 +1371,9 @@ let tag_byte_size : type a. a typ -> int =
   | _ -> ( match field_wire_size typ with Some n -> n | None -> assert false)
 
 (* Read one element of a typ at a given buffer position. Used by Repeat. *)
-let rec read_elem : type a. a typ -> bytes -> int -> a =
- fun typ buf off ->
+let rec read_elem : type a. a typ -> runtime -> int -> a =
+ fun typ runtime off ->
+  let buf = Types.eval_bytes runtime in
   match typ with
   | Uint8 -> Bytes.get_uint8 buf off
   | Uint16 Little -> Bytes.get_uint16_le buf off
@@ -1315,14 +1396,14 @@ let rec read_elem : type a. a typ -> bytes -> int -> a =
   | Float64 Little -> Int64.float_of_bits (Bytes.get_int64_le buf off)
   | Float64 Big -> Int64.float_of_bits (Bytes.get_int64_be buf off)
   | Uint_var { size = Int n; endian } -> Uint_var.read endian buf off n
-  | Codec { codec_decode; _ } -> codec_decode buf off
-  | Map { inner; decode; _ } -> decode (read_elem inner buf off)
-  | Where { inner; _ } -> read_elem inner buf off
+  | Codec { codec_decode; _ } -> codec_decode runtime off
+  | Map { inner; decode; _ } -> decode (read_elem inner runtime off)
+  | Where { inner; _ } -> read_elem inner runtime off
   | Enum { base; cases; closed; _ } ->
-      enum_check cases closed ~at:off (read_elem base buf off)
+      enum_check cases closed ~at:off (read_elem base runtime off)
   | Casetype { tag; cases; _ } ->
-      let tag_val = read_elem tag buf off in
-      read_case_body ~at:off ~tag cases tag_val buf (off + tag_byte_size tag)
+      let tag_val = read_elem tag runtime off in
+      read_case_body ~at:off ~tag cases tag_val runtime (off + tag_byte_size tag)
   | Unit -> ()
   (* NUL-terminated string element: the bytes up to (not including) the NUL. *)
   | Zeroterm ->
@@ -1352,20 +1433,20 @@ let rec read_elem : type a. a typ -> bytes -> int -> a =
       | Some esz ->
           let acc = Stdlib.ref s.empty in
           for i = 0 to n - 1 do
-            acc := s.add !acc (read_elem elem buf (off + (i * esz)))
+            acc := s.add !acc (read_elem elem runtime (off + (i * esz)))
           done;
           s.finish !acc)
   (* A nested region as an element: decode its inner at the region start; the
      enclosing region size (padding) is accounted for by the caller. *)
-  | Single_elem { elem; _ } -> read_elem elem buf off
+  | Single_elem { elem; _ } -> read_elem elem runtime off
   | _ -> failwith "read_elem: unsupported element type in repeat"
 
 (* Dispatch a casetype's matched case body. A top-level recursion rather than a
    [let rec find] inside [read_elem]: the inner form would allocate a fresh
    closure on every casetype element decoded. *)
 and read_case_body : type a k.
-    at:int -> tag:k typ -> (a, k) case_branch list -> k -> bytes -> int -> a =
- fun ~at ~tag cases tag_val buf body_off ->
+    at:int -> tag:k typ -> (a, k) case_branch list -> k -> runtime -> int -> a =
+ fun ~at ~tag cases tag_val runtime body_off ->
   match cases with
   | [] ->
       (* No branch matched the discriminant. [tag] is integer-typed in the
@@ -1374,14 +1455,15 @@ and read_case_body : type a k.
       raise_invalid_tag ~at (Option.value ~default:0 (Eval.int_of tag tag_val))
   | Case_branch { cb_tag = Some t; cb_inner; cb_inject; _ } :: _
     when t = tag_val ->
-      cb_inject tag_val (read_elem cb_inner buf body_off)
+      cb_inject tag_val (read_elem cb_inner runtime body_off)
   | Case_branch { cb_tag = None; cb_inner; cb_inject; _ } :: _ ->
-      cb_inject tag_val (read_elem cb_inner buf body_off)
-  | _ :: rest -> read_case_body ~at ~tag rest tag_val buf body_off
+      cb_inject tag_val (read_elem cb_inner runtime body_off)
+  | _ :: rest -> read_case_body ~at ~tag rest tag_val runtime body_off
 
 (* Write one element of a typ at a given buffer position. Used by Repeat. *)
-let rec write_elem : type a. a typ -> bytes -> int -> a -> unit =
- fun typ buf off v ->
+let rec write_elem : type a. a typ -> runtime -> int -> a -> unit =
+ fun typ runtime off v ->
+  let buf = Types.eval_bytes runtime in
   match typ with
   | Uint8 -> Bytes.set_uint8 buf off v
   | Uint16 Little -> Bytes.set_uint16_le buf off v
@@ -1404,15 +1486,15 @@ let rec write_elem : type a. a typ -> bytes -> int -> a -> unit =
   | Float64 Little -> Bytes.set_int64_le buf off (Int64.bits_of_float v)
   | Float64 Big -> Bytes.set_int64_be buf off (Int64.bits_of_float v)
   | Uint_var { size = Int n; endian } -> Uint_var.write endian buf off n v
-  | Codec { codec_encode; _ } -> ignore (codec_encode v buf off : int)
-  | Map { inner; encode; _ } -> write_elem inner buf off (encode v)
-  | Where { inner; _ } -> write_elem inner buf off v
-  | Enum { base; _ } -> write_elem base buf off v
+  | Codec { codec_encode; _ } -> ignore (codec_encode v runtime off : int)
+  | Map { inner; encode; _ } -> write_elem inner runtime off (encode v)
+  | Where { inner; _ } -> write_elem inner runtime off v
+  | Enum { base; _ } -> write_elem base runtime off v
   | Unit -> ()
   (* Casetype reuses the full field encoder (tag + dispatched body); the
      repeat loop advances by [elem_size_of], so the returned offset is
      discarded here. *)
-  | Casetype _ -> ignore (build_field_encoder typ buf off v : int)
+  | Casetype _ -> ignore (build_field_encoder_ctx typ runtime buf off v : int)
   (* NUL-terminated string element: the bytes followed by a NUL terminator. *)
   | Zeroterm ->
       let n = String.length v in
@@ -1428,16 +1510,18 @@ let rec write_elem : type a. a typ -> bytes -> int -> a -> unit =
 
 (* Compute the wire size of one element at a buffer position. Used by Repeat
    for variable-size elements. *)
-let rec elem_size_of : type a. a typ -> bytes -> int -> int =
- fun typ buf off ->
+let rec elem_size_of : type a. a typ -> runtime -> int -> int =
+ fun typ runtime off ->
+  let buf = Types.eval_bytes runtime in
   match typ with
-  | Codec { codec_size_of; _ } -> codec_size_of buf off
+  | Codec { codec_size_of; _ } -> codec_size_of runtime off
   | Casetype { tag; cases; _ } ->
       let tag_size = tag_byte_size tag in
-      let tag_val = read_elem tag buf off in
-      tag_size + size_case_body ~at:off ~tag cases tag_val buf (off + tag_size)
-  | Map { inner; _ } -> elem_size_of inner buf off
-  | Where { inner; _ } -> elem_size_of inner buf off
+      let tag_val = read_elem tag runtime off in
+      tag_size
+      + size_case_body ~at:off ~tag cases tag_val runtime (off + tag_size)
+  | Map { inner; _ } -> elem_size_of inner runtime off
+  | Where { inner; _ } -> elem_size_of inner runtime off
   (* Bytes up to the NUL plus the one-byte terminator. *)
   | Zeroterm ->
       let nul = zeroterm_nul_pos buf ~first:off ~limit:(Bytes.length buf) in
@@ -1457,16 +1541,17 @@ let rec elem_size_of : type a. a typ -> bytes -> int -> int =
    as [read_case_body]: a per-call [let rec find] would allocate a closure on
    every element. *)
 and size_case_body : type a k.
-    at:int -> tag:k typ -> (a, k) case_branch list -> k -> bytes -> int -> int =
- fun ~at ~tag cases tag_val buf body_off ->
+    at:int -> tag:k typ -> (a, k) case_branch list -> k -> runtime -> int -> int
+    =
+ fun ~at ~tag cases tag_val runtime body_off ->
   match cases with
   | [] ->
       raise_invalid_tag ~at (Option.value ~default:0 (Eval.int_of tag tag_val))
   | Case_branch { cb_tag = Some t; cb_inner; _ } :: _ when t = tag_val ->
-      elem_size_of cb_inner buf body_off
+      elem_size_of cb_inner runtime body_off
   | Case_branch { cb_tag = None; cb_inner; _ } :: _ ->
-      elem_size_of cb_inner buf body_off
-  | _ :: rest -> size_case_body ~at ~tag rest tag_val buf body_off
+      elem_size_of cb_inner runtime body_off
+  | _ :: rest -> size_case_body ~at ~tag rest tag_val runtime body_off
 
 (* -- Compiled field: intermediate plan for one field's contribution -- *)
 
@@ -1474,28 +1559,28 @@ and size_case_body : type a k.
    record state. The per-type [compile_*] helpers build one; [apply_compiled]
    consumes it and produces the updated record state. *)
 type ('a, 'r) compiled_field = {
-  raw_reader : bytes -> int -> 'a;
-  raw_writer : 'r -> bytes -> int -> int -> int;
-      (* [raw_writer v buf base write_off] writes the field's bytes
-         starting at [write_off] in [buf] and returns the offset just
+  raw_reader : runtime -> int -> 'a;
+  raw_writer : 'r -> runtime -> int -> int -> int;
+      (* [raw_writer v runtime base write_off] writes the field's bytes
+         starting at [write_off] in [runtime.buf] and returns the offset just
          after them. [base] is the record's base offset, used by
          buffer-driven helpers (size cross-checks, dynamic-gate cross
          checks) -- the field's own write position comes from
          [write_off]. *)
-  extra_writers : ('r -> bytes -> int -> int -> int) list;
+  extra_writers : ('r -> runtime -> int -> int -> int) list;
       (* Writers that run strictly before [raw_writer] -- e.g. a bf_clear that
          opens a new packed base word. Returns the input [write_off] unchanged. *)
   field_access : field_access;
   size_delta : int; (* added to [min_wire_size] *)
   next_off : next_off; (* new [next_off] *)
   bf_after : bf_codec_state option;
-  int_reader : bytes -> int -> int;
+  int_reader : runtime -> int -> int;
       (* Entry stored in [field_readers] under the field name; const 0 for
          composite types that have no int-array slot of their own. *)
   nested_readers : field_reader list;
       (* Embedded sub-codec field readers, shifted into the parent frame. *)
   validator_off : int; (* [-1] when the byte offset is dynamic *)
-  populate : slots -> bytes -> int -> unit;
+  populate : slots -> runtime -> int -> unit;
       (* Pre-built populate function for the int-array validator path; the
          slot index (n_fields at the time the field is compiled) is baked
          in. Composite types use a no-op. *)
@@ -1525,10 +1610,10 @@ let layout_ctx_of : type f r. (f, r) record -> layout_ctx =
 let static_off_of (ctx : layout_ctx) : int option =
   match ctx.next_off with Static n -> Some n | Dynamic _ -> None
 
-let off_fn_of (ctx : layout_ctx) : bytes -> int -> int =
+let off_fn_of (ctx : layout_ctx) : runtime -> int -> int =
   match ctx.next_off with
-  | Static n -> fun _buf _base -> n
-  | Dynamic f -> fun buf base -> f buf base - base
+  | Static n -> fun _runtime _base -> n
+  | Dynamic f -> fun runtime base -> f runtime base - base
 
 (* Byte offset used as [sizeof_this] when compiling constraints/actions: a
    real static offset when known, the [-1] sentinel otherwise. *)
@@ -1554,44 +1639,51 @@ let advance_next_off (no : next_off) (n : int) : next_off =
   | Static k -> Static (k + n)
   | Dynamic f -> Dynamic (fun buf base -> f buf base + n)
 
-let null_int_reader : bytes -> int -> int = fun _buf _base -> 0
-let no_populate : slots -> bytes -> int -> unit = fun _arr _buf _base -> ()
+let null_int_reader : runtime -> int -> int = fun _runtime _base -> 0
+
+let no_populate : slots -> runtime -> int -> unit =
+ fun _arr _runtime _base -> ()
 
 (* Reader+writer pair for a Codec-or-scalar inner type placed at the current
    frame offset. Extracted so [compile_optional] and [compile_optional_or]
    share it. *)
 let inner_codec_accessors : type w.
-    w typ -> layout_ctx -> (bytes -> int -> w) * (bytes -> int -> w -> int) =
+    w typ -> layout_ctx -> (runtime -> int -> w) * (runtime -> int -> w -> int)
+    =
  fun inner ctx ->
   let field_off_static = static_off_of ctx in
   let field_off_fn = off_fn_of ctx in
-  let reader : bytes -> int -> w =
+  let reader : runtime -> int -> w =
     match inner with
     | Codec { codec_decode; _ } -> (
         match field_off_static with
-        | Some fo -> fun buf base -> codec_decode buf (base + fo)
+        | Some fo -> fun runtime base -> codec_decode runtime (base + fo)
         | None ->
-            fun buf base ->
-              let fo = field_off_fn buf base in
-              codec_decode buf (base + fo))
+            fun runtime base ->
+              let fo = field_off_fn runtime base in
+              codec_decode runtime (base + fo))
     | _ -> (
         match field_off_static with
-        | Some fo -> build_field_reader inner fo
+        | Some fo ->
+            let reader = build_field_reader_ctx inner fo in
+            fun runtime base -> reader runtime base
         | None ->
-            let reader_at_0 = build_field_reader inner 0 in
-            fun buf base ->
-              let fo = field_off_fn buf base in
-              reader_at_0 buf (base + fo))
+            let reader_at_0 = build_field_reader_ctx inner 0 in
+            fun runtime base ->
+              let fo = field_off_fn runtime base in
+              reader_at_0 runtime (base + fo))
   in
   (* Writer takes the absolute byte position to write at. The caller
      gets this from the threaded [write_off]; no buffer-driven
      [off_fn] lookup happens on the encode path. *)
-  let writer : bytes -> int -> w -> int =
+  let writer : runtime -> int -> w -> int =
     match inner with
-    | Codec { codec_encode; _ } -> fun buf off iv -> codec_encode iv buf off
+    | Codec { codec_encode; _ } ->
+        fun runtime off iv -> codec_encode iv runtime off
     | _ ->
-        let enc = build_field_encoder inner in
-        fun buf off iv -> enc buf off iv
+        fun runtime off iv ->
+          build_field_encoder_ctx inner runtime (Types.eval_bytes runtime) off
+            iv
   in
   (reader, writer)
 
@@ -1599,13 +1691,13 @@ let build_nested_readers ctx readers =
   match static_off_of ctx with
   | Some fo ->
       List.map
-        (fun (n, reader) -> (n, fun buf base -> reader buf (base + fo)))
+        (fun (n, reader) -> (n, fun runtime base -> reader runtime (base + fo)))
         readers
   | None ->
       let off_fn = off_fn_of ctx in
       List.map
         (fun (n, reader) ->
-          (n, fun buf base -> reader buf (base + off_fn buf base)))
+          (n, fun runtime base -> reader runtime (base + off_fn runtime base)))
         readers
 
 (* -- Per-type [compile_field] helpers -- *)
@@ -1644,20 +1736,21 @@ let compile_bits : type r.
         0,
         base_byte_size,
         [
-          (fun _v buf _base write_off ->
-            clear_at buf write_off;
+          (fun _v runtime _base write_off ->
+            clear_at (Types.eval_bytes runtime) write_off;
             write_off);
         ] )
   in
   let shift = Bitfield.shift ~bit_order ~total ~bits_used ~width in
-  let raw_reader = build_bf_reader base base_off shift width in
+  let read = build_bf_reader base base_off shift width in
+  let raw_reader runtime base = read (Types.eval_bytes runtime) base in
   let raw_writer_inner = build_bf_writer base 0 shift width in
   let get = fld.get in
   let back, advance =
     if is_continuation then (base_byte_size, 0) else (0, base_byte_size)
   in
-  let raw_writer v buf _base write_off =
-    raw_writer_inner buf (write_off - back) (get v);
+  let raw_writer v runtime _base write_off =
+    raw_writer_inner (Types.eval_bytes runtime) (write_off - back) (get v);
     write_off + advance
   in
   {
@@ -1685,9 +1778,9 @@ let compile_bits : type r.
 let compile_codec_variable : type a r.
     layout_ctx ->
     get:(r -> a) ->
-    codec_decode:(bytes -> int -> a) ->
-    codec_encode:(a -> bytes -> int -> int) ->
-    codec_size_of:(bytes -> int -> int) ->
+    codec_decode:(runtime -> int -> a) ->
+    codec_encode:(a -> runtime -> int -> int) ->
+    codec_size_of:(runtime -> int -> int) ->
     nested_readers:field_reader list ->
     (a, r) compiled_field =
  fun ctx ~get ~codec_decode ~codec_encode ~codec_size_of ~nested_readers ->
@@ -1726,10 +1819,10 @@ let compile_codec_variable : type a r.
 let compile_codec : type a r.
     layout_ctx ->
     (a, r) field ->
-    codec_decode:(bytes -> int -> a) ->
-    codec_encode:(a -> bytes -> int -> int) ->
+    codec_decode:(runtime -> int -> a) ->
+    codec_encode:(a -> runtime -> int -> int) ->
     codec_fixed_size:int option ->
-    codec_size_of:(bytes -> int -> int) ->
+    codec_size_of:(runtime -> int -> int) ->
     codec_field_readers:field_reader list ->
     (a, r) compiled_field =
  fun ctx fld ~codec_decode ~codec_encode ~codec_fixed_size ~codec_size_of
@@ -1775,18 +1868,18 @@ let dynamic_optional_next_off ctx present_fn fsize =
       if present_fn buf base then off + fsize else off)
 
 (* Absolute byte position a [next_off] points at, given the record [base]. *)
-let next_off_pos : next_off -> bytes -> int -> int = function
-  | Static n -> fun _buf base -> base + n
+let next_off_pos : next_off -> runtime -> int -> int = function
+  | Static n -> fun _runtime base -> base + n
   | Dynamic f -> f
 
 let optional_compiled : type a r.
     layout_ctx ->
-    ?int_reader:(bytes -> int -> int) ->
-    raw_reader:(bytes -> int -> a) ->
-    raw_writer:(r -> bytes -> int -> int -> int) ->
+    ?int_reader:(runtime -> int -> int) ->
+    raw_reader:(runtime -> int -> a) ->
+    raw_writer:(r -> runtime -> int -> int -> int) ->
     size_delta:int ->
     next_off:next_off ->
-    populate:(slots -> bytes -> int -> unit) ->
+    populate:(slots -> runtime -> int -> unit) ->
     unit ->
     (a, r) compiled_field =
  fun ctx ?(int_reader = null_int_reader) ~raw_reader ~raw_writer ~size_delta
@@ -1813,14 +1906,15 @@ let repeat_raw_fixed : type elt seq.
     (elt, seq) seq_map ->
     elt typ ->
     int ->
-    off_fn:(bytes -> int -> int) ->
-    size_fn:(bytes -> int -> int) ->
-    bytes ->
+    off_fn:(runtime -> int -> int) ->
+    size_fn:(runtime -> int -> int) ->
+    runtime ->
     int ->
     seq =
- fun (Seq_map seq) elem esz ~off_fn ~size_fn buf base ->
-  let budget = size_fn buf base in
-  let start = base + off_fn buf base in
+ fun (Seq_map seq) elem esz ~off_fn ~size_fn runtime base ->
+  let buf = Types.eval_bytes runtime in
+  let budget = size_fn runtime base in
+  let start = base + off_fn runtime base in
   (* The budget comes from a length field, i.e. untrusted input. Bound it to the
      buffer before reading so an oversized length fails cleanly instead of
      crashing [read_elem] with an out-of-range [Bytes.sub]. *)
@@ -1832,31 +1926,32 @@ let repeat_raw_fixed : type elt seq.
   let n = if esz > 0 then budget / esz else 0 in
   let rec loop acc i =
     if i >= n then seq.finish acc
-    else loop (seq.add acc (read_elem elem buf (start + (i * esz)))) (i + 1)
+    else loop (seq.add acc (read_elem elem runtime (start + (i * esz)))) (i + 1)
   in
   loop seq.empty 0
 
 let repeat_raw_variable : type elt seq.
     (elt, seq) seq_map ->
     elt typ ->
-    off_fn:(bytes -> int -> int) ->
-    size_fn:(bytes -> int -> int) ->
-    bytes ->
+    off_fn:(runtime -> int -> int) ->
+    size_fn:(runtime -> int -> int) ->
+    runtime ->
     int ->
     seq =
- fun (Seq_map seq) elem ~off_fn ~size_fn buf base ->
-  let budget = size_fn buf base in
-  let start = base + off_fn buf base in
+ fun (Seq_map seq) elem ~off_fn ~size_fn runtime base ->
+  let buf = Types.eval_bytes runtime in
+  let budget = size_fn runtime base in
+  let start = base + off_fn runtime base in
   (* Bound the untrusted budget to the buffer (see [repeat_raw_fixed]). *)
   if budget < 0 || start + budget > Bytes.length buf then
     raise_eof ~at:start ~expected:(start + budget) ~got:(Bytes.length buf);
   let rec loop acc pos remaining =
     if remaining <= 0 then seq.finish acc
     else
-      let esz = elem_size_of elem buf pos in
+      let esz = elem_size_of elem runtime pos in
       if esz <= 0 || esz > remaining then
         raise_eof ~at:pos ~expected:esz ~got:remaining;
-      let v = read_elem elem buf pos in
+      let v = read_elem elem runtime pos in
       loop (seq.add acc v) (pos + esz) (remaining - esz)
   in
   loop seq.empty start budget
@@ -1865,9 +1960,9 @@ let repeat_raw_reader : type elt seq.
     (elt, seq) seq_map ->
     elt typ ->
     elem_size:int option ->
-    off_fn:(bytes -> int -> int) ->
-    size_fn:(bytes -> int -> int) ->
-    bytes ->
+    off_fn:(runtime -> int -> int) ->
+    size_fn:(runtime -> int -> int) ->
+    runtime ->
     int ->
     seq =
  fun seq elem ~elem_size ~off_fn ~size_fn ->
@@ -1887,7 +1982,7 @@ let compile_repeat : type elt seq r.
      when a [Repeat] sits after a variable-size field, the running offset is
      [Dynamic] and is resolved at runtime rather than from a static offset. *)
   let off_fn, (field_access : field_access), validator_off =
-    let sizeof_this : bytes -> int -> int =
+    let sizeof_this : runtime -> int -> int =
       match ctx.next_off with
       | Static n -> fun _buf _base -> n
       | Dynamic prev_end -> fun buf base -> prev_end buf base - base
@@ -1908,9 +2003,9 @@ let compile_repeat : type elt seq r.
   let elem_size = field_wire_size elem in
   let raw_reader = repeat_raw_reader seq elem ~elem_size ~off_fn ~size_fn in
   let get = fld.get in
-  let raw_writer v buf base write_off =
+  let raw_writer v runtime base write_off =
     let items = get v in
-    let expected = size_fn buf base in
+    let expected = size_fn runtime base in
     let sized_items =
       Types.exact_repeat_elements seq ~expected
         ~size_of:(Types.size_of_typ_value elem)
@@ -1919,7 +2014,7 @@ let compile_repeat : type elt seq r.
     let pos = Stdlib.ref write_off in
     List.iter
       (fun (item, size) ->
-        write_elem elem buf !pos item;
+        write_elem elem runtime !pos item;
         pos := !pos + size)
       sized_items;
     !pos
@@ -1943,11 +2038,16 @@ let compile_repeat : type elt seq r.
    not including) [limit]. Raises [Parse_error] when the region ends before a
    terminator is found -- a truncated / unterminated zero-terminated string. *)
 let var_bytes_reader : type a.
-    a typ -> (bytes -> int -> int) -> (bytes -> int -> int) -> bytes -> int -> a
-    =
- fun typ off_fn size_fn buf base ->
-  let fo = off_fn buf base in
-  let sz = size_fn buf base in
+    a typ ->
+    (runtime -> int -> int) ->
+    (runtime -> int -> int) ->
+    runtime ->
+    int ->
+    a =
+ fun typ off_fn size_fn runtime base ->
+  let buf = Types.eval_bytes runtime in
+  let fo = off_fn runtime base in
+  let sz = size_fn runtime base in
   let first = base + fo in
   (* [fo] and [sz] derive from length fields, i.e. untrusted input. A field
      sized past the buffer (or a negative size from an overrun offset) would
@@ -1983,19 +2083,19 @@ let var_bytes_reader : type a.
           if c <> '\000' then raise_non_zero_padding ~at:(base + fo + i))
         s;
       s
-  | Casetype _ -> read_elem typ buf (base + fo)
+  | Casetype _ -> read_elem typ runtime (base + fo)
   | Single_elem { elem; at_most; _ } ->
       let first = base + fo in
-      let consumed = elem_size_of elem buf first in
+      let consumed = elem_size_of elem runtime first in
       if consumed > sz || ((not at_most) && consumed <> sz) then
         raise_eof ~at:(first + min consumed sz) ~expected:sz ~got:consumed;
-      read_elem elem buf first
+      read_elem elem runtime first
   | _ -> assert false
 
 (* Kept at top level: as local closures they would be heap-allocated on
    every call (two allocations per variable-bytes field on each encode). *)
-let var_bytes_check_len size_fn buf base ~actual =
-  let expected = size_fn buf base in
+let var_bytes_check_len size_fn runtime base ~actual =
+  let expected = size_fn runtime base in
   if actual <> expected then
     Fmt.invalid_arg
       "Codec.encode: byte field length %d does not match expected %d \
@@ -2010,28 +2110,29 @@ let var_bytes_write_str buf write_off s =
 let var_bytes_writer : type a r.
     a typ ->
     (r -> a) ->
-    (bytes -> int -> int) ->
+    (runtime -> int -> int) ->
     r ->
-    bytes ->
+    runtime ->
     int ->
     int ->
     int =
- fun typ get size_fn v buf base write_off ->
+ fun typ get size_fn v runtime base write_off ->
+  let buf = Types.eval_bytes runtime in
   let value = get v in
   match typ with
   | Byte_slice _ ->
       let src = (value : Slice.t) in
       let len = Slice.length src in
-      var_bytes_check_len size_fn buf base ~actual:len;
+      var_bytes_check_len size_fn runtime base ~actual:len;
       Bytes.blit (Slice.bytes src) (Slice.first src) buf write_off len;
       write_off + len
   | Byte_array _ ->
       let s = (value : string) in
-      var_bytes_check_len size_fn buf base ~actual:(String.length s);
+      var_bytes_check_len size_fn runtime base ~actual:(String.length s);
       var_bytes_write_str buf write_off s
   | Byte_array_where _ ->
       let s = (value : string) in
-      var_bytes_check_len size_fn buf base ~actual:(String.length s);
+      var_bytes_check_len size_fn runtime base ~actual:(String.length s);
       var_bytes_write_str buf write_off s
   | All_bytes -> var_bytes_write_str buf write_off (value : string)
   | All_zeros -> var_bytes_write_str buf write_off (value : string)
@@ -2046,7 +2147,7 @@ let var_bytes_writer : type a r.
       let s = (value : string) in
       if String.contains s '\000' then
         invalid_arg "Codec.encode: zeroterm string contains a NUL byte";
-      let region = size_fn buf base in
+      let region = size_fn runtime base in
       let len = String.length s in
       if len + 1 > region then
         Fmt.invalid_arg
@@ -2056,19 +2157,26 @@ let var_bytes_writer : type a r.
       (* Single fill covers the NUL terminator and any trailing padding. *)
       Bytes.fill buf (write_off + len) (region - len) '\x00';
       write_off + region
-  | Casetype _ -> build_field_encoder typ buf write_off value
+  | Casetype _ -> build_field_encoder_ctx typ runtime buf write_off value
   | Single_elem { elem; at_most; _ } ->
-      let n = size_fn buf base in
+      let n = size_fn runtime base in
       let actual = Types.size_of_typ_value elem value in
       Types.check_nested_size ~at_most ~expected:n ~actual;
-      let inner_end = build_field_encoder elem buf write_off value in
+      let inner_end =
+        build_field_encoder_ctx elem runtime buf write_off value
+      in
       if inner_end < write_off + n then
         Bytes.fill buf inner_end (write_off + n - inner_end) '\x00';
       write_off + n
   | _ -> assert false
 
 let compile_var_size_fn : type a.
-    layout_ctx -> a typ -> off_fn:(bytes -> int -> int) -> bytes -> int -> int =
+    layout_ctx ->
+    a typ ->
+    off_fn:(runtime -> int -> int) ->
+    runtime ->
+    int ->
+    int =
  fun ctx typ ~off_fn ->
   match typ with
   | All_bytes | All_zeros ->
@@ -2076,16 +2184,19 @@ let compile_var_size_fn : type a.
          current offset. The OCaml decoder gets the buffer length via
          [Bytes.length buf]; the 3D projection emits [all_bytes], which
          3D handles natively. *)
-      fun buf base -> Bytes.length buf - (base + off_fn buf base)
+      fun runtime base ->
+        Bytes.length (Types.eval_bytes runtime) - (base + off_fn runtime base)
   | Casetype _ ->
       (* Tag is decoded first; the case body's size is whatever the
          selected case's inner typ reports. *)
-      fun buf base -> elem_size_of typ buf (base + off_fn buf base)
+      fun runtime base -> elem_size_of typ runtime (base + off_fn runtime base)
   | Zeroterm ->
       (* Consumed bytes = string length plus the one-byte NUL terminator. *)
-      fun buf base ->
-        let first = base + off_fn buf base in
-        zeroterm_nul_pos buf ~first ~limit:(Bytes.length buf) - first + 1
+      fun runtime base ->
+        let first = base + off_fn runtime base in
+        zeroterm_nul_pos (Types.eval_bytes runtime) ~first
+          ~limit:(Bytes.length (Types.eval_bytes runtime))
+        - first + 1
   | _ ->
       let size_expr =
         match typ with
@@ -2097,7 +2208,7 @@ let compile_var_size_fn : type a.
         | Zeroterm_at_most { size } -> size
         | _ -> invalid_arg "add_field: unsupported variable-size field type"
       in
-      let sizeof_this : bytes -> int -> int =
+      let sizeof_this : runtime -> int -> int =
         match ctx.next_off with
         | Static n -> fun _buf _base -> n
         | Dynamic prev_end -> fun buf base -> prev_end buf base - base
@@ -2110,7 +2221,7 @@ let compile_var_bytes : type a r.
   let typ = fld.typ in
   let off_fn, validator_off =
     match ctx.next_off with
-    | Static n -> ((fun (_buf : bytes) (_base : int) -> n), n)
+    | Static n -> ((fun (_runtime : runtime) (_base : int) -> n), n)
     | Dynamic prev_end -> ((fun buf base -> prev_end buf base - base), -1)
   in
   let size_fn = compile_var_size_fn ctx typ ~off_fn in
@@ -2123,16 +2234,16 @@ let compile_var_bytes : type a r.
     match typ with
     | Uint_var { endian; _ } ->
         let get = fld.get in
-        let raw_reader : bytes -> int -> a =
-         fun buf base ->
-          let fo = off_fn buf base in
-          let sz = size_fn buf base in
-          Uint_var.read endian buf (base + fo) sz
+        let raw_reader : runtime -> int -> a =
+         fun runtime base ->
+          let fo = off_fn runtime base in
+          let sz = size_fn runtime base in
+          Uint_var.read endian (Types.eval_bytes runtime) (base + fo) sz
         in
-        let raw_writer : r -> bytes -> int -> int -> int =
-         fun v buf base write_off ->
-          let sz = size_fn buf base in
-          Uint_var.write endian buf write_off sz (get v);
+        let raw_writer : r -> runtime -> int -> int -> int =
+         fun v runtime base write_off ->
+          let sz = size_fn runtime base in
+          Uint_var.write endian (Types.eval_bytes runtime) write_off sz (get v);
           write_off + sz
         in
         let int_reader buf base = int_of_typ_value typ (raw_reader buf base) in
@@ -2173,17 +2284,20 @@ let compile_scalar_or_var : type a r.
       let field_off = match field_off_static with Some n -> n | None -> -1 in
       let raw_reader =
         match field_off_static with
-        | Some _ -> build_field_reader typ field_off
+        | Some _ ->
+            let reader = build_field_reader_ctx typ field_off in
+            fun runtime base -> reader runtime base
         | None ->
-            let reader_at_0 = build_field_reader typ 0 in
-            fun buf base ->
-              let off = field_off_fn buf base in
-              reader_at_0 buf (base + off)
+            let reader_at_0 = build_field_reader_ctx typ 0 in
+            fun runtime base ->
+              let off = field_off_fn runtime base in
+              reader_at_0 runtime (base + off)
       in
-      let raw_encoder = build_field_encoder typ in
       let get = fld.get in
-      let raw_writer : r -> bytes -> int -> int -> int =
-       fun v buf _base write_off -> raw_encoder buf write_off (get v)
+      let raw_writer : r -> runtime -> int -> int -> int =
+       fun v runtime _base write_off ->
+        build_field_encoder_ctx typ runtime (Types.eval_bytes runtime) write_off
+          (get v)
       in
       let int_reader buf base = int_of_typ_value typ (raw_reader buf base) in
       let populate = build_populate typ ctx.n_fields raw_reader in
@@ -2655,7 +2769,7 @@ let add_field : type a f r. (a -> f, r) record -> (a, r) field -> (f, r) record
 type (_, _) readers_fwd =
   | FNil : ('r, 'r) readers_fwd
   | FCons :
-      (bytes -> int -> 'a) * ('rest, 'result) readers_fwd
+      (runtime -> int -> 'a) * ('rest, 'result) readers_fwd
       -> ('a -> 'rest, 'result) readers_fwd
 
 (* Convert a [readers] snoc-list to a [readers_fwd] cons-list. O(n), runs
@@ -2686,7 +2800,7 @@ let to_fwd : type full result.
    patterns across ~500 lines; the flat table is both shorter and easier to
    read. *)
 let rec apply_fwd : type mid result.
-    mid -> (mid, result) readers_fwd -> bytes -> int -> result =
+    mid -> (mid, result) readers_fwd -> runtime -> int -> result =
  fun f fwd buf off ->
   match fwd with
   | FNil -> f
@@ -2756,7 +2870,8 @@ let rec apply_fwd : type mid result.
       apply_fwd (f (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off) (r5 buf off) (r6 buf off) (r7 buf off) (r8 buf off) (r9 buf off) (r10 buf off) (r11 buf off) (r12 buf off) (r13 buf off) (r14 buf off) (r15 buf off) (r16 buf off) (r17 buf off) (r18 buf off) (r19 buf off) (r20 buf off) (r21 buf off) (r22 buf off) (r23 buf off) (r24 buf off) (r25 buf off) (r26 buf off) (r27 buf off) (r28 buf off) (r29 buf off) (r30 buf off) (r31 buf off) (r32 buf off)) rest buf off
 [@@ocamlformat "disable"]
 
-let build_decode : type full r. full -> (full, r) readers -> bytes -> int -> r =
+let build_decode : type full r. full -> (full, r) readers -> runtime -> int -> r
+    =
  fun make readers ->
   match readers with
   | Nil -> fun _buf _off -> make
@@ -2820,12 +2935,12 @@ let validate_or_eof buf f =
     raise_eof ~at:len ~expected:(len + 1) ~got:len
 
 let build_validators validators_rev checkers_rev compiled_where struct_fields
-    n_total =
+    param_slots n_total =
   let validator_fns = Array.of_list (List.map snd validators_rev) in
   let n_validators = Array.length validator_fns in
-  let validate_arr arr buf off =
+  let validate_arr arr runtime off =
     for i = 0 to n_validators - 1 do
-      validator_fns.(i) arr buf off
+      validator_fns.(i) arr runtime off
     done;
     match compiled_where with
     | Some f when not (f arr) -> raise_constraint ~at:off ~which:Where ()
@@ -2833,9 +2948,9 @@ let build_validators validators_rev checkers_rev compiled_where struct_fields
   in
   let checker_fns = Array.of_list (List.map snd checkers_rev) in
   let n_checkers = Array.length checker_fns in
-  let populate arr buf off =
+  let populate arr runtime off =
     for i = 0 to n_checkers - 1 do
-      checker_fns.(i) arr buf off
+      checker_fns.(i) arr runtime off
     done
   in
   (* Run the validator pass only when the struct actually has something to
@@ -2865,7 +2980,19 @@ let build_validators validators_rev checkers_rev compiled_where struct_fields
             let n = Array.length slots in
             Array.blit slots 0 arr.ints (n_total - n) n
         | None -> ());
-        validate_or_eof buf (fun () -> validate_arr arr buf off)
+        let runtime =
+          Types.eval_ctx
+            ~set_param:(fun name value ->
+              match Hashtbl.find_opt param_slots name with
+              | Some idx -> arr.ints.(idx) <- value
+              | None -> ())
+            buf
+            (fun name ->
+              match Hashtbl.find_opt param_slots name with
+              | Some idx -> arr.ints.(idx)
+              | None -> 0)
+        in
+        validate_or_eof buf (fun () -> validate_arr arr runtime off)
   in
   (validate_arr, populate, validate)
 
@@ -2897,14 +3024,15 @@ let fill_param_slots tbl param_base handles =
    must hold at least [min_size] bytes, and the codec's resolved wire size must
    fit. Shared with [validate] so a constraint-free codec is still bounds-checked
    before a zero-copy [get] reads its fields. *)
-let check_decode_bounds wire_size_info min_size buf off =
+let check_decode_bounds wire_size_info min_size runtime off =
+  let buf = Types.eval_bytes runtime in
   if off + min_size > Bytes.length buf then
     raise_eof ~at:off ~expected:min_size ~got:(Bytes.length buf - off);
   match wire_size_info with
   | Fixed _ -> ()
   | Variable { compute; _ } ->
       let end_off =
-        try compute buf off
+        try compute runtime off
         with Invalid_argument _ ->
           raise_eof ~at:off ~expected:min_size ~got:(Bytes.length buf - off)
       in
@@ -2914,17 +3042,27 @@ let check_decode_bounds wire_size_info min_size buf off =
         raise_eof ~at:off ~expected:(end_off - off) ~got:(Bytes.length buf - off)
 
 let build_checked_decode raw_decode wire_size_info min_size =
- fun buf off ->
-  check_decode_bounds wire_size_info min_size buf off;
-  raw_decode buf off
+ fun runtime off ->
+  check_decode_bounds wire_size_info min_size runtime off;
+  raw_decode runtime off
 
 (* [Codec.validate] is the safety gate before a batch of zero-copy [get] calls on
    untrusted input, so it must run decode's structural bounds check even for a
    constraint-free codec (whose constraint validator [validate_checks] is a
    no-op), or a [get] on a truncated buffer would read out of bounds. *)
-let validate_with_bounds wire_size_info min_size validate_checks =
+let validate_with_bounds wire_size_info min_size param_slots param_base
+    validate_checks =
  fun ?env_slots buf off ->
-  check_decode_bounds wire_size_info min_size buf off;
+  let runtime =
+    match env_slots with
+    | None -> no_runtime buf
+    | Some slots ->
+        Types.eval_ctx buf (fun name ->
+            match Hashtbl.find_opt param_slots name with
+            | Some idx -> slots.(idx - param_base)
+            | None -> 0)
+  in
+  check_decode_bounds wire_size_info min_size runtime off;
   validate_checks ?env_slots buf off
 
 (* Whether a field consumes the rest of the buffer: a greedy leaf ([all_bytes] /
@@ -3168,7 +3306,7 @@ let seal : type r. (r, r) record -> r t =
   in
   let validate_arr, populate, validate_checks =
     build_validators validators (List.rev r.checkers_rev) compiled_where
-      struct_fields n_total
+      struct_fields r.param_slots n_total
   in
   (* Per-field action runners *)
   let field_actions = List.rev r.field_actions_rev in
@@ -3190,7 +3328,8 @@ let seal : type r. (r, r) record -> r t =
     field_actions;
     decode = build_checked_decode raw_decode wire_size_info min_size;
     encode =
-      (fun v buf off ->
+      (fun v runtime off ->
+        let buf = Types.eval_bytes runtime in
         let need = size_of_value v in
         if off + need > Bytes.length buf then
           Fmt.invalid_arg "Codec.encode %s: buffer too short (need %d, got %d)"
@@ -3198,12 +3337,14 @@ let seal : type r. (r, r) record -> r t =
             (Bytes.length buf - off);
         let write_off = Stdlib.ref off in
         for i = 0 to n_writers - 1 do
-          write_off := writers.(i) v buf off !write_off
+          write_off := writers.(i) v runtime off !write_off
         done;
         !write_off);
     wire_size = wire_size_info;
     struct_fields;
-    validate = validate_with_bounds wire_size_info min_size validate_checks;
+    validate =
+      validate_with_bounds wire_size_info min_size r.param_slots param_base
+        validate_checks;
     validate_arr;
     populate;
     n_array_slots = n_total;
@@ -3226,12 +3367,13 @@ type validator = {
   min_size : int;
   wire_size : wire_size_info;
   validate : bytes -> int -> unit;
+  validate_ctx : runtime -> int -> unit;
 }
 
 (* Internal accumulator -- the validator-relevant subset of [record]. *)
 type validator_acc = {
-  validators_rev : (int * (slots -> bytes -> int -> unit)) list;
-  checkers_rev : (int * (slots -> bytes -> int -> unit)) list;
+  validators_rev : (int * (slots -> runtime -> int -> unit)) list;
+  checkers_rev : (int * (slots -> runtime -> int -> unit)) list;
   field_readers : field_reader list;
   n_fields : int;
   n_array_slots : int;
@@ -3276,12 +3418,12 @@ let layout_ctx_of_validator_acc acc =
 (* Common access patterns over [next_off]: a fresh-buffer offset
    function and a "previous end" helper that hides the static/dynamic
    split. *)
-let acc_off_fn (acc : validator_acc) : bytes -> int -> int =
+let acc_off_fn (acc : validator_acc) : runtime -> int -> int =
   match acc.next_off with
   | Static n -> fun _buf _base -> n
   | Dynamic f -> fun buf base -> f buf base - base
 
-let acc_prev_end (acc : validator_acc) : bytes -> int -> int =
+let acc_prev_end (acc : validator_acc) : runtime -> int -> int =
   match acc.next_off with
   | Static n -> fun _buf base -> base + n
   | Dynamic f -> f
@@ -3338,7 +3480,9 @@ let rec apply_struct_field acc inner_struct =
   let inner_v = validator_of_struct inner_struct in
   let static_off = match acc.next_off with Static n -> n | Dynamic _ -> -1 in
   let off_fn = acc_off_fn acc in
-  let validator _arr buf base = inner_v.validate buf (base + off_fn buf base) in
+  let validator _arr runtime base =
+    inner_v.validate_ctx runtime (base + off_fn runtime base)
+  in
   let prev_end = acc_prev_end acc in
   let size_delta, next_off =
     match (acc.next_off, inner_v.wire_size) with
@@ -3418,33 +3562,44 @@ and validator_of_struct (s : Types.struct_) : validator =
     build_validators
       (List.rev acc.validators_rev)
       (List.rev acc.checkers_rev)
-      compiled_where s.fields n_total
+      compiled_where s.fields acc.param_slots n_total
   in
   (* Full validation: fire field actions and check the where clause.
      [build_validators]'s third return [validate] is checkers-only (no
      actions). [validate_arr] runs full validators against a per-domain
      scratch, zeroed on entry. *)
   let get_arr = domain_local_slots n_total in
-  let validate buf off =
+  let validate_ctx runtime off =
     let arr = get_arr () in
     if n_total > 0 then clear_slots arr n_total;
-    validate_arr arr buf off
+    List.iteri
+      (fun i (Param.Pack p) ->
+        arr.ints.(param_base + i) <- Types.eval_param runtime p.Types.name)
+      param_handles;
+    validate_arr arr runtime off
   in
-  { min_size = acc.min_size; wire_size = wire_size_info; validate }
+  let validate buf off = validate_ctx (no_runtime buf) off in
+  {
+    min_size = acc.min_size;
+    wire_size = wire_size_info;
+    validate;
+    validate_ctx;
+  }
 
 let validate_struct (v : validator) buf off = v.validate buf off
 
 let struct_size_of (v : validator) buf off =
   match v.wire_size with
   | Fixed n -> n
-  | Variable { compute; _ } -> compute buf off - off
+  | Variable { compute; _ } -> compute (no_runtime buf) off - off
 
 let struct_min_size (v : validator) = v.min_size
 
 let wire_size_info_of_validator (v : validator) =
   match v.wire_size with
   | Fixed n -> `Fixed n
-  | Variable { compute; _ } -> `Variable compute
+  | Variable { compute; _ } ->
+      `Variable (fun buf off -> compute (no_runtime buf) off)
 
 (* Heterogeneous field list. [] seals the view; (::) adds a field.
    Tracks the constructor type: ('a -> 'b -> 'r, 'r) matches a
@@ -3478,26 +3633,14 @@ let min_wire_size (t : _ t) =
 let wire_size_at (t : _ t) buf off =
   match t.wire_size with
   | Fixed n -> n
-  | Variable { compute; _ } -> compute buf off - off
+  | Variable { compute; _ } -> compute (no_runtime buf) off - off
 
 let size_of_value (t : _ t) v = t.size_of_value v
 
 let is_fixed (t : _ t) =
   match t.wire_size with Fixed _ -> true | Variable _ -> false
 
-let raw_decode (t : _ t) buf off = t.decode buf off
-
-(* Copy each input param's env value into its [cell]. The encode
-   closures read [Param_ref p] via [!(p.cell ())] (see [bytes_leaves]
-   in [compile_expr]), so the cells are the runtime backing for
-   parametric field sizes. Mirror of the env -> array blit in
-   [decode_exn]. *)
-let load_env_into_cells (t : 'r t) (env : Param.env) =
-  (* The env slot of [param_handles.(i)] is [i] (the env is built in the same
-     order, see [env] below). *)
-  List.iteri
-    (fun i (Param.Pack p) -> p.cell () := env.slots.(i))
-    t.param_handles
+let raw_decode (t : _ t) buf off = t.decode (no_runtime buf) off
 
 (* Reject [encode] on a parametric codec without an env, and reject envs
    that left an input param unbound. Either case would silently resolve
@@ -3544,32 +3687,45 @@ let require_env ~op t = function
 
 let raw_encode ?env:e t v buf off =
   require_env ~op:"encode" t e;
-  (match e with Some env -> load_env_into_cells t env | None -> ());
-  t.encode v buf off
+  t.encode v (runtime ?env:e buf) off
 
-(* Encode a sub-codec embedded as a field/element. The enclosing codec has
-   already seeded every input param's [cell] from its own env (its
-   [param_handles] include the sub's, see [iter_param_refs_typ]), so the sub
-   must not re-run [require_env] (it has no env of its own here). *)
-let embed_encode (t : 'r t) v buf off = t.encode v buf off
+let embed_encode_ctx (t : 'r t) v runtime off = t.encode v runtime off
 
-(* Decode a sub-codec embedded as a field/element, enforcing its [where] and
-   field constraints (the plain field-reader decode skips them). Param values
-   come from the [cell]s the enclosing codec seeded; copy them into the
-   sub's per-decode slots so its constraints resolve correctly. *)
-let embed_decode (t : 'r t) buf off =
-  let v = t.decode buf off in
-  let env_slots =
-    Array.of_list
-      (List.map (fun (Param.Pack p) -> !(p.Types.cell ())) t.param_handles)
-  in
-  t.validate ~env_slots buf off;
+let embed_encode (t : 'r t) v buf off =
+  embed_encode_ctx t v (no_runtime buf) off
+
+let validate_runtime t runtime off =
+  let arr = t.decode_scratch () in
+  clear_slots arr t.n_array_slots;
+  List.iteri
+    (fun i (Param.Pack p) ->
+      arr.ints.(t.param_base + i) <- Types.eval_param runtime p.Types.name)
+    t.param_handles;
+  t.validate_arr arr runtime off;
+  List.iteri
+    (fun i (Param.Pack p) ->
+      if p.Types.mutable_ then
+        Types.eval_set_param runtime p.name arr.ints.(t.param_base + i))
+    t.param_handles
+
+let embed_decode_ctx (t : 'r t) runtime off =
+  let v = t.decode runtime off in
+  validate_runtime t runtime off;
   v
+
+let embed_decode (t : 'r t) buf off = embed_decode_ctx t (no_runtime buf) off
+
+let wire_size_info_ctx (t : _ t) =
+  match t.wire_size with
+  | Fixed n -> `Fixed n
+  | Variable { compute; _ } ->
+      `Variable (fun runtime off -> compute runtime off - off)
 
 let wire_size_info (t : _ t) =
   match t.wire_size with
   | Fixed n -> `Fixed n
-  | Variable { compute; _ } -> `Variable (fun buf off -> compute buf off - off)
+  | Variable { compute; _ } ->
+      `Variable (fun buf off -> compute (no_runtime buf) off - off)
 
 let env (t : _ t) : Param.env =
   {
@@ -3587,32 +3743,23 @@ let decode_exn ?env:e t buf off =
      and misaligning the rest of the record. This is a usage error, not malformed
      input, so it raises [Invalid_argument] rather than returning a parse error. *)
   require_env ~op:"decode" t e;
-  (* Seed the input cells from the env before reading fields: the field
-     readers resolve [Param_ref p] via [!(p.cell ())], so a parametric size
-     (byte_array / byte_slice / uint_var) must see the env's value. Mirror of
-     the seeding [encode] does. [Param.bind] also writes the cell directly, but
-     [Param.bind_by_name] only has the name and writes [env.slots]; without
-     this it would read as 0 and silently truncate the field. *)
-  (match e with
-  | Some env -> load_env_into_cells t env
-  | None -> ());
-  let v = t.decode buf off in
+  let runtime = runtime ?env:e buf in
+  let v = t.decode runtime off in
   let arr = t.decode_scratch () in
   clear_slots arr t.n_array_slots;
   (match e with
   | Some (e : Param.env) when t.n_params > 0 ->
       Array.blit e.slots 0 arr.ints t.param_base t.n_params
   | _ -> ());
-  t.validate_arr arr buf off;
+  t.validate_arr arr runtime off;
   (match e with
   | Some (e : Param.env) ->
       (* Array slot of [param_handles.(i)] is [param_base + i]; its env slot is
-         [i]. Write decoded output params back into the env (and the cell). *)
+         [i]. Write decoded output params back into the environment. *)
       List.iteri
-        (fun i (Param.Pack p) ->
+        (fun i (Param.Pack _p) ->
           let v = arr.ints.(t.param_base + i) in
-          e.slots.(i) <- v;
-          p.cell () := v)
+          e.slots.(i) <- v)
         t.param_handles
   | None -> ());
   v
@@ -3622,9 +3769,8 @@ let decode ?env t buf off =
 
 let encode ?env:e t v buf off =
   require_env ~op:"encode" t e;
-  (match e with Some env -> load_env_into_cells t env | None -> ());
   let expected = t.size_of_value v in
-  let actual = t.encode v buf off - off in
+  let actual = t.encode v (runtime ?env:e buf) off - off in
   (* Underrun = silent data corruption: the trailing bytes the caller
      allocated stay uninitialised and the decoder reads them as part
      of the value. Overrun is loud already. *)
@@ -3654,45 +3800,50 @@ let validate ?env:e (t : _ t) buf off =
    For Fixed: use build_field_reader which handles Where/Enum/Map.
    For Bitfield: the GADT ensures 'a = int via Bits constructor.
    For Dynamic: compute offset at read time. *)
-let rec build_staged_reader : type a. a typ -> field_access -> bytes -> int -> a
-    =
+let rec build_staged_reader : type a.
+    a typ -> field_access -> runtime -> int -> a =
  fun typ access ->
   match (typ, access) with
   | Bits _, Bitfield { base; byte_off; shift; width } ->
-      build_bf_reader base byte_off shift width
-  | _, Fixed off -> build_field_reader typ off
+      let read = build_bf_reader base byte_off shift width in
+      fun runtime base -> read (Types.eval_bytes runtime) base
+  | _, Fixed off ->
+      let read = build_field_reader typ off in
+      fun runtime base -> read (Types.eval_bytes runtime) base
   | _, Dynamic fn ->
       let reader_at_0 = build_field_reader typ 0 in
-      fun buf base ->
-        let off = fn buf base in
-        reader_at_0 buf (base + off)
+      fun runtime base ->
+        let off = fn runtime base in
+        reader_at_0 (Types.eval_bytes runtime) (base + off)
   | Byte_slice _, Variable { off; size_fn } ->
-      fun buf base ->
-        let sz = size_fn buf base in
-        Slice.make_or_eod buf ~first:(base + off) ~length:sz
+      fun runtime base ->
+        let sz = size_fn runtime base in
+        Slice.make_or_eod (Types.eval_bytes runtime) ~first:(base + off)
+          ~length:sz
   | Byte_array _, Variable { off; size_fn } ->
-      fun buf base ->
-        let sz = size_fn buf base in
-        Bytes.sub_string buf (base + off) sz
+      fun runtime base ->
+        let sz = size_fn runtime base in
+        Bytes.sub_string (Types.eval_bytes runtime) (base + off) sz
   | Byte_array_where _, Variable { off; size_fn } ->
-      fun buf base ->
-        let sz = size_fn buf base in
-        Bytes.sub_string buf (base + off) sz
+      fun runtime base ->
+        let sz = size_fn runtime base in
+        Bytes.sub_string (Types.eval_bytes runtime) (base + off) sz
   | Byte_slice _, Variable_dynamic { off_fn; size_fn } ->
-      fun buf base ->
-        let fo = off_fn buf base in
-        let sz = size_fn buf base in
-        Slice.make_or_eod buf ~first:(base + fo) ~length:sz
+      fun runtime base ->
+        let fo = off_fn runtime base in
+        let sz = size_fn runtime base in
+        Slice.make_or_eod (Types.eval_bytes runtime) ~first:(base + fo)
+          ~length:sz
   | Byte_array _, Variable_dynamic { off_fn; size_fn } ->
-      fun buf base ->
-        let fo = off_fn buf base in
-        let sz = size_fn buf base in
-        Bytes.sub_string buf (base + fo) sz
+      fun runtime base ->
+        let fo = off_fn runtime base in
+        let sz = size_fn runtime base in
+        Bytes.sub_string (Types.eval_bytes runtime) (base + fo) sz
   | Byte_array_where _, Variable_dynamic { off_fn; size_fn } ->
-      fun buf base ->
-        let fo = off_fn buf base in
-        let sz = size_fn buf base in
-        Bytes.sub_string buf (base + fo) sz
+      fun runtime base ->
+        let fo = off_fn runtime base in
+        let sz = size_fn runtime base in
+        Bytes.sub_string (Types.eval_bytes runtime) (base + fo) sz
   | Where { inner; _ }, _ -> build_staged_reader inner access
   | Enum { base; cases; closed; _ }, _ ->
       let read = build_staged_reader base access in
@@ -3708,49 +3859,60 @@ let rec build_staged_reader : type a. a typ -> field_access -> bytes -> int -> a
 
 (* Build a staged writer from field type and access info. *)
 let rec build_staged_writer : type a.
-    a typ -> field_access -> bytes -> int -> a -> unit =
+    a typ -> field_access -> runtime -> int -> a -> unit =
  fun typ access ->
   match (typ, access) with
   | Bits _, Bitfield { base; byte_off; shift; width } ->
-      build_bf_accessor_writer base byte_off shift width
+      let write = build_bf_accessor_writer base byte_off shift width in
+      fun runtime base value -> write (Types.eval_bytes runtime) base value
   | _, Fixed off ->
-      let enc = build_field_encoder typ in
-      fun buf base value ->
-        let _ = enc buf (base + off) value in
+      fun runtime base value ->
+        let _ =
+          build_field_encoder_ctx typ runtime (Types.eval_bytes runtime)
+            (base + off) value
+        in
         ()
   | _, Dynamic fn ->
-      let enc = build_field_encoder typ in
-      fun buf base value ->
-        let off = fn buf base in
-        let _ = enc buf (base + off) value in
+      fun runtime base value ->
+        let off = fn runtime base in
+        let _ =
+          build_field_encoder_ctx typ runtime (Types.eval_bytes runtime)
+            (base + off) value
+        in
         ()
   | Byte_slice _, Variable { off; _ } ->
-      fun buf base value ->
+      fun runtime base value ->
+        let buf = Types.eval_bytes runtime in
         let src = (value : Slice.t) in
         let len = Slice.length src in
         Bytes.blit (Slice.bytes src) (Slice.first src) buf (base + off) len
   | Byte_array _, Variable { off; _ } ->
-      fun buf base value ->
+      fun runtime base value ->
+        let buf = Types.eval_bytes runtime in
         let s = (value : string) in
         Bytes.blit_string s 0 buf (base + off) (String.length s)
   | Byte_array_where _, Variable { off; _ } ->
-      fun buf base value ->
+      fun runtime base value ->
+        let buf = Types.eval_bytes runtime in
         let s = (value : string) in
         Bytes.blit_string s 0 buf (base + off) (String.length s)
   | Byte_slice _, Variable_dynamic { off_fn; _ } ->
-      fun buf base value ->
-        let fo = off_fn buf base in
+      fun runtime base value ->
+        let buf = Types.eval_bytes runtime in
+        let fo = off_fn runtime base in
         let src = (value : Slice.t) in
         let len = Slice.length src in
         Bytes.blit (Slice.bytes src) (Slice.first src) buf (base + fo) len
   | Byte_array _, Variable_dynamic { off_fn; _ } ->
-      fun buf base value ->
-        let fo = off_fn buf base in
+      fun runtime base value ->
+        let buf = Types.eval_bytes runtime in
+        let fo = off_fn runtime base in
         let s = (value : string) in
         Bytes.blit_string s 0 buf (base + fo) (String.length s)
   | Byte_array_where _, Variable_dynamic { off_fn; _ } ->
-      fun buf base value ->
-        let fo = off_fn buf base in
+      fun runtime base value ->
+        let buf = Types.eval_bytes runtime in
+        let fo = off_fn runtime base in
         let s = (value : string) in
         Bytes.blit_string s 0 buf (base + fo) (String.length s)
   | Where { inner; _ }, _ -> build_staged_writer inner access
@@ -3775,7 +3937,7 @@ let[@inline] get (type a r) ?env (codec : r t) (f : (a, r) field) :
   let access = field_access codec f.name in
   let read = build_staged_reader f.typ access in
   match List.assoc_opt f.name codec.field_actions with
-  | None -> Staged.stage read
+  | None -> Staged.stage (fun buf off -> read (runtime ?env buf) off)
   | Some act ->
       (* Reuse the codec's own domain-local scratch rather than minting another
          [Domain.DLS] key here: [get] returns a staged reader, but a caller that
@@ -3794,21 +3956,21 @@ let[@inline] get (type a r) ?env (codec : r t) (f : (a, r) field) :
             let param_base = codec.param_base in
             ( (fun arr ->
                 List.iteri
-                  (fun i (Param.Pack p) ->
+                  (fun i (Param.Pack _p) ->
                     let v = arr.ints.(param_base + i) in
-                    e.slots.(i) <- v;
-                    p.cell () := v)
+                    e.slots.(i) <- v)
                   param_handles),
               fun arr ->
                 if n_params > 0 then
                   Array.blit e.slots 0 arr.ints param_base n_params )
       in
       Staged.stage (fun buf off ->
-          let v = read buf off in
+          let runtime = runtime ?env buf in
+          let v = read runtime off in
           let arr = get_arr () in
           clear_slots arr n;
           blit_input arr;
-          populate arr buf off;
+          populate arr runtime off;
           act arr;
           sync arr;
           v)
@@ -3816,12 +3978,19 @@ let[@inline] get (type a r) ?env (codec : r t) (f : (a, r) field) :
 let[@inline] set (type a r) (codec : r t) (f : (a, r) field) :
     (bytes -> int -> a -> unit) Staged.t =
   let access = field_access codec f.name in
-  Staged.stage (build_staged_writer f.typ access)
+  let write = build_staged_writer f.typ access in
+  Staged.stage (fun buf off value -> write (no_runtime buf) off value)
 
 let name (t : _ t) = t.name
 let rename new_name (t : _ t) = { t with name = new_name }
 let doc (t : _ t) = t.doc
-let field_readers (t : _ t) = t.field_readers
+let field_readers_ctx (t : _ t) = t.field_readers
+
+let field_readers (t : _ t) =
+  List.map
+    (fun (name, read) -> (name, fun buf off -> read (no_runtime buf) off))
+    t.field_readers
+
 let pp ppf (t : _ t) = Fmt.string ppf t.name
 let field_ref (type a r) (f : (a, r) field) : int expr = Ref (I, f.name)
 
@@ -3843,10 +4012,10 @@ let[@inline] slice_offset (type r) (codec : r t) (f : (Slice.t, r) field) :
     (bytes -> int -> int) Staged.t =
   match field_access codec f.name with
   | Fixed off -> Staged.stage (fun _buf base -> base + off)
-  | Dynamic fn -> Staged.stage (fun buf base -> base + fn buf base)
+  | Dynamic fn -> Staged.stage (fun buf base -> base + fn (no_runtime buf) base)
   | Variable { off; _ } -> Staged.stage (fun _buf base -> base + off)
   | Variable_dynamic { off_fn; _ } ->
-      Staged.stage (fun buf base -> base + off_fn buf base)
+      Staged.stage (fun buf base -> base + off_fn (no_runtime buf) base)
   | Bitfield _ ->
       Fmt.invalid_arg
         "Codec.slice_offset: field %S is a bitfield, not a byte slice" f.name
@@ -3864,7 +4033,7 @@ let[@inline] slice_length (type r) (codec : r t) (f : (Slice.t, r) field) :
              -- internal inconsistency"
             f.name)
   | _, Variable { size_fn; _ } | _, Variable_dynamic { size_fn; _ } ->
-      Staged.stage size_fn
+      Staged.stage (fun buf base -> size_fn (no_runtime buf) base)
   | _, (Fixed _ | Dynamic _) ->
       Fmt.invalid_arg "Codec.slice_length: field %S is not a byte slice" f.name
   | _, Bitfield _ ->

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -1824,6 +1824,9 @@ let repeat_raw_fixed : type elt seq.
      crashing [read_elem] with an out-of-range [Bytes.sub]. *)
   if budget < 0 || start + budget > Bytes.length buf then
     raise_eof ~at:start ~expected:(start + budget) ~got:(Bytes.length buf);
+  let remainder = if esz > 0 then budget mod esz else budget in
+  if remainder <> 0 then
+    raise_eof ~at:(start + budget - remainder) ~expected:esz ~got:remainder;
   let n = if esz > 0 then budget / esz else 0 in
   let rec loop acc i =
     if i >= n then seq.finish acc
@@ -1848,8 +1851,10 @@ let repeat_raw_variable : type elt seq.
   let rec loop acc pos remaining =
     if remaining <= 0 then seq.finish acc
     else
-      let v = read_elem elem buf pos in
       let esz = elem_size_of elem buf pos in
+      if esz <= 0 || esz > remaining then
+        raise_eof ~at:pos ~expected:esz ~got:remaining;
+      let v = read_elem elem buf pos in
       loop (seq.add acc v) (pos + esz) (remaining - esz)
   in
   loop seq.empty start budget
@@ -1875,7 +1880,7 @@ let compile_repeat : type elt seq r.
     elt typ ->
     (elt, seq) seq_map ->
     (seq, r) compiled_field =
- fun ctx fld size_expr elem (Seq_map seq) ->
+ fun ctx fld size_expr elem seq ->
   (* Same dynamic-offset dispatch as [compile_var_bytes] / [compile_codec]:
      when a [Repeat] sits after a variable-size field, the running offset is
      [Dynamic] and is resolved at runtime rather than from a static offset. *)
@@ -1899,23 +1904,22 @@ let compile_repeat : type elt seq r.
     | _ -> assert false
   in
   let elem_size = field_wire_size elem in
-  let raw_reader =
-    repeat_raw_reader (Seq_map seq) elem ~elem_size ~off_fn ~size_fn
-  in
+  let raw_reader = repeat_raw_reader seq elem ~elem_size ~off_fn ~size_fn in
   let get = fld.get in
-  let step =
-    match elem_size with
-    | Some esz -> fun _buf _pos -> esz
-    | None -> fun buf pos -> elem_size_of elem buf pos
-  in
-  let raw_writer v buf _base write_off =
+  let raw_writer v buf base write_off =
     let items = get v in
+    let expected = size_fn buf base in
+    let sized_items =
+      Types.exact_repeat_elements seq ~expected
+        ~size_of:(Types.size_of_typ_value elem)
+        items
+    in
     let pos = Stdlib.ref write_off in
-    seq.iter
-      (fun item ->
+    List.iter
+      (fun (item, size) ->
         write_elem elem buf !pos item;
-        pos := !pos + step buf !pos)
-      items;
+        pos := !pos + size)
+      sized_items;
     !pos
   in
   {

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -155,11 +155,12 @@ and build_field_encoder : type a. a typ -> bytes -> int -> a -> int =
   | Unit -> fun _buf off () -> off
   | Codec { codec_encode; _ } -> fun buf off v -> codec_encode v buf off
   | Casetype { tag; cases; _ } -> build_casetype_encoder tag cases
-  | Array { len = Int _; elem; seq = Seq_map s } ->
+  | Array { len = Int expected; elem; seq } ->
       let enc_elem = build_field_encoder elem in
       fun buf start_off vs ->
         let cur = Stdlib.ref start_off in
-        s.iter (fun v -> cur := enc_elem buf !cur v) vs;
+        Types.exact_array_elements seq ~expected vs
+        |> List.iter (fun v -> cur := enc_elem buf !cur v);
         !cur
   (* NUL-terminated string element / casetype case body: the bytes then a NUL.
      [zeroterm_at_most] pads the rest of its fixed [n]-byte region with zeros. *)

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -3087,6 +3087,11 @@ let rec field_consumes_rest : type a. a Types.typ -> bool =
   | Types.Map { inner; _ } -> field_consumes_rest inner
   | Types.Where { inner; _ } -> field_consumes_rest inner
   | Types.Enum { base; _ } -> field_consumes_rest base
+  | Types.Optional { present = Types.Bool false; _ }
+  | Types.Optional_or { present = Types.Bool false; _ } ->
+      false
+  | Types.Optional { inner; _ } -> field_consumes_rest inner
+  | Types.Optional_or { inner; _ } -> field_consumes_rest inner
   | _ -> false
 
 (* A greedy field consumes the rest of the buffer, so it is only meaningful as

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -54,6 +54,14 @@ let bits_field_encoder ~width ~base ~bit_order buf off v =
   | _ -> Bitfield.write_word base buf off ((v land mask) lsl shift));
   off + Bitfield.byte_size base
 
+let float32_field_encoder setter buf off v =
+  setter buf off (Int32.bits_of_float v);
+  off + 4
+
+let float64_field_encoder setter buf off v =
+  setter buf off (Int64.bits_of_float v);
+  off + 8
+
 let rec build_casetype_encoder_ctx : type a k.
     k typ ->
     (a, k) case_branch list ->
@@ -133,22 +141,10 @@ and build_field_encoder_ctx : type a.
         off + 4
   | Int64 Little -> setter_off 8 Bytes.set_int64_le
   | Int64 Big -> setter_off 8 Bytes.set_int64_be
-  | Float32 Little ->
-      fun buf off v ->
-        Bytes.set_int32_le buf off (Int32.bits_of_float v);
-        off + 4
-  | Float32 Big ->
-      fun buf off v ->
-        Bytes.set_int32_be buf off (Int32.bits_of_float v);
-        off + 4
-  | Float64 Little ->
-      fun buf off v ->
-        Bytes.set_int64_le buf off (Int64.bits_of_float v);
-        off + 8
-  | Float64 Big ->
-      fun buf off v ->
-        Bytes.set_int64_be buf off (Int64.bits_of_float v);
-        off + 8
+  | Float32 Little -> float32_field_encoder Bytes.set_int32_le
+  | Float32 Big -> float32_field_encoder Bytes.set_int32_be
+  | Float64 Little -> float64_field_encoder Bytes.set_int64_le
+  | Float64 Big -> float64_field_encoder Bytes.set_int64_be
   | Uint_var { size = Int n; endian } ->
       fun buf off v ->
         Uint_var.write endian buf off n v;
@@ -2934,6 +2930,32 @@ let validate_or_eof buf f =
     let len = Bytes.length buf in
     raise_eof ~at:len ~expected:(len + 1) ~got:len
 
+let has_validation_checks compiled_where struct_fields =
+  compiled_where <> None
+  || List.exists
+       (fun (Types.Field f) ->
+         f.constraint_ <> None || f.action <> None
+         || field_reader_validates f.field_typ)
+       struct_fields
+
+let seed_param_slots arr n_total = function
+  | None -> ()
+  | Some slots ->
+      let n = Array.length slots in
+      Array.blit slots 0 arr.ints (n_total - n) n
+
+let validation_runtime param_slots arr buf =
+  Types.eval_ctx
+    ~set_param:(fun name value ->
+      match Hashtbl.find_opt param_slots name with
+      | Some idx -> arr.ints.(idx) <- value
+      | None -> ())
+    buf
+    (fun name ->
+      match Hashtbl.find_opt param_slots name with
+      | Some idx -> arr.ints.(idx)
+      | None -> 0)
+
 let build_validators validators_rev checkers_rev compiled_where struct_fields
     param_slots n_total =
   let validator_fns = Array.of_list (List.map snd validators_rev) in
@@ -2958,14 +2980,7 @@ let build_validators validators_rev checkers_rev compiled_where struct_fields
      [validate_with_bounds]. A codec of plain scalars and byte spans then
      validates with no allocation, so validating it on a hot read path (a
      [Codec.get] preceded by [validate]) stays cheap. *)
-  let has_checks =
-    compiled_where <> None
-    || List.exists
-         (fun (Types.Field f) ->
-           f.constraint_ <> None || f.action <> None
-           || field_reader_validates f.field_typ)
-         struct_fields
-  in
+  let has_checks = has_validation_checks compiled_where struct_fields in
   let validate =
     if not has_checks then fun ?env_slots:_ _buf _off -> ()
     else
@@ -2973,25 +2988,10 @@ let build_validators validators_rev checkers_rev compiled_where struct_fields
       fun ?env_slots buf off ->
         let arr = get_arr () in
         clear_slots arr n_total;
-        (match env_slots with
-        | Some slots ->
-            (* Seed param slots so [where] clauses referencing [Param.input]
-               evaluate correctly. *)
-            let n = Array.length slots in
-            Array.blit slots 0 arr.ints (n_total - n) n
-        | None -> ());
-        let runtime =
-          Types.eval_ctx
-            ~set_param:(fun name value ->
-              match Hashtbl.find_opt param_slots name with
-              | Some idx -> arr.ints.(idx) <- value
-              | None -> ())
-            buf
-            (fun name ->
-              match Hashtbl.find_opt param_slots name with
-              | Some idx -> arr.ints.(idx)
-              | None -> 0)
-        in
+        (* Seed param slots so [where] clauses referencing [Param.input]
+           evaluate correctly. *)
+        seed_param_slots arr n_total env_slots;
+        let runtime = validation_runtime param_slots arr buf in
         validate_or_eof buf (fun () -> validate_arr arr runtime off)
   in
   (validate_arr, populate, validate)
@@ -3005,7 +3005,7 @@ let collect_param_handles codec_name struct_fields where =
         Hashtbl.add seen p.name packed;
         handles := packed :: !handles
     | Some (Param.Pack existing) ->
-        if not (Obj.repr p == Obj.repr existing) then
+        if p.Types.id <> existing.Types.id then
           Fmt.invalid_arg "Codec.v %S: duplicate parameter name %S" codec_name
             p.name
   in
@@ -3284,6 +3284,30 @@ let reject_invalid_codec_shape name fields =
   reject_nested_where name fields;
   reject_certain_byte_size_mul name fields
 
+let build_size_of_value size_funcs =
+  let n = Array.length size_funcs in
+  fun value ->
+    let total = Stdlib.ref 0 in
+    for i = 0 to n - 1 do
+      total := !total + size_funcs.(i) value
+    done;
+    !total
+
+let build_record_encoder name writers size_of_value =
+  let n = Array.length writers in
+  fun value runtime off ->
+    let buf = Types.eval_bytes runtime in
+    let need = size_of_value value in
+    if off + need > Bytes.length buf then
+      Fmt.invalid_arg "Codec.encode %s: buffer too short (need %d, got %d)" name
+        need
+        (Bytes.length buf - off);
+    let write_off = Stdlib.ref off in
+    for i = 0 to n - 1 do
+      write_off := writers.(i) value runtime off !write_off
+    done;
+    !write_off
+
 let seal : type r. (r, r) record -> r t =
  fun (Record r) ->
   let codec_id = Atomic.fetch_and_add id_counter 1 in
@@ -3295,7 +3319,6 @@ let seal : type r. (r, r) record -> r t =
   in
   let min_size = r.min_wire_size in
   let writers = Array.of_list (List.rev r.writers_rev) in
-  let n_writers = Array.length writers in
   let raw_decode = build_decode r.make r.readers in
   let validators = List.rev r.validators_rev in
   let param_base = r.n_array_slots in
@@ -3316,14 +3339,7 @@ let seal : type r. (r, r) record -> r t =
   (* Per-field action runners *)
   let field_actions = List.rev r.field_actions_rev in
   let size_funcs = Array.of_list (List.rev r.size_of_value_rev) in
-  let n_size_funcs = Array.length size_funcs in
-  let size_of_value v =
-    let total = Stdlib.ref 0 in
-    for i = 0 to n_size_funcs - 1 do
-      total := !total + size_funcs.(i) v
-    done;
-    !total
-  in
+  let size_of_value = build_size_of_value size_funcs in
   {
     id = codec_id;
     name = r.name;
@@ -3332,19 +3348,7 @@ let seal : type r. (r, r) record -> r t =
     field_readers = List.rev r.field_readers;
     field_actions;
     decode = build_checked_decode raw_decode wire_size_info min_size;
-    encode =
-      (fun v runtime off ->
-        let buf = Types.eval_bytes runtime in
-        let need = size_of_value v in
-        if off + need > Bytes.length buf then
-          Fmt.invalid_arg "Codec.encode %s: buffer too short (need %d, got %d)"
-            r.name need
-            (Bytes.length buf - off);
-        let write_off = Stdlib.ref off in
-        for i = 0 to n_writers - 1 do
-          write_off := writers.(i) v runtime off !write_off
-        done;
-        !write_off);
+    encode = build_record_encoder r.name writers size_of_value;
     wire_size = wire_size_info;
     struct_fields;
     validate =

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -2860,14 +2860,18 @@ let build_validators validators_rev checkers_rev compiled_where struct_fields
   in
   (validate_arr, populate, validate)
 
-let collect_param_handles struct_fields where =
+let collect_param_handles codec_name struct_fields where =
   let seen = Hashtbl.create 4 in
   let handles = Stdlib.ref ([] : Param.packed list) in
   let visit (Param.Pack p as packed) =
-    if not (Hashtbl.mem seen p.name) then begin
-      Hashtbl.add seen p.name ();
-      handles := packed :: !handles
-    end
+    match Hashtbl.find_opt seen p.name with
+    | None ->
+        Hashtbl.add seen p.name packed;
+        handles := packed :: !handles
+    | Some (Param.Pack existing) ->
+        if not (Obj.repr p == Obj.repr existing) then
+          Fmt.invalid_arg "Codec.v %S: duplicate parameter name %S" codec_name
+            p.name
   in
   iter_param_refs_fields visit struct_fields where;
   List.rev !handles
@@ -3111,7 +3115,19 @@ let reject_certain_byte_size_mul name fields =
         f.field_typ)
     fields
 
+let reject_duplicate_field_names name fields =
+  let seen = Hashtbl.create (List.length fields) in
+  List.iter
+    (fun (Types.Field f) ->
+      match f.field_name with
+      | None -> ()
+      | Some field when Hashtbl.mem seen field ->
+          Fmt.invalid_arg "Codec.v %S: duplicate field name %S" name field
+      | Some field -> Hashtbl.add seen field ())
+    fields
+
 let reject_invalid_codec_shape name fields =
+  reject_duplicate_field_names name fields;
   reject_greedy_not_last name fields;
   reject_nested_where name fields;
   reject_certain_byte_size_mul name fields
@@ -3134,7 +3150,7 @@ let seal : type r. (r, r) record -> r t =
   (* Collect and index params *)
   let struct_fields = List.rev r.fields_rev in
   reject_invalid_codec_shape r.name struct_fields;
-  let param_handles = collect_param_handles struct_fields r.where in
+  let param_handles = collect_param_handles r.name struct_fields r.where in
   let n_params = List.length param_handles in
   fill_param_slots r.param_slots param_base param_handles;
   let n_total = param_base + n_params in
@@ -3381,7 +3397,7 @@ and validator_of_struct (s : Types.struct_) : validator =
     | Static n -> Fixed n
     | Dynamic f -> Variable { min_size = acc.min_size; compute = f }
   in
-  let param_handles = collect_param_handles s.fields s.where in
+  let param_handles = collect_param_handles s.name s.fields s.where in
   let n_params = List.length param_handles in
   let param_base = acc.n_array_slots in
   fill_param_slots acc.param_slots param_base param_handles;
@@ -3609,13 +3625,13 @@ let encode ?env:e t v buf off =
        spans %d -- writer wrote fewer bytes than promised"
       t.name expected actual
 
-let collect_params (fields : Types.field list) where =
-  collect_param_handles fields where
+let collect_params name (fields : Types.field list) where =
+  collect_param_handles name fields where
   |> List.map (fun (Param.Pack p) ->
       { param_name = p.name; param_typ = p.packed_typ; mutable_ = p.mutable_ })
 
 let to_struct t =
-  let formals = collect_params t.struct_fields t.where in
+  let formals = collect_params t.name t.struct_fields t.where in
   match (formals, t.where) with
   | [], None -> struct' t.name t.struct_fields
   | _ -> param_struct t.name formals ?where:t.where t.struct_fields

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -3489,6 +3489,11 @@ let unbound_params (t : 'r t) (env : Param.env) : string list =
 let has_input_params (t : 'r t) =
   List.exists (fun (Param.Pack p) -> not p.Types.mutable_) t.param_handles
 
+let check_env_owner ~op t (env : Param.env) =
+  if env.codec_id <> t.id then
+    Fmt.invalid_arg "Codec.%s: env was not created by Codec.env for %S" op
+      t.name
+
 let require_env ~op t = function
   | None when not (has_input_params t) -> ()
   | None ->
@@ -3497,6 +3502,7 @@ let require_env ~op t = function
          Param.bind p N])."
         op t.name
   | Some env -> (
+      check_env_owner ~op t env;
       match unbound_params t env with
       | [] -> ()
       | missing ->
@@ -3609,8 +3615,9 @@ let to_struct t =
   | [], None -> struct' t.name t.struct_fields
   | _ -> param_struct t.name formals ?where:t.where t.struct_fields
 
-let validate ?env (t : _ t) buf off =
-  let env_slots = Option.map (fun (e : Param.env) -> e.slots) env in
+let validate ?env:e (t : _ t) buf off =
+  require_env ~op:"validate" t e;
+  let env_slots = Option.map (fun (env : Param.env) -> env.slots) e in
   t.validate ?env_slots buf off
 
 (* Build a staged reader from field type and access info.
@@ -3734,6 +3741,7 @@ let field_access (codec : _ t) name =
 
 let[@inline] get (type a r) ?env (codec : r t) (f : (a, r) field) :
     (bytes -> int -> a) Staged.t =
+  Option.iter (check_env_owner ~op:"get" codec) env;
   let access = field_access codec f.name in
   let read = build_staged_reader f.typ access in
   match List.assoc_opt f.name codec.field_actions with
@@ -3752,9 +3760,6 @@ let[@inline] get (type a r) ?env (codec : r t) (f : (a, r) field) :
         match env with
         | None -> ((fun _arr -> ()), fun _arr -> ())
         | Some (e : Param.env) ->
-            if e.codec_id <> codec.id then
-              Fmt.invalid_arg
-                "Codec.get: env was not created by Codec.env for %S" codec.name;
             let param_handles = codec.param_handles in
             let param_base = codec.param_base in
             ( (fun arr ->

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -3011,6 +3011,106 @@ let reject_nested_where name fields =
       check_typ (Option.value ~default:"<anon>" f.field_name) f.field_typ)
     fields
 
+(* EverParse represents byte sizes as [u32]. Its verifier rejects a product
+   [count * width] when the declared upper bound permits 2^32 or more, but the
+   resulting F* diagnostic points into generated code. Recognise only the
+   deliberately narrow, certain case: a literal coefficient multiplied by a
+   field with a simple [field <= K] constraint. Everything else stays with
+   EverParse so this diagnostic cannot create false positives. *)
+let min_known_bound a b =
+  match (a, b) with
+  | None, x | x, None -> x
+  | Some a, Some b -> Some (Int.min a b)
+
+let rec simple_upper_bound field : bool expr -> int option = function
+  | Le (Ref (I, candidate), Int bound) when String.equal field candidate ->
+      Some bound
+  | And (a, b) ->
+      min_known_bound (simple_upper_bound field a) (simple_upper_bound field b)
+  | _ -> None
+
+let byte_size_bound_for fields field =
+  List.fold_left
+    (fun bound (Types.Field f) ->
+      match (f.field_name, f.constraint_) with
+      | Some candidate, Some constraint_ when String.equal field candidate ->
+          min_known_bound bound (simple_upper_bound field constraint_)
+      | _ -> bound)
+    None fields
+
+let reject_byte_size_product name fields sized_field field coefficient =
+  match byte_size_bound_for fields field with
+  | Some bound when bound >= 0 && coefficient > 0 ->
+      let limit = 0x1_0000_0000L in
+      let coefficient64 = Int64.of_int coefficient in
+      let first_overflowing_bound =
+        let quotient = Int64.div limit coefficient64 in
+        if Int64.rem limit coefficient64 = 0L then quotient
+        else Int64.succ quotient
+      in
+      if Int64.compare (Int64.of_int bound) first_overflowing_bound >= 0 then
+        Fmt.invalid_arg
+          "Codec.v %S: byte-size for field %S multiplies %S (bounded by <= %d) \
+           by %d, which permits at least 2^32 bytes; tighten the field bound \
+           for EverParse's u32 byte-size limit"
+          name sized_field field bound coefficient
+  | _ -> ()
+
+let rec check_byte_size_expr name fields sized_field : int expr -> unit =
+  function
+  | Mul (Ref (I, field), Int coefficient) | Mul (Int coefficient, Ref (I, field))
+    ->
+      reject_byte_size_product name fields sized_field field coefficient
+  | Add (a, b)
+  | Sub (a, b)
+  | Mul (a, b)
+  | Div (a, b)
+  | Mod (a, b)
+  | Land (a, b)
+  | Lor (a, b)
+  | Lxor (a, b)
+  | Lsl (a, b)
+  | Lsr (a, b) ->
+      check_byte_size_expr name fields sized_field a;
+      check_byte_size_expr name fields sized_field b
+  | Lnot a | Cast (_, a) -> check_byte_size_expr name fields sized_field a
+  | If_then_else (_, a, b) ->
+      check_byte_size_expr name fields sized_field a;
+      check_byte_size_expr name fields sized_field b
+  | Int _ | Ref _ | Param_ref _ | Sizeof _ | Sizeof_this | Field_pos -> ()
+
+let rec check_byte_size_typ : type a.
+    string -> Types.field list -> string -> a Types.typ -> unit =
+ fun name fields sized_field -> function
+  | Uint_var { size; _ }
+  | Byte_array { size }
+  | Byte_array_where { size; _ }
+  | Byte_slice { size }
+  | Single_elem { size; _ }
+  | Zeroterm_at_most { size }
+  | Repeat { size; _ } ->
+      check_byte_size_expr name fields sized_field size
+  | Map { inner; _ } -> check_byte_size_typ name fields sized_field inner
+  | Where { inner; _ } -> check_byte_size_typ name fields sized_field inner
+  | Apply { typ; _ } -> check_byte_size_typ name fields sized_field typ
+  | Optional { inner; _ } -> check_byte_size_typ name fields sized_field inner
+  | Optional_or { inner; _ } ->
+      check_byte_size_typ name fields sized_field inner
+  | _ -> ()
+
+let reject_certain_byte_size_mul name fields =
+  List.iter
+    (fun (Types.Field f) ->
+      check_byte_size_typ name fields
+        (Option.value ~default:"<anon>" f.field_name)
+        f.field_typ)
+    fields
+
+let reject_invalid_codec_shape name fields =
+  reject_greedy_not_last name fields;
+  reject_nested_where name fields;
+  reject_certain_byte_size_mul name fields
+
 let seal : type r. (r, r) record -> r t =
  fun (Record r) ->
   let codec_id = Atomic.fetch_and_add id_counter 1 in
@@ -3028,8 +3128,7 @@ let seal : type r. (r, r) record -> r t =
   let param_base = r.n_array_slots in
   (* Collect and index params *)
   let struct_fields = List.rev r.fields_rev in
-  reject_greedy_not_last r.name struct_fields;
-  reject_nested_where r.name struct_fields;
+  reject_invalid_codec_shape r.name struct_fields;
   let param_handles = collect_param_handles struct_fields r.where in
   let n_params = List.length param_handles in
   fill_param_slots r.param_slots param_base param_handles;

--- a/lib/codec.mli
+++ b/lib/codec.mli
@@ -141,10 +141,10 @@ val get :
   ?env:Param.env -> 'r t -> ('a, 'r) field -> (bytes -> int -> 'a) Staged.t
 (** [get ?env c f] is a staged zero-copy getter for field [f] in codec [c]. If
     [f] has an action, it fires on every read. [env] syncs output parameters
-    after each action; fields without actions have zero overhead regardless of
-    [env]. An environment created for another codec raises [Invalid_argument].
-    Does not check record-level where-clauses or other fields' constraints --
-    call {!validate} first on untrusted input. *)
+    after each action and supplies parameters for dependent field layouts; omit
+    it for parameter-free accessors. An environment created for another codec
+    raises [Invalid_argument]. Does not check record-level where-clauses or
+    other fields' constraints -- call {!validate} first on untrusted input. *)
 
 val set : 'r t -> ('a, 'r) field -> (bytes -> int -> 'a -> unit) Staged.t
 (** Staged zero-copy field setter. Does not check constraints or fire actions --
@@ -165,17 +165,26 @@ val raw_encode : ?env:Param.env -> 'r t -> 'r -> bytes -> int -> int
     semantics as {!encode}. Internal use. *)
 
 val embed_encode : 'r t -> 'r -> bytes -> int -> int
-(** Encode a sub-codec embedded as a field/element. Assumes the enclosing codec
-    has already seeded any input param cells from its env, so it skips the env
-    check {!encode} performs. Internal use. *)
+(** Encode a parameter-free sub-codec embedded as a field/element, skipping the
+    env check {!encode} performs. Internal use. *)
+
+val embed_encode_ctx : 'r t -> 'r -> Types.eval_ctx -> int -> int
+(** Context-threaded embedded encode. Internal use. *)
 
 val embed_decode : 'r t -> bytes -> int -> 'r
 (** Decode a sub-codec embedded as a field/element, enforcing its [where] and
     field constraints against param values seeded by the enclosing codec.
     Internal use. *)
 
+val embed_decode_ctx : 'r t -> Types.eval_ctx -> int -> 'r
+(** Context-threaded embedded decode. Internal use. *)
+
 val wire_size_info : 'r t -> [ `Fixed of int | `Variable of bytes -> int -> int ]
 (** Wire size information for embedding. *)
+
+val wire_size_info_ctx :
+  'r t -> [ `Fixed of int | `Variable of Types.eval_ctx -> int -> int ]
+(** Context-threaded wire size information for embedding. Internal use. *)
 
 val name : 'r t -> string
 (** [name c] returns the codec's name. *)
@@ -195,6 +204,9 @@ val field_readers : 'r t -> (string * (bytes -> int -> int)) list
 (** [field_readers c] returns the int-valued field readers of [c], indexed by
     field name. Used for cross-codec name resolution when [c] is embedded as a
     sub-codec via {!Wire.codec}. *)
+
+val field_readers_ctx : 'r t -> (string * (Types.eval_ctx -> int -> int)) list
+(** Context-threaded field readers for embedding. Internal use. *)
 
 val pp : Format.formatter -> 'r t -> unit
 (** Pretty-print a codec (shows its name). *)

--- a/lib/codec.mli
+++ b/lib/codec.mli
@@ -59,7 +59,8 @@ val size_of_value : 'r t -> 'r -> int
     write. Computed from [v], not from a buffer: works for variable-size codecs
     whose tail is [all_bytes] / [rest_bytes] / [all_zeros], where the
     buffer-driven {!wire_size_at} cannot distinguish "value's tail" from
-    "remaining buffer space". *)
+    "remaining buffer space". Fixed-size byte arrays and slices contribute their
+    declared region size, including any zero-padding or truncation. *)
 
 val is_fixed : 'r t -> bool
 (** [is_fixed c] is [true] iff the codec [c] has a fixed wire size. *)

--- a/lib/codec.mli
+++ b/lib/codec.mli
@@ -72,11 +72,11 @@ val decode :
     If [?env] is supplied, input params are read from it and output params are
     written back to it after decoding.
 
-    Raises [Invalid_argument] when the codec has input params and no env is
-    supplied, or the env left any input param unbound (the error names the
-    offending param). An unbound input param would resolve a parametric field
-    size to 0 and silently truncate the field, so it is rejected up front the
-    same way {!encode} does. *)
+    Raises [Invalid_argument] when [?env] was created for a different codec,
+    when the codec has input params and no env is supplied, or when the env left
+    any input param unbound (the error names the offending param). An unbound
+    input param would resolve a parametric field size to 0 and silently truncate
+    the field, so it is rejected up front the same way {!encode} does. *)
 
 val decode_exn : ?env:Param.env -> 'r t -> bytes -> int -> 'r
 (** [decode_exn ?env c buf off] is like {!decode} but raises
@@ -115,10 +115,11 @@ val encode : ?env:Param.env -> 'r t -> 'r -> bytes -> int -> unit
     {!decode} when reading the bytes back, but [encode] does not need a prior
     decode to obtain it.
 
-    Raises [Invalid_argument] when the codec has parameters and no env is
-    supplied, when the env left any input param unbound (the error names the
-    offending param), when the destination buffer is too short, or when a
-    parametric byte field's value length does not match its env-bound size. *)
+    Raises [Invalid_argument] when [?env] was created for a different codec,
+    when the codec has parameters and no env is supplied, when the env left any
+    input param unbound (the error names the offending param), when the
+    destination buffer is too short, or when a parametric byte field's value
+    length does not match its env-bound size. *)
 
 val to_struct : 'r t -> Types.struct_
 (** Project to a {!Types.struct_} declaration. *)
@@ -128,15 +129,18 @@ val validate : ?env:Param.env -> 'r t -> bytes -> int -> unit
     without constructing a record and without firing actions. [?env] supplies
     bindings for any [Param.input] referenced in those clauses.
 
-    Raises {!Types.Parse_error} on constraint/where-clause failure. *)
+    Raises [Invalid_argument] if [?env] belongs to another codec or leaves an
+    input parameter unbound, and {!Types.Parse_error} on constraint/where-clause
+    failure. *)
 
 val get :
   ?env:Param.env -> 'r t -> ('a, 'r) field -> (bytes -> int -> 'a) Staged.t
 (** [get ?env c f] is a staged zero-copy getter for field [f] in codec [c]. If
     [f] has an action, it fires on every read. [env] syncs output parameters
     after each action; fields without actions have zero overhead regardless of
-    [env]. Does not check record-level where-clauses or other fields'
-    constraints -- call {!validate} first on untrusted input. *)
+    [env]. An environment created for another codec raises [Invalid_argument].
+    Does not check record-level where-clauses or other fields' constraints --
+    call {!validate} first on untrusted input. *)
 
 val set : 'r t -> ('a, 'r) field -> (bytes -> int -> 'a -> unit) Staged.t
 (** Staged zero-copy field setter. Does not check constraints or fire actions --

--- a/lib/codec.mli
+++ b/lib/codec.mli
@@ -40,7 +40,10 @@ val v :
 (** [v name constructor fields] seals a codec from a field list. [?doc] attaches
     a free-text note (e.g. an RFC citation) that the documentation projection
     renders as a [/*++ ... --*/] comment on the codec's 3D typedef; see
-    {!Everparse.project}. *)
+    {!Everparse.project}.
+
+    Raises [Invalid_argument] if two fields have the same name, or if distinct
+    parameter handles referenced by the codec have the same name. *)
 
 val wire_size : 'r t -> int
 (** Fixed wire size in bytes. Raises if variable-length. *)

--- a/lib/eval.ml
+++ b/lib/eval.ml
@@ -124,7 +124,9 @@ let rec expr : type a. ctx -> a expr -> a =
       failwith
         ("Eval.expr: unbound int64 field " ^ name
        ^ " (cross-field references are only valid inside a struct)")
-  | Param_ref p -> !(p.cell ())
+  | Param_ref p ->
+      Fmt.invalid_arg
+        "Eval.expr: parameter %S requires a codec evaluation context" p.name
   | Sizeof t -> field_wire_size t |> Option.value ~default:0
   | Sizeof_this -> 0
   | Field_pos -> 0

--- a/lib/field.mli
+++ b/lib/field.mli
@@ -85,8 +85,9 @@ val repeat :
   size:int Types.expr ->
   'a Types.typ ->
   'a list t
-(** [repeat name ~size t] parses elements of type [t] until [size] bytes have
-    been consumed. *)
+(** [repeat name ~size t] parses elements of type [t] until exactly [size] bytes
+    have been consumed. Encoding rejects values whose encoded size differs from
+    the budget. *)
 
 val repeat_seq :
   string ->
@@ -98,7 +99,7 @@ val repeat_seq :
   size:int Types.expr ->
   'a Types.typ ->
   'seq t
-(** Repeat with a custom sequence builder. *)
+(** Repeat with a custom sequence builder and the same exact byte budget. *)
 
 val anon : 'a Types.typ -> 'a anon
 (** [anon typ] creates an anonymous (padding) field. *)

--- a/lib/field.mli
+++ b/lib/field.mli
@@ -131,10 +131,8 @@ val action : 'a t -> Types.action option
 val doc : 'a t -> string option
 (** Field note attached via {!v}'s [?doc], if any. *)
 
-type packed =
-  | Named : 'a t -> packed
-  | Anon : 'a anon -> packed
-      (** Existentially packed field for heterogeneous lists. *)
+(** Existentially packed field for heterogeneous lists. *)
+type packed = Named : 'a t -> packed | Anon : 'a anon -> packed
 
 val decl_of_packed : packed -> Types.field
 (** [decl_of_packed p] is the {!Types.field} declaration of [p]. *)

--- a/lib/param.ml
+++ b/lib/param.ml
@@ -9,15 +9,22 @@ let pp ppf (p : (_, _) t) = Fmt.string ppf p.Types.name
    the relevant field. Avoids drift between the parallel cases. *)
 type 'a int_cvt = { fwd : 'a -> int; bwd : int -> 'a }
 
+exception Unfittable_native_int
+
+let optint_to_int to_int value =
+  match to_int value with
+  | value -> value
+  | exception (Failure _ | Invalid_argument _) -> raise Unfittable_native_int
+
 let rec int_cvt : type a. a Types.typ -> a int_cvt =
  fun typ ->
   let id : 'a int_cvt = { fwd = (fun v -> v); bwd = (fun v -> v) } in
   match typ with
   | Uint8 -> id
   | Uint16 _ -> id
-  | Uint_var _ -> { fwd = UInt63.to_int; bwd = UInt63.of_int }
-  | Uint32 _ -> { fwd = UInt32.to_int; bwd = UInt32.of_int }
-  | Uint63 _ -> { fwd = UInt63.to_int; bwd = UInt63.of_int }
+  | Uint_var _ -> { fwd = optint_to_int UInt63.to_int; bwd = UInt63.of_int }
+  | Uint32 _ -> { fwd = optint_to_int UInt32.to_int; bwd = UInt32.of_int }
+  | Uint63 _ -> { fwd = optint_to_int UInt63.to_int; bwd = UInt63.of_int }
   | Uint64 _ ->
       {
         fwd =
@@ -111,7 +118,14 @@ let env_idx (env : env) name =
   find 0
 
 let bind (p : ('a, input) t) (v : 'a) (env : env) : env =
-  let iv = to_int p.Types.typ v in
+  let iv =
+    match to_int p.Types.typ v with
+    | value -> value
+    | exception Unfittable_native_int ->
+        Fmt.invalid_arg
+          "Param.bind %S: value does not fit this platform's native int"
+          p.Types.name
+  in
   let slots = Array.copy env.slots in
   let bound = Array.copy env.bound in
   let i = env_idx env p.Types.name in

--- a/lib/param.ml
+++ b/lib/param.ml
@@ -11,6 +11,8 @@ type 'a int_cvt = { fwd : 'a -> int; bwd : int -> 'a }
 
 exception Unfittable_native_int
 
+let id_counter = Atomic.make 0
+
 let optint_to_int to_int value =
   match to_int value with
   | value -> value
@@ -71,11 +73,13 @@ let check_typ name typ =
 
 let input name typ =
   check_typ "input" typ;
-  { Types.name; typ; packed_typ = Types.Pack_typ typ; mutable_ = false }
+  let id = Atomic.fetch_and_add id_counter 1 in
+  { Types.id; name; typ; packed_typ = Types.Pack_typ typ; mutable_ = false }
 
 let output name typ =
   check_typ "output" typ;
-  { Types.name; typ; packed_typ = Types.Pack_typ typ; mutable_ = true }
+  let id = Atomic.fetch_and_add id_counter 1 in
+  { Types.id; name; typ; packed_typ = Types.Pack_typ typ; mutable_ = true }
 
 let decl (t : ('a, 'k) t) : Types.param =
   { param_name = t.name; param_typ = t.packed_typ; mutable_ = t.mutable_ }

--- a/lib/param.ml
+++ b/lib/param.ml
@@ -69,33 +69,13 @@ let check_typ name typ =
     Fmt.invalid_arg "Param.%s: only integer-representable types are supported"
       name
 
-(* A per-domain backing ref for a handle's [cell]. The handle is created once
-   and shared across domains, so a plain [ref 0] would let concurrent
-   encode/decode of the same parametric codec overwrite each other's value;
-   [Domain.DLS] gives each domain its own ref, still reused within the domain. *)
-let domain_local_cell () =
-  let key = Domain.DLS.new_key (fun () -> ref 0) in
-  fun () -> Domain.DLS.get key
-
 let input name typ =
   check_typ "input" typ;
-  {
-    Types.name;
-    typ;
-    packed_typ = Types.Pack_typ typ;
-    mutable_ = false;
-    cell = domain_local_cell ();
-  }
+  { Types.name; typ; packed_typ = Types.Pack_typ typ; mutable_ = false }
 
 let output name typ =
   check_typ "output" typ;
-  {
-    Types.name;
-    typ;
-    packed_typ = Types.Pack_typ typ;
-    mutable_ = true;
-    cell = domain_local_cell ();
-  }
+  { Types.name; typ; packed_typ = Types.Pack_typ typ; mutable_ = true }
 
 let decl (t : ('a, 'k) t) : Types.param =
   { param_name = t.name; param_typ = t.packed_typ; mutable_ = t.mutable_ }
@@ -133,7 +113,6 @@ let bind (p : ('a, input) t) (v : 'a) (env : env) : env =
     slots.(i) <- iv;
     bound.(i) <- true
   end;
-  p.cell () := iv;
   { env with Types.slots; bound }
 
 let bind_by_name name (iv : int) (env : env) : env =
@@ -149,6 +128,9 @@ let bind_by_name name (iv : int) (env : env) : env =
 
 let get (env : env) (p : ('a, 'k) t) : 'a =
   let i = env_idx env p.Types.name in
-  if i < 0 then of_int p.typ !(p.cell ()) else of_int p.typ env.slots.(i)
+  if i < 0 then
+    Fmt.invalid_arg
+      "Param.get: parameter %S does not belong to this environment" p.Types.name
+  else of_int p.typ env.slots.(i)
 
 type packed = Pack : ('a, 'k) t -> packed

--- a/lib/param.mli
+++ b/lib/param.mli
@@ -29,7 +29,8 @@ val expr : ('a, 'k) t -> int Types.expr
 
 type env = Types.param_env
 (** Immutable parameter environment backed by a flat [int array]. Create one
-    with {!Codec.env}, bind inputs with {!bind}, read outputs with {!get}. *)
+    with {!Codec.env}, bind inputs with {!bind}, read outputs with {!get}. An
+    environment belongs to that codec and cannot be used with another one. *)
 
 val bind : ('a, input) t -> 'a -> env -> env
 (** [bind p v env] returns an environment with input [p] set to [v].

--- a/lib/param.mli
+++ b/lib/param.mli
@@ -32,7 +32,10 @@ type env = Types.param_env
     with {!Codec.env}, bind inputs with {!bind}, read outputs with {!get}. *)
 
 val bind : ('a, input) t -> 'a -> env -> env
-(** [bind p v env] returns an environment with input [p] set to [v]. *)
+(** [bind p v env] returns an environment with input [p] set to [v].
+
+    Raises [Invalid_argument] naming [p] if [v] cannot fit the platform's native
+    integer representation used by parameter environments. *)
 
 val bind_by_name : string -> int -> env -> env
 (** [bind_by_name name v env] binds the input parameter called [name] to the

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -99,6 +99,7 @@ let raise_constraint ~at ~which ?value () =
   raise_error ~at (Constraint_failed { which; value })
 
 type ('a, 'k) param_handle = {
+  id : int;
   name : string;
   typ : 'a typ;
   packed_typ : packed_typ;

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -16,6 +16,36 @@ type ('elt, 'seq) seq_map =
 type param_input
 type param_output
 
+type bound_eval_ctx = {
+  bytes : bytes;
+  param : string -> int;
+  set_param : string -> int -> unit;
+}
+
+type eval_ctx = Obj.t
+
+(* A parameter-free operation is the common hot path. Represent its context by
+   the bytes block itself (whose runtime tag is [String_tag]) so introducing an
+   explicit context does not add an allocation to every encode/decode. A bound
+   context is a normal record and therefore has tag 0. The type stays abstract
+   outside this module, containing the representation distinction here. *)
+let empty_eval_ctx bytes : eval_ctx = Obj.repr bytes
+
+let eval_ctx ?(set_param = fun _ _ -> ()) bytes param : eval_ctx =
+  Obj.repr { bytes; param; set_param }
+
+let eval_bytes (ctx : eval_ctx) : bytes =
+  if Obj.tag ctx = Obj.string_tag then Obj.obj ctx
+  else (Obj.obj ctx : bound_eval_ctx).bytes
+
+let eval_param (ctx : eval_ctx) name =
+  if Obj.tag ctx = Obj.string_tag then 0
+  else (Obj.obj ctx : bound_eval_ctx).param name
+
+let eval_set_param (ctx : eval_ctx) name value =
+  if Obj.tag ctx <> Obj.string_tag then
+    (Obj.obj ctx : bound_eval_ctx).set_param name value
+
 (* Parse errors, defined before [typ] so [typ]'s own [Where] / [Field]
    constructors win type-directed disambiguation everywhere below; the
    [predicate] constructors are reached only through a [predicate]-typed
@@ -73,15 +103,6 @@ type ('a, 'k) param_handle = {
   typ : 'a typ;
   packed_typ : packed_typ;
   mutable_ : bool;
-  cell : unit -> int ref;
-      (* [cell] is the per-handle backing read by encode/size expressions and
-         the value-forwarding vehicle for embedded sub-codecs. Domain-local: a
-         handle lives inside a codec shared across domains, so a single [int ref]
-         would race across domains the way the validator scratch did; [cell ()]
-         returns this domain's ref. Slot resolution (decode array index, env
-         index) is NOT stored here: it is per-codec, since one handle may be
-         referenced both standalone and from an embedding, which would clash on
-         a single mutable field. *)
 }
 
 and packed_typ = Pack_typ : 'a typ -> packed_typ
@@ -208,18 +229,18 @@ and _ typ =
   | Apply : { typ : 'a typ; args : packed_expr list } -> 'a typ
   | Codec : {
       codec_name : string;
-      codec_decode : bytes -> int -> 'r;
-      codec_encode : 'r -> bytes -> int -> int;
+      codec_decode : eval_ctx -> int -> 'r;
+      codec_encode : 'r -> eval_ctx -> int -> int;
           (* Returns the offset after the bytes the encoder wrote. *)
       codec_fixed_size : int option;
-      codec_size_of : bytes -> int -> int;
+      codec_size_of : eval_ctx -> int -> int;
       codec_size_of_value : 'r -> int;
           (* Encoded byte length of a value, computed from the value rather
              than by re-reading the buffer. The buffer-driven [codec_size_of]
              is wrong for variable-size codecs ending in [all_bytes] /
              [rest_bytes] / [all_zeros]: it reads "remaining buffer space",
              not the value's actual tail length. *)
-      codec_field_readers : (string * (bytes -> int -> int)) list;
+      codec_field_readers : (string * (eval_ctx -> int -> int)) list;
       codec_struct : struct_;
           (** Structural representation of the codec. Mirrors [codec_decode] /
               [codec_encode] but in a form 3D projection can walk. *)

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -1098,6 +1098,25 @@ let is_int_dispatch_typ : type a. a typ -> bool = function
       true
   | _ -> false
 
+let uint32_case_index k =
+  match UInt32.to_int k with
+  | index -> index
+  | exception (Failure _ | Invalid_argument _) ->
+      let index =
+        UInt32.to_int32 k |> Int64.of_int32 |> Int64.logand 0xFFFF_FFFFL
+      in
+      Fmt.invalid_arg
+        "Wire.casetype: case index %Ld does not fit this platform's native int"
+        index
+
+let uint63_case_index k =
+  match UInt63.to_int k with
+  | index -> index
+  | exception (Failure _ | Invalid_argument _) ->
+      Fmt.invalid_arg
+        "Wire.casetype: case index %a does not fit this platform's native int"
+        UInt63.pp k
+
 (* Project a case-branch discriminator value of type ['k] to a 3D constant
    expression. Only called for int-shaped tags; non-int tags don't reach
    here because their casetype field is rewritten away before
@@ -1107,9 +1126,9 @@ let case_index_to_expr : type k. k typ -> k -> packed_expr =
   match tag_typ with
   | Uint8 -> Pack_expr (Int k)
   | Uint16 _ -> Pack_expr (Int k)
-  | Uint32 _ -> Pack_expr (Int (UInt32.to_int k))
-  | Uint63 _ -> Pack_expr (Int (UInt63.to_int k))
-  | Uint_var _ -> Pack_expr (Int (UInt63.to_int k))
+  | Uint32 _ -> Pack_expr (Int (uint32_case_index k))
+  | Uint63 _ -> Pack_expr (Int (uint63_case_index k))
+  | Uint_var _ -> Pack_expr (Int (uint63_case_index k))
   | Int8 -> Pack_expr (Int k)
   | Int16 _ -> Pack_expr (Int k)
   | Int32 _ -> Pack_expr (Int k)

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -475,6 +475,19 @@ let seq_list : ('a, 'a list) seq_map =
       iter = List.iter;
     }
 
+let exact_array_elements (type a seq) (Seq_map s : (a, seq) seq_map) ~expected
+    (values : seq) =
+  let actual = Stdlib.ref 0 in
+  let elements = Stdlib.ref [] in
+  s.iter
+    (fun value ->
+      incr actual;
+      elements := value :: !elements)
+    values;
+  if !actual <> expected then
+    Fmt.invalid_arg "Wire.array: expected %d elements, got %d" expected !actual;
+  List.rev !elements
+
 (* The 3D projection of [array]/[optional]/[optional_or]/[repeat] turns
    their length / predicate / byte budget into a [byte-size] suffix.
    That works as long as the wrapped element exposes a wire size we can
@@ -2898,6 +2911,11 @@ let rec size_of_typ_value : type a. a typ -> a -> int =
       let total = Stdlib.ref 0 in
       s.iter (fun e -> total := !total + size_of_typ_value elem e) v;
       !total
+  | Array { len = Int expected; elem; seq } ->
+      exact_array_elements seq ~expected v
+      |> List.fold_left
+           (fun total value -> total + size_of_typ_value elem value)
+           0
   | Array { elem; seq = Seq_map s; _ } ->
       let total = Stdlib.ref 0 in
       s.iter (fun e -> total := !total + size_of_typ_value elem e) v;

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -498,6 +498,14 @@ let exact_repeat_elements seq ~expected ~size_of values =
     Fmt.invalid_arg "Wire.repeat: expected %d bytes, got %d" expected actual;
   sized
 
+let check_nested_size ~at_most ~expected ~actual =
+  if actual > expected then
+    Fmt.invalid_arg "Wire.nested%s: region is %d bytes, value needs %d"
+      (if at_most then "_at_most" else "")
+      expected actual;
+  if (not at_most) && actual <> expected then
+    Fmt.invalid_arg "Wire.nested: expected %d bytes, got %d" expected actual
+
 (* The 3D projection of [array]/[optional]/[optional_or]/[repeat] turns
    their length / predicate / byte budget into a [byte-size] suffix.
    That works as long as the wrapped element exposes a wire size we can
@@ -2912,7 +2920,10 @@ let rec size_of_typ_value : type a. a typ -> a -> int =
          the runtime gate would have said at decode. *)
       size_of_typ_value inner v
   | Codec { codec_size_of_value; _ } -> codec_size_of_value v
-  | Single_elem { size = Int n; _ } -> n
+  | Single_elem { size = Int n; elem; at_most } ->
+      let actual = size_of_typ_value elem v in
+      check_nested_size ~at_most ~expected:n ~actual;
+      n
   | Single_elem _ -> 0
   | Repeat { size = Int expected; elem; seq } ->
       exact_repeat_elements seq ~expected ~size_of:(size_of_typ_value elem) v

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -475,18 +475,28 @@ let seq_list : ('a, 'a list) seq_map =
       iter = List.iter;
     }
 
-let exact_array_elements (type a seq) (Seq_map s : (a, seq) seq_map) ~expected
-    (values : seq) =
-  let actual = Stdlib.ref 0 in
+let sequence_elements (type a seq) (Seq_map s : (a, seq) seq_map) (values : seq)
+    =
   let elements = Stdlib.ref [] in
-  s.iter
-    (fun value ->
-      incr actual;
-      elements := value :: !elements)
-    values;
-  if !actual <> expected then
-    Fmt.invalid_arg "Wire.array: expected %d elements, got %d" expected !actual;
+  s.iter (fun value -> elements := value :: !elements) values;
   List.rev !elements
+
+let exact_array_elements seq ~expected values =
+  let elements = sequence_elements seq values in
+  let actual = List.length elements in
+  if actual <> expected then
+    Fmt.invalid_arg "Wire.array: expected %d elements, got %d" expected actual;
+  elements
+
+let exact_repeat_elements seq ~expected ~size_of values =
+  let sized =
+    sequence_elements seq values
+    |> List.map (fun value -> (value, size_of value))
+  in
+  let actual = List.fold_left (fun total (_, size) -> total + size) 0 sized in
+  if actual <> expected then
+    Fmt.invalid_arg "Wire.repeat: expected %d bytes, got %d" expected actual;
+  sized
 
 (* The 3D projection of [array]/[optional]/[optional_or]/[repeat] turns
    their length / predicate / byte budget into a [byte-size] suffix.
@@ -2904,6 +2914,9 @@ let rec size_of_typ_value : type a. a typ -> a -> int =
   | Codec { codec_size_of_value; _ } -> codec_size_of_value v
   | Single_elem { size = Int n; _ } -> n
   | Single_elem _ -> 0
+  | Repeat { size = Int expected; elem; seq } ->
+      exact_repeat_elements seq ~expected ~size_of:(size_of_typ_value elem) v
+      |> List.fold_left (fun total (_, size) -> total + size) 0
   | Repeat { elem; seq = Seq_map s; _ } ->
       (* Sum the actual element sizes from the value, like [Array]. The byte
          budget ([size]) is only a literal when fixed; a dynamic budget left

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -2894,8 +2894,11 @@ let rec size_of_typ_value : type a. a typ -> a -> int =
   | Zeroterm -> String.length v + 1
   | Zeroterm_at_most { size = Int n } -> n
   | Zeroterm_at_most _ -> 0
+  | Byte_array { size = Int n } -> n
   | Byte_array _ -> String.length v
+  | Byte_array_where { size = Int n; _ } -> n
   | Byte_array_where _ -> String.length v
+  | Byte_slice { size = Int n } -> n
   | Byte_slice _ -> Bytesrw.Bytes.Slice.length v
   | Uint_var { size = Int n; _ } -> n
   | Uint_var _ -> 0

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -74,6 +74,10 @@ type ('elt, 'seq) seq_map =
 val seq_list : ('a, 'a list) seq_map
 (** Default builder: accumulate into a list. *)
 
+val exact_array_elements : ('a, 'seq) seq_map -> expected:int -> 'seq -> 'a list
+(** Materialise an array value after checking its declared element count.
+    Internal helper shared by direct and compiled encoders. *)
+
 (** {1 Param handles} *)
 
 type param_input

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -1,6 +1,7 @@
 (** Core type definitions for the Wire DSL. *)
 
-type endian = Little | Big  (** Byte order. *)
+(** Byte order. *)
+type endian = Little | Big
 
 type eval_ctx
 (** Explicit runtime context for buffer and parameter expression evaluation.
@@ -31,6 +32,9 @@ val eval_set_param : eval_ctx -> string -> int -> unit
 (** Which predicate a {!Constraint_failed} came from. *)
 type predicate = Where | Field | Action | Per_byte
 
+(** Parse failure categories. For {!constructor-Constraint_failed}, [value] is
+    the offending field's value for a single-field self-constraint and [None]
+    for a cross-field or where predicate. *)
 type error_kind =
   | Unexpected_eof of { expected : int; got : int }
   | Invalid_enum of { value : int; valid : int list }
@@ -39,8 +43,6 @@ type error_kind =
   | Non_zero_padding
   | Value_out_of_range of { value : int64 }
   | Constraint_failed of { which : predicate; value : int64 option }
-      (** [value] is the offending field's value for a single-field
-          self-constraint, [None] for a cross-field or where predicate. *)
 
 type parse_error = { at : int; field : string list; kind : error_kind }
 (** [at] is the absolute byte offset of the failing field. Alongside it the
@@ -63,24 +65,23 @@ val eof :
 (** [eof ~expected ~got ()] is [parse_error (Unexpected_eof { expected; got })]:
     the input ended with [got] bytes where [expected] were needed. *)
 
-type bit_order =
-  | Msb_first
-  | Lsb_first
-      (** Which end of a packed base word the first declared bitfield occupies.
+(** Which end of a packed base word the first declared bitfield occupies.
 
-          [Msb_first] places the first declared field at the most significant
-          bit, matching how RFC, CCSDS, and IETF specs draw their bit diagrams.
-          [Lsb_first] places it at bit 0, matching MSVC C bit-field packing.
+    {!constructor-Msb_first} places the first declared field at the most
+    significant bit, matching how RFC, CCSDS, and IETF specs draw their bit
+    diagrams. {!constructor-Lsb_first} places it at bit 0, matching MSVC C
+    bit-field packing.
 
-          Bit order is independent of byte order. Every combination of base word
-          and bit order is a valid wire description. When projecting to
-          EverParse 3D, the export layer reverses field declaration order within
-          a bit group if the user's bit order differs from EverParse's native
-          choice for the base; this preserves byte layout in memory and is
-          invisible to the user. *)
+    Bit order is independent of byte order. Every combination of base word and
+    bit order is a valid wire description. When projecting to EverParse 3D, the
+    export layer reverses field declaration order within a bit group if the
+    user's bit order differs from EverParse's native choice for the base; this
+    preserves byte layout in memory and is invisible to the user. *)
+type bit_order = Msb_first | Lsb_first
 
 (** {1 Sequence builders} *)
 
+(** Builder for sequence accumulation. Existentially hides the builder type. *)
 type ('elt, 'seq) seq_map =
   | Seq_map : {
       empty : 'b;
@@ -89,8 +90,6 @@ type ('elt, 'seq) seq_map =
       iter : ('elt -> unit) -> 'seq -> unit;
     }
       -> ('elt, 'seq) seq_map
-      (** Builder for sequence accumulation. Existentially hides the builder
-          type. *)
 
 val seq_list : ('a, 'a list) seq_map
 (** Default builder: accumulate into a list. *)
@@ -118,6 +117,7 @@ type param_input
 type param_output
 
 type ('a, 'k) param_handle = {
+  id : int;
   name : string;
   typ : 'a typ;
   packed_typ : packed_typ;
@@ -133,6 +133,7 @@ and packed_typ = Pack_typ : 'a typ -> packed_typ
 
 and _ ref_kind = I : int ref_kind | I64 : int64 ref_kind
 
+(** Typed expressions used in constraints, actions, and sizes. *)
 and _ expr =
   | Int : int -> int expr
   | Int64 : int64 -> int64 expr
@@ -166,14 +167,11 @@ and _ expr =
   | Not : bool expr -> bool expr
   | Cast : [ `U8 | `U16 | `U32 | `U64 ] * int expr -> int expr
   | If_then_else : bool expr * int expr * int expr -> int expr
-      (** Ternary [(cond ? then_ : else_)] for conditional byte-size. *)
 
 (** {1 Types} *)
 
-and bitfield_base =
-  | U8
-  | U16 of endian
-  | U32 of endian  (** Base storage for bitfield extractions. *)
+(** Base storage for bitfield extractions. *)
+and bitfield_base = U8 | U16 of endian | U32 of endian
 
 and _ typ =
   | Uint8 : int typ  (** 8-bit unsigned. *)
@@ -292,8 +290,8 @@ and ('a, 'k) case_branch =
     }
       -> ('a, 'k) case_branch
 
-and packed_expr =
-  | Pack_expr : 'a expr -> packed_expr  (** Existentially packed expression. *)
+(** Existentially packed expression. *)
+and packed_expr = Pack_expr : 'a expr -> packed_expr
 
 and struct_ = {
   name : string;
@@ -303,6 +301,7 @@ and struct_ = {
 }
 (** Struct declaration. *)
 
+(** A single struct field. *)
 and field =
   | Field : {
       field_name : string option;
@@ -311,15 +310,15 @@ and field =
       action : action option;
       field_doc : string option;
     }
-      -> field  (** A single struct field. *)
+      -> field
 
 and param = { param_name : string; param_typ : packed_typ; mutable_ : bool }
 (** Formal parameter. *)
 
-and action =
-  | Success of action_stmt list
-  | Act of action_stmt list  (** Action attached to a field. *)
+(** Action attached to a field. *)
+and action = Success of action_stmt list | Act of action_stmt list
 
+(** Statements available in field actions. *)
 and action_stmt =
   | Assign : ('a, param_output) param_handle * int expr -> action_stmt
   | Field_assign of string * string * int expr
@@ -327,17 +326,17 @@ and action_stmt =
   | Return of bool expr
   | Abort
   | If of bool expr * action_stmt list * action_stmt list option
-  | Var of string * int expr  (** Action statement. *)
+  | Var of string * int expr
 
 type param_env = {
   codec_id : int;
   names : string array;
-      (** Parallel to [slots]: the param name at each slot, so a handle resolves
-          to its slot by name (per-env, hence per-codec). *)
+      (** Parallel to {!field-slots}: the param name at each slot, so a handle
+          resolves to its slot by name (per-env, hence per-codec). *)
   slots : int array;
   bound : bool array;
-      (** Parallel to [slots]; set by [Param.bind] so consumers can detect
-          unbound input params. *)
+      (** Parallel to {!field-slots}; set by [Param.bind] so consumers can
+          detect unbound input params. *)
 }
 
 (** {1 Expression Constructors} *)

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -2,6 +2,27 @@
 
 type endian = Little | Big  (** Byte order. *)
 
+type eval_ctx
+(** Explicit runtime context for buffer and parameter expression evaluation.
+    Internal to the direct and compiled interpreters. *)
+
+val empty_eval_ctx : bytes -> eval_ctx
+(** A runtime context with no parameter bindings. *)
+
+val eval_ctx :
+  ?set_param:(string -> int -> unit) -> bytes -> (string -> int) -> eval_ctx
+(** A runtime context with explicit parameter lookup. Internal use. *)
+
+val eval_bytes : eval_ctx -> bytes
+(** The context's input/output buffer. Internal use. *)
+
+val eval_param : eval_ctx -> string -> int
+(** Look up a parameter, returning 0 in an unbound context. Internal use. *)
+
+val eval_set_param : eval_ctx -> string -> int -> unit
+(** Update a bound output parameter, if the context accepts writes. Internal
+    use. *)
+
 (* The parse-error types are declared here, before {!typ}, so that {!typ}'s own
    [Where] / [Field] constructors win type-directed disambiguation throughout;
    the {!predicate} constructors are reached only through a [predicate]-typed
@@ -101,7 +122,6 @@ type ('a, 'k) param_handle = {
   typ : 'a typ;
   packed_typ : packed_typ;
   mutable_ : bool;
-  cell : unit -> int ref;
 }
 
 and packed_typ = Pack_typ : 'a typ -> packed_typ
@@ -236,14 +256,14 @@ and _ typ =
       (** Parameterised type application. *)
   | Codec : {
       codec_name : string;
-      codec_decode : bytes -> int -> 'r;
-      codec_encode : 'r -> bytes -> int -> int;
+      codec_decode : eval_ctx -> int -> 'r;
+      codec_encode : 'r -> eval_ctx -> int -> int;
       codec_fixed_size : int option;
-      codec_size_of : bytes -> int -> int;
+      codec_size_of : eval_ctx -> int -> int;
       codec_size_of_value : 'r -> int;
           (** Encoded byte length of a value, computed from the value rather
               than by re-reading the buffer. *)
-      codec_field_readers : (string * (bytes -> int -> int)) list;
+      codec_field_readers : (string * (eval_ctx -> int -> int)) list;
       codec_struct : struct_;
           (** Structural form of the codec, used by the 3D projection. *)
     }

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -574,7 +574,8 @@ val array_seq : ('a, 'seq) seq_map -> len:int expr -> 'a typ -> 'seq typ
 (** Fixed-count array with custom builder. *)
 
 val byte_array : size:int expr -> string typ
-(** Byte span as a string. *)
+(** Byte span as a string. A fixed-size span zero-pads short values and
+    truncates long values on encode. *)
 
 val byte_array_where :
   size:int expr -> per_byte:(int expr -> bool expr) -> string typ
@@ -582,7 +583,8 @@ val byte_array_where :
     byte must satisfy [per_byte]. The argument to [per_byte] is an expression
     bound to the current byte's integer value. Decode raises
     {!exception:Parse_error} on the first byte that violates the constraint;
-    encode raises [Invalid_argument]. *)
+    encode raises [Invalid_argument]. A fixed-size span otherwise zero-pads
+    short values and truncates long values on encode. *)
 
 val synth_name_of_elt_var : string -> string
 (** [synth_name_of_elt_var ev] is the 3D-side synthesised refinement-typedef
@@ -597,7 +599,8 @@ val index_bound_elt : 'a typ -> (string * bool expr) option
     used by the EverParse projection. *)
 
 val byte_slice : size:int expr -> Bytesrw.Bytes.Slice.t typ
-(** Zero-copy byte span. *)
+(** Zero-copy byte span. A fixed-size span zero-pads short values and truncates
+    long values on encode. *)
 
 val optional : bool expr -> 'a typ -> 'a option typ
 (** Conditionally present field. *)

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -78,6 +78,15 @@ val exact_array_elements : ('a, 'seq) seq_map -> expected:int -> 'seq -> 'a list
 (** Materialise an array value after checking its declared element count.
     Internal helper shared by direct and compiled encoders. *)
 
+val exact_repeat_elements :
+  ('a, 'seq) seq_map ->
+  expected:int ->
+  size_of:('a -> int) ->
+  'seq ->
+  ('a * int) list
+(** Materialise and size a repeat value after checking its byte budget. Internal
+    helper shared by direct and compiled encoders. *)
+
 (** {1 Param handles} *)
 
 type param_input

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -87,6 +87,10 @@ val exact_repeat_elements :
 (** Materialise and size a repeat value after checking its byte budget. Internal
     helper shared by direct and compiled encoders. *)
 
+val check_nested_size : at_most:bool -> expected:int -> actual:int -> unit
+(** Check an inner value against an exact or at-most nested region. Internal
+    helper shared by sizing and encoders. *)
+
 (** {1 Param handles} *)
 
 type param_input

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -209,69 +209,40 @@ let parse_struct_typ s buf off len =
   Codec.validate_struct v buf off;
   ((), off + sz)
 
+let parse_fixed size get buf off len =
+  check_eof len (off + size);
+  (get buf off, off + size)
+
+let int32_le buf off = Int32.to_int (Bytes.get_int32_le buf off)
+let int32_be buf off = Int32.to_int (Bytes.get_int32_be buf off)
+let float32_le buf off = Int32.float_of_bits (Bytes.get_int32_le buf off)
+let float32_be buf off = Int32.float_of_bits (Bytes.get_int32_be buf off)
+let float64_le buf off = Int64.float_of_bits (Bytes.get_int64_le buf off)
+let float64_be buf off = Int64.float_of_bits (Bytes.get_int64_be buf off)
+
 let rec parse_direct : type a. a typ -> bytes -> int -> int -> a * int =
  fun typ buf off len ->
   match typ with
-  | Uint8 ->
-      check_eof len (off + 1);
-      (Bytes.get_uint8 buf off, off + 1)
-  | Uint16 Little ->
-      check_eof len (off + 2);
-      (Bytes.get_uint16_le buf off, off + 2)
-  | Uint16 Big ->
-      check_eof len (off + 2);
-      (Bytes.get_uint16_be buf off, off + 2)
-  | Uint32 Little ->
-      check_eof len (off + 4);
-      (UInt32.le buf off, off + 4)
-  | Uint32 Big ->
-      check_eof len (off + 4);
-      (UInt32.be buf off, off + 4)
-  | Uint63 Little ->
-      check_eof len (off + 8);
-      (UInt63.le buf off, off + 8)
-  | Uint63 Big ->
-      check_eof len (off + 8);
-      (UInt63.be buf off, off + 8)
-  | Uint64 Little ->
-      check_eof len (off + 8);
-      (Bytes.get_int64_le buf off, off + 8)
-  | Uint64 Big ->
-      check_eof len (off + 8);
-      (Bytes.get_int64_be buf off, off + 8)
-  | Int8 ->
-      check_eof len (off + 1);
-      (Bytes.get_int8 buf off, off + 1)
-  | Int16 Little ->
-      check_eof len (off + 2);
-      (Bytes.get_int16_le buf off, off + 2)
-  | Int16 Big ->
-      check_eof len (off + 2);
-      (Bytes.get_int16_be buf off, off + 2)
-  | Int32 Little ->
-      check_eof len (off + 4);
-      (Int32.to_int (Bytes.get_int32_le buf off), off + 4)
-  | Int32 Big ->
-      check_eof len (off + 4);
-      (Int32.to_int (Bytes.get_int32_be buf off), off + 4)
-  | Int64 Little ->
-      check_eof len (off + 8);
-      (Bytes.get_int64_le buf off, off + 8)
-  | Int64 Big ->
-      check_eof len (off + 8);
-      (Bytes.get_int64_be buf off, off + 8)
-  | Float32 Little ->
-      check_eof len (off + 4);
-      (Int32.float_of_bits (Bytes.get_int32_le buf off), off + 4)
-  | Float32 Big ->
-      check_eof len (off + 4);
-      (Int32.float_of_bits (Bytes.get_int32_be buf off), off + 4)
-  | Float64 Little ->
-      check_eof len (off + 8);
-      (Int64.float_of_bits (Bytes.get_int64_le buf off), off + 8)
-  | Float64 Big ->
-      check_eof len (off + 8);
-      (Int64.float_of_bits (Bytes.get_int64_be buf off), off + 8)
+  | Uint8 -> parse_fixed 1 Bytes.get_uint8 buf off len
+  | Uint16 Little -> parse_fixed 2 Bytes.get_uint16_le buf off len
+  | Uint16 Big -> parse_fixed 2 Bytes.get_uint16_be buf off len
+  | Uint32 Little -> parse_fixed 4 UInt32.le buf off len
+  | Uint32 Big -> parse_fixed 4 UInt32.be buf off len
+  | Uint63 Little -> parse_fixed 8 UInt63.le buf off len
+  | Uint63 Big -> parse_fixed 8 UInt63.be buf off len
+  | Uint64 Little -> parse_fixed 8 Bytes.get_int64_le buf off len
+  | Uint64 Big -> parse_fixed 8 Bytes.get_int64_be buf off len
+  | Int8 -> parse_fixed 1 Bytes.get_int8 buf off len
+  | Int16 Little -> parse_fixed 2 Bytes.get_int16_le buf off len
+  | Int16 Big -> parse_fixed 2 Bytes.get_int16_be buf off len
+  | Int32 Little -> parse_fixed 4 int32_le buf off len
+  | Int32 Big -> parse_fixed 4 int32_be buf off len
+  | Int64 Little -> parse_fixed 8 Bytes.get_int64_le buf off len
+  | Int64 Big -> parse_fixed 8 Bytes.get_int64_be buf off len
+  | Float32 Little -> parse_fixed 4 float32_le buf off len
+  | Float32 Big -> parse_fixed 4 float32_be buf off len
+  | Float64 Little -> parse_fixed 8 float64_le buf off len
+  | Float64 Big -> parse_fixed 8 float64_be buf off len
   | Uint_var { size; endian } ->
       let n = Eval.expr Eval.empty size in
       check_eof len (off + n);

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -66,12 +66,12 @@ let is_nan (f : float Field.t) : bool Types.expr =
       && Land (r, Int 0x007F_FFFF) <> Int 0)
 
 let codec (c : 'r Codec.t) : 'r typ =
-  let codec_decode = Codec.embed_decode c in
-  let codec_encode = Codec.embed_encode c in
-  let codec_field_readers = Codec.field_readers c in
+  let codec_decode = Codec.embed_decode_ctx c in
+  let codec_encode = Codec.embed_encode_ctx c in
+  let codec_field_readers = Codec.field_readers_ctx c in
   let codec_struct = Codec.to_struct c in
   let codec_size_of_value = Codec.size_of_value c in
-  match Codec.wire_size_info c with
+  match Codec.wire_size_info_ctx c with
   | `Fixed n ->
       Codec
         {
@@ -336,7 +336,12 @@ let rec parse_direct : type a. a typ -> bytes -> int -> int -> a * int =
       check_enum_membership ~at:off ~closed cases v;
       (v, off')
   | Codec { codec_decode; codec_fixed_size; codec_size_of; _ } ->
-      parse_codec_typ codec_decode codec_fixed_size codec_size_of buf off len
+      let runtime = Types.empty_eval_ctx buf in
+      parse_codec_typ
+        (fun _buf off -> codec_decode runtime off)
+        codec_fixed_size
+        (fun _buf off -> codec_size_of runtime off)
+        buf off len
   | Struct s -> parse_struct_typ s buf off len
   | Casetype { cases; tag; _ } -> parse_casetype tag cases buf off len
   | Optional { present; inner } ->
@@ -782,8 +787,9 @@ let rec encode_into : type a. a typ -> a -> encoder -> unit =
   | Enum { base; _ } -> encode_into base v enc
   | Map { inner; encode; _ } -> encode_into inner (encode v) enc
   | Codec { codec_encode; codec_fixed_size; codec_size_of_value; _ } ->
-      encode_codec ~encode:codec_encode ~fixed_size:codec_fixed_size
-        ~size_of_value:codec_size_of_value v enc
+      encode_codec
+        ~encode:(fun v buf off -> codec_encode v (Types.empty_eval_ctx buf) off)
+        ~fixed_size:codec_fixed_size ~size_of_value:codec_size_of_value v enc
   | Optional { present; inner } ->
       if Eval.expr Eval.empty present then encode_into inner (Option.get v) enc
   | Optional_or { present; inner; _ } ->
@@ -918,7 +924,7 @@ let rec encode_direct : type a. a typ -> bytes -> int -> a -> int =
   | Map { inner; encode; _ } -> encode_direct inner buf off (encode v)
   | Where { inner; _ } -> encode_direct inner buf off v
   | Enum { base; _ } -> encode_direct base buf off v
-  | Codec { codec_encode; _ } -> codec_encode v buf off
+  | Codec { codec_encode; _ } -> codec_encode v (Types.empty_eval_ctx buf) off
   | _ -> encode_via_writer typ buf off v
 
 let to_bytes typ v =

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -406,10 +406,13 @@ and parse_repeat_loop : type elt seq.
     seq * int =
  fun ~elem ~seq:(Seq_map s) buf off len ~budget ->
   let start = off in
+  if budget < 0 then raise_eof ~at:off ~expected:0 ~got:budget;
+  check_eof len (start + budget);
+  let region_end = start + budget in
   let rec loop acc off' =
-    if off' - start >= budget then (s.finish acc, off')
+    if off' = region_end then (s.finish acc, off')
     else
-      let v, off'' = parse_direct elem buf off' len in
+      let v, off'' = parse_direct elem buf off' region_end in
       loop (s.add acc v) off''
   in
   loop s.empty off
@@ -781,8 +784,12 @@ let rec encode_into : type a. a typ -> a -> encoder -> unit =
       if Eval.expr Eval.empty present then encode_into inner (Option.get v) enc
   | Optional_or { present; inner; _ } ->
       if Eval.expr Eval.empty present then encode_into inner v enc
-  | Repeat { elem; seq = Seq_map seq; _ } ->
-      seq.iter (fun elem_v -> encode_into elem elem_v enc) v
+  | Repeat { size; elem; seq } ->
+      let expected = Eval.expr Eval.empty size in
+      Types.exact_repeat_elements seq ~expected
+        ~size_of:(Types.size_of_typ_value elem)
+        v
+      |> List.iter (fun (elem_v, _) -> encode_into elem elem_v enc)
   | Casetype { tag; cases; _ } -> encode_casetype tag cases v enc
   | Struct _ -> failwith "struct encoding: use Codec.encode"
   | Type_ref _ -> failwith "type_ref requires a type registry"

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -746,8 +746,10 @@ let rec encode_into : type a. a typ -> a -> encoder -> unit =
         write_byte enc 0
       done
   | Where { inner; _ } -> encode_into inner v enc
-  | Array { elem; seq = Seq_map seq; _ } ->
-      seq.iter (fun elem_v -> encode_into elem elem_v enc) v
+  | Array { len; elem; seq } ->
+      let expected = Eval.expr Eval.empty len in
+      Types.exact_array_elements seq ~expected v
+      |> List.iter (fun elem_v -> encode_into elem elem_v enc)
   | Byte_array _ -> write_string enc v
   | Byte_array_where { elt_var; cond; _ } ->
       String.iteri

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -319,10 +319,13 @@ let rec parse_direct : type a. a typ -> bytes -> int -> int -> a * int =
       let n = Eval.expr Eval.empty size in
       check_eof len (off + n);
       (Slice.make_or_eod buf ~first:off ~length:n, off + n)
-  | Single_elem { size; elem; at_most = _ } ->
+  | Single_elem { size; elem; at_most } ->
       let n = Eval.expr Eval.empty size in
       check_eof len (off + n);
-      let v, _ = parse_direct elem buf off (off + n) in
+      let v, inner_end = parse_direct elem buf off (off + n) in
+      let consumed = inner_end - off in
+      if (not at_most) && consumed <> n then
+        raise_eof ~at:inner_end ~expected:n ~got:consumed;
       (v, off + n)
   | Map { inner; decode; _ } ->
       let v, off' = parse_direct inner buf off len in
@@ -768,10 +771,11 @@ let rec encode_into : type a. a typ -> a -> encoder -> unit =
       let off = Slice.first v in
       let len = Slice.length v in
       write_string enc (Bytes.sub_string src off len)
-  | Single_elem { size; elem; _ } ->
+  | Single_elem { size; elem; at_most } ->
       let n = Eval.expr Eval.empty size in
-      encode_into elem v enc;
       let inner_sz = Types.size_of_typ_value elem v in
+      Types.check_nested_size ~at_most ~expected:n ~actual:inner_sz;
+      encode_into elem v enc;
       for _ = inner_sz to n - 1 do
         write_byte enc 0
       done
@@ -905,7 +909,9 @@ let rec encode_direct : type a. a typ -> bytes -> int -> a -> int =
       off + n
   | Byte_array { size = Int n } -> Codec.blit_string_padded n buf off v
   | Byte_slice { size = Int n } -> Codec.blit_slice_padded n buf off v
-  | Single_elem { size = Int n; elem; at_most = _ } ->
+  | Single_elem { size = Int n; elem; at_most } ->
+      let inner_sz = Types.size_of_typ_value elem v in
+      Types.check_nested_size ~at_most ~expected:n ~actual:inner_sz;
       let off' = encode_direct elem buf off v in
       if off' < off + n then Bytes.fill buf off' (off + n - off') '\x00';
       off + n

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -401,7 +401,36 @@ module Field : sig
     'a typ ->
     'a option t
   (** [optional name ~present t] is a field present iff [present] evaluates to
-      [true]. Absent fields decode as [None] and consume zero bytes. *)
+      [true]. Absent fields decode as [None] and consume zero bytes.
+
+      To make a whole field group conditional, define the group as a sub-codec
+      and pass [codec group] as [t]. Expressions inside the group can refer to
+      its earlier fields, so the group may start with a byte-length prefix
+      followed by {!repeat}; fields after the optional group remain in the
+      parent codec. This shape projects to 3D as a gate-selected sub-codec.
+
+      {[
+      type ext = { len : int; items : int list }
+
+      let f_ext_len = Field.v "ExtLen" uint8
+
+      let ext_codec =
+        Codec.v "Ext"
+          (fun len items -> { len; items })
+          Codec.
+            [
+              (f_ext_len $ fun e -> e.len);
+              ( Field.repeat "ExtItems" ~size:(Field.ref f_ext_len) uint8
+              $ fun e -> e.items );
+            ]
+
+      let f_gate = Field.v "Gate" uint8
+
+      let f_ext =
+        Field.optional "Ext"
+          ~present:Expr.(Field.ref f_gate <> int 0)
+          (codec ext_codec)
+      ]} *)
 
   val optional_or :
     string ->

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -694,11 +694,12 @@ val array : len:int expr -> 'a typ -> 'a list typ
     element count, not a byte size. It projects to 3D only when [t] has a fixed
     wire size: 3D arrays are byte-budgeted, so the count is lowered to
     [len * sizeof t] bytes. For variable-size elements use {!Field.repeat},
-    which is bounded by a byte budget instead. *)
+    which is bounded by a byte budget instead. Encoding a list whose cardinality
+    differs from [len] raises [Invalid_argument] before writing. *)
 
 val array_seq : ('a, 'seq) seq_map -> len:int expr -> 'a typ -> 'seq typ
 (** Like {!array} but accumulates into a custom sequence via a {!type-seq_map}.
-*)
+    Encoding enforces the same exact cardinality. *)
 
 val byte_array : size:int expr -> string typ
 (** Fixed-size byte sequence copied as a string.

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -153,7 +153,10 @@ module Param : sig
       read outputs with {!get}. *)
 
   val bind : ('a, input) t -> 'a -> env -> env
-  (** [bind p v env] returns an environment with input [p] set to [v]. *)
+  (** [bind p v env] returns an environment with input [p] set to [v].
+
+      Raises [Invalid_argument] naming [p] if [v] cannot fit the platform's
+      native integer representation used by parameter environments. *)
 
   val bind_by_name : string -> int -> env -> env
   (** [bind_by_name name v env] binds the input parameter called [name] to the
@@ -787,7 +790,9 @@ val default :
 val casetype : string -> 'k typ -> ('a, 'k) case_def list -> 'a typ
 (** [casetype name tag defs] is a tag-dispatched union. The discriminator typ
     ['k] can be an integer, a string, or any other typ with decidable equality;
-    every case must supply an explicit [~index]. *)
+    every case must supply an explicit [~index]. Projecting an integer-tagged
+    casetype raises [Invalid_argument] naming the case index when it cannot fit
+    the platform's native integer representation. *)
 
 val size : 'a typ -> int option
 (** [size t] is the fixed wire size of a description, if known statically. *)

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -459,12 +459,15 @@ module Field : sig
     'a typ ->
     'a list t
   (** [repeat name ~size t] parses elements of type [t] until [size] bytes are
-      consumed. The bound is a byte budget, not an element count, which is what
-      lets the elements be variable-size (a tagged union, a length-prefixed
-      sub-codec). It projects to 3D as [t name[:byte-size size]]. There is no
-      count-driven form: "a count field, then that many variable-size elements"
-      is expressible neither here nor in 3D (3D arrays are byte-budgeted), so
-      that shape needs caller-side iteration over the element parser. *)
+      consumed exactly. The bound is a byte budget, not an element count, which
+      is what lets the elements be variable-size (a tagged union, a
+      length-prefixed sub-codec). An element cannot cross the region boundary;
+      encoding raises [Invalid_argument] when the supplied values span fewer or
+      more bytes than [size]. It projects to 3D as [t name[:byte-size size]].
+      There is no count-driven form: "a count field, then that many
+      variable-size elements" is expressible neither here nor in 3D (3D arrays
+      are byte-budgeted), so that shape needs caller-side iteration over the
+      element parser. *)
 
   val repeat_seq :
     string ->
@@ -476,7 +479,8 @@ module Field : sig
     size:int expr ->
     'a typ ->
     'seq t
-  (** Like {!repeat} but accumulates into a custom sequence via [seq]. *)
+  (** Like {!repeat} but accumulates into a custom sequence via [seq], with the
+      same exact byte-budget requirement. *)
 
   val anon : 'a typ -> 'a anon
   (** [anon typ] creates an anonymous (padding) field. *)

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -697,7 +697,13 @@ val array_seq : ('a, 'seq) seq_map -> len:int expr -> 'a typ -> 'seq typ
 *)
 
 val byte_array : size:int expr -> string typ
-(** Fixed-size byte sequence copied as a string. *)
+(** Fixed-size byte sequence copied as a string.
+
+    When [size] contains the simple product of a field and a literal, and that
+    field has a simple [field <= bound] constraint, {!Codec.v} rejects the codec
+    if [bound * literal] can reach [2^32]. EverParse represents byte sizes as
+    [u32] and cannot verify such a schema; tighten the field bound. More complex
+    bounds are left to EverParse. *)
 
 val byte_array_where :
   size:int expr -> per_byte:(int expr -> bool expr) -> string typ

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -741,14 +741,17 @@ val nested : size:int expr -> 'a typ -> 'a typ
 
     This is for layouts where a length expression denotes the size of a region,
     but that region is known to contain exactly one value, such as a single
-    nested message. *)
+    nested message. Decoding rejects an inner value that consumes fewer bytes;
+    encoding raises [Invalid_argument] unless the value's encoded size is
+    exactly [size]. *)
 
 val nested_at_most : size:int expr -> 'a typ -> 'a typ
 (** [nested_at_most ~size t] is like {!nested}, but treats [size] as an upper
     bound rather than an exact size.
 
     This is for length-prefixed regions where the one logical element may
-    consume fewer bytes than the available space. *)
+    consume fewer bytes than the available space. Encoding zero-pads the unused
+    region; a value larger than [size] raises [Invalid_argument]. *)
 
 val enum : string -> (string * int) list -> int typ -> int typ
 (** [enum name cases base] validates that the decoded integer is one of the

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -150,7 +150,8 @@ module Param : sig
 
   type env = Param.env
   (** Parameter environment. Create with {!Codec.env}, bind inputs with {!bind},
-      read outputs with {!get}. *)
+      read outputs with {!get}. An environment belongs to that codec and cannot
+      be used with another one. *)
 
   val bind : ('a, input) t -> 'a -> env -> env
   (** [bind p v env] returns an environment with input [p] set to [v].
@@ -1019,10 +1020,11 @@ module Codec : sig
       If [?env] is supplied, input params are read from it and output params are
       written back to it on success.
 
-      Raises [Invalid_argument] when the codec has input params and the env is
-      missing or leaves one unbound, the same precondition {!encode} enforces:
-      an unbound input param would resolve a parametric field size to 0 and
-      silently truncate the field. *)
+      Raises [Invalid_argument] when [?env] was created for a different codec,
+      or when the codec has input params and the env is missing or leaves one
+      unbound, the same precondition {!encode} enforces: an unbound input param
+      would resolve a parametric field size to 0 and silently truncate the
+      field. *)
 
   val decode_exn : ?env:Param.env -> 'r t -> bytes -> int -> 'r
   (** Like {!decode} but raises {!exception:Parse_error} on failure. *)
@@ -1036,23 +1038,26 @@ module Codec : sig
       [?env] (built with [Codec.env c |> Param.bind p N]). The bound widths must
       match the field values in [r]; the encoder cross-checks them.
 
-      Raises [Invalid_argument] when the codec has parameters and no env is
-      supplied, when the env left any input param unbound (the error names it),
-      when the destination buffer is too short, or when a parametric byte
-      field's value length does not match its env-bound size. *)
+      Raises [Invalid_argument] when [?env] was created for a different codec,
+      when the codec has parameters and no env is supplied, when the env left
+      any input param unbound (the error names it), when the destination buffer
+      is too short, or when a parametric byte field's value length does not
+      match its env-bound size. *)
 
   val validate : ?env:Param.env -> 'r t -> bytes -> int -> unit
   (** [validate ?env c buf off] checks field [~constraint_] and [~where] clauses
       without constructing a record and without firing actions. [?env] supplies
       bindings for any {!val:Param.input} referenced in those clauses.
 
-      Raises {!Validation_error} on failure. *)
+      Raises [Invalid_argument] when [?env] belongs to another codec or leaves
+      an input parameter unbound, and {!Validation_error} on failure. *)
 
   val get :
     ?env:Param.env -> 'r t -> ('a, 'r) field -> (bytes -> int -> 'a) Staged.t
   (** Staged field reader. If the field has an [~action], the action fires on
-      every read. Pass [~env] to sync output parameters after each action.
-      Fields without actions have zero overhead regardless of [~env].
+      every read. Pass [~env] to sync output parameters after each action. An
+      environment created for another codec raises [Invalid_argument]. Fields
+      without actions have zero per-read overhead regardless of [~env].
 
       Does not check [~where] clauses or other fields' constraints -- call
       {!validate} first on untrusted input. *)

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -708,6 +708,9 @@ val array_seq : ('a, 'seq) seq_map -> len:int expr -> 'a typ -> 'seq typ
 val byte_array : size:int expr -> string typ
 (** Fixed-size byte sequence copied as a string.
 
+    Encoding zero-pads a string shorter than [size] and truncates one longer
+    than [size].
+
     When [size] contains the simple product of a field and a literal, and that
     field has a simple [field <= bound] constraint, {!Codec.v} rejects the codec
     if [bound * literal] can reach [2^32]. EverParse represents byte sizes as
@@ -721,12 +724,14 @@ val byte_array_where :
     expression bound to the current byte's integer value.
 
     Decode raises {!exception:Parse_error} on the first byte that violates the
-    constraint; encode raises [Invalid_argument]. The motivating shape is SSH
-    name-list payloads (RFC 4251 sec 5), where every byte must be printable
-    US-ASCII. *)
+    constraint; encode raises [Invalid_argument]. Encoding otherwise follows
+    {!byte_array}: short strings are zero-padded and long strings are truncated.
+    The motivating shape is SSH name-list payloads (RFC 4251 sec 5), where every
+    byte must be printable US-ASCII. *)
 
 val byte_slice : size:int expr -> Bytesrw.Bytes.Slice.t typ
-(** Fixed-size byte sequence exposed as a zero-copy slice. *)
+(** Fixed-size byte sequence exposed as a zero-copy slice. Encoding zero-pads a
+    slice shorter than [size] and truncates one longer than [size]. *)
 
 val rest_bytes : (int, _) Param.t -> string typ
 (** [rest_bytes total] is the trailing payload of a record whose total decoded

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -1069,8 +1069,9 @@ module Codec : sig
     ?env:Param.env -> 'r t -> ('a, 'r) field -> (bytes -> int -> 'a) Staged.t
   (** Staged field reader. If the field has an [~action], the action fires on
       every read. Pass [~env] to sync output parameters after each action. An
-      environment created for another codec raises [Invalid_argument]. Fields
-      without actions have zero per-read overhead regardless of [~env].
+      environment created for another codec raises [Invalid_argument]. Omit
+      [~env] for parameter-free accessors; dependent layouts use it to resolve
+      their parameters.
 
       Does not check [~where] clauses or other fields' constraints -- call
       {!validate} first on untrusted input. *)

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -1,8 +1,8 @@
 (** Binary wire format descriptions.
 
-    A wire format is a sequence of typed {!Field}s -- integers, bitfields,
-    enumerations, byte arrays -- laid out at fixed bit offsets in a buffer. A
-    {!Codec} binds those fields to an OCaml record, giving you:
+    A wire format is a sequence of typed {!module-Field} values -- integers,
+    bitfields, enumerations, byte arrays -- laid out at fixed bit offsets in a
+    buffer. A {!Codec} binds those fields to an OCaml record, giving you:
 
     - Zero-copy field access via staged getters and setters.
     - Full-record [decode] / [encode] between bytes and OCaml values.
@@ -60,29 +60,25 @@ end
 type 'a expr = 'a Types.expr
 type bitfield = U8 | U16 | U16be | U32 | U32be
 
-type bit_order = Types.bit_order =
-  | Msb_first
-  | Lsb_first
-      (** Which end of a packed base word the first declared bitfield occupies.
+(** Which end of a packed base word the first declared bitfield occupies.
 
-          - [Msb_first] (default): the first declared field lands at the most
-            significant bit of the base word, matching how RFC, CCSDS, and IETF
-            specs draw their bit diagrams. Copy-pasting a spec into field
-            declarations just works.
+    - {!constructor-Msb_first} (default): the first declared field lands at the
+      most significant bit of the base word, matching how RFC, CCSDS, and IETF
+      specs draw their bit diagrams. Copy-pasting a spec into field declarations
+      just works.
 
-          - [Lsb_first]: the first declared field lands at bit 0 of the base
-            word, matching MSVC's C bit-field packing. Useful when mirroring a C
-            struct.
+    - {!constructor-Lsb_first}: the first declared field lands at bit 0 of the
+      base word, matching MSVC's C bit-field packing. Useful when mirroring a C
+      struct.
 
-          Bit order is independent of byte order: any combination of base word
-          and bit order is a valid wire description, and the EverParse 3D
-          projection reverses declaration order within a bit group when
-          necessary so that every pairing emits a valid 3D schema with identical
-          byte layout. *)
+    Bit order is independent of byte order: any combination of base word and bit
+    order is a valid wire description, and the EverParse 3D projection reverses
+    declaration order within a bit group when necessary so that every pairing
+    emits a valid 3D schema with identical byte layout. *)
+type bit_order = Types.bit_order = Msb_first | Lsb_first
 
-type endian = Types.endian =
-  | Little
-  | Big  (** Byte order for multi-byte integers. *)
+(** Byte order for multi-byte integers. *)
+type endian = Types.endian = Little | Big
 
 type 'a typ = 'a Types.typ
 
@@ -516,7 +512,7 @@ module Field : sig
   (** Field note attached via {!v}'s [?doc], if any. *)
 
   val decl_of_packed : packed -> Types.field
-  (** The {!Types.field} declaration of a packed field. *)
+  (** The underlying field declaration of a packed field. *)
 end
 
 (** {1 Type Descriptions}
@@ -538,19 +534,19 @@ val uint16be : int typ
 (** Unsigned 16-bit big-endian integer. *)
 
 val uint32 : Optint.t typ
-(** Unsigned 32-bit little-endian integer. Decodes to an {!Optint.t} so a value
+(** Unsigned 32-bit little-endian integer. Decodes to an [Optint.t] so a value
     with bit 31 set survives on a narrow-int target (js/wasm). *)
 
 val uint32be : Optint.t typ
-(** Unsigned 32-bit big-endian integer. Decodes to an {!Optint.t}. *)
+(** Unsigned 32-bit big-endian integer. Decodes to an [Optint.t]. *)
 
 val uint63 : Optint.Int63.t typ
 (** Unsigned 63-bit little-endian integer carried on 8 bytes. Decodes to an
-    {!Optint.Int63.t}. *)
+    [Optint.Int63.t]. *)
 
 val uint63be : Optint.Int63.t typ
 (** Unsigned 63-bit big-endian integer carried on 8 bytes. Decodes to an
-    {!Optint.Int63.t}. *)
+    [Optint.Int63.t]. *)
 
 val uint64 : int64 typ
 (** [uint64] is an unsigned 64-bit little-endian integer represented as an OCaml
@@ -612,7 +608,7 @@ val is_nan : float Field.t -> bool expr
 val uint : ?endian:endian -> int expr -> UInt63.t typ
 (** [uint size] is an unsigned integer of [size] bytes (1-7) with the given byte
     order (default {!Big}). The size may be a dynamic expression for
-    parameter-driven widths. Decodes to a {!UInt63.t}: a 7-byte value needs 56
+    parameter-driven widths. Decodes to a [UInt63.t]: a 7-byte value needs 56
     bits, which does not fit an int on a narrow-int target (js/wasm). *)
 
 val bits : ?bit_order:bit_order -> width:int -> bitfield -> int typ
@@ -680,6 +676,7 @@ val zeroterm_at_most : size:int expr -> string typ
 val where : bool expr -> 'a typ -> 'a typ
 (** Refine a description with a boolean constraint. *)
 
+(** Builder for sequence accumulation (Jsont-style). *)
 type ('elt, 'seq) seq_map = ('elt, 'seq) Types.seq_map =
   | Seq_map : {
       empty : 'b;
@@ -688,7 +685,6 @@ type ('elt, 'seq) seq_map = ('elt, 'seq) Types.seq_map =
       iter : ('elt -> unit) -> 'seq -> unit;
     }
       -> ('elt, 'seq) seq_map
-      (** Builder for sequence accumulation (Jsont-style). *)
 
 val seq_list : ('a, 'a list) seq_map
 (** Default builder: accumulate into a list. *)
@@ -813,14 +809,17 @@ val size : 'a typ -> int option
 
 (** {1 Parsing Errors}
 
-    Direct decoding reports failures as values of type {!parse_error}. The cases
-    distinguish structural failure on input, such as unexpected end of input or
-    a constraint violation, from semantic failure such as an invalid enum or
-    tag. *)
+    Direct decoding reports failures as values of type {!type-parse_error}. The
+    cases distinguish structural failure on input, such as unexpected end of
+    input or a constraint violation, from semantic failure such as an invalid
+    enum or tag. *)
 
 (** Which predicate a {!Constraint_failed} came from. *)
 type predicate = Where | Field | Action | Per_byte
 
+(** Parse failure categories. For {!constructor-Constraint_failed}, [value] is
+    the offending field's value for a single-field self-constraint and [None]
+    for a cross-field or where predicate. *)
 type error_kind =
   | Unexpected_eof of { expected : int; got : int }
   | Invalid_enum of { value : int; valid : int list }
@@ -829,8 +828,6 @@ type error_kind =
   | Non_zero_padding
   | Value_out_of_range of { value : int64 }
   | Constraint_failed of { which : predicate; value : int64 option }
-      (** [value] is the offending field's value for a single-field
-          self-constraint, [None] for a cross-field or where predicate. *)
 
 type parse_error = { at : int; field : string list; kind : error_kind }
 (** [at] is the absolute byte offset of the failing field. Alongside it the
@@ -876,7 +873,7 @@ val eof :
     values with bytes.
 
     Use them when you want a value now: one-shot decoding, streaming code built
-    around {!Bytesrw}, tests, small tools, and formats that are naturally
+    around [Bytesrw], tests, small tools, and formats that are naturally
     consumed as values.
 
     Use {!Codec} instead when the format is record-shaped and the main goal is
@@ -937,7 +934,7 @@ val of_bytes_exn : 'a typ -> bytes -> 'a
     data-dependent and should not be silently ignored. *)
 
 val to_writer : 'a typ -> 'a -> Bytesrw.Bytes.Writer.t -> unit
-(** Encodes one value to a {!Bytesrw.Bytes.Writer.t}.
+(** Encodes one value to a [Bytesrw.Bytes.Writer.t].
 
     This function is exception-based. Unsupported description forms, such as
     unresolved type references, raise an exception rather than returning an
@@ -951,8 +948,8 @@ val to_string : 'a typ -> 'a -> string
 
 (** {1 Codecs}
 
-    A codec is the primary way to work with a wire format. It binds {!Field}s to
-    an OCaml record type and provides:
+    A codec is the primary way to work with a wire format. It binds
+    {!module-Field} values to an OCaml record type and provides:
 
     - {b Zero-copy field access}: {!Codec.get} and {!Codec.set} read and write
       individual fields directly in a buffer -- no intermediate record
@@ -1063,7 +1060,7 @@ module Codec : sig
       bindings for any {!val:Param.input} referenced in those clauses.
 
       Raises [Invalid_argument] when [?env] belongs to another codec or leaves
-      an input parameter unbound, and {!Validation_error} on failure. *)
+      an input parameter unbound, and {!exception-Parse_error} on failure. *)
 
   val get :
     ?env:Param.env -> 'r t -> ('a, 'r) field -> (bytes -> int -> 'a) Staged.t
@@ -1087,7 +1084,7 @@ module Codec : sig
 
       Zero-copy access to the offset/length of a [byte_slice] field. The naive
       nesting [Slice.first (Codec.get c f buf base)] forces [Codec.get] to
-      allocate a fresh {!Bytesrw.Bytes.Slice.t} -- 4 words -- only for
+      allocate a fresh [Bytesrw.Bytes.Slice.t] -- 4 words -- only for
       [Slice.first] to extract one int and discard the rest. {!slice_offset}
       skips the make and returns the int directly. *)
 
@@ -1143,7 +1140,7 @@ module Codec : sig
   (** [validator_of_struct s] compiles [s] into a validator. *)
 
   val validate_struct : validator -> bytes -> int -> unit
-  (** Run the validator. Raises {!Validation_error} on failure. *)
+  (** Run the validator. Raises {!exception-Parse_error} on failure. *)
 
   val struct_size_of : validator -> bytes -> int -> int
   (** Byte size of the struct starting at [off]. *)
@@ -1185,7 +1182,8 @@ val codec : 'r Codec.t -> 'r typ
 
     {!Everparse} is the pure export layer. The normal workflow is:
 
-    - build a record-shaped description with {!Field} and {!Codec};
+    - build a record-shaped description with {!module-Field} and
+      {!module-Codec};
     - project it with {!Everparse.project};
     - emit one [.3d] file per schema with {!Everparse.write};
     - run EverParse/C tooling with [Wire_3d];
@@ -1285,7 +1283,8 @@ module Everparse : sig
 
         These constructors exist for EverParse features that currently have no
         codec-level equivalent, plus the struct-level projection knobs. Most
-        users should stay on the {!Field}/{!Codec} path and use {!project}. *)
+        users should stay on the {!module-Field}/{!module-Codec} path and use
+        {!project}. *)
 
     type nonrec struct_ = struct_
     type field = Field.packed
@@ -1364,16 +1363,8 @@ module Everparse : sig
     val field_names : struct_ -> string list
     (** Named field names in declaration order. *)
 
-    type ocaml_kind =
-      | Int
-      | Int64
-      | Float32
-      | Float64
-      | Bool
-      | String
-      | Unit
-          (** The OCaml representation kind of a field (for FFI stub
-              generation). *)
+    (** The OCaml representation kind of a field (for FFI stub generation). *)
+    type ocaml_kind = Int | Int64 | Float32 | Float64 | Bool | String | Unit
 
     val field_kinds : struct_ -> (string * ocaml_kind) list
     (** Named field names with their OCaml type kind. *)

--- a/merlint.toml
+++ b/merlint.toml
@@ -2,3 +2,10 @@
 [[rules]]
 files = "examples/net/net.ml"
 exclude = ["E350"]
+
+# A parameter-free evaluation context is represented directly by its bytes
+# block so the explicit context does not regress allocation-free codec paths.
+# The unsafe representation is confined to this module and hidden by its mli.
+[[rules]]
+files = "lib/types.ml"
+exclude = ["E100"]

--- a/scripts/install-git-hooks
+++ b/scripts/install-git-hooks
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -eu
+
+repo=$(git rev-parse --show-toplevel)
+git config core.hooksPath scripts
+echo "Git hooks now use $repo/scripts"

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -16,8 +16,7 @@ then
   exit 1
 fi
 
-merlint="$HOME/git/blacksun/mono/_build/default/merlint/bin/main.exe"
-if [ -x "$merlint" ]; then
+if merlint=$(command -v merlint 2>/dev/null); then
   git diff --cached --name-only --diff-filter=ACM -z -- \
     '*.ml' '*.mli' '*.mll' '*.mly' \
     | xargs -0 "$merlint" --no-build >/tmp/git-merlint-hook.log 2>&1 \

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+set -eu
+
+if git diff --cached --quiet -- '*.ml' '*.mli' '*.mll' '*.mly'; then
+  exit 0
+fi
+
+# Keep this file-local: a repo-wide [dune fmt] discovers symlinked workspace
+# subtrees and can hit https://github.com/ocaml/dune/issues/10635.
+if ! git diff --cached --name-only --diff-filter=ACM -z -- \
+  '*.ml' '*.mli' '*.mll' '*.mly' \
+  | xargs -0 opam exec -- ocamlformat --check --
+then
+  echo "Staged OCaml files are not formatted; run opam exec -- dune fmt." >&2
+  exit 1
+fi
+
+merlint="$HOME/git/blacksun/mono/_build/default/merlint/bin/main.exe"
+if [ -x "$merlint" ]; then
+  git diff --cached --name-only --diff-filter=ACM -z -- \
+    '*.ml' '*.mli' '*.mll' '*.mly' \
+    | xargs -0 "$merlint" --no-build >/tmp/git-merlint-hook.log 2>&1 \
+    || {
+      echo "merlint failed; see /tmp/git-merlint-hook.log for details" >&2
+      exit 1
+    }
+fi

--- a/test/3d/dune
+++ b/test/3d/dune
@@ -6,7 +6,7 @@
 (test
  (name test)
  (modules test test_wire_3d)
- (libraries wire wire.3d alcotest re unix))
+ (libraries wire wire.3d alcotest re unix fmt))
 
 (rule
  (targets

--- a/test/3d/test_wire_3d.ml
+++ b/test/3d/test_wire_3d.ml
@@ -1361,6 +1361,27 @@ let test_optional_length_prefixed_group_projects () =
       (Sys.file_exists (Filename.concat dir "ProjectedTransferSegment.c"))
   end
 
+(* A bare UINT64 field was once reported as failing EverParse extraction.
+   [generate_c] runs the whole pipeline (F* verification, then C extraction)
+   and raises if EverParse rejects the module, so this pins the shape rather
+   than only its rendering. *)
+let test_bare_uint64_projects () =
+  if not (Wire_3d.has_3d_exe ()) then ()
+  else begin
+    let codec =
+      Codec.v "BareUint64"
+        (fun value -> value)
+        Codec.[ Field.v "value" uint64 $ Fun.id ]
+    in
+    let dir = Filename.temp_dir "wire_3d_bare_uint64" "" in
+    let schema = Everparse.project ~mode:`Ffi codec in
+    Wire_3d.generate_3d ~outdir:dir [ schema ];
+    Wire_3d.generate_c ~outdir:dir [ schema ];
+    Alcotest.(check bool)
+      "C generated for bare uint64" true
+      (Sys.file_exists (Filename.concat dir "BareUint64.c"))
+  end
+
 (* A [nested ~size] / [nested_at_most] field projects through EverParse:
    byte-span and enum inners go through a synthesised wrapper struct, and scalar
    and sub-record inners render inline (rather than as an extern setter param
@@ -1468,6 +1489,7 @@ let suite =
         test_field_optional_byte_array;
       Alcotest.test_case "optional length-prefixed group projects" `Slow
         test_optional_length_prefixed_group_projects;
+      Alcotest.test_case "bare uint64 projects" `Slow test_bare_uint64_projects;
       Alcotest.test_case "nested field projects through EverParse" `Slow
         test_nested_field_projects;
       Alcotest.test_case "e2e: compile + run across naming conventions" `Slow

--- a/test/3d/test_wire_3d.ml
+++ b/test/3d/test_wire_3d.ml
@@ -357,6 +357,16 @@ let diff_bits_codec =
     (fun a b -> (a, b))
     [ Codec.( $ ) fa fst; Codec.( $ ) fb snd ]
 
+let diff_nested_exact_codec =
+  let open Wire in
+  Codec.v "NestedExact" Fun.id
+    Codec.[ Field.v "value" (nested ~size:(int 4) zeroterm) $ Fun.id ]
+
+let diff_nested_at_most_codec =
+  let open Wire in
+  Codec.v "NestedAtMost" Fun.id
+    Codec.[ Field.v "value" (nested_at_most ~size:(int 4) zeroterm) $ Fun.id ]
+
 (* A parameterized codec: the harness must bind the input param in the OCaml
    oracle and pass the same value to the EverParse validator, or a length-bound
    frame can never be checked (the blocker for CCSDS TC/AOS/TM/USLP). *)
@@ -417,6 +427,23 @@ let test_doc_differential_no_params () =
   else
     differential_ok ~name:"plainspec" ~package:"plain-doc" ~corpus:(`Fuzz 100)
       [ Wire_3d.pack diff_enum_codec; Wire_3d.pack diff_range_codec ]
+
+let test_doc_differential_nested_regions () =
+  if not (Wire_3d.has_3d_exe ()) then ()
+  else
+    differential_ok ~name:"nestedspec" ~package:"nested-doc"
+      ~corpus:
+        (`Lines
+           [
+             "NestedExact - 41000000 0";
+             "NestedExact - 41424300 1";
+             "NestedAtMost - 41000000 1";
+             "NestedAtMost - 41424300 1";
+           ])
+      [
+        Wire_3d.pack diff_nested_exact_codec;
+        Wire_3d.pack diff_nested_at_most_codec;
+      ]
 
 (* The installed standalone archive must export only the checked
    [<Base>CheckWire<Codec>] wrappers, not the raw [<Base>Validate*] entry points
@@ -1452,6 +1479,8 @@ let suite =
         test_doc_differential;
       Alcotest.test_case "doc differential no params (needs 3d.exe)" `Quick
         test_doc_differential_no_params;
+      Alcotest.test_case "doc differential nested regions (needs 3d.exe)" `Quick
+        test_doc_differential_nested_regions;
       Alcotest.test_case "doc differential signed (needs 3d.exe)" `Quick
         test_doc_differential_signed;
       Alcotest.test_case "doc differential large payload (needs 3d.exe)" `Quick

--- a/test/3d/test_wire_3d.ml
+++ b/test/3d/test_wire_3d.ml
@@ -542,12 +542,15 @@ let test_archive_hides_raw_validators () =
            ~objcopy:"objcopy" ~ar:"ar" ~archive ~base ~wrappers
     in
     let run cmd =
-      let ic = Unix.open_process_in (Fmt.str "cd %s && %s 2>&1" tmpdir cmd) in
-      let out = In_channel.input_all ic in
-      (out, Unix.close_process_in ic)
+      Fmt.kstr
+        (fun command ->
+          let ic = Unix.open_process_in command in
+          let out = In_channel.input_all ic in
+          (out, Unix.close_process_in ic))
+        "cd %s && %s 2>&1" tmpdir cmd
     in
     let build_out, build_status = run (String.concat " && " steps) in
-    let nm_out, _ = run (Fmt.str "nm %s" archive) in
+    let nm_out, _ = Fmt.kstr run "nm %s" archive in
     ignore (Fmt.kstr Sys.command "rm -rf %s" tmpdir);
     (match build_status with
     | Unix.WEXITED 0 -> ()

--- a/test/3d/test_wire_3d.ml
+++ b/test/3d/test_wire_3d.ml
@@ -394,6 +394,16 @@ let diff_nested_at_most_codec =
   Codec.v "NestedAtMost" Fun.id
     Codec.[ Field.v "value" (nested_at_most ~size:(int 4) zeroterm) $ Fun.id ]
 
+let diff_array_exact_codec =
+  let open Wire in
+  Codec.v "ArrayExact" Fun.id
+    Codec.[ Field.v "items" (array ~len:(int 3) uint8) $ Fun.id ]
+
+let diff_repeat_exact_codec =
+  let open Wire in
+  Codec.v "RepeatExact" Fun.id
+    Codec.[ Field.repeat "items" ~size:(int 4) uint16be $ Fun.id ]
+
 (* A parameterized codec: the harness must bind the input param in the OCaml
    oracle and pass the same value to the EverParse validator, or a length-bound
    frame can never be checked (the blocker for CCSDS TC/AOS/TM/USLP). *)
@@ -470,6 +480,28 @@ let test_doc_differential_nested_regions () =
       [
         Wire_3d.pack diff_nested_exact_codec;
         Wire_3d.pack diff_nested_at_most_codec;
+      ]
+
+let test_doc_differential_region_cardinality () =
+  if not (Wire_3d.has_3d_exe ()) then ()
+  else
+    differential_ok ~name:"invariantspec" ~package:"invariant-doc"
+      ~corpus:
+        (`Lines
+           [
+             "ArrayExact - 010203 1";
+             "ArrayExact - 0102 0";
+             "ArrayExact - 01020304 0";
+             "RepeatExact - 00010002 1";
+             "RepeatExact - 0001 0";
+             "RepeatExact - 000100020003 0";
+             "NestedExact - 41424300 1";
+             "NestedExact - 41000000 0";
+           ])
+      [
+        Wire_3d.pack diff_array_exact_codec;
+        Wire_3d.pack diff_repeat_exact_codec;
+        Wire_3d.pack diff_nested_exact_codec;
       ]
 
 (* The installed standalone archive must export only the checked
@@ -1510,6 +1542,8 @@ let suite =
         test_doc_differential_no_params;
       Alcotest.test_case "doc differential nested regions (needs 3d.exe)" `Quick
         test_doc_differential_nested_regions;
+      Alcotest.test_case "doc differential region/cardinality (needs 3d.exe)"
+        `Quick test_doc_differential_region_cardinality;
       Alcotest.test_case "doc differential signed (needs 3d.exe)" `Quick
         test_doc_differential_signed;
       Alcotest.test_case "doc differential large payload (needs 3d.exe)" `Quick

--- a/test/3d/test_wire_3d.ml
+++ b/test/3d/test_wire_3d.ml
@@ -82,6 +82,33 @@ let test_generate_3d_files () =
   Sys.remove path;
   Unix.rmdir tmpdir
 
+let test_parse_3d_uses_argv_and_cwd () =
+  let outdir = Filename.temp_dir "wire 3d;out " "" in
+  let bindir = Filename.temp_dir "wire 3d;bin " "" in
+  let exe = Filename.concat bindir "3d.exe" in
+  let observed = Filename.concat outdir "observed" in
+  let file = "schema name;literal.3d" in
+  let old_path = Sys.getenv_opt "PATH" in
+  Fun.protect
+    ~finally:(fun () ->
+      Unix.putenv "PATH" (Option.value ~default:"" old_path);
+      Wire_3d.rm_rf outdir;
+      Wire_3d.rm_rf bindir)
+    (fun () ->
+      Out_channel.with_open_text exe (fun oc ->
+          output_string oc
+            "#!/bin/sh\n\
+             { pwd; for arg do printf '%s\\n' \"$arg\"; done; } > observed\n");
+      Unix.chmod exe 0o755;
+      Unix.putenv "PATH" bindir;
+      (match Wire_3d.parse_3d ~batch:true ~outdir file with
+      | Ok () -> ()
+      | Error e -> Alcotest.failf "fake EverParse failed: %s" e);
+      Alcotest.(check (list string))
+        "cwd and literal argv"
+        [ Unix.realpath outdir; "--batch"; file ]
+        (In_channel.with_open_text observed In_channel.input_lines))
+
 let test_schema_of_struct () =
   let s = Wire.Everparse.Raw.project_struct ~mode:`Ffi simple_struct in
   (* generate_3d uses the schema -- check we can produce a .3d file *)
@@ -1461,6 +1488,8 @@ let suite =
       Alcotest.test_case "everparse_name" `Quick test_everparse_name;
       Alcotest.test_case "pascal_case" `Quick test_pascal_case;
       Alcotest.test_case "generate 3d files" `Quick test_generate_3d_files;
+      Alcotest.test_case "parse_3d uses argv and cwd" `Quick
+        test_parse_3d_uses_argv_and_cwd;
       Alcotest.test_case "schema_of_struct" `Quick test_schema_of_struct;
       Alcotest.test_case "ensure_dir" `Quick test_ensure_dir;
       Alcotest.test_case "generate_c (needs 3d.exe)" `Quick test_generate_c;

--- a/test/3d/test_wire_3d.ml
+++ b/test/3d/test_wire_3d.ml
@@ -1318,6 +1318,49 @@ let test_field_optional_byte_array () =
   Alcotest.(check bool)
     "byte-size suffix uses inner size" true (contains out "8")
 
+(* A gate-selected sub-codec may contain a group-local length followed by a
+   repeat and still leave later fields in the parent. Run the full EverParse
+   extraction here: rendering alone would not catch an invalid casetype or
+   dependent repeat in the generated F*. *)
+let test_optional_length_prefixed_group_projects () =
+  if not (Wire_3d.has_3d_exe ()) then ()
+  else begin
+    let f_ext_len = Field.v "ext_items_len" uint8 in
+    let extensions =
+      Codec.v "ProjectedTransferExtensions"
+        (fun len items -> (len, items))
+        Codec.
+          [
+            f_ext_len $ fst;
+            Field.repeat "ext_items" ~size:(Field.ref f_ext_len) uint8 $ snd;
+          ]
+    in
+    let f_start = Field.v "start" uint8 in
+    let f_data_len = Field.v "data_len" uint8 in
+    let codec =
+      Codec.v "ProjectedTransferSegment"
+        (fun start ext data_len data -> (start, ext, data_len, data))
+        Codec.
+          [
+            (f_start $ fun (start, _, _, _) -> start);
+            ( Field.optional "extensions"
+                ~present:Expr.(Field.ref f_start <> int 0)
+                (codec extensions)
+            $ fun (_, ext, _, _) -> ext );
+            (f_data_len $ fun (_, _, data_len, _) -> data_len);
+            ( Field.v "data" (byte_array ~size:(Field.ref f_data_len))
+            $ fun (_, _, _, data) -> data );
+          ]
+    in
+    let dir = Filename.temp_dir "wire_3d_optional_group" "" in
+    let schema = Everparse.project ~mode:`Ffi codec in
+    Wire_3d.generate_3d ~outdir:dir [ schema ];
+    Wire_3d.generate_c ~outdir:dir [ schema ];
+    Alcotest.(check bool)
+      "C generated for conditional group" true
+      (Sys.file_exists (Filename.concat dir "ProjectedTransferSegment.c"))
+  end
+
 (* A [nested ~size] / [nested_at_most] field projects through EverParse:
    byte-span and enum inners go through a synthesised wrapper struct, and scalar
    and sub-record inners render inline (rather than as an extern setter param
@@ -1423,6 +1466,8 @@ let suite =
         test_array_rejects_unsized_elem;
       Alcotest.test_case "Field.optional: byte_array inner projects" `Quick
         test_field_optional_byte_array;
+      Alcotest.test_case "optional length-prefixed group projects" `Slow
+        test_optional_length_prefixed_group_projects;
       Alcotest.test_case "nested field projects through EverParse" `Slow
         test_nested_field_projects;
       Alcotest.test_case "e2e: compile + run across naming conventions" `Slow

--- a/test/bench/dune
+++ b/test/bench/dune
@@ -1,7 +1,7 @@
 (test
  (name test)
  (modules test test_bench_lib test_demo_bench_cases)
- (libraries bench_lib demo_bench_cases alcotest unix))
+ (libraries bench_lib demo_bench_cases alcotest unix fmt))
 
 (executable
  (name bench)

--- a/test/diff/dune
+++ b/test/diff/dune
@@ -26,7 +26,7 @@
 (executable
  (name gen_schemas)
  (modules gen_schemas)
- (libraries schema))
+ (libraries schema wire))
 
 (rule
  (alias gen_schemas)
@@ -46,7 +46,7 @@
 (executable
  (name gen_c)
  (modules gen_c)
- (libraries wire wire.3d wire.stubs unix))
+ (libraries wire wire.3d unix fmt))
 
 (rule
  (alias gen_c)
@@ -94,7 +94,7 @@
 (executable
  (name fuzz_schema)
  (modules fuzz_schema)
- (libraries schema alcobar))
+ (libraries schema alcobar wire))
 
 (rule
  (alias fuzz)

--- a/test/dune
+++ b/test/dune
@@ -1,3 +1,3 @@
 (test
  (name test)
- (libraries wire wire.3d test_helpers alcotest re))
+ (libraries wire test_helpers alcotest re bytesrw fmt optint))

--- a/test/stubs/dune
+++ b/test/stubs/dune
@@ -2,4 +2,4 @@
  (name test)
  (enabled_if
   (= %{env:BUILD_EVERPARSE=} "1"))
- (libraries wire wire.3d wire.stubs net alcotest re unix))
+ (libraries wire wire.3d wire.stubs net alcotest re unix fmt))

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -587,6 +587,50 @@ let test_record_byte_array_padding () =
             (String.sub decoded.uuid 0 5)
       | Error e -> Alcotest.failf "%a" pp_parse_error e)
 
+let codec_seq_array : ('a, 'a array) seq_map =
+  Seq_map
+    {
+      empty = [];
+      add = (fun acc value -> value :: acc);
+      finish = (fun values -> Array.of_list (List.rev values));
+      iter = Array.iter;
+    }
+
+let expect_codec_array_cardinality label codec value expected actual =
+  let buf = Bytes.make 8 '\x7f' in
+  match Codec.encode codec value buf 0 with
+  | () -> Alcotest.failf "%s: expected an array cardinality error" label
+  | exception Invalid_argument msg ->
+      Alcotest.(check bool)
+        (label ^ ": expected count")
+        true
+        (contains ~sub:(Fmt.str "expected %d" expected) msg);
+      Alcotest.(check bool)
+        (label ^ ": actual count") true
+        (contains ~sub:(Fmt.str "got %d" actual) msg);
+      Alcotest.(check string)
+        (label ^ ": buffer unchanged")
+        (String.make 8 '\x7f') (Bytes.to_string buf)
+
+let test_codec_array_cardinality () =
+  let list =
+    Codec.v "ArrayList" Fun.id
+      Codec.[ Field.v "values" (array ~len:(int 3) uint8) $ Fun.id ]
+  in
+  expect_codec_array_cardinality "short list" list [ 1; 2 ] 3 2;
+  expect_codec_array_cardinality "long list" list [ 1; 2; 3; 4 ] 3 4;
+  let custom =
+    Codec.v "ArrayCustom" Fun.id
+      Codec.
+        [
+          Field.v "values" (array_seq codec_seq_array ~len:(int 3) uint8)
+          $ Fun.id;
+        ]
+  in
+  expect_codec_array_cardinality "short custom sequence" custom [| 1; 2 |] 3 2;
+  expect_codec_array_cardinality "long custom sequence" custom [| 1; 2; 3; 4 |]
+    3 4
+
 (* Field.repeat over a zeroterm element: a list of NUL-terminated strings
    within a byte budget. Used to raise Failure at decode; now decodes and
    projects through a synthesised element struct. *)
@@ -6061,6 +6105,8 @@ let suite =
         test_record_byte_array_roundtrip;
       Alcotest.test_case "record: byte_array padding" `Quick
         test_record_byte_array_padding;
+      Alcotest.test_case "array: encode cardinality" `Quick
+        test_codec_array_cardinality;
       Alcotest.test_case "repeat: zeroterm element roundtrip" `Quick
         test_repeat_zeroterm_element;
       Alcotest.test_case "repeat: zeroterm element projection" `Quick

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -77,6 +77,32 @@ let test_record_roundtrip () =
             "c roundtrip" (Optint.to_int original.c) (Optint.to_int decoded.c)
       | Error e -> Alcotest.failf "%a" pp_parse_error e)
 
+let test_duplicate_names_rejected () =
+  let check_invalid ~kind ~name f =
+    match f () with
+    | () -> Alcotest.failf "duplicate %s name was accepted" kind
+    | exception Invalid_argument msg ->
+        Alcotest.(check bool) "codec named" true (contains ~sub:"DupNames" msg);
+        Alcotest.(check bool) "kind named" true (contains ~sub:kind msg);
+        Alcotest.(check bool) "duplicate named" true (contains ~sub:name msg)
+  in
+  check_invalid ~kind:"field" ~name:"dup" (fun () ->
+      ignore
+        (Codec.v "DupNames"
+           (fun a b -> (a, b))
+           Codec.[ Field.v "dup" uint8 $ fst; Field.v "dup" uint8 $ snd ]));
+  let first = Param.input "count" uint8 in
+  let second = Param.input "count" uint8 in
+  check_invalid ~kind:"parameter" ~name:"count" (fun () ->
+      ignore
+        (Codec.v "DupNames"
+           (fun a b -> (a, b))
+           Codec.
+             [
+               Field.v "a" (byte_array ~size:(Param.expr first)) $ fst;
+               Field.v "b" (byte_array ~size:(Param.expr second)) $ snd;
+             ]))
+
 let test_struct_of_record () =
   let output = render_3d simple_record_codec in
   Alcotest.(check bool) "contains UINT8" true (contains ~sub:"UINT8" output);
@@ -6097,6 +6123,8 @@ let suite =
       Alcotest.test_case "record: encode" `Quick test_record_encode;
       Alcotest.test_case "record: decode" `Quick test_record_decode;
       Alcotest.test_case "record: roundtrip" `Quick test_record_roundtrip;
+      Alcotest.test_case "record: duplicate names rejected" `Quick
+        test_duplicate_names_rejected;
       Alcotest.test_case "record: struct_of_codec" `Quick test_struct_of_record;
       Alcotest.test_case "record: metadata decode ok" `Quick
         test_codec_metadata_decode_ok;

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -2418,6 +2418,55 @@ let test_bitfield_on_non_bitfield () =
   | _ -> Alcotest.fail "expected error for non-bitfield"
   | exception Invalid_argument _ -> ()
 
+let expect_foreign_env ~op ~codec f =
+  match f () with
+  | _ -> Alcotest.failf "expected Invalid_argument from %s" op
+  | exception Invalid_argument msg ->
+      Alcotest.(check bool) "names the operation" true (contains ~sub:op msg);
+      Alcotest.(check bool) "names the codec" true (contains ~sub:codec msg)
+
+let test_foreign_env_codec_operations () =
+  let p_a = Param.input "limit_a" uint8 in
+  let f_a = Field.v "v" uint8 in
+  let codec_a =
+    Codec.v "EnvA"
+      ~where:Expr.(Field.ref f_a <= Param.expr p_a)
+      Fun.id
+      Codec.[ f_a $ Fun.id ]
+  in
+  let p_b = Param.input "limit_b" uint8 in
+  let f_b = Field.v "v" uint8 in
+  let codec_b =
+    Codec.v "EnvB"
+      ~where:Expr.(Field.ref f_b <= Param.expr p_b)
+      Fun.id
+      Codec.[ f_b $ Fun.id ]
+  in
+  let env_b = Codec.env codec_b |> Param.bind p_b 0xff in
+  let buf = Bytes.of_string "\x01" in
+  expect_foreign_env ~op:"Codec.encode" ~codec:"EnvA" (fun () ->
+      Codec.encode ~env:env_b codec_a 1 buf 0);
+  expect_foreign_env ~op:"Codec.decode" ~codec:"EnvA" (fun () ->
+      Codec.decode ~env:env_b codec_a buf 0);
+  expect_foreign_env ~op:"Codec.validate" ~codec:"EnvA" (fun () ->
+      Codec.validate ~env:env_b codec_a buf 0);
+  let p_c = Param.input "limit_c" uint8 in
+  let p_d = Param.input "floor_d" uint8 in
+  let f_c = Field.v "v" uint8 in
+  let codec_c =
+    Codec.v "EnvC"
+      ~where:
+        Expr.(
+          Field.ref f_c <= Param.expr p_c && Field.ref f_c >= Param.expr p_d)
+      Fun.id
+      Codec.[ f_c $ Fun.id ]
+  in
+  let env_a = Codec.env codec_a |> Param.bind p_a 0xff in
+  expect_foreign_env ~op:"Codec.encode" ~codec:"EnvC" (fun () ->
+      Codec.encode ~env:env_a codec_c 1 buf 0);
+  expect_foreign_env ~op:"Codec.decode" ~codec:"EnvC" (fun () ->
+      Codec.decode ~env:env_a codec_c buf 0)
+
 let test_env_from_wrong_codec () =
   (* Using env from codec1 with get ~env on codec2 *)
   let out1 = Param.output "out_wrong" uint8 in
@@ -2433,12 +2482,8 @@ let test_env_from_wrong_codec () =
   let cf_v2 = Codec.(Field.v "v" uint8 $ fun v -> v) in
   let codec2 = Codec.v "Wrong2" (fun v -> v) [ cf_v2 ] in
   let env1 = Codec.env codec1 in
-  (* Use env1 (from codec1) with codec2's get -- should not crash *)
-  let get_v2 = Staged.unstage (Codec.get ~env:env1 codec2 cf_v2) in
-  (* No action on cf_v2, so env is ignored -- should work fine *)
-  Alcotest.(check int)
-    "wrong env ignored" 0x42
-    (get_v2 (Bytes.of_string "\x42") 0)
+  expect_foreign_env ~op:"Codec.get" ~codec:"Wrong2" (fun () ->
+      Codec.get ~env:env1 codec2 cf_v2)
 
 let test_env_wrongcodec_with_action () =
   (* Using env from a different codec with an action field.
@@ -6167,6 +6212,8 @@ let suite =
         test_set_field_notin_codec;
       Alcotest.test_case "misuse: bitfield on non-bitfield" `Quick
         test_bitfield_on_non_bitfield;
+      Alcotest.test_case "misuse: foreign env codec operations" `Quick
+        test_foreign_env_codec_operations;
       Alcotest.test_case "misuse: env from wrong codec" `Quick
         test_env_from_wrong_codec;
       Alcotest.test_case "misuse: wrong env with action" `Quick

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -1446,6 +1446,38 @@ let test_casetype_wrapped_greedy_not_last_rejected () =
            (fun p tail -> (p, tail))
            Codec.[ Field.v "p" payload $ fst; Field.v "tail" uint8 $ snd ]))
 
+let test_optional_greedy_not_last_rejected () =
+  let greedy =
+    Codec.v "GreedyOptionalBody"
+      (fun n z -> (n, z))
+      Codec.[ Field.v "n" uint8 $ fst; Field.v "z" all_zeros $ snd ]
+  in
+  let check_rejected label field =
+    Alcotest.(check bool)
+      label true
+      (raises_invalid (fun () ->
+           Codec.v "OptionalGreedyNotLast"
+             (fun body tail -> (body, tail))
+             Codec.[ field $ fst; Field.v "tail" uint8 $ snd ]))
+  in
+  check_rejected "present optional greedy body before tail rejected"
+    (Field.optional "body" ~present:Expr.true_ (codec greedy));
+  check_rejected "dynamic optional greedy body before tail rejected"
+    (Field.optional "body" ~present:Expr.(int 1 = int 1) (codec greedy));
+  check_rejected "optional_or greedy body before tail rejected"
+    (Field.optional_or "body" ~present:Expr.true_ ~default:(0, "")
+       (codec greedy));
+  Alcotest.(check bool)
+    "statically absent optional greedy body before tail accepted" false
+    (raises_invalid (fun () ->
+         Codec.v "AbsentOptionalGreedy"
+           (fun body tail -> (body, tail))
+           Codec.
+             [
+               Field.optional "body" ~present:Expr.false_ (codec greedy) $ fst;
+               Field.v "tail" uint8 $ snd;
+             ]))
+
 (* [uint] is a 1-to-7-byte unsigned integer; a literal size outside that range
    is refused at construction. *)
 let test_uint_size_bounds () =
@@ -6380,6 +6412,8 @@ let suite =
         test_casetype_greedy_case_not_last_rejected;
       Alcotest.test_case "casetype wrapped greedy case body must be last" `Quick
         test_casetype_wrapped_greedy_not_last_rejected;
+      Alcotest.test_case "optional greedy body must be last" `Quick
+        test_optional_greedy_not_last_rejected;
       Alcotest.test_case "uint rejects out-of-range size" `Quick
         test_uint_size_bounds;
       Alcotest.test_case "bits rejects out-of-range width" `Quick

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -1089,6 +1089,30 @@ let test_nested_at_most_over_array () =
     "roundtrip" true
     (decode_ok (Codec.decode codec buf 0) = v)
 
+let test_nested_exact_region () =
+  let make name typ =
+    Codec.v name Fun.id Codec.[ Field.v "value" typ $ Fun.id ]
+  in
+  let exact = make "NestedExact" (nested ~size:(int 4) zeroterm) in
+  let at_most = make "NestedAtMost" (nested_at_most ~size:(int 4) zeroterm) in
+  let padded = Bytes.of_string "A\x00\x00\x00" in
+  (match Codec.decode exact padded 0 with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "compiled exact nested accepted trailing padding");
+  Alcotest.(check string)
+    "compiled at-most accepts padding" "A"
+    (decode_ok (Codec.decode at_most padded 0));
+  Alcotest.(check string)
+    "compiled exact accepts full consumption" "ABC"
+    (decode_ok (Codec.decode exact (Bytes.of_string "ABC\x00") 0));
+  (match Codec.size_of_value exact "A" with
+  | _ -> Alcotest.fail "compiled exact nested encode accepted padding"
+  | exception Invalid_argument msg ->
+      Alcotest.(check bool) "nested error" true (contains ~sub:"nested" msg));
+  let buf = Bytes.create 4 in
+  Codec.encode at_most "A" buf 0;
+  Alcotest.(check bytes) "compiled at-most pads" padded buf
+
 (* A casetype whose case body is a [nested] region (a scalar in a fixed span):
    the tag-dispatched case decodes and sizes through the region. *)
 type nest_case = N of int | U of int
@@ -6216,6 +6240,7 @@ let suite =
         test_nested_over_array;
       Alcotest.test_case "nested_at_most over array roundtrip" `Quick
         test_nested_at_most_over_array;
+      Alcotest.test_case "nested exact region" `Quick test_nested_exact_region;
       Alcotest.test_case "casetype nested case body roundtrip" `Quick
         test_casetype_nested_case_body;
       Alcotest.test_case "array rejects non-projectable element" `Quick

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -4377,6 +4377,45 @@ let test_repeat_encode () =
   Alcotest.(check int) "item1.tag" 0x02 (Bytes.get_uint8 buf 4);
   Alcotest.(check int) "item1.value" 0x0002 (Bytes.get_uint16_be buf 5)
 
+let expect_repeat_encode_error label codec value =
+  let buf = Bytes.make 8 '\x7f' in
+  match Codec.encode codec value buf 0 with
+  | () -> Alcotest.failf "%s: expected a repeat byte-budget error" label
+  | exception Invalid_argument msg ->
+      Alcotest.(check bool)
+        (label ^ ": names repeat") true
+        (contains ~sub:"repeat" msg)
+
+let test_repeat_exact_budget () =
+  let f_size = Field.v "size" uint8 in
+  let fixed =
+    Codec.v "RepeatFixedBudget"
+      (fun size items -> (size, items))
+      Codec.
+        [
+          f_size $ fst;
+          Field.repeat "items" ~size:(Field.ref f_size) uint16be $ snd;
+        ]
+  in
+  (match Codec.decode fixed (Bytes.of_string "\x01\xaa") 0 with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "fixed-width repeat accepted a remainder");
+  expect_repeat_encode_error "fixed underrun" fixed (6, [ 1 ]);
+  expect_repeat_encode_error "fixed overshoot" fixed (2, [ 1; 2 ]);
+  let f_var_size = Field.v "size" uint8 in
+  let variable =
+    Codec.v "RepeatVariableBudget"
+      (fun size items -> (size, items))
+      Codec.
+        [
+          f_var_size $ fst;
+          Field.repeat "items" ~size:(Field.ref f_var_size) zeroterm $ snd;
+        ]
+  in
+  match Codec.decode variable (Bytes.of_string "\x01A\x00") 0 with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "variable-width repeat crossed its byte budget"
+
 let test_repeat_roundtrip () =
   let items =
     [
@@ -6474,6 +6513,8 @@ let suite =
       Alcotest.test_case "repeat: decode multiple" `Quick
         test_repeat_decode_multiple;
       Alcotest.test_case "repeat: encode" `Quick test_repeat_encode;
+      Alcotest.test_case "repeat: exact byte budget" `Quick
+        test_repeat_exact_budget;
       Alcotest.test_case "repeat: roundtrip" `Quick test_repeat_roundtrip;
       Alcotest.test_case "repeat: primitive" `Quick test_repeat_primitive;
       Alcotest.test_case "repeat: size_of_value" `Quick

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -2085,12 +2085,13 @@ let test_action_unfired_by_validate () =
       $ fun v -> v)
   in
   let codec = Codec.v "ActionValidate" (fun v -> v) [ cf_v2 ] in
+  let env = Codec.env codec in
   let buf = Bytes.of_string "\x42" in
-  Codec.validate codec buf 0;
+  Codec.validate ~env codec buf 0;
   (* validate does NOT fire actions *)
   Alcotest.(check int)
     "action not fired by validate" 0
-    !(action_out2.Wire.Private.Types.cell ())
+    (Param.get env action_out2)
 
 let test_get_noaction_zero_overhead () =
   (* get on a field without an action should not allocate.
@@ -2334,6 +2335,27 @@ let test_embed_where_enforced () =
   Alcotest.(check int)
     "satisfying value accepted" 5
     (decode_ok (Codec.decode outer (Bytes.make 1 '\x05') 0))
+
+let test_embed_output_param () =
+  let out = Param.output "embedded_out" uint8 in
+  let f_v = Field.v "v" uint8 in
+  let sub_field =
+    Codec.(
+      Field.v "v"
+        ~action:(Action.on_success [ Action.assign out (Field.ref f_v) ])
+        uint8
+      $ Fun.id)
+  in
+  let sub = Codec.v "EmbeddedOutputSub" Fun.id Codec.[ sub_field ] in
+  let outer =
+    Codec.v "EmbeddedOutputOuter" Fun.id
+      Codec.[ Field.v "sub" (codec sub) $ Fun.id ]
+  in
+  let env = Codec.env outer in
+  Alcotest.(check int)
+    "decoded value" 42
+    (decode_ok (Codec.decode ~env outer (Bytes.of_string "\x2A") 0));
+  Alcotest.(check int) "forwarded output" 42 (Param.get env out)
 
 (* A list of param-constrained sub-records within a byte budget, the param
    forwarded through the repeat (the shape that first exposed the gap). *)
@@ -6158,6 +6180,77 @@ let test_encode_var_bytes_no_closure () =
   in
   Alcotest.(check int) "var-bytes encode allocates nothing" 0 words
 
+(* [Codec.get] and [Codec.set] resolve a field's type and offset when the
+   accessor is staged. Pin the per-call contract separately from functional
+   correctness: rebuilding a reader closure returns the right value but still
+   puts pressure on a hot-path minor heap. *)
+type alloc_accessor = {
+  alloc_hi : int;
+  alloc_lo : int;
+  alloc_u8 : int;
+  alloc_u16 : int;
+  alloc_i32 : int;
+}
+
+let alloc_hi = Field.v "Hi" (bits ~width:4 U8)
+let alloc_lo = Field.v "Lo" (bits ~width:4 U8)
+let alloc_u8 = Field.v "U8" uint8
+let alloc_u16 = Field.v "U16" uint16be
+let alloc_i32 = Field.v "I32" int32be
+let alloc_bf_hi = Codec.(alloc_hi $ fun r -> r.alloc_hi)
+let alloc_bf_lo = Codec.(alloc_lo $ fun r -> r.alloc_lo)
+let alloc_bf_u8 = Codec.(alloc_u8 $ fun r -> r.alloc_u8)
+let alloc_bf_u16 = Codec.(alloc_u16 $ fun r -> r.alloc_u16)
+let alloc_bf_i32 = Codec.(alloc_i32 $ fun r -> r.alloc_i32)
+
+let alloc_accessor_codec =
+  Codec.v "AllocAccessor"
+    (fun alloc_hi alloc_lo alloc_u8 alloc_u16 alloc_i32 ->
+      { alloc_hi; alloc_lo; alloc_u8; alloc_u16; alloc_i32 })
+    Codec.[ alloc_bf_hi; alloc_bf_lo; alloc_bf_u8; alloc_bf_u16; alloc_bf_i32 ]
+
+let per_call_words f =
+  ignore (Sys.opaque_identity (f ()));
+  let iters = 200_000 in
+  Gc.full_major ();
+  let before = Gc.minor_words () in
+  for _ = 1 to iters do
+    ignore (Sys.opaque_identity (f ()))
+  done;
+  let after = Gc.minor_words () in
+  int_of_float (Float.round ((after -. before) /. float_of_int iters))
+
+let check_no_per_call_allocation name f =
+  Alcotest.(check int)
+    (Fmt.str "%s allocates nothing" name)
+    0 (per_call_words f)
+
+let test_get_no_allocation () =
+  skip_unless_gc_counters ();
+  let buf = Bytes.make (Codec.wire_size alloc_accessor_codec) '\007' in
+  let get f = Staged.unstage (Codec.get alloc_accessor_codec f) in
+  let get_hi = get alloc_bf_hi
+  and get_u8 = get alloc_bf_u8
+  and get_u16 = get alloc_bf_u16
+  and get_i32 = get alloc_bf_i32 in
+  check_no_per_call_allocation "get bits" (fun () -> get_hi buf 0);
+  check_no_per_call_allocation "get uint8" (fun () -> get_u8 buf 0);
+  check_no_per_call_allocation "get uint16be" (fun () -> get_u16 buf 0);
+  check_no_per_call_allocation "get int32be" (fun () -> get_i32 buf 0)
+
+let test_set_no_allocation () =
+  skip_unless_gc_counters ();
+  let buf = Bytes.make (Codec.wire_size alloc_accessor_codec) '\007' in
+  let set f = Staged.unstage (Codec.set alloc_accessor_codec f) in
+  let set_hi = set alloc_bf_hi
+  and set_u8 = set alloc_bf_u8
+  and set_u16 = set alloc_bf_u16
+  and set_i32 = set alloc_bf_i32 in
+  check_no_per_call_allocation "set bits" (fun () -> set_hi buf 0 3);
+  check_no_per_call_allocation "set uint8" (fun () -> set_u8 buf 0 7);
+  check_no_per_call_allocation "set uint16be" (fun () -> set_u16 buf 0 513);
+  check_no_per_call_allocation "set int32be" (fun () -> set_i32 buf 0 70_000)
+
 (* -- Suite -- *)
 
 let suite =
@@ -6352,6 +6445,8 @@ let suite =
         test_embed_param_requires_env;
       Alcotest.test_case "embed: sub-codec where enforced" `Quick
         test_embed_where_enforced;
+      Alcotest.test_case "embed: output parameter forwarded" `Quick
+        test_embed_output_param;
       Alcotest.test_case "embed: param forwarded through repeat" `Quick
         test_embed_param_repeat;
       Alcotest.test_case "action: output only" `Quick
@@ -6675,4 +6770,8 @@ let suite =
       (* encode allocation *)
       Alcotest.test_case "encode: var-bytes fields allocate nothing" `Quick
         test_encode_var_bytes_no_closure;
+      Alcotest.test_case "get: immediate fields allocate nothing" `Quick
+        test_get_no_allocation;
+      Alcotest.test_case "set: immediate fields allocate nothing" `Quick
+        test_set_no_allocation;
     ] )

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -683,6 +683,81 @@ let test_optional_self_delimiting_codec () =
   Alcotest.(check int) "absent size" 1 n;
   Alcotest.(check (option string)) "absent desc" None d.desc
 
+(* A conditional group can carry its own length prefix and dependent list.
+   Keeping those fields in a sub-codec lets their expressions stay local to
+   the group, while a following payload remains in the parent codec. This is
+   the shape of an optional secondary header that declares its own length. *)
+type transfer_extensions = { items_len : int; items : int list }
+
+let transfer_extensions_codec =
+  let f_len = Field.v "ext_items_len" uint8 in
+  let f_items = Field.repeat "ext_items" ~size:(Field.ref f_len) uint8 in
+  Codec.v "TransferExtensions"
+    (fun items_len items -> { items_len; items })
+    Codec.[ (f_len $ fun r -> r.items_len); (f_items $ fun r -> r.items) ]
+
+type transfer_segment = {
+  start : int;
+  extensions : transfer_extensions option;
+  data_len : int;
+  data : string;
+}
+
+let transfer_segment_codec =
+  let f_start = Field.v "start" uint8 in
+  let f_extensions =
+    Field.optional "extensions"
+      ~present:Expr.(Field.ref f_start <> int 0)
+      (codec transfer_extensions_codec)
+  in
+  let f_data_len = Field.v "data_len" uint8 in
+  let f_data = Field.v "data" (byte_array ~size:(Field.ref f_data_len)) in
+  Codec.v "TransferSegment"
+    (fun start extensions data_len data ->
+      { start; extensions; data_len; data })
+    Codec.
+      [
+        (f_start $ fun r -> r.start);
+        (f_extensions $ fun r -> r.extensions);
+        (f_data_len $ fun r -> r.data_len);
+        (f_data $ fun r -> r.data);
+      ]
+
+let test_optional_length_prefixed_group () =
+  let present =
+    {
+      start = 1;
+      extensions = Some { items_len = 2; items = [ 0xA1; 0xB2 ] };
+      data_len = 3;
+      data = "xyz";
+    }
+  in
+  let n, decoded = roundtrip transfer_segment_codec present in
+  Alcotest.(check int) "present size" 8 n;
+  Alcotest.(check (list int))
+    "extension items" [ 0xA1; 0xB2 ] (Option.get decoded.extensions).items;
+  Alcotest.(check string) "following data" "xyz" decoded.data;
+  let absent = { start = 0; extensions = None; data_len = 2; data = "ok" } in
+  let n, decoded = roundtrip transfer_segment_codec absent in
+  Alcotest.(check int) "absent size" 4 n;
+  Alcotest.(check bool)
+    "extensions absent" true
+    (Option.is_none decoded.extensions);
+  Alcotest.(check string) "following data" "ok" decoded.data;
+  let out = render_3d transfer_segment_codec in
+  Alcotest.(check bool)
+    "group is its own struct" true
+    (contains ~sub:"typedef struct WireTransferExtensions" out);
+  Alcotest.(check bool)
+    "group-local dependent repeat" true
+    (contains ~sub:"UINT8 ext_items[:byte-size ext_items_len]" out);
+  Alcotest.(check bool)
+    "group is gate-selected" true
+    (contains ~sub:"Opt_TransferExtensions(" out);
+  Alcotest.(check bool)
+    "later fields stay in the parent" true
+    (contains ~sub:"UINT8 data[:byte-size data_len]" out)
+
 (* Wire.array over a fixed byte_array element: a fixed-count list of n-byte
    chunks (e.g. an array of IPv4 addresses). Used to project a double
    [:byte-size]; the element is now emitted as bare bytes under the budget. *)
@@ -5949,6 +6024,8 @@ let suite =
         test_optional_var_byte_array;
       Alcotest.test_case "optional: self-delimiting codec inner roundtrip"
         `Quick test_optional_self_delimiting_codec;
+      Alcotest.test_case "optional: length-prefixed group roundtrip" `Quick
+        test_optional_length_prefixed_group;
       Alcotest.test_case "repeat: byte_array element roundtrip" `Quick
         test_repeat_byte_array_element;
       Alcotest.test_case "repeat: byte_array element projection" `Quick

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -1662,23 +1662,47 @@ let test_codec_bitfield_overflow_1bit () =
   Codec.encode codec 0 buf 0;
   Codec.encode codec 1 buf 0
 
-let test_encode_underrun_raises () =
-  (* byte_array ~size:n truncates a value longer than n at write time,
-     while size_of_value reports String.length v. Passing a 5-byte value
-     to a 3-byte field is the simplest underrun: the assertion must fire. *)
-  let codec =
-    Codec.v "Mismatch" Fun.id
-      Codec.[ Field.v "data" (byte_array ~size:(Wire.int 3)) $ Fun.id ]
+let test_fixed_byte_region_size_of_value () =
+  let check_string label typ cases =
+    let codec = Codec.v label Fun.id Codec.[ Field.v "data" typ $ Fun.id ] in
+    List.iter
+      (fun (case, value, expected) ->
+        Alcotest.(check int)
+          (case ^ " size") 3
+          (Codec.size_of_value codec value);
+        let buf = Bytes.create 3 in
+        Codec.encode codec value buf 0;
+        Alcotest.(check bytes) case (Bytes.of_string expected) buf)
+      cases
   in
-  let buf = Bytes.create 5 in
-  match Codec.encode codec "AAAAA" buf 0 with
-  | exception Invalid_argument m
-    when String.length m > 0
-         && contains ~sub:"writer wrote fewer bytes than promised" m ->
-      ()
-  | exception Invalid_argument m ->
-      Alcotest.failf "wrong Invalid_argument message: %s" m
-  | () -> Alcotest.fail "expected underrun assertion to fire"
+  let cases =
+    [
+      ("short", "A", "A\x00\x00");
+      ("exact", "ABC", "ABC");
+      ("long", "ABCDE", "ABC");
+    ]
+  in
+  check_string "FixedBytes" (byte_array ~size:(int 3)) cases;
+  check_string "FixedBytesWhere"
+    (byte_array_where ~size:(int 3) ~per_byte:(fun _ -> Expr.true_))
+    cases;
+  let codec =
+    Codec.v "FixedSlice" Fun.id
+      Codec.[ Field.v "data" (byte_slice ~size:(int 3)) $ Fun.id ]
+  in
+  List.iter
+    (fun (case, value, expected) ->
+      let bytes = Bytes.of_string value in
+      let slice =
+        Bytesrw.Bytes.Slice.make bytes ~first:0 ~length:(Bytes.length bytes)
+      in
+      Alcotest.(check int)
+        (case ^ " slice size") 3
+        (Codec.size_of_value codec slice);
+      let buf = Bytes.create 3 in
+      Codec.encode codec slice buf 0;
+      Alcotest.(check bytes) (case ^ " slice") (Bytes.of_string expected) buf)
+    cases
 
 let test_packed_bf_size () =
   let f_a = Field.v "a" (bits ~width:1 U8) in
@@ -6298,8 +6322,8 @@ let suite =
         test_packed_bf_size;
       Alcotest.test_case "codec bitfield: size_of_value mapped bit" `Quick
         test_packed_mapped_bf_size;
-      Alcotest.test_case "encode: underrun raises" `Quick
-        test_encode_underrun_raises;
+      Alcotest.test_case "fixed byte regions: size_of_value" `Quick
+        test_fixed_byte_region_size_of_value;
       (* action semantics *)
       Alcotest.test_case "action: fires on decode_env" `Quick
         test_action_fires_decode_env;

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -671,6 +671,47 @@ let test_3d_field_sub_mul_rejected () =
     "constant arithmetic still projects" false
     (projects_or_raises constc)
 
+let test_3d_byte_size_mul_bound_rejected () =
+  let construct ~bound ~coeff =
+    let f_count =
+      Field.v "count" uint32 ~self_constraint:(fun count ->
+          Expr.(count <= int bound))
+    in
+    Codec.v "SizedProduct"
+      (fun count data -> (count, data))
+      Codec.
+        [
+          f_count $ fst;
+          Field.v "data" (byte_array ~size:Expr.(Field.ref f_count * int coeff))
+          $ snd;
+        ]
+  in
+  let rejected =
+    match construct ~bound:536_870_912 ~coeff:8 with
+    | _ -> false
+    | exception Invalid_argument msg ->
+        contains ~sub:"byte-size" msg && contains ~sub:"2^32" msg
+  in
+  Alcotest.(check bool) "2^32 maximum rejected clearly" true rejected;
+  Alcotest.(check bool)
+    "maximum below 2^32 remains projectable" false
+    (projects_or_raises (construct ~bound:536_870_911 ~coeff:8));
+  let f_count = Field.v "count" uint32 in
+  let unbounded =
+    Codec.v "UnboundedProduct"
+      (fun count data -> (count, data))
+      Codec.
+        [
+          f_count $ fst;
+          Field.v "data"
+            (byte_array ~size:Expr.(int max_int * Field.ref f_count))
+          $ snd;
+        ]
+  in
+  Alcotest.(check bool)
+    "unbounded products remain EverParse's decision" false
+    (projects_or_raises unbounded)
+
 let test_schema_authoritative () =
   (* [Everparse.project] is the projectability gate: a non-projectable constraint
      raises when the codec is projected, not only later when it is rendered, so
@@ -1388,6 +1429,8 @@ let suite =
         test_3d_arith_constraint_widens;
       Alcotest.test_case "3d: field sub/mul constraint rejected" `Quick
         test_3d_field_sub_mul_rejected;
+      Alcotest.test_case "3d: certain byte-size multiplication overflow" `Quick
+        test_3d_byte_size_mul_bound_rejected;
       Alcotest.test_case "3d: schema is the projectability gate" `Quick
         test_schema_authoritative;
       Alcotest.test_case "3d: array enum element decl" `Quick

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -119,6 +119,28 @@ let test_casetype_enum_tag_labels () =
     "no raw-integer case label" false
     (contains ~sub:"case 2:" output)
 
+let test_casetype_wide_index_error () =
+  let high = Wire.Private.UInt32.be (Bytes.of_string "\x80\x00\x00\x00") 0 in
+  let body =
+    casetype "WideIndex" uint32
+      [ case ~index:high empty ~inject:Fun.id ~project:Option.some ]
+  in
+  let render () =
+    to_3d
+      (module_ [ typedef (struct_ "WideIndexRecord" [ field "body" body ]) ])
+  in
+  if Sys.int_size > 32 then
+    Alcotest.(check bool)
+      "wide case index rendered" true
+      (contains ~sub:"2147483648" (render ()))
+  else
+    match render () with
+    | _ -> Alcotest.fail "expected an unfittable case-index error"
+    | exception Invalid_argument msg ->
+        Alcotest.(check bool)
+          "names the case index" true
+          (contains ~sub:"case index" msg)
+
 let test_pretty_print () =
   let simple =
     struct_ "Simple" [ field "a" uint8; field "b" uint16be; field "c" uint32 ]
@@ -1393,6 +1415,8 @@ let suite =
       Alcotest.test_case "generation: casetype" `Quick test_casetype;
       Alcotest.test_case "generation: casetype enum-tag labels" `Quick
         test_casetype_enum_tag_labels;
+      Alcotest.test_case "generation: wide casetype index error" `Quick
+        test_casetype_wide_index_error;
       Alcotest.test_case "generation: if_then_else projects" `Quick
         test_if_then_else_projects;
       Alcotest.test_case "generation: pretty print" `Quick test_pretty_print;

--- a/test/test_param.ml
+++ b/test/test_param.ml
@@ -8,6 +8,11 @@ open Test_helpers
 (* -- Param.input / Param.output / Param.decl -- *)
 
 let contains ~sub s = Re.execp (Re.compile (Re.str sub)) s
+let err_parse fmt = Fmt.kstr (fun message -> Error message) fmt
+
+let string_error = function
+  | Ok value -> Ok value
+  | Error error -> err_parse "%a" pp_parse_error error
 
 (* Render a one-field struct carrying [p] to 3D for substring assertions. *)
 let render_param_3d p =
@@ -417,6 +422,104 @@ let test_param_size_zero () =
   Alcotest.(check string) "data" "" r.data;
   Alcotest.(check int) "tag" 0xFF r.tag
 
+let test_param_size_reentrant_codec () =
+  let size = Param.input "reentrant_size" uint8 in
+  let codec_ref = ref None in
+  let inner_env_ref = ref None in
+  let inside = ref false in
+  let reenter f =
+    if not !inside then begin
+      inside := true;
+      Fun.protect
+        ~finally:(fun () -> inside := false)
+        (fun () -> f (Option.get !codec_ref) (Option.get !inner_env_ref))
+    end
+  in
+  let trigger =
+    map uint8
+      ~encode:(fun v ->
+        reenter (fun codec env ->
+            let buf = Bytes.create 2 in
+            Codec.encode ~env codec (7, "Z") buf 0);
+        v)
+      ~decode:(fun v ->
+        reenter (fun codec env ->
+            ignore
+              (decode_ok (Codec.decode ~env codec (Bytes.of_string "\x07Z") 0)));
+        v)
+  in
+  let codec =
+    Codec.v "ReentrantParam"
+      (fun tag data -> (tag, data))
+      Codec.
+        [
+          Field.v "Tag" trigger $ fst;
+          Field.v "Data" (byte_array ~size:(Param.expr size)) $ snd;
+        ]
+  in
+  codec_ref := Some codec;
+  let inner_env = Codec.env codec |> Param.bind size 1 in
+  inner_env_ref := Some inner_env;
+  let outer_env = Codec.env codec |> Param.bind size 2 in
+  let buf = Bytes.create 3 in
+  Codec.encode ~env:outer_env codec (9, "AB") buf 0;
+  Alcotest.(check bytes)
+    "outer encode keeps its size" (Bytes.of_string "\x09AB") buf;
+  Alcotest.(check (pair int string))
+    "outer decode keeps its size" (9, "AB")
+    (decode_ok (Codec.decode ~env:outer_env codec buf 0))
+
+let test_param_size_in_casetype () =
+  (* Casetype dispatch must preserve the outer encode context when its selected
+     body is an embedded codec. Otherwise the inner parameter lookup falls back
+     to the unbound sentinel and a param-sized byte field rejects its value. *)
+  let size = Param.input "case_size" uint8 in
+  let inner =
+    Codec.v "ParamCaseBody" Fun.id
+      Codec.[ Field.v "data" (byte_array ~size:(Param.expr size)) $ Fun.id ]
+  in
+  let typ =
+    casetype "ParamCase" uint8
+      [
+        case ~index:1 (codec inner)
+          ~inject:(fun value -> `Body value)
+          ~project:(function `Body value -> Some value);
+      ]
+  in
+  let outer =
+    Codec.v "ParamCaseOuter" Fun.id Codec.[ Field.v "case" typ $ Fun.id ]
+  in
+  let env = Codec.env outer |> Param.bind size 2 in
+  let buf = Bytes.create 3 in
+  Codec.encode ~env outer (`Body "AB") buf 0;
+  Alcotest.(check bytes) "encoded casetype" (Bytes.of_string "\x01AB") buf;
+  Alcotest.(check (result string string))
+    "decoded casetype" (Ok "AB")
+    (match Codec.decode ~env outer buf 0 with
+    | Ok (`Body value) -> Ok value
+    | Error error -> err_parse "%a" pp_parse_error error)
+
+let test_param_through_typ_wrappers () =
+  (* Fixed-size typ wrappers use the scalar fast path. That path must carry the
+     outer context through to an embedded codec's parameterized constraint. *)
+  let limit = Param.input "wrapped_limit" uint8 in
+  let value = Field.v "value" uint8 in
+  let inner =
+    Codec.v "ParamWrappedBody" Fun.id
+      ~where:Expr.(Field.ref value <= Param.expr limit)
+      Codec.[ value $ Fun.id ]
+  in
+  let wrapped = where Expr.true_ (codec inner) in
+  let field = Field.optional "body" ~present:Expr.true_ wrapped in
+  let outer = Codec.v "ParamWrappedOuter" Fun.id Codec.[ field $ Fun.id ] in
+  let env = Codec.env outer |> Param.bind limit 100 in
+  let buf = Bytes.of_string "\x2d" in
+  Alcotest.(check (result (option int) string))
+    "decoded wrapped codec" (Ok (Some 45))
+    (string_error (Codec.decode ~env outer buf 0));
+  Codec.encode ~env outer (Some 45) buf 0;
+  Alcotest.(check bytes) "encoded wrapped codec" (Bytes.of_string "\x2d") buf
+
 (* -- Suite -- *)
 
 let suite =
@@ -460,4 +563,10 @@ let suite =
       Alcotest.test_case "param: different sizes" `Quick
         test_param_size_different_sizes;
       Alcotest.test_case "param: size zero" `Quick test_param_size_zero;
+      Alcotest.test_case "param: re-entrant codec" `Quick
+        test_param_size_reentrant_codec;
+      Alcotest.test_case "param: size inside casetype" `Quick
+        test_param_size_in_casetype;
+      Alcotest.test_case "param: context through typ wrappers" `Quick
+        test_param_through_typ_wrappers;
     ] )

--- a/test/test_param.ml
+++ b/test/test_param.ml
@@ -39,6 +39,30 @@ let test_input_binding () =
   let env = Codec.env c |> Param.bind p 42 in
   Alcotest.(check int) "value" 42 (Param.get env p)
 
+let test_wide_input_binding_error () =
+  let p = Param.input "wide_limit" uint32 in
+  let f_x = Field.v "x" uint8 in
+  let c =
+    Codec.v "WideInputBinding"
+      ~where:Expr.(Field.ref f_x <= Param.expr p)
+      (fun x -> x)
+      Codec.[ f_x $ Fun.id ]
+  in
+  let high = Wire.Private.UInt32.be (Bytes.of_string "\x80\x00\x00\x00") 0 in
+  if Sys.int_size > 32 then begin
+    let env = Codec.env c |> Param.bind p high in
+    Alcotest.(check int32)
+      "wide value" Int32.min_int
+      (Wire.Private.UInt32.to_int32 (Param.get env p))
+  end
+  else
+    match Param.bind p high (Codec.env c) with
+    | _ -> Alcotest.fail "expected an unfittable parameter error"
+    | exception Invalid_argument msg ->
+        Alcotest.(check bool)
+          "names the parameter" true
+          (contains ~sub:"wide_limit" msg)
+
 let test_output_binding () =
   let out = Param.output "out" uint8 in
   let f_x = Field.v "x" uint8 in
@@ -403,6 +427,8 @@ let suite =
       Alcotest.test_case "output spec" `Quick test_output_spec;
       (* bindings *)
       Alcotest.test_case "input binding" `Quick test_input_binding;
+      Alcotest.test_case "wide input binding error" `Quick
+        test_wide_input_binding_error;
       Alcotest.test_case "output binding" `Quick test_output_binding;
       (* runtime: input params *)
       Alcotest.test_case "input param constraint" `Quick

--- a/test/test_param.ml
+++ b/test/test_param.ml
@@ -520,6 +520,73 @@ let test_param_through_typ_wrappers () =
   Codec.encode ~env outer (Some 45) buf 0;
   Alcotest.(check bytes) "encoded wrapped codec" (Bytes.of_string "\x2d") buf
 
+(* -- Concurrent decode -- *)
+
+type barrier = {
+  parties : int;
+  arrived : int Atomic.t;
+  generation : int Atomic.t;
+}
+
+let barrier parties =
+  { parties; arrived = Atomic.make 0; generation = Atomic.make 0 }
+
+let await barrier =
+  let generation = Atomic.get barrier.generation in
+  if Atomic.fetch_and_add barrier.arrived 1 = barrier.parties - 1 then begin
+    Atomic.set barrier.arrived 0;
+    Atomic.incr barrier.generation
+  end
+  else
+    while Atomic.get barrier.generation = generation do
+      Domain.cpu_relax ()
+    done
+
+let test_multi_domain_decode () =
+  (* The mapped fields rendezvous during validation, after their values have
+     been read but before they are written into the codec's scratch slots. If
+     two domains share that scratch, one domain must either fail [b = a] or
+     copy the other domain's output parameter. Independent scratch and eval
+     contexts let both decodes complete with their own values. *)
+  let validation_barrier = barrier 2 in
+  let synchronized_uint8 =
+    map uint8 ~decode:Fun.id ~encode:(fun value ->
+        await validation_barrier;
+        value)
+  in
+  let limit = Param.input "domain_limit" uint8 in
+  let observed = Param.output "domain_observed" uint8 in
+  let f_a = Field.v "a" synchronized_uint8 in
+  let f_b = Field.v "b" synchronized_uint8 in
+  let checked_b =
+    Field.v "b" synchronized_uint8
+      ~constraint_:Expr.(Field.ref f_b = Field.ref f_a)
+      ~action:(Action.on_success [ Action.assign observed (Field.ref f_b) ])
+  in
+  let codec =
+    Codec.v "ConcurrentParams"
+      ~where:Expr.(Field.ref f_b <= Param.expr limit)
+      (fun a b -> (a, b))
+      Codec.[ f_a $ fst; checked_b $ snd ]
+  in
+  let worker value =
+    let env = Codec.env codec |> Param.bind limit value in
+    let buf = Bytes.make 2 (Char.chr value) in
+    let ok = ref true in
+    for _ = 1 to 1_000 do
+      match Codec.decode ~env codec buf 0 with
+      | Ok decoded ->
+          if decoded <> (value, value) || Param.get env observed <> value then
+            ok := false
+      | Error _ -> ok := false
+    done;
+    !ok
+  in
+  let first = Domain.spawn (fun () -> worker 0x11) in
+  let second = Domain.spawn (fun () -> worker 0x22) in
+  Alcotest.(check bool) "first domain" true (Domain.join first);
+  Alcotest.(check bool) "second domain" true (Domain.join second)
+
 (* -- Suite -- *)
 
 let suite =
@@ -569,4 +636,6 @@ let suite =
         test_param_size_in_casetype;
       Alcotest.test_case "param: context through typ wrappers" `Quick
         test_param_through_typ_wrappers;
+      Alcotest.test_case "param: multi-domain decode" `Quick
+        test_multi_domain_decode;
     ] )

--- a/test/test_wire.ml
+++ b/test/test_wire.ml
@@ -783,6 +783,84 @@ let test_nested_exact_region_direct () =
   Alcotest.(check string)
     "at-most encode pads" "A\x00\x00\x00" (to_string at_most "A")
 
+type invariant_encoding = Rejected | Encoded of string
+
+let direct_encoding typ value =
+  try Encoded (to_string typ value) with Invalid_argument _ -> Rejected
+
+let compiled_encoding codec value =
+  try
+    let buf = Bytes.create (Codec.size_of_value codec value) in
+    Codec.encode codec value buf 0;
+    Encoded (Bytes.unsafe_to_string buf)
+  with Invalid_argument _ -> Rejected
+
+let check_invariant_encoding label typ codec value =
+  let direct = direct_encoding typ value in
+  let compiled = compiled_encoding codec value in
+  Alcotest.(check bool)
+    (label ^ ": direct and compiled acceptance")
+    true (direct = compiled);
+  match direct with
+  | Rejected ->
+      Alcotest.(check bool)
+        (label ^ ": sizing rejects too")
+        true
+        (match Wire.Private.Types.size_of_typ_value typ value with
+        | _ -> false
+        | exception Invalid_argument _ -> true)
+  | Encoded bytes ->
+      Alcotest.(check int)
+        (label ^ ": direct sizing")
+        (String.length bytes)
+        (Wire.Private.Types.size_of_typ_value typ value);
+      Alcotest.(check int)
+        (label ^ ": compiled sizing")
+        (String.length bytes)
+        (Codec.size_of_value codec value);
+      Alcotest.(check bool)
+        (label ^ ": direct round-trip")
+        true
+        (of_string typ bytes = Ok value);
+      Alcotest.(check bool)
+        (label ^ ": compiled round-trip")
+        true
+        (Codec.decode codec (Bytes.of_string bytes) 0 = Ok value)
+
+let test_region_cardinality_contract () =
+  let array_typ = array ~len:(int 3) uint8 in
+  let array_codec =
+    Codec.v "InvariantArray" Fun.id Codec.[ Field.v "items" array_typ $ Fun.id ]
+  in
+  for n = 0 to 5 do
+    let values = List.init n Fun.id in
+    check_invariant_encoding
+      (Fmt.str "array count %d" n)
+      array_typ array_codec values
+  done;
+  let repeat_typ = Field.typ (Field.repeat "items" ~size:(int 4) uint16be) in
+  let repeat_codec =
+    Codec.v "InvariantRepeat" Fun.id
+      Codec.[ Field.v "items" repeat_typ $ Fun.id ]
+  in
+  for n = 0 to 4 do
+    let values = List.init n Fun.id in
+    check_invariant_encoding
+      (Fmt.str "repeat count %d" n)
+      repeat_typ repeat_codec values
+  done;
+  let nested_typ = nested ~size:(int 4) zeroterm in
+  let nested_codec =
+    Codec.v "InvariantNested" Fun.id
+      Codec.[ Field.v "item" nested_typ $ Fun.id ]
+  in
+  List.iter
+    (fun value ->
+      check_invariant_encoding
+        (Fmt.str "nested value length %d" (String.length value))
+        nested_typ nested_codec value)
+    [ ""; "A"; "AB"; "ABC"; "ABCD" ]
+
 let test_encode_byte_array () =
   let t = byte_array ~size:(int 5) in
   let encoded = to_string t "hello" in
@@ -1250,6 +1328,8 @@ let suite =
         test_repeat_exact_budget_direct;
       Alcotest.test_case "nested: exact region" `Quick
         test_nested_exact_region_direct;
+      Alcotest.test_case "region/cardinality interpreter contract" `Quick
+        test_region_cardinality_contract;
       Alcotest.test_case "encode: byte_array" `Quick test_encode_byte_array;
       Alcotest.test_case "encode: variants" `Quick test_encode_variants;
       Alcotest.test_case "encode: bitfield" `Quick test_encode_bitfield;

--- a/test/test_wire.ml
+++ b/test/test_wire.ml
@@ -4,6 +4,8 @@ open Wire
 open Wire.Everparse.Raw
 open Test_helpers
 
+let contains ~sub s = Re.execp (Re.compile (Re.str sub)) s
+
 (* Helper: parse from a string delivered in slices of [chunk_size] bytes.
    Forces multi-byte values to straddle slice boundaries. *)
 let parse_chunked ~chunk_size typ s =
@@ -708,6 +710,36 @@ let test_encode_array () =
   let encoded = to_string t [ 1; 2; 3 ] in
   Alcotest.(check string) "array encoding" "\x01\x02\x03" encoded
 
+let seq_array : ('a, 'a array) seq_map =
+  Seq_map
+    {
+      empty = [];
+      add = (fun acc value -> value :: acc);
+      finish = (fun values -> Array.of_list (List.rev values));
+      iter = Array.iter;
+    }
+
+let expect_direct_array_cardinality label typ value expected actual =
+  match to_string typ value with
+  | _ -> Alcotest.failf "%s: expected an array cardinality error" label
+  | exception Invalid_argument msg ->
+      Alcotest.(check bool)
+        (label ^ ": expected count")
+        true
+        (contains ~sub:(Fmt.str "expected %d" expected) msg);
+      Alcotest.(check bool)
+        (label ^ ": actual count") true
+        (contains ~sub:(Fmt.str "got %d" actual) msg)
+
+let test_encode_array_cardinality () =
+  let list = array ~len:(int 3) uint8 in
+  expect_direct_array_cardinality "short list" list [ 1; 2 ] 3 2;
+  expect_direct_array_cardinality "long list" list [ 1; 2; 3; 4 ] 3 4;
+  let custom = array_seq seq_array ~len:(int 3) uint8 in
+  expect_direct_array_cardinality "short custom sequence" custom [| 1; 2 |] 3 2;
+  expect_direct_array_cardinality "long custom sequence" custom [| 1; 2; 3; 4 |]
+    3 4
+
 let test_encode_byte_array () =
   let t = byte_array ~size:(int 5) in
   let encoded = to_string t "hello" in
@@ -1169,6 +1201,8 @@ let suite =
       Alcotest.test_case "encode: uint32 le" `Quick test_encode_uint32_le;
       Alcotest.test_case "encode: uint32 be" `Quick test_encode_uint32_be;
       Alcotest.test_case "encode: array" `Quick test_encode_array;
+      Alcotest.test_case "encode: array cardinality" `Quick
+        test_encode_array_cardinality;
       Alcotest.test_case "encode: byte_array" `Quick test_encode_byte_array;
       Alcotest.test_case "encode: variants" `Quick test_encode_variants;
       Alcotest.test_case "encode: bitfield" `Quick test_encode_bitfield;

--- a/test/test_wire.ml
+++ b/test/test_wire.ml
@@ -763,6 +763,26 @@ let test_repeat_exact_budget_direct () =
   | Error _ -> ()
   | Ok _ -> Alcotest.fail "variable-width repeat crossed its byte budget"
 
+let test_nested_exact_region_direct () =
+  let exact = nested ~size:(int 4) zeroterm in
+  let at_most = nested_at_most ~size:(int 4) zeroterm in
+  let expect_parse_error label = function
+    | Error _ -> ()
+    | Ok _ -> Alcotest.failf "%s: accepted an under-consumed exact region" label
+  in
+  expect_parse_error "exact decode" (of_string exact "A\x00\x00\x00");
+  Alcotest.(check (result string reject))
+    "at-most decode" (Ok "A")
+    (of_string at_most "A\x00\x00\x00");
+  Alcotest.(check (result string reject))
+    "exact decode fully consumed" (Ok "ABC")
+    (of_string exact "ABC\x00");
+  Alcotest.check_raises "exact encode rejects padding"
+    (Invalid_argument "Wire.nested: expected 4 bytes, got 2") (fun () ->
+      ignore (to_string exact "A"));
+  Alcotest.(check string)
+    "at-most encode pads" "A\x00\x00\x00" (to_string at_most "A")
+
 let test_encode_byte_array () =
   let t = byte_array ~size:(int 5) in
   let encoded = to_string t "hello" in
@@ -1228,6 +1248,8 @@ let suite =
         test_encode_array_cardinality;
       Alcotest.test_case "repeat: exact byte budget" `Quick
         test_repeat_exact_budget_direct;
+      Alcotest.test_case "nested: exact region" `Quick
+        test_nested_exact_region_direct;
       Alcotest.test_case "encode: byte_array" `Quick test_encode_byte_array;
       Alcotest.test_case "encode: variants" `Quick test_encode_variants;
       Alcotest.test_case "encode: bitfield" `Quick test_encode_bitfield;

--- a/test/test_wire.ml
+++ b/test/test_wire.ml
@@ -740,6 +740,29 @@ let test_encode_array_cardinality () =
   expect_direct_array_cardinality "long custom sequence" custom [| 1; 2; 3; 4 |]
     3 4
 
+let expect_direct_repeat_encode_error label typ value =
+  match to_string typ value with
+  | _ -> Alcotest.failf "%s: expected a repeat byte-budget error" label
+  | exception Invalid_argument msg ->
+      Alcotest.(check bool)
+        (label ^ ": names repeat") true
+        (contains ~sub:"repeat" msg)
+
+let test_repeat_exact_budget_direct () =
+  let fixed = Field.typ (Field.repeat "items" ~size:(int 2) uint16be) in
+  expect_direct_repeat_encode_error "fixed underrun" fixed [];
+  expect_direct_repeat_encode_error "fixed overshoot" fixed [ 1; 2 ];
+  let fixed_remainder =
+    Field.typ (Field.repeat "items" ~size:(int 1) uint16be)
+  in
+  (match of_string fixed_remainder "\x01" with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "fixed-width repeat accepted a remainder");
+  let variable = Field.typ (Field.repeat "items" ~size:(int 1) zeroterm) in
+  match of_string variable "A\x00" with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "variable-width repeat crossed its byte budget"
+
 let test_encode_byte_array () =
   let t = byte_array ~size:(int 5) in
   let encoded = to_string t "hello" in
@@ -1203,6 +1226,8 @@ let suite =
       Alcotest.test_case "encode: array" `Quick test_encode_array;
       Alcotest.test_case "encode: array cardinality" `Quick
         test_encode_array_cardinality;
+      Alcotest.test_case "repeat: exact byte budget" `Quick
+        test_repeat_exact_budget_direct;
       Alcotest.test_case "encode: byte_array" `Quick test_encode_byte_array;
       Alcotest.test_case "encode: variants" `Quick test_encode_variants;
       Alcotest.test_case "encode: bitfield" `Quick test_encode_bitfield;

--- a/test/wasm/dune
+++ b/test/wasm/dune
@@ -24,8 +24,8 @@
  (name test)
  (modes js wasm)
  (libraries wire test_helpers alcotest re bytesrw fmt optint)
- (enabled_if
-  (and
-   %{bin-available:wasm_of_ocaml}
-   %{bin-available:js_of_ocaml}
-   %{bin-available:node})))
+ (enabled_if %{bin-available:node})
+ (js_of_ocaml
+  (enabled_if %{bin-available:js_of_ocaml}))
+ (wasm_of_ocaml
+  (enabled_if %{bin-available:wasm_of_ocaml})))

--- a/test/wasm/dune
+++ b/test/wasm/dune
@@ -22,7 +22,7 @@
 (test
  (name test)
  (modes js wasm)
- (libraries wire wire.3d test_helpers alcotest re)
+ (libraries wire test_helpers alcotest re bytesrw fmt optint)
  (enabled_if
   (and
    %{bin-available:wasm_of_ocaml}

--- a/test/wasm/dune
+++ b/test/wasm/dune
@@ -11,7 +11,8 @@
 
 ; Verbose keeps alcotest away from its per-test output capture, whose
 ; primitives (alcotest_before_test) exist only for native and js_of_ocaml;
-; ALCOTEST_COLUMNS short-circuits the terminal-dimensions one.
+; ALCOTEST_COLUMNS short-circuits the terminal-dimensions one. Remove this
+; override once https://github.com/mirage/alcotest/pull/436 is released.
 
 (env
  (_


### PR DESCRIPTION
Replace the two remaining `#NNN` placeholders in the unreleased changelog with the documentation-coverage PR that introduced those entries.