### PR TITLE
wire: stop a zero-width repeat element from looping forever

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,11 @@
 
 ### Fixed
 
+- `Field.repeat` and `Field.repeat_seq` now reject a `byte_array` or
+  `byte_slice` element declared with a size of zero, and `Wire.of_string` /
+  `Wire.of_bytes` report an end-of-input error instead of looping forever when
+  a repeat element turns out to consume no bytes (#256, @samoht)
+
 - `Wire.Everparse.write ~mode:`Standalone` now fails with a clear error when
   two codecs of a family declare different types under the same name, instead
   of silently emitting the first and generating verified C that enforces the

--- a/lib/field.ml
+++ b/lib/field.ml
@@ -120,8 +120,10 @@ let rec is_repeat_element : type a. a Types.typ -> bool =
   | Int64 _ | Float32 _ | Float64 _ | Uint_var _ | Zeroterm ->
       true
   (* [Unit] is 0-width: a byte-budget list of it carries no bytes and projects to
-     a zero-size element EverParse refuses to extract, like the [array] case. *)
-  | Byte_array { size = Int _ } | Byte_slice { size = Int _ } -> true
+     a zero-size element EverParse refuses to extract, like the [array] case. A
+     byte span whose declared size is a literal zero (or less) is 0-width for
+     the same reason, so admit only a positive one. *)
+  | Byte_array { size = Int n } | Byte_slice { size = Int n } -> n > 0
   | Codec { codec_struct; _ } ->
       (not (codec_ends_greedy codec_struct)) && Types.struct_nz codec_struct
   | Casetype { cases; _ } ->
@@ -137,8 +139,8 @@ let reject_unprojectable_repeat ~combinator typ =
   if not (is_repeat_element typ) then
     Fmt.invalid_arg
       "Wire.%s: element type does not project to 3D as a repeat element -- the \
-       byte-budget loop only supports fixed-width scalars and byte spans, \
-       NUL-terminated strings, sub-codecs, and casetypes."
+       byte-budget loop only supports fixed-width scalars, byte spans of at \
+       least one byte, NUL-terminated strings, sub-codecs, and casetypes."
       combinator
 
 let repeat name ?constraint_ ?self_constraint ?self_int64 ?action ~size typ =

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -392,6 +392,13 @@ and parse_repeat_loop : type elt seq.
     if off' = region_end then (s.finish acc, off')
     else
       let v, off'' = parse_direct elem buf off' region_end in
+      (* An element that consumes nothing never moves the cursor to
+         [region_end], so the byte-budget loop would spin. A literal zero-size
+         span is refused by [Field.repeat], but a [uint ~size] whose size
+         expression evaluates to zero is only detectable here, so report the
+         same eof [Codec.decode]'s compiled repeat reports for it. *)
+      if off'' <= off' then
+        raise_eof ~at:off' ~expected:(off'' - off') ~got:(region_end - off');
       loop (s.add acc v) off''
   in
   loop s.empty off

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -1195,6 +1195,37 @@ let test_repeat_rejects_unprojectable () =
     (repeat_rejects
        (byte_array_where ~size:(int 2) ~per_byte:(fun _ -> Expr.true_)))
 
+(* A byte span of literal size zero carries no bytes, so a byte-budget list of
+   it has nothing for EverParse to extract and the decoder's loop would never
+   reach the end of its region. Refused at construction like [empty]. *)
+let test_repeat_rejects_zero_width_span () =
+  Alcotest.(check bool)
+    "byte_array of size 0" true
+    (repeat_rejects (byte_array ~size:(int 0)));
+  Alcotest.(check bool)
+    "byte_slice of size 0" true
+    (repeat_rejects (byte_slice ~size:(int 0)));
+  Alcotest.(check bool)
+    "byte_array of negative size" true
+    (repeat_rejects (byte_array ~size:(int (-1))));
+  Alcotest.(check bool)
+    "byte_array of size 0 under a map" true
+    (repeat_rejects
+       (map ~decode:String.length
+          ~encode:(fun _ -> "")
+          (byte_array ~size:(int 0))));
+  Alcotest.(check bool)
+    "repeat_seq over byte_array of size 0" true
+    (match
+       Field.repeat_seq "items" ~seq:seq_list ~size:(int 4)
+         (byte_array ~size:(int 0))
+     with
+    | _ -> false
+    | exception Invalid_argument _ -> true);
+  Alcotest.(check bool)
+    "byte_array of size 1 allowed" false
+    (repeat_rejects (byte_array ~size:(int 1)))
+
 (* A sub-codec whose last field is greedy ([all_bytes] / [all_zeros]) reads the
    rest of the buffer as its tail, so it cannot be a repeat element (the first
    element would consume everything). It is fine standalone. *)
@@ -6407,6 +6438,8 @@ let suite =
         test_repeat_byte_array_projection;
       Alcotest.test_case "repeat: rejects unprojectable element" `Quick
         test_repeat_rejects_unprojectable;
+      Alcotest.test_case "repeat: rejects zero-width byte span" `Quick
+        test_repeat_rejects_zero_width_span;
       Alcotest.test_case "repeat: rejects greedy-tail sub-codec" `Quick
         test_repeat_rejects_greedy_tail_codec;
       Alcotest.test_case "array: byte_array element roundtrip" `Quick

--- a/test/test_wire.ml
+++ b/test/test_wire.ml
@@ -763,6 +763,26 @@ let test_repeat_exact_budget_direct () =
   | Error _ -> ()
   | Ok _ -> Alcotest.fail "variable-width repeat crossed its byte budget"
 
+(* A [uint ~size] whose size expression evaluates to zero consumes no bytes, so
+   the byte-budget loop would never reach the end of its region. The direct
+   decoder reports the same eof the compiled [Codec.decode] repeat reports.
+
+   The size must stay unfoldable, hence [sizeof empty] rather than arithmetic
+   such as [int 1 - int 1]: constant folding would reduce that to a literal
+   zero, which [uint] refuses at construction, and the decoder's guard would
+   never be reached. Do not "simplify" this back to arithmetic. *)
+let test_repeat_zero_width_element_direct () =
+  let zero_width =
+    Field.typ (Field.repeat "items" ~size:(int 4) (uint (sizeof empty)))
+  in
+  match of_string zero_width "abcd" with
+  | Ok _ -> Alcotest.fail "zero-width repeat element accepted"
+  | Error e ->
+      Alcotest.(check string)
+        "reports a zero-byte element"
+        "@0: unexpected EOF: expected 0 bytes, got 4"
+        (Fmt.str "%a" pp_parse_error e)
+
 let test_nested_exact_region_direct () =
   let exact = nested ~size:(int 4) zeroterm in
   let at_most = nested_at_most ~size:(int 4) zeroterm in
@@ -1337,6 +1357,8 @@ let suite =
         test_encode_array_cardinality;
       Alcotest.test_case "repeat: exact byte budget" `Quick
         test_repeat_exact_budget_direct;
+      Alcotest.test_case "repeat: zero-width element" `Quick
+        test_repeat_zero_width_element_direct;
       Alcotest.test_case "nested: exact region" `Quick
         test_nested_exact_region_direct;
       Alcotest.test_case "region/cardinality interpreter contract" `Quick


### PR DESCRIPTION
`Wire.of_string` used to loop forever on a `Field.repeat` whose element consumes no bytes, because the byte-budget loop only stops when the cursor reaches the end of its region.

A byte span declared with a literal size of zero is now refused at construction, and the direct decoder reports the same end-of-input the compiled `Codec.decode` path already reports when the width is only known at decode time.