### PR TITLE
everparse: reject conflicting redeclarations when merging schemas

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,12 @@
 
 ### Fixed
 
+- `Wire.Everparse.write ~mode:`Standalone` now fails with a clear error when
+  two codecs of a family declare different types under the same name, instead
+  of silently emitting the first and generating verified C that enforces the
+  wrong specification for every other codec. Types declared identically by
+  several codecs still collapse to a single emitted declaration (#255, @samoht)
+
 - Parameter-free fixed-offset `Codec.get` and `Codec.set` accessors no longer
   add per-call allocation: direct scalars represented as immediate OCaml
   values, bitfields, enums, and maps whose callbacks return immediate values

--- a/lib/everparse.ml
+++ b/lib/everparse.ml
@@ -633,11 +633,26 @@ let write_ffi ~outdir schemas =
     (fun s -> Types.to_3d_file (Filename.concat outdir (filename s)) s.module_)
     schemas
 
+(* Identity of a declaration for merge purposes: the 3D it renders to on its
+   own. [Types.decl] holds closures (codec and map encode/decode pairs), so
+   polymorphic equality raises on it, and the rendered text is exactly what the
+   merged file would say about the type. Rendering is deterministic: its only
+   render-time global, the anonymous-field counter, is reset per struct.
+   A declaration with no 3D projection raises the same message every time, so
+   two identical ones still compare equal and the projection error surfaces at
+   emit time as before, not as a spurious collision. *)
+let decl_identity d =
+  match Types.to_3d ~enum_as_type:true (Types.module_ [ d ]) with
+  | text -> Ok text
+  | exception e -> Error (Printexc.to_string e)
+
 (* Merge several clean (doc) schemas into one module: union their decls, keeping
    the first definition of each named typedef / enum / casetype so a type shared
    across codecs (a common enum, a refined-byte element) is emitted once.
    Dependency order survives because each input module already lists a type
-   before the typedef that uses it, and the shared type keeps its first slot. *)
+   before the typedef that uses it, and the shared type keeps its first slot.
+   Two schemas declaring different types under one name cannot both be honoured
+   by a single merged spec, so that is rejected rather than resolved silently. *)
 let merge ~name (ts : t list) : t =
   let decl_name = function
     | Types.Typedef { struct_ = { name; _ }; _ } -> Some name
@@ -646,19 +661,28 @@ let merge ~name (ts : t list) : t =
     | _ -> None
   in
   let seen = Hashtbl.create 16 in
-  let keep d =
+  let keep owner d =
     match decl_name d with
     | None -> true
-    | Some n when Hashtbl.mem seen n -> false
-    | Some n ->
-        Hashtbl.add seen n ();
-        true
+    | Some n -> (
+        let identity = decl_identity d in
+        match Hashtbl.find_opt seen n with
+        | None ->
+            Hashtbl.add seen n (owner, identity);
+            true
+        | Some (first_owner, first_identity) ->
+            if first_identity = identity then false
+            else
+              Fmt.invalid_arg
+                "Everparse.write: schemas %S and %S both declare %S with \
+                 different definitions; rename one of them"
+                first_owner owner n)
   in
   let decls =
     List.fold_left
-      (fun acc t ->
+      (fun acc (t : t) ->
         List.fold_left
-          (fun acc d -> if keep d then d :: acc else acc)
+          (fun acc d -> if keep t.name d then d :: acc else acc)
           acc t.module_.decls)
       [] ts
     |> List.rev

--- a/lib/everparse.mli
+++ b/lib/everparse.mli
@@ -141,7 +141,8 @@ val write : ?mode:mode -> outdir:string -> ?name:string -> t list -> unit
     [~name] is ignored. With [`Standalone] (the default), the schemas are merged
     into a single [<name>.3d] -- a type shared across several codecs is emitted
     once -- so a whole protocol family reads as one spec, and [~name] is
-    required. *)
+    required. Raises [Invalid_argument] if two schemas declare different types
+    under the same name, since one merged spec cannot honour both. *)
 
 module Raw : sig
   type nonrec struct_ = struct_

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -1276,7 +1276,8 @@ module Everparse : sig
       and [~name] is ignored. With [`Standalone] (the default), the schemas are
       merged into a single [<name>.3d] -- a type shared across several codecs is
       emitted once -- so a whole protocol family reads as one spec, and [~name]
-      is required. *)
+      is required. Raises [Invalid_argument] if two schemas declare different
+      types under the same name, since one merged spec cannot honour both. *)
 
   module Raw : sig
     (** Escape hatch for manual 3D authoring.

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -474,6 +474,46 @@ let test_doc_merge_dedup () =
     "second struct present" true
     (contains ~sub:"Two" content)
 
+let test_doc_merge_name_collision () =
+  (* Two codecs declaring different types under one name cannot both be honoured
+     by a single merged spec. Emitting the first and dropping the second would
+     hand codec [Two] a C validator enforcing codec [One]'s enum, the exact
+     inverse of what [Two] accepts in OCaml, so the merge is rejected. *)
+  let one = enum "Shared" [ ("A", 0); ("B", 1) ] uint8 in
+  let two = enum "Shared" [ ("X", 7); ("Y", 9) ] uint8 in
+  let codec name e =
+    Codec.v name (fun v -> v) Codec.[ (Field.v "x" e $ fun v -> v) ]
+  in
+  let dir = Filename.get_temp_dir_name () in
+  let write name cs =
+    Everparse.write ~mode:`Standalone ~outdir:dir ~name
+      (List.map (Everparse.project ~mode:`Standalone) cs)
+  in
+  let msg =
+    match
+      write "wire_doc_merge_collision" [ codec "One" one; codec "Two" two ]
+    with
+    | () -> Alcotest.fail "expected a name-collision error"
+    | exception Invalid_argument msg -> msg
+  in
+  Alcotest.(check bool)
+    "names both schemas" true
+    (contains ~sub:{|"One"|} msg && contains ~sub:{|"Two"|} msg);
+  Alcotest.(check bool)
+    "names the colliding declaration" true
+    (contains ~sub:{|"Shared"|} msg);
+  (* Two codecs building their own copy of the same declaration is the normal
+     case for a protocol family and still collapses to one emitted type. *)
+  let copy = enum "Shared" [ ("A", 0); ("B", 1) ] uint8 in
+  let name = "wire_doc_merge_equal_copies" in
+  write name [ codec "One" one; codec "Two" copy ];
+  let path = Filename.concat dir (String.capitalize_ascii name ^ ".3d") in
+  let content = In_channel.with_open_text path In_channel.input_all in
+  Sys.remove path;
+  Alcotest.(check int)
+    "equal copies declared once" 1
+    (List.length (Re.all (Re.compile (Re.str "enum Shared")) content))
+
 let test_doc_field_citation () =
   (* [Field.v ~doc] renders as a plain [/* ... */] comment above the field --
      3d.exe rejects [/*++ --*/] at field position, so the per-field note uses
@@ -1477,6 +1517,8 @@ let suite =
         test_doc_enum_as_type;
       Alcotest.test_case "doc: merge dedups shared types" `Quick
         test_doc_merge_dedup;
+      Alcotest.test_case "doc: merge rejects conflicting redeclaration" `Quick
+        test_doc_merge_name_collision;
       Alcotest.test_case "doc: field ~doc renders as citation comment" `Quick
         test_doc_field_citation;
       Alcotest.test_case "doc: bit order matches schema projection" `Quick


### PR DESCRIPTION
`Wire.Everparse.write` in `Standalone` mode used to keep the first declaration of each name when merging a codec family, so two codecs declaring different types under one name silently produced verified C that enforced the wrong specification for every codec but the first. It now rejects that merge with an error naming both schemas and the colliding name, while declarations that are identical across codecs still collapse to a single emitted type.