### PR TITLE
ascii: render every expression constructor in diagrams

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,11 @@
 
 ### Fixed
 
+- `Wire.Ascii` diagrams now render every expression a size or constraint can
+  contain. Bitmasks, shifts, division, casts, conditionals, `sizeof` and
+  parameter references used to print as a bare `?`, so a trailing payload
+  sized by `Wire.rest_bytes` showed up as `(? - ? bytes)` (#257, @samoht)
+
 - `Field.repeat` and `Field.repeat_seq` now reject a `byte_array` or
   `byte_slice` element declared with a size of zero, and `Wire.of_string` /
   `Wire.of_bytes` report an end-of-input error instead of looping forever when

--- a/lib/ascii.ml
+++ b/lib/ascii.ml
@@ -13,61 +13,78 @@ type segment =
   | Fixed of { name : string; bits : int }
   | Variable of { label : string }
 
-(* Render an expression as a short annotation. *)
+(* Render an expression as a short annotation.
+
+   This never raises: a diagram is documentation, so constructs that have no 3D
+   projection ([Field_pos], negative literals) still get a rendering here even
+   though {!Types.pp_expr} rejects them. The match is exhaustive on purpose, so
+   a new expression constructor is a compile error rather than a silent
+   placeholder in the output. *)
 let rec pp_expr : type a. Buffer.t -> a Types.expr -> unit =
- fun buf -> function
+ fun buf expr ->
+  let infix : type b c. b Types.expr -> string -> c Types.expr -> unit =
+   fun a op b ->
+    pp_expr buf a;
+    Buffer.add_string buf op;
+    pp_expr buf b
+  in
+  match expr with
   | Int n -> Buffer.add_string buf (string_of_int n)
   | Int64 n -> Buffer.add_string buf (Int64.to_string n)
   | Bool b -> Buffer.add_string buf (string_of_bool b)
   | Ref (_, name) -> Buffer.add_string buf name
-  | Add (a, b) ->
-      pp_expr buf a;
-      Buffer.add_string buf " + ";
-      pp_expr buf b
-  | Sub (a, b) ->
-      pp_expr buf a;
-      Buffer.add_string buf " - ";
-      pp_expr buf b
-  | Mul (a, b) ->
-      pp_expr buf a;
-      Buffer.add_string buf " * ";
-      pp_expr buf b
-  | Eq (a, b) ->
-      pp_expr buf a;
-      Buffer.add_string buf " == ";
-      pp_expr buf b
-  | Le (a, b) ->
-      pp_expr buf a;
-      Buffer.add_string buf " <= ";
-      pp_expr buf b
-  | Lt (a, b) ->
-      pp_expr buf a;
-      Buffer.add_string buf " < ";
-      pp_expr buf b
-  | Ge (a, b) ->
-      pp_expr buf a;
-      Buffer.add_string buf " >= ";
-      pp_expr buf b
-  | Gt (a, b) ->
-      pp_expr buf a;
-      Buffer.add_string buf " > ";
-      pp_expr buf b
-  | Ne (a, b) ->
-      pp_expr buf a;
-      Buffer.add_string buf " != ";
-      pp_expr buf b
-  | And (a, b) ->
-      pp_expr buf a;
-      Buffer.add_string buf " && ";
-      pp_expr buf b
-  | Or (a, b) ->
-      pp_expr buf a;
-      Buffer.add_string buf " || ";
-      pp_expr buf b
+  | Param_ref p -> Buffer.add_string buf p.name
+  (* A [sizeof] over a fixed-size description is a constant, and the byte count
+     is what the diagram wants to show. *)
+  | Sizeof t -> (
+      match Types.field_wire_size t with
+      | Some n -> Buffer.add_string buf (string_of_int n)
+      | None -> Buffer.add_string buf "sizeof")
+  | Sizeof_this -> Buffer.add_string buf "sizeof(this)"
+  | Field_pos -> Buffer.add_string buf "field_pos"
+  | Add (a, b) -> infix a " + " b
+  | Sub (a, b) -> infix a " - " b
+  | Mul (a, b) -> infix a " * " b
+  | Div (a, b) -> infix a " / " b
+  | Mod (a, b) -> infix a " % " b
+  | Land (a, b) -> infix a " & " b
+  | Land64 (a, b) -> infix a " & " b
+  | Lor (a, b) -> infix a " | " b
+  | Lxor (a, b) -> infix a " ^ " b
+  | Lnot a ->
+      Buffer.add_string buf "~";
+      pp_expr buf a
+  | Lsl (a, b) -> infix a " << " b
+  | Lsr (a, b) -> infix a " >> " b
+  | Lsr64 (a, b) -> infix a " >> " b
+  | Eq (a, b) -> infix a " == " b
+  | Ne (a, b) -> infix a " != " b
+  | Lt (a, b) -> infix a " < " b
+  | Le (a, b) -> infix a " <= " b
+  | Gt (a, b) -> infix a " > " b
+  | Ge (a, b) -> infix a " >= " b
+  | And (a, b) -> infix a " && " b
+  | Or (a, b) -> infix a " || " b
   | Not a ->
       Buffer.add_string buf "!";
       pp_expr buf a
-  | _ -> Buffer.add_string buf "?"
+  | Cast (t, e) ->
+      Buffer.add_string buf
+        (match t with
+        | `U8 -> "(u8) "
+        | `U16 -> "(u16) "
+        | `U32 -> "(u32) "
+        | `U64 -> "(u64) ");
+      pp_expr buf e
+  (* Spelled out rather than as a C ternary: "?" is the one character a reader
+     must be able to trust is never a rendering failure. *)
+  | If_then_else (c, t, e) ->
+      Buffer.add_string buf "if ";
+      pp_expr buf c;
+      Buffer.add_string buf " then ";
+      pp_expr buf t;
+      Buffer.add_string buf " else ";
+      pp_expr buf e
 
 let string_of_expr (type a) (e : a Types.expr) =
   let buf = Buffer.create 32 in

--- a/test/test_ascii.ml
+++ b/test/test_ascii.ml
@@ -111,6 +111,74 @@ let test_variable () =
     "contains data" true
     (Re.execp (Re.compile (Re.str "data")) output)
 
+(* -- Expression rendering --
+
+   Every expression constructor must reach the diagram. A "?" in the output
+   means the printer dropped one, which is what the old catch-all did to masks,
+   shifts, [sizeof] and parameter references. *)
+
+let renders name s expect =
+  let output = Ascii.of_struct s in
+  if String.contains output '?' then
+    Alcotest.failf "%s: expression dropped from diagram:@\n%s" name output;
+  Alcotest.(check bool)
+    (Fmt.str "%s renders %S" name expect)
+    true
+    (Re.execp (Re.compile (Re.str expect)) output)
+
+let len_ref = field_ref (field "len" uint16be)
+
+let sized_by size =
+  struct_ "Sized" [ field "len" uint16be; field "data" (byte_array ~size) ]
+
+let expr_cases =
+  [
+    ("div", Expr.(len_ref / int 4), "len / 4");
+    ("mod", Expr.(len_ref mod int 4), "len % 4");
+    ("land", Expr.(len_ref land int 255), "len & 255");
+    ("lor", Expr.(len_ref lor int 1), "len | 1");
+    ("lxor", Expr.(len_ref lxor int 1), "len ^ 1");
+    ("lnot", Expr.(lnot len_ref), "~len");
+    ("lsl", Expr.(len_ref lsl int 2), "len << 2");
+    ("lsr", Expr.(len_ref lsr int 2), "len >> 2");
+    ("cast", Expr.to_uint8 len_ref, "(u8) len");
+    ( "if_then_else",
+      Expr.(if_then_else (len_ref = int 0) (int 8) len_ref),
+      "if len == 0 then 8 else len" );
+    ("sizeof", sizeof uint32be, "data (4 bytes)");
+    ("sizeof of a variable type", sizeof (byte_array ~size:len_ref), "sizeof");
+    ("sizeof_this", Expr.(len_ref - sizeof_this), "len - sizeof(this)");
+    ("field_pos", Expr.(len_ref + field_pos), "len + field_pos");
+    ("negative literal", Expr.(len_ref + int (-1)), "-1");
+  ]
+
+let test_expr_operators () =
+  List.iter
+    (fun (name, e, expect) -> renders name (sized_by e) expect)
+    expr_cases
+
+(* [Wire.rest_bytes] is the everyday source of both constructors: the trailing
+   payload of a record sized by an input parameter. *)
+let test_param_ref () =
+  let total = Param.input "total" int32be in
+  let s =
+    param_struct "Trailing"
+      [ Param.decl total ]
+      [ field "hdr" uint32be; field "rest" (rest_bytes total) ]
+  in
+  renders "rest_bytes" s "total - sizeof(this)"
+
+let wide self_int64 =
+  struct_ "Wide" [ Field.Named (Field.v "mask" ~self_int64 uint64be) ]
+
+let test_int64_operators () =
+  renders "land64"
+    (wide (fun self -> Expr.(land64 self (int64 255L) = int64 0L)))
+    "mask & 255";
+  renders "lsr64"
+    (wide (fun self -> Expr.(lsr64 self (int 56) = int64 0L)))
+    "mask >> 56"
+
 (* -- Codec rendering --
    [multi_record_codec] lives in {!Test_helpers}. *)
 
@@ -162,6 +230,9 @@ let suite =
       Alcotest.test_case "non-aligned" `Quick test_non_aligned;
       Alcotest.test_case "empty" `Quick test_empty;
       Alcotest.test_case "variable length" `Quick test_variable;
+      Alcotest.test_case "expression operators" `Quick test_expr_operators;
+      Alcotest.test_case "parameter reference" `Quick test_param_ref;
+      Alcotest.test_case "64-bit operators" `Quick test_int64_operators;
       Alcotest.test_case "of_codec" `Quick test_of_codec;
       Alcotest.test_case "pp_codec" `Quick test_pp_codec;
       Alcotest.test_case "pp_struct" `Quick test_pp_struct;


### PR DESCRIPTION
A size or constraint using a bitmask, a shift, a division, `sizeof` or a parameter reference used to render as a bare `?` in an `Ascii` bit diagram, so a `Wire.rest_bytes` payload read as `(? - ? bytes)`.
The catch-all is gone, so a new expression constructor is now a compile error in the diagram printer rather than another silent placeholder.