### PR TITLE
types: drop the Obj-tagged evaluation context

### DIFF
--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -167,7 +167,7 @@ and build_field_encoder_ctx : type a.
       fun runtime buf off v -> enc runtime buf off (encode v)
   | Unit -> fun _runtime _buf off () -> off
   | Codec { codec_encode; _ } ->
-      fun runtime _buf off v -> codec_encode v runtime off
+      fun runtime buf off v -> codec_encode v runtime buf off
   | Casetype { tag; cases; _ } -> build_casetype_encoder_ctx tag cases
   | Array { len = Int expected; elem; seq } ->
       let enc_elem = build_field_encoder_ctx elem in
@@ -214,7 +214,7 @@ and build_field_encoder_ctx : type a.
 
 let build_field_encoder typ =
   let encode = build_field_encoder_ctx typ in
-  fun buf off v -> encode (Types.empty_eval_ctx buf) buf off v
+  fun buf off v -> encode Types.unbound_eval_ctx buf off v
 
 (* An [enum] decodes through its base integer type; validate that the value is
    one of the named cases, raising [Invalid_enum] otherwise, so the decoder
@@ -234,115 +234,94 @@ let enum_check cases closed =
 (** Build a direct field reader that reads at a fixed offset. No tuples, no refs
     \- just pure value read. Caller must ensure the buffer is large enough. *)
 let rec build_field_reader_ctx : type a.
-    a typ -> int -> Types.eval_ctx -> int -> a =
+    a typ -> int -> Types.eval_ctx -> bytes -> int -> a =
  fun typ field_off ->
   match typ with
-  | Uint8 ->
-      fun runtime base ->
-        Bytes.get_uint8 (Types.eval_bytes runtime) (base + field_off)
+  | Uint8 -> fun _runtime buf base -> Bytes.get_uint8 buf (base + field_off)
   | Uint16 Little ->
-      fun runtime base ->
-        Bytes.get_uint16_le (Types.eval_bytes runtime) (base + field_off)
+      fun _runtime buf base -> Bytes.get_uint16_le buf (base + field_off)
   | Uint16 Big ->
-      fun runtime base ->
-        Bytes.get_uint16_be (Types.eval_bytes runtime) (base + field_off)
-  | Uint32 Little ->
-      fun runtime base -> UInt32.le (Types.eval_bytes runtime) (base + field_off)
-  | Uint32 Big ->
-      fun runtime base -> UInt32.be (Types.eval_bytes runtime) (base + field_off)
-  | Uint63 Little ->
-      fun runtime base -> UInt63.le (Types.eval_bytes runtime) (base + field_off)
-  | Uint63 Big ->
-      fun runtime base -> UInt63.be (Types.eval_bytes runtime) (base + field_off)
+      fun _runtime buf base -> Bytes.get_uint16_be buf (base + field_off)
+  | Uint32 Little -> fun _runtime buf base -> UInt32.le buf (base + field_off)
+  | Uint32 Big -> fun _runtime buf base -> UInt32.be buf (base + field_off)
+  | Uint63 Little -> fun _runtime buf base -> UInt63.le buf (base + field_off)
+  | Uint63 Big -> fun _runtime buf base -> UInt63.be buf (base + field_off)
   | Uint64 Little ->
-      fun runtime base ->
-        Bytes.get_int64_le (Types.eval_bytes runtime) (base + field_off)
+      fun _runtime buf base -> Bytes.get_int64_le buf (base + field_off)
   | Uint64 Big ->
-      fun runtime base ->
-        Bytes.get_int64_be (Types.eval_bytes runtime) (base + field_off)
-  | Int8 ->
-      fun runtime base ->
-        Bytes.get_int8 (Types.eval_bytes runtime) (base + field_off)
+      fun _runtime buf base -> Bytes.get_int64_be buf (base + field_off)
+  | Int8 -> fun _runtime buf base -> Bytes.get_int8 buf (base + field_off)
   | Int16 Little ->
-      fun runtime base ->
-        Bytes.get_int16_le (Types.eval_bytes runtime) (base + field_off)
+      fun _runtime buf base -> Bytes.get_int16_le buf (base + field_off)
   | Int16 Big ->
-      fun runtime base ->
-        Bytes.get_int16_be (Types.eval_bytes runtime) (base + field_off)
+      fun _runtime buf base -> Bytes.get_int16_be buf (base + field_off)
   | Int32 Little ->
-      fun runtime base ->
-        Int32.to_int
-          (Bytes.get_int32_le (Types.eval_bytes runtime) (base + field_off))
+      fun _runtime buf base ->
+        Int32.to_int (Bytes.get_int32_le buf (base + field_off))
   | Int32 Big ->
-      fun runtime base ->
-        Int32.to_int
-          (Bytes.get_int32_be (Types.eval_bytes runtime) (base + field_off))
+      fun _runtime buf base ->
+        Int32.to_int (Bytes.get_int32_be buf (base + field_off))
   | Int64 Little ->
-      fun runtime base ->
-        Bytes.get_int64_le (Types.eval_bytes runtime) (base + field_off)
+      fun _runtime buf base -> Bytes.get_int64_le buf (base + field_off)
   | Int64 Big ->
-      fun runtime base ->
-        Bytes.get_int64_be (Types.eval_bytes runtime) (base + field_off)
+      fun _runtime buf base -> Bytes.get_int64_be buf (base + field_off)
   | Float32 Little ->
-      fun runtime base ->
-        Int32.float_of_bits
-          (Bytes.get_int32_le (Types.eval_bytes runtime) (base + field_off))
+      fun _runtime buf base ->
+        Int32.float_of_bits (Bytes.get_int32_le buf (base + field_off))
   | Float32 Big ->
-      fun runtime base ->
-        Int32.float_of_bits
-          (Bytes.get_int32_be (Types.eval_bytes runtime) (base + field_off))
+      fun _runtime buf base ->
+        Int32.float_of_bits (Bytes.get_int32_be buf (base + field_off))
   | Float64 Little ->
-      fun runtime base ->
-        Int64.float_of_bits
-          (Bytes.get_int64_le (Types.eval_bytes runtime) (base + field_off))
+      fun _runtime buf base ->
+        Int64.float_of_bits (Bytes.get_int64_le buf (base + field_off))
   | Float64 Big ->
-      fun runtime base ->
-        Int64.float_of_bits
-          (Bytes.get_int64_be (Types.eval_bytes runtime) (base + field_off))
+      fun _runtime buf base ->
+        Int64.float_of_bits (Bytes.get_int64_be buf (base + field_off))
   | Uint_var { size = Int n; endian } ->
-      fun runtime base ->
-        Uint_var.read endian (Types.eval_bytes runtime) (base + field_off) n
+      fun _runtime buf base -> Uint_var.read endian buf (base + field_off) n
   | Byte_array { size = Int n } ->
-      fun runtime base ->
-        Bytes.sub_string (Types.eval_bytes runtime) (base + field_off) n
+      fun _runtime buf base -> Bytes.sub_string buf (base + field_off) n
   | Byte_array_where { size = Int n; _ } ->
-      fun runtime base ->
-        Bytes.sub_string (Types.eval_bytes runtime) (base + field_off) n
+      fun _runtime buf base -> Bytes.sub_string buf (base + field_off) n
   | Byte_slice { size = Int n } ->
-      fun runtime base ->
-        Slice.make_or_eod (Types.eval_bytes runtime) ~first:(base + field_off)
-          ~length:n
+      fun _runtime buf base ->
+        Slice.make_or_eod buf ~first:(base + field_off) ~length:n
   | Where { inner; _ } -> build_field_reader_ctx inner field_off
   | Enum { base; cases; closed; _ } ->
       let read = build_field_reader_ctx base field_off in
       let check = enum_check cases closed in
-      fun runtime base -> check ~at:(base + field_off) (read runtime base)
+      fun runtime buf base ->
+        check ~at:(base + field_off) (read runtime buf base)
   | Map { inner; decode; _ } ->
       let read = build_field_reader_ctx inner field_off in
-      fun runtime base -> decode (read runtime base)
-  | Unit -> fun _runtime _base -> ()
+      fun runtime buf base -> decode (read runtime buf base)
+  | Unit -> fun _runtime _buf _base -> ()
   (* A fixed-size sub-record / sub-codec as an array or nested element: decode
      it at the element offset. The element must be fixed-width (the Array case
      already gates on [field_wire_size]), so the sub-codec is too. *)
   | Codec { codec_decode; _ } ->
-      fun runtime base -> codec_decode runtime (base + field_off)
+      fun runtime buf base -> codec_decode runtime buf (base + field_off)
   | Array { len = Int n; elem; seq = Seq_map s } -> (
       match field_wire_size elem with
       | Some elem_sz ->
           let read_elem = build_field_reader_ctx elem 0 in
-          fun runtime base ->
+          fun runtime buf base ->
             let acc = Stdlib.ref s.empty in
             for i = 0 to n - 1 do
-              let v = read_elem runtime (base + field_off + (i * elem_sz)) in
+              let v =
+                read_elem runtime buf (base + field_off + (i * elem_sz))
+              in
               acc := s.add !acc v
             done;
             s.finish !acc
       | None ->
-          fun _runtime _base -> failwith "build_field_reader: unsupported type")
-  | _ -> fun _runtime _base -> failwith "build_field_reader: unsupported type"
+          fun _runtime _buf _base ->
+            failwith "build_field_reader: unsupported type")
+  | _ ->
+      fun _runtime _buf _base -> failwith "build_field_reader: unsupported type"
 
 (* [eval_ctx] is necessary for parameter-dependent layouts, but routing every
-   fixed scalar access through it costs a tag test and an indirect buffer load.
+   fixed scalar access through it costs an extra argument and a match per read.
    Keep a direct bytes-only reader for the types whose layout cannot consult an
    environment. The option is resolved once, while [Codec.get] is staged. *)
 let rec build_immediate_reader : type a.
@@ -488,77 +467,82 @@ let raise_field_constraint ~field_idx ~at arr =
    only mirrors values the int can hold; a 64-bit host keeps the direct
    store. *)
 let populate_uint32 idx reader =
-  if Sys.int_size > 32 then fun slots buf base ->
-    set_int_slot slots idx (UInt32.to_int (reader buf base))
-  else fun slots buf base ->
+  if Sys.int_size > 32 then fun slots runtime buf base ->
+    set_int_slot slots idx (UInt32.to_int (reader runtime buf base))
+  else fun slots runtime buf base ->
     Option.iter (set_int_slot slots idx)
-      (Int32.unsigned_to_int (UInt32.to_int32 (reader buf base)))
+      (Int32.unsigned_to_int (UInt32.to_int32 (reader runtime buf base)))
 
 let populate_uint63 idx reader =
-  if Sys.int_size >= 63 then fun slots buf base ->
-    set_int_slot slots idx (UInt63.to_int (reader buf base))
-  else fun slots buf base ->
+  if Sys.int_size >= 63 then fun slots runtime buf base ->
+    set_int_slot slots idx (UInt63.to_int (reader runtime buf base))
+  else fun slots runtime buf base ->
     Option.iter (set_int_slot slots idx)
-      (Int64.unsigned_to_int (Optint.Int63.to_int64 (reader buf base)))
+      (Int64.unsigned_to_int (Optint.Int63.to_int64 (reader runtime buf base)))
+
+let populate_int idx reader slots runtime buf base =
+  set_int_slot slots idx (reader runtime buf base)
+
+(* Floats store their IEEE 754 bit pattern in the int slot so [Ref name] in a
+   constraint sees the value the 3D side sees; a float64 also fills the int64
+   slot with the full pattern, which its predicates read (the int slot cannot
+   hold bits 52-62 on a narrow-int platform). The user-facing reader still
+   returns the [float], reinterpreted via [Int*.float_of_bits] elsewhere. *)
+let populate_float32 idx read slots _runtime buf base =
+  set_int_slot slots idx (Int32.to_int (read buf base))
+
+let populate_float64 idx read slots _runtime buf base =
+  let bits = read buf base in
+  set_int64_slot slots idx bits;
+  set_int_slot slots idx (Int64.to_int bits)
 
 let rec build_populate : type a.
-    a typ -> int -> (runtime -> int -> a) -> slots -> runtime -> int -> unit =
+    a typ ->
+    int ->
+    (runtime -> bytes -> int -> a) ->
+    slots ->
+    runtime ->
+    bytes ->
+    int ->
+    unit =
  fun typ idx reader ->
   match typ with
-  | Uint8 -> fun slots buf base -> set_int_slot slots idx (reader buf base)
-  | Uint16 _ -> fun slots buf base -> set_int_slot slots idx (reader buf base)
+  | Uint8 -> populate_int idx reader
+  | Uint16 _ -> populate_int idx reader
+  | Int8 -> populate_int idx reader
+  | Int16 _ -> populate_int idx reader
+  | Int32 _ -> populate_int idx reader
+  | Bits _ -> populate_int idx reader
   | Uint_var _ -> populate_uint63 idx reader
   | Uint32 _ -> populate_uint32 idx reader
   | Uint63 _ -> populate_uint63 idx reader
-  | Int8 -> fun slots buf base -> set_int_slot slots idx (reader buf base)
-  | Int16 _ -> fun slots buf base -> set_int_slot slots idx (reader buf base)
-  | Int32 _ -> fun slots buf base -> set_int_slot slots idx (reader buf base)
-  | Bits _ -> fun slots buf base -> set_int_slot slots idx (reader buf base)
   (* [Uint64] / [Int64] populate both slots: the full value in [int64s] for
      full-width [Field.int64] refs, and the truncated value in [ints] so legacy
      int-kind [Field.ref] / [Field.int] constraints keep their pre-int64
      behavior instead of silently reading an unpopulated zero. ([has_int64_slot]
      gates the int64 ref API to exactly these types.) *)
   | Uint64 _ ->
-      fun slots buf base ->
-        let v = reader buf base in
+      fun slots runtime buf base ->
+        let v = reader runtime buf base in
         set_int64_slot slots idx v;
         Option.iter (set_int_slot slots idx) (Int64.unsigned_to_int v)
   | Int64 _ ->
-      fun slots buf base ->
-        let v = reader buf base in
+      fun slots runtime buf base ->
+        let v = reader runtime buf base in
         set_int64_slot slots idx v;
         set_int_slot slots idx (Int64.to_int v)
-  (* Floats store their IEEE 754 bit pattern in the int slot so [Ref name] in a
-     constraint sees the value the 3D side sees; a float64 also fills the
-     int64 slot with the full pattern, which its predicates read (the int slot
-     cannot hold bits 52-62 on a narrow-int platform). The user-facing reader
-     still returns the [float], reinterpreted via [Int*.float_of_bits]
-     elsewhere. *)
-  | Float32 Little ->
-      fun slots runtime base ->
-        set_int_slot slots idx
-          (Bytes.get_int32_le (Types.eval_bytes runtime) base |> Int32.to_int)
-  | Float32 Big ->
-      fun slots runtime base ->
-        set_int_slot slots idx
-          (Bytes.get_int32_be (Types.eval_bytes runtime) base |> Int32.to_int)
-  | Float64 Little ->
-      fun slots runtime base ->
-        let bits = Bytes.get_int64_le (Types.eval_bytes runtime) base in
-        set_int64_slot slots idx bits;
-        set_int_slot slots idx (Int64.to_int bits)
-  | Float64 Big ->
-      fun slots runtime base ->
-        let bits = Bytes.get_int64_be (Types.eval_bytes runtime) base in
-        set_int64_slot slots idx bits;
-        set_int_slot slots idx (Int64.to_int bits)
+  | Float32 Little -> populate_float32 idx Bytes.get_int32_le
+  | Float32 Big -> populate_float32 idx Bytes.get_int32_be
+  | Float64 Little -> populate_float64 idx Bytes.get_int64_le
+  | Float64 Big -> populate_float64 idx Bytes.get_int64_be
   | Where { inner; _ } -> build_populate inner idx reader
   | Enum { base; cases; closed; _ } ->
       let check = enum_check cases closed in
-      build_populate base idx (fun buf b -> check ~at:b (reader buf b))
+      build_populate base idx (fun runtime buf b ->
+          check ~at:b (reader runtime buf b))
   | Map { inner; encode; _ } ->
-      build_populate inner idx (fun buf base -> encode (reader buf base))
+      build_populate inner idx (fun runtime buf base ->
+          encode (reader runtime buf base))
   | Optional_or { inner; _ } ->
       (* [Optional_or] returns the inner type directly (no [option] wrapper),
          so the reader is already of the inner's value type. *)
@@ -567,25 +551,27 @@ let rec build_populate : type a.
       (* The optional decodes as ['inner option]; populate from the inner
          value when present, leave the slot at 0 when absent. *)
       let inner_populate =
-        build_populate inner idx (fun buf base ->
-            match reader buf base with Some v -> v | None -> assert false)
+        build_populate inner idx (fun runtime buf base ->
+            match reader runtime buf base with
+            | Some v -> v
+            | None -> assert false)
       in
-      fun slots buf base ->
-        match reader buf base with
-        | Some _ -> inner_populate slots buf base
+      fun slots runtime buf base ->
+        match reader runtime buf base with
+        | Some _ -> inner_populate slots runtime buf base
         | None -> ())
   | Byte_array _ | Byte_slice _ | All_bytes | Unit ->
       (* A plain byte span (or unit) carries no constrained data, so its reader
          only re-slices the buffer. Running it for effect would allocate a string
          or slice per validate with nothing to check; skip it so validating a
          span-only codec stays allocation-free on a hot read path. *)
-      fun _slots _buf _base -> ()
+      fun _slots _runtime _buf _base -> ()
   | _ ->
       (* No int slot to populate, but the reader performs a real decode-side
          check (all-zeros span, NUL terminator, refined span, embedded codec /
          array element constraints), so run it for effect: [Codec.validate] then
          rejects exactly what [decode] does. The value is discarded. *)
-      fun _slots buf base -> ignore (reader buf base)
+      fun _slots runtime buf base -> ignore (reader runtime buf base)
 
 (* Bitfield extraction descriptor: word reader + packed shift/mask.
    Packing shift and mask into a single int lets [extract] be a direct
@@ -599,11 +585,11 @@ type bf_info = {
   bf_mask : Optint.t;
 }
 
-let no_runtime = Types.empty_eval_ctx
+let no_runtime = Types.unbound_eval_ctx
 
-let runtime ?env bytes =
+let runtime ?env () =
   match env with
-  | None -> Types.empty_eval_ctx bytes
+  | None -> no_runtime
   | Some env ->
       let rec find name i =
         if i >= Array.length env.Types.names then -1
@@ -614,7 +600,6 @@ let runtime ?env bytes =
         ~set_param:(fun name value ->
           let i = find name 0 in
           if i >= 0 then env.slots.(i) <- value)
-        bytes
         (fun name ->
           let i = find name 0 in
           if i < 0 then 0 else env.slots.(i))
@@ -627,11 +612,11 @@ type field_access =
       shift : int;
       width : int;
     }
-  | Dynamic of (runtime -> int -> int)
-  | Variable of { off : int; size_fn : runtime -> int -> int }
+  | Dynamic of (runtime -> bytes -> int -> int)
+  | Variable of { off : int; size_fn : runtime -> bytes -> int -> int }
   | Variable_dynamic of {
-      off_fn : runtime -> int -> int;
-      size_fn : runtime -> int -> int;
+      off_fn : runtime -> bytes -> int -> int;
+      size_fn : runtime -> bytes -> int -> int;
     }
 
 type ('a, 'r) field = {
@@ -674,7 +659,7 @@ let struct' = struct_
 type (_, _) readers =
   | Nil : ('f, 'f) readers
   | Snoc :
-      ('full, 'a -> 'rest) readers * (runtime -> int -> 'a)
+      ('full, 'a -> 'rest) readers * (runtime -> bytes -> int -> 'a)
       -> ('full, 'rest) readers
 
 (* Bitfield group state: tracks the current base word being packed. *)
@@ -688,12 +673,12 @@ type bf_codec_state = {
 
 (* Track the byte offset for the next field: static (constant) until we hit
    a variable-size field, then dynamic (computed from the buffer). *)
-type next_off = Static of int | Dynamic of (runtime -> int -> int)
-(* [compute runtime base] returns the absolute byte offset where the next field
-   starts. [base] is the record's base offset in [runtime.buf]. *)
+type next_off = Static of int | Dynamic of (runtime -> bytes -> int -> int)
+(* [compute runtime buf base] returns the absolute byte offset where the next
+   field starts. [base] is the record's base offset in [buf]. *)
 
-type field_reader = string * (runtime -> int -> int)
-(* Name + runtime-and-base reader for a previously-declared int field. *)
+type field_reader = string * (runtime -> bytes -> int -> int)
+(* Name + context/buffer/base reader for a previously-declared int field. *)
 
 (* Single GADT walker for [a expr] used by both call surfaces (closure
    over bytes for variable-size sizing; int_array lookup for constraint
@@ -704,16 +689,16 @@ type field_reader = string * (runtime -> int -> int)
 type packed_param = Pack_param : ('a, 'k) param_handle -> packed_param
 
 (* Leaves resolution strategy for a given access layer. The context is
-   threaded as two curried arguments rather than a single packed value: the
-   closure access layer passes [buf base] with no per-call tuple, and the
-   int-array layer passes [arr ()] with an immediate unit. *)
-type ('c1, 'c2) leaves = {
-  ref_ : string -> 'c1 -> 'c2 -> int;
-  i64 : string -> 'c1 -> 'c2 -> int64;
-  param_ref : packed_param -> 'c1 -> 'c2 -> int;
-  sizeof_typ : packed_typ -> 'c1 -> 'c2 -> int;
-  sizeof_this : 'c1 -> 'c2 -> int;
-  field_pos : 'c1 -> 'c2 -> int;
+   threaded as three curried arguments rather than a single packed value: the
+   closure access layer passes [runtime buf base] with no per-call tuple, and
+   the int-array layer passes [arr () ()] with immediate units. *)
+type ('c1, 'c2, 'c3) leaves = {
+  ref_ : string -> 'c1 -> 'c2 -> 'c3 -> int;
+  i64 : string -> 'c1 -> 'c2 -> 'c3 -> int64;
+  param_ref : packed_param -> 'c1 -> 'c2 -> 'c3 -> int;
+  sizeof_typ : packed_typ -> 'c1 -> 'c2 -> 'c3 -> int;
+  sizeof_this : 'c1 -> 'c2 -> 'c3 -> int;
+  field_pos : 'c1 -> 'c2 -> 'c3 -> int;
 }
 
 (* The shift amount of [Lsr64] is an [int expr]; only constants make sense
@@ -722,21 +707,21 @@ let lsr64_shift_amount : int expr -> int = function
   | Int n -> n
   | _ -> invalid_arg "Wire: Lsr64 shift amount must be a constant"
 
-let rec compile_int64 : type c1 c2.
-    (c1, c2) leaves -> int64 expr -> c1 -> c2 -> int64 =
+let rec compile_int64 : type c1 c2 c3.
+    (c1, c2, c3) leaves -> int64 expr -> c1 -> c2 -> c3 -> int64 =
  fun l e ->
   match e with
-  | Int64 n -> fun _ _ -> n
+  | Int64 n -> fun _ _ _ -> n
   | Ref (I64, name) -> l.i64 name
   | Land64 (a, b) ->
       let fa = compile_int64 l a and fb = compile_int64 l b in
-      fun c1 c2 -> Int64.logand (fa c1 c2) (fb c1 c2)
+      fun c1 c2 c3 -> Int64.logand (fa c1 c2 c3) (fb c1 c2 c3)
   | Lsr64 (a, b) ->
       let fa = compile_int64 l a and n = lsr64_shift_amount b in
-      fun c1 c2 -> Int64.shift_right_logical (fa c1 c2) n
+      fun c1 c2 c3 -> Int64.shift_right_logical (fa c1 c2 c3) n
 
-let try_int64 : type a c1 c2.
-    (c1, c2) leaves -> a expr -> (c1 -> c2 -> int64) option =
+let try_int64 : type a c1 c2 c3.
+    (c1, c2, c3) leaves -> a expr -> (c1 -> c2 -> c3 -> int64) option =
  fun l e ->
   let go e = Some (compile_int64 l e) in
   match e with
@@ -746,12 +731,12 @@ let try_int64 : type a c1 c2.
   | Lsr64 _ as e -> go e
   | _ -> None
 
-let rec compile_int : type c1 c2. (c1, c2) leaves -> int expr -> c1 -> c2 -> int
-    =
+let rec compile_int : type c1 c2 c3.
+    (c1, c2, c3) leaves -> int expr -> c1 -> c2 -> c3 -> int =
  fun l e ->
   let rec_ = compile_int l in
   match e with
-  | Int n -> fun _ _ -> n
+  | Int n -> fun _ _ _ -> n
   | Ref (I, name) -> l.ref_ name
   | Param_ref p -> l.param_ref (Pack_param p)
   | Sizeof t -> l.sizeof_typ (Pack_typ t)
@@ -759,53 +744,53 @@ let rec compile_int : type c1 c2. (c1, c2) leaves -> int expr -> c1 -> c2 -> int
   | Field_pos -> l.field_pos
   | Add (a, b) ->
       let fa = rec_ a and fb = rec_ b in
-      fun c d -> fa c d + fb c d
+      fun c1 c2 c3 -> fa c1 c2 c3 + fb c1 c2 c3
   | Sub (a, b) ->
       let fa = rec_ a and fb = rec_ b in
-      fun c d -> fa c d - fb c d
+      fun c1 c2 c3 -> fa c1 c2 c3 - fb c1 c2 c3
   | Mul (a, b) ->
       let fa = rec_ a and fb = rec_ b in
-      fun c d -> fa c d * fb c d
+      fun c1 c2 c3 -> fa c1 c2 c3 * fb c1 c2 c3
   | Div (a, b) ->
       let fa = rec_ a and fb = rec_ b in
-      fun c d -> fa c d / fb c d
+      fun c1 c2 c3 -> fa c1 c2 c3 / fb c1 c2 c3
   | Mod (a, b) ->
       let fa = rec_ a and fb = rec_ b in
-      fun c d -> fa c d mod fb c d
+      fun c1 c2 c3 -> fa c1 c2 c3 mod fb c1 c2 c3
   | Land (a, b) ->
       let fa = rec_ a and fb = rec_ b in
-      fun c d -> fa c d land fb c d
+      fun c1 c2 c3 -> fa c1 c2 c3 land fb c1 c2 c3
   | Lor (a, b) ->
       let fa = rec_ a and fb = rec_ b in
-      fun c d -> fa c d lor fb c d
+      fun c1 c2 c3 -> fa c1 c2 c3 lor fb c1 c2 c3
   | Lxor (a, b) ->
       let fa = rec_ a and fb = rec_ b in
-      fun c d -> fa c d lxor fb c d
+      fun c1 c2 c3 -> fa c1 c2 c3 lxor fb c1 c2 c3
   | Lnot a ->
       let fa = rec_ a in
-      fun c d -> lnot (fa c d)
+      fun c1 c2 c3 -> lnot (fa c1 c2 c3)
   | Lsl (a, b) ->
       let fa = rec_ a and fb = rec_ b in
-      fun c d -> fa c d lsl fb c d
+      fun c1 c2 c3 -> fa c1 c2 c3 lsl fb c1 c2 c3
   | Lsr (a, b) ->
       let fa = rec_ a and fb = rec_ b in
-      fun c d -> fa c d lsr fb c d
+      fun c1 c2 c3 -> fa c1 c2 c3 lsr fb c1 c2 c3
   | Cast (w, a) -> (
       let fa = rec_ a in
       match w with
-      | `U8 -> fun c d -> fa c d land 0xFF
-      | `U16 -> fun c d -> fa c d land 0xFFFF
-      | `U32 -> fun c d -> fa c d land UInt32.mask32
+      | `U8 -> fun c1 c2 c3 -> fa c1 c2 c3 land 0xFF
+      | `U16 -> fun c1 c2 c3 -> fa c1 c2 c3 land 0xFFFF
+      | `U32 -> fun c1 c2 c3 -> fa c1 c2 c3 land UInt32.mask32
       | `U64 -> fa)
   | If_then_else (c, t, e) ->
       let fc = compile_bool l c in
       let ft = rec_ t and fe = rec_ e in
-      fun c' d' -> if fc c' d' then ft c' d' else fe c' d'
+      fun c1 c2 c3 -> if fc c1 c2 c3 then ft c1 c2 c3 else fe c1 c2 c3
 
 (* Typed-GADT projector: refines [a expr] to [int expr] / [bool expr]
    so [Eq] / [Ne] can dispatch to the right compiler at the right type. *)
-and try_int : type a c1 c2.
-    (c1, c2) leaves -> a expr -> (c1 -> c2 -> int) option =
+and try_int : type a c1 c2 c3.
+    (c1, c2, c3) leaves -> a expr -> (c1 -> c2 -> c3 -> int) option =
  fun l e ->
   let go e = Some (compile_int l e) in
   match e with
@@ -830,8 +815,8 @@ and try_int : type a c1 c2.
   | If_then_else _ as e -> go e
   | _ -> None
 
-and try_bool : type a c1 c2.
-    (c1, c2) leaves -> a expr -> (c1 -> c2 -> bool) option =
+and try_bool : type a c1 c2 c3.
+    (c1, c2, c3) leaves -> a expr -> (c1 -> c2 -> c3 -> bool) option =
  fun l e ->
   let go e = Some (compile_bool l e) in
   match e with
@@ -847,12 +832,12 @@ and try_bool : type a c1 c2.
   | Not _ as e -> go e
   | _ -> None
 
-and compile_bool : type c1 c2. (c1, c2) leaves -> bool expr -> c1 -> c2 -> bool
-    =
+and compile_bool : type c1 c2 c3.
+    (c1, c2, c3) leaves -> bool expr -> c1 -> c2 -> c3 -> bool =
  fun l e ->
   let bool_rec = compile_bool l in
   match e with
-  | Bool b -> fun _ _ -> b
+  | Bool b -> fun _ _ _ -> b
   | Eq (a, b) -> (
       match
         ( try_int l a,
@@ -862,9 +847,12 @@ and compile_bool : type c1 c2. (c1, c2) leaves -> bool expr -> c1 -> c2 -> bool
           try_bool l a,
           try_bool l b )
       with
-      | Some fa, Some fb, _, _, _, _ -> fun c d -> fa c d = fb c d
-      | _, _, Some fa, Some fb, _, _ -> fun c d -> fa c d = fb c d
-      | _, _, _, _, Some fa, Some fb -> fun c d -> fa c d = fb c d
+      | Some fa, Some fb, _, _, _, _ ->
+          fun c1 c2 c3 -> fa c1 c2 c3 = fb c1 c2 c3
+      | _, _, Some fa, Some fb, _, _ ->
+          fun c1 c2 c3 -> fa c1 c2 c3 = fb c1 c2 c3
+      | _, _, _, _, Some fa, Some fb ->
+          fun c1 c2 c3 -> fa c1 c2 c3 = fb c1 c2 c3
       | _ -> assert false)
   | Ne (a, b) -> (
       match
@@ -875,49 +863,55 @@ and compile_bool : type c1 c2. (c1, c2) leaves -> bool expr -> c1 -> c2 -> bool
           try_bool l a,
           try_bool l b )
       with
-      | Some fa, Some fb, _, _, _, _ -> fun c d -> fa c d <> fb c d
-      | _, _, Some fa, Some fb, _, _ -> fun c d -> fa c d <> fb c d
-      | _, _, _, _, Some fa, Some fb -> fun c d -> fa c d <> fb c d
+      | Some fa, Some fb, _, _, _, _ ->
+          fun c1 c2 c3 -> fa c1 c2 c3 <> fb c1 c2 c3
+      | _, _, Some fa, Some fb, _, _ ->
+          fun c1 c2 c3 -> fa c1 c2 c3 <> fb c1 c2 c3
+      | _, _, _, _, Some fa, Some fb ->
+          fun c1 c2 c3 -> fa c1 c2 c3 <> fb c1 c2 c3
       | _ -> assert false)
   | Lt (a, b) -> (
       match (try_int l a, try_int l b, try_int64 l a, try_int64 l b) with
-      | Some fa, Some fb, _, _ -> fun c d -> fa c d < fb c d
+      | Some fa, Some fb, _, _ -> fun c1 c2 c3 -> fa c1 c2 c3 < fb c1 c2 c3
       | _, _, Some fa, Some fb ->
-          fun c d -> Int64.unsigned_compare (fa c d) (fb c d) < 0
+          fun c1 c2 c3 -> Int64.unsigned_compare (fa c1 c2 c3) (fb c1 c2 c3) < 0
       | _ -> assert false)
   | Le (a, b) -> (
       match (try_int l a, try_int l b, try_int64 l a, try_int64 l b) with
-      | Some fa, Some fb, _, _ -> fun c d -> fa c d <= fb c d
+      | Some fa, Some fb, _, _ -> fun c1 c2 c3 -> fa c1 c2 c3 <= fb c1 c2 c3
       | _, _, Some fa, Some fb ->
-          fun c d -> Int64.unsigned_compare (fa c d) (fb c d) <= 0
+          fun c1 c2 c3 ->
+            Int64.unsigned_compare (fa c1 c2 c3) (fb c1 c2 c3) <= 0
       | _ -> assert false)
   | Gt (a, b) -> (
       match (try_int l a, try_int l b, try_int64 l a, try_int64 l b) with
-      | Some fa, Some fb, _, _ -> fun c d -> fa c d > fb c d
+      | Some fa, Some fb, _, _ -> fun c1 c2 c3 -> fa c1 c2 c3 > fb c1 c2 c3
       | _, _, Some fa, Some fb ->
-          fun c d -> Int64.unsigned_compare (fa c d) (fb c d) > 0
+          fun c1 c2 c3 -> Int64.unsigned_compare (fa c1 c2 c3) (fb c1 c2 c3) > 0
       | _ -> assert false)
   | Ge (a, b) -> (
       match (try_int l a, try_int l b, try_int64 l a, try_int64 l b) with
-      | Some fa, Some fb, _, _ -> fun c d -> fa c d >= fb c d
+      | Some fa, Some fb, _, _ -> fun c1 c2 c3 -> fa c1 c2 c3 >= fb c1 c2 c3
       | _, _, Some fa, Some fb ->
-          fun c d -> Int64.unsigned_compare (fa c d) (fb c d) >= 0
+          fun c1 c2 c3 ->
+            Int64.unsigned_compare (fa c1 c2 c3) (fb c1 c2 c3) >= 0
       | _ -> assert false)
   | And (a, b) ->
       let fa = bool_rec a and fb = bool_rec b in
-      fun c d -> fa c d && fb c d
+      fun c1 c2 c3 -> fa c1 c2 c3 && fb c1 c2 c3
   | Or (a, b) ->
       let fa = bool_rec a and fb = bool_rec b in
-      fun c d -> fa c d || fb c d
+      fun c1 c2 c3 -> fa c1 c2 c3 || fb c1 c2 c3
   | Not e ->
       let fe = bool_rec e in
-      fun c d -> not (fe c d)
+      fun c1 c2 c3 -> not (fe c1 c2 c3)
   | Ref _ -> .
 
-(* Runtime access layer: the context carries both the buffer and the immutable
-   parameter environment for this operation. *)
-let bytes_leaves ?(sizeof_this : runtime -> int -> int = fun _ _ -> 0)
-    (env : field_reader list) : (runtime, int) leaves =
+(* Closure access layer: reads leaves out of the buffer, resolving parameters
+   through the operation's immutable evaluation context. *)
+let bytes_leaves
+    ?(sizeof_this : runtime -> bytes -> int -> int = fun _ _ _ -> 0)
+    (env : field_reader list) : (runtime, bytes, int) leaves =
   {
     ref_ =
       (fun name ->
@@ -927,20 +921,21 @@ let bytes_leaves ?(sizeof_this : runtime -> int -> int = fun _ _ -> 0)
             Fmt.invalid_arg "Codec: unbound field ref %S in size expression"
               name);
     i64 =
-      (fun name _ _ ->
+      (fun name _ _ _ ->
         Fmt.invalid_arg
           "Codec: full-width field ref %S is only available in field \
            constraints"
           name);
-    param_ref = (fun (Pack_param p) rt _ -> Types.eval_param rt p.name);
+    param_ref = (fun (Pack_param p) rt _ _ -> Types.eval_param rt p.name);
     sizeof_typ =
       (fun (Pack_typ t) ->
         match field_wire_size t with
-        | Some n -> fun _ _ -> n
+        | Some n -> fun _ _ _ -> n
         | None -> invalid_arg "Codec: sizeof on variable-size type");
     sizeof_this;
     field_pos =
-      (fun _ _ -> invalid_arg "Codec: [field_pos] only valid inside an action");
+      (fun _ _ _ ->
+        invalid_arg "Codec: [field_pos] only valid inside an action");
   }
 
 let compile_expr ?sizeof_this env e =
@@ -968,18 +963,18 @@ type compile_ctx = {
 let mk_ctx ?(sizeof_this = 0) ?(field_pos = 0) ~param_slots idx =
   { idx; sizeof_this; field_pos; param_slots }
 
-let array_leaves (cc : compile_ctx) : (slots, unit) leaves =
+let array_leaves (cc : compile_ctx) : (slots, unit, unit) leaves =
   {
     ref_ =
       (fun name ->
         let i = cc.idx name in
-        fun a () -> a.ints.(i));
+        fun a () () -> a.ints.(i));
     i64 =
       (fun name ->
         let i = cc.idx name in
-        fun a () -> a.int64s.(i));
+        fun a () () -> a.int64s.(i));
     param_ref =
-      (fun (Pack_param p) a () ->
+      (fun (Pack_param p) a () () ->
         (* The per-codec slot map is filled at seal, after these leaves are
            built, so it must be consulted per call. *)
         match Hashtbl.find_opt cc.param_slots p.Types.name with
@@ -988,20 +983,20 @@ let array_leaves (cc : compile_ctx) : (slots, unit) leaves =
     sizeof_typ =
       (fun (Pack_typ t) ->
         let n = field_wire_size t |> Option.value ~default:0 in
-        fun _ () -> n);
-    sizeof_this = (fun _ () -> cc.sizeof_this);
-    field_pos = (fun _ () -> cc.field_pos);
+        fun _ () () -> n);
+    sizeof_this = (fun _ () () -> cc.sizeof_this);
+    field_pos = (fun _ () () -> cc.field_pos);
   }
 
 (* The int-array layer needs only the array, so the second context argument is
    an immediate unit -- threaded here so callers keep the [arr -> _] shape. *)
 let compile_int_arr cc e =
   let f = compile_int (array_leaves cc) e in
-  fun arr -> f arr ()
+  fun arr -> f arr () ()
 
 let compile_bool_arr cc e =
   let f = compile_bool (array_leaves cc) e in
-  fun arr -> f arr ()
+  fun arr -> f arr () ()
 
 (* Compile action statements to operate on an int array instead of Eval.ctx.
    Assign updates the mutable parameter's array slot.
@@ -1073,7 +1068,7 @@ type ('f, 'r) record =
       name : string;
       make : 'full;
       readers : ('full, 'f) readers;
-      writers_rev : ('r -> runtime -> int -> int -> int) list;
+      writers_rev : ('r -> runtime -> bytes -> int -> int -> int) list;
       size_of_value_rev : ('r -> int) list;
           (* Per-field value-driven size functions (one per writer). At
              seal we sum them into [size_of_value]; encode uses that
@@ -1085,9 +1080,11 @@ type ('f, 'r) record =
       next_off : next_off; (* where the next field starts *)
       fields_rev : Types.field list;
       validators_rev :
-        (int (* byte offset *) * (slots -> runtime -> int -> unit)) list;
+        (int (* byte offset *) * (slots -> runtime -> bytes -> int -> unit))
+        list;
       checkers_rev :
-        (int (* byte offset *) * (slots -> runtime -> int -> unit)) list;
+        (int (* byte offset *) * (slots -> runtime -> bytes -> int -> unit))
+        list;
       field_actions_rev : (string * compiled_action) list;
       n_fields : int; (* count of named fields (for field indexing) *)
       n_array_slots : int;
@@ -1104,7 +1101,7 @@ type ('f, 'r) record =
 
 type wire_size_info =
   | Fixed of int
-  | Variable of { min_size : int; compute : runtime -> int -> int }
+  | Variable of { min_size : int; compute : runtime -> bytes -> int -> int }
 
 let id_counter = Atomic.make 0
 
@@ -1115,16 +1112,16 @@ type 'r t = {
   field_access : (string * field_access) list;
   field_readers : field_reader list;
   field_actions : (string * compiled_action) list;
-  decode : runtime -> int -> 'r;
-  encode : 'r -> runtime -> int -> int;
-      (* Public encode entry. [encode v runtime base] writes the record at
+  decode : runtime -> bytes -> int -> 'r;
+  encode : 'r -> runtime -> bytes -> int -> int;
+      (* Public encode entry. [encode v runtime buf base] writes the record at
          [base], threads each per-field writer's return as the next
          writer's [write_off], and returns the final offset. *)
   wire_size : wire_size_info;
   struct_fields : Types.field list;
   validate : ?env_slots:int array -> bytes -> int -> unit;
-  validate_arr : slots -> runtime -> int -> unit;
-  populate : slots -> runtime -> int -> unit;
+  validate_arr : slots -> runtime -> bytes -> int -> unit;
+  populate : slots -> runtime -> bytes -> int -> unit;
   n_array_slots : int;
   decode_scratch : unit -> slots;
       (* Validation scratch, one per domain (see [domain_local_slots]) and
@@ -1469,9 +1466,8 @@ let tag_byte_size : type a. a typ -> int =
   | _ -> ( match field_wire_size typ with Some n -> n | None -> assert false)
 
 (* Read one element of a typ at a given buffer position. Used by Repeat. *)
-let rec read_elem : type a. a typ -> runtime -> int -> a =
- fun typ runtime off ->
-  let buf = Types.eval_bytes runtime in
+let rec read_elem : type a. a typ -> runtime -> bytes -> int -> a =
+ fun typ runtime buf off ->
   match typ with
   | Uint8 -> Bytes.get_uint8 buf off
   | Uint16 Little -> Bytes.get_uint16_le buf off
@@ -1494,14 +1490,15 @@ let rec read_elem : type a. a typ -> runtime -> int -> a =
   | Float64 Little -> Int64.float_of_bits (Bytes.get_int64_le buf off)
   | Float64 Big -> Int64.float_of_bits (Bytes.get_int64_be buf off)
   | Uint_var { size = Int n; endian } -> Uint_var.read endian buf off n
-  | Codec { codec_decode; _ } -> codec_decode runtime off
-  | Map { inner; decode; _ } -> decode (read_elem inner runtime off)
-  | Where { inner; _ } -> read_elem inner runtime off
+  | Codec { codec_decode; _ } -> codec_decode runtime buf off
+  | Map { inner; decode; _ } -> decode (read_elem inner runtime buf off)
+  | Where { inner; _ } -> read_elem inner runtime buf off
   | Enum { base; cases; closed; _ } ->
-      enum_check cases closed ~at:off (read_elem base runtime off)
+      enum_check cases closed ~at:off (read_elem base runtime buf off)
   | Casetype { tag; cases; _ } ->
-      let tag_val = read_elem tag runtime off in
-      read_case_body ~at:off ~tag cases tag_val runtime (off + tag_byte_size tag)
+      let tag_val = read_elem tag runtime buf off in
+      read_case_body ~at:off ~tag cases tag_val runtime buf
+        (off + tag_byte_size tag)
   | Unit -> ()
   (* NUL-terminated string element: the bytes up to (not including) the NUL. *)
   | Zeroterm ->
@@ -1531,20 +1528,27 @@ let rec read_elem : type a. a typ -> runtime -> int -> a =
       | Some esz ->
           let acc = Stdlib.ref s.empty in
           for i = 0 to n - 1 do
-            acc := s.add !acc (read_elem elem runtime (off + (i * esz)))
+            acc := s.add !acc (read_elem elem runtime buf (off + (i * esz)))
           done;
           s.finish !acc)
   (* A nested region as an element: decode its inner at the region start; the
      enclosing region size (padding) is accounted for by the caller. *)
-  | Single_elem { elem; _ } -> read_elem elem runtime off
+  | Single_elem { elem; _ } -> read_elem elem runtime buf off
   | _ -> failwith "read_elem: unsupported element type in repeat"
 
 (* Dispatch a casetype's matched case body. A top-level recursion rather than a
    [let rec find] inside [read_elem]: the inner form would allocate a fresh
    closure on every casetype element decoded. *)
 and read_case_body : type a k.
-    at:int -> tag:k typ -> (a, k) case_branch list -> k -> runtime -> int -> a =
- fun ~at ~tag cases tag_val runtime body_off ->
+    at:int ->
+    tag:k typ ->
+    (a, k) case_branch list ->
+    k ->
+    runtime ->
+    bytes ->
+    int ->
+    a =
+ fun ~at ~tag cases tag_val runtime buf body_off ->
   match cases with
   | [] ->
       (* No branch matched the discriminant. [tag] is integer-typed in the
@@ -1553,15 +1557,14 @@ and read_case_body : type a k.
       raise_invalid_tag ~at (Option.value ~default:0 (Eval.int_of tag tag_val))
   | Case_branch { cb_tag = Some t; cb_inner; cb_inject; _ } :: _
     when t = tag_val ->
-      cb_inject tag_val (read_elem cb_inner runtime body_off)
+      cb_inject tag_val (read_elem cb_inner runtime buf body_off)
   | Case_branch { cb_tag = None; cb_inner; cb_inject; _ } :: _ ->
-      cb_inject tag_val (read_elem cb_inner runtime body_off)
-  | _ :: rest -> read_case_body ~at ~tag rest tag_val runtime body_off
+      cb_inject tag_val (read_elem cb_inner runtime buf body_off)
+  | _ :: rest -> read_case_body ~at ~tag rest tag_val runtime buf body_off
 
 (* Write one element of a typ at a given buffer position. Used by Repeat. *)
-let rec write_elem : type a. a typ -> runtime -> int -> a -> unit =
- fun typ runtime off v ->
-  let buf = Types.eval_bytes runtime in
+let rec write_elem : type a. a typ -> runtime -> bytes -> int -> a -> unit =
+ fun typ runtime buf off v ->
   match typ with
   | Uint8 -> Bytes.set_uint8 buf off v
   | Uint16 Little -> Bytes.set_uint16_le buf off v
@@ -1584,10 +1587,10 @@ let rec write_elem : type a. a typ -> runtime -> int -> a -> unit =
   | Float64 Little -> Bytes.set_int64_le buf off (Int64.bits_of_float v)
   | Float64 Big -> Bytes.set_int64_be buf off (Int64.bits_of_float v)
   | Uint_var { size = Int n; endian } -> Uint_var.write endian buf off n v
-  | Codec { codec_encode; _ } -> ignore (codec_encode v runtime off : int)
-  | Map { inner; encode; _ } -> write_elem inner runtime off (encode v)
-  | Where { inner; _ } -> write_elem inner runtime off v
-  | Enum { base; _ } -> write_elem base runtime off v
+  | Codec { codec_encode; _ } -> ignore (codec_encode v runtime buf off : int)
+  | Map { inner; encode; _ } -> write_elem inner runtime buf off (encode v)
+  | Where { inner; _ } -> write_elem inner runtime buf off v
+  | Enum { base; _ } -> write_elem base runtime buf off v
   | Unit -> ()
   (* Casetype reuses the full field encoder (tag + dispatched body); the
      repeat loop advances by [elem_size_of], so the returned offset is
@@ -1608,18 +1611,17 @@ let rec write_elem : type a. a typ -> runtime -> int -> a -> unit =
 
 (* Compute the wire size of one element at a buffer position. Used by Repeat
    for variable-size elements. *)
-let rec elem_size_of : type a. a typ -> runtime -> int -> int =
- fun typ runtime off ->
-  let buf = Types.eval_bytes runtime in
+let rec elem_size_of : type a. a typ -> runtime -> bytes -> int -> int =
+ fun typ runtime buf off ->
   match typ with
-  | Codec { codec_size_of; _ } -> codec_size_of runtime off
+  | Codec { codec_size_of; _ } -> codec_size_of runtime buf off
   | Casetype { tag; cases; _ } ->
       let tag_size = tag_byte_size tag in
-      let tag_val = read_elem tag runtime off in
+      let tag_val = read_elem tag runtime buf off in
       tag_size
-      + size_case_body ~at:off ~tag cases tag_val runtime (off + tag_size)
-  | Map { inner; _ } -> elem_size_of inner runtime off
-  | Where { inner; _ } -> elem_size_of inner runtime off
+      + size_case_body ~at:off ~tag cases tag_val runtime buf (off + tag_size)
+  | Map { inner; _ } -> elem_size_of inner runtime buf off
+  | Where { inner; _ } -> elem_size_of inner runtime buf off
   (* Bytes up to the NUL plus the one-byte terminator. *)
   | Zeroterm ->
       let nul = zeroterm_nul_pos buf ~first:off ~limit:(Bytes.length buf) in
@@ -1639,17 +1641,23 @@ let rec elem_size_of : type a. a typ -> runtime -> int -> int =
    as [read_case_body]: a per-call [let rec find] would allocate a closure on
    every element. *)
 and size_case_body : type a k.
-    at:int -> tag:k typ -> (a, k) case_branch list -> k -> runtime -> int -> int
-    =
- fun ~at ~tag cases tag_val runtime body_off ->
+    at:int ->
+    tag:k typ ->
+    (a, k) case_branch list ->
+    k ->
+    runtime ->
+    bytes ->
+    int ->
+    int =
+ fun ~at ~tag cases tag_val runtime buf body_off ->
   match cases with
   | [] ->
       raise_invalid_tag ~at (Option.value ~default:0 (Eval.int_of tag tag_val))
   | Case_branch { cb_tag = Some t; cb_inner; _ } :: _ when t = tag_val ->
-      elem_size_of cb_inner runtime body_off
+      elem_size_of cb_inner runtime buf body_off
   | Case_branch { cb_tag = None; cb_inner; _ } :: _ ->
-      elem_size_of cb_inner runtime body_off
-  | _ :: rest -> size_case_body ~at ~tag rest tag_val runtime body_off
+      elem_size_of cb_inner runtime buf body_off
+  | _ :: rest -> size_case_body ~at ~tag rest tag_val runtime buf body_off
 
 (* -- Compiled field: intermediate plan for one field's contribution -- *)
 
@@ -1657,28 +1665,28 @@ and size_case_body : type a k.
    record state. The per-type [compile_*] helpers build one; [apply_compiled]
    consumes it and produces the updated record state. *)
 type ('a, 'r) compiled_field = {
-  raw_reader : runtime -> int -> 'a;
-  raw_writer : 'r -> runtime -> int -> int -> int;
-      (* [raw_writer v runtime base write_off] writes the field's bytes
-         starting at [write_off] in [runtime.buf] and returns the offset just
+  raw_reader : runtime -> bytes -> int -> 'a;
+  raw_writer : 'r -> runtime -> bytes -> int -> int -> int;
+      (* [raw_writer v runtime buf base write_off] writes the field's bytes
+         starting at [write_off] in [buf] and returns the offset just
          after them. [base] is the record's base offset, used by
          buffer-driven helpers (size cross-checks, dynamic-gate cross
          checks) -- the field's own write position comes from
          [write_off]. *)
-  extra_writers : ('r -> runtime -> int -> int -> int) list;
+  extra_writers : ('r -> runtime -> bytes -> int -> int -> int) list;
       (* Writers that run strictly before [raw_writer] -- e.g. a bf_clear that
          opens a new packed base word. Returns the input [write_off] unchanged. *)
   field_access : field_access;
   size_delta : int; (* added to [min_wire_size] *)
   next_off : next_off; (* new [next_off] *)
   bf_after : bf_codec_state option;
-  int_reader : runtime -> int -> int;
+  int_reader : runtime -> bytes -> int -> int;
       (* Entry stored in [field_readers] under the field name; const 0 for
          composite types that have no int-array slot of their own. *)
   nested_readers : field_reader list;
       (* Embedded sub-codec field readers, shifted into the parent frame. *)
   validator_off : int; (* [-1] when the byte offset is dynamic *)
-  populate : slots -> runtime -> int -> unit;
+  populate : slots -> runtime -> bytes -> int -> unit;
       (* Pre-built populate function for the int-array validator path; the
          slot index (n_fields at the time the field is compiled) is baked
          in. Composite types use a no-op. *)
@@ -1708,10 +1716,10 @@ let layout_ctx_of : type f r. (f, r) record -> layout_ctx =
 let static_off_of (ctx : layout_ctx) : int option =
   match ctx.next_off with Static n -> Some n | Dynamic _ -> None
 
-let off_fn_of (ctx : layout_ctx) : runtime -> int -> int =
+let off_fn_of (ctx : layout_ctx) : runtime -> bytes -> int -> int =
   match ctx.next_off with
-  | Static n -> fun _runtime _base -> n
-  | Dynamic f -> fun runtime base -> f runtime base - base
+  | Static n -> fun _runtime _buf _base -> n
+  | Dynamic f -> fun runtime buf base -> f runtime buf base - base
 
 (* Byte offset used as [sizeof_this] when compiling constraints/actions: a
    real static offset when known, the [-1] sentinel otherwise. *)
@@ -1735,53 +1743,54 @@ let require_static_off (ctx : layout_ctx) ~what : int =
 let advance_next_off (no : next_off) (n : int) : next_off =
   match no with
   | Static k -> Static (k + n)
-  | Dynamic f -> Dynamic (fun buf base -> f buf base + n)
+  | Dynamic f -> Dynamic (fun runtime buf base -> f runtime buf base + n)
 
-let null_int_reader : runtime -> int -> int = fun _runtime _base -> 0
+let null_int_reader : runtime -> bytes -> int -> int =
+ fun _runtime _buf _base -> 0
 
-let no_populate : slots -> runtime -> int -> unit =
- fun _arr _runtime _base -> ()
+let no_populate : slots -> runtime -> bytes -> int -> unit =
+ fun _arr _runtime _buf _base -> ()
 
 (* Reader+writer pair for a Codec-or-scalar inner type placed at the current
    frame offset. Extracted so [compile_optional] and [compile_optional_or]
    share it. *)
 let inner_codec_accessors : type w.
-    w typ -> layout_ctx -> (runtime -> int -> w) * (runtime -> int -> w -> int)
-    =
+    w typ ->
+    layout_ctx ->
+    (runtime -> bytes -> int -> w) * (runtime -> bytes -> int -> w -> int) =
  fun inner ctx ->
   let field_off_static = static_off_of ctx in
   let field_off_fn = off_fn_of ctx in
-  let reader : runtime -> int -> w =
+  let reader : runtime -> bytes -> int -> w =
     match inner with
     | Codec { codec_decode; _ } -> (
         match field_off_static with
-        | Some fo -> fun runtime base -> codec_decode runtime (base + fo)
+        | Some fo -> fun runtime buf base -> codec_decode runtime buf (base + fo)
         | None ->
-            fun runtime base ->
-              let fo = field_off_fn runtime base in
-              codec_decode runtime (base + fo))
+            fun runtime buf base ->
+              let fo = field_off_fn runtime buf base in
+              codec_decode runtime buf (base + fo))
     | _ -> (
         match field_off_static with
         | Some fo ->
             let reader = build_field_reader_ctx inner fo in
-            fun runtime base -> reader runtime base
+            fun runtime buf base -> reader runtime buf base
         | None ->
             let reader_at_0 = build_field_reader_ctx inner 0 in
-            fun runtime base ->
-              let fo = field_off_fn runtime base in
-              reader_at_0 runtime (base + fo))
+            fun runtime buf base ->
+              let fo = field_off_fn runtime buf base in
+              reader_at_0 runtime buf (base + fo))
   in
   (* Writer takes the absolute byte position to write at. The caller
      gets this from the threaded [write_off]; no buffer-driven
      [off_fn] lookup happens on the encode path. *)
-  let writer : runtime -> int -> w -> int =
+  let writer : runtime -> bytes -> int -> w -> int =
     match inner with
     | Codec { codec_encode; _ } ->
-        fun runtime off iv -> codec_encode iv runtime off
+        fun runtime buf off iv -> codec_encode iv runtime buf off
     | _ ->
-        fun runtime off iv ->
-          build_field_encoder_ctx inner runtime (Types.eval_bytes runtime) off
-            iv
+        fun runtime buf off iv ->
+          build_field_encoder_ctx inner runtime buf off iv
   in
   (reader, writer)
 
@@ -1789,13 +1798,16 @@ let build_nested_readers ctx readers =
   match static_off_of ctx with
   | Some fo ->
       List.map
-        (fun (n, reader) -> (n, fun runtime base -> reader runtime (base + fo)))
+        (fun (n, reader) ->
+          (n, fun runtime buf base -> reader runtime buf (base + fo)))
         readers
   | None ->
       let off_fn = off_fn_of ctx in
       List.map
         (fun (n, reader) ->
-          (n, fun runtime base -> reader runtime (base + off_fn runtime base)))
+          ( n,
+            fun runtime buf base ->
+              reader runtime buf (base + off_fn runtime buf base) ))
         readers
 
 (* -- Per-type [compile_field] helpers -- *)
@@ -1834,21 +1846,21 @@ let compile_bits : type r.
         0,
         base_byte_size,
         [
-          (fun _v runtime _base write_off ->
-            clear_at (Types.eval_bytes runtime) write_off;
+          (fun _v _runtime buf _base write_off ->
+            clear_at buf write_off;
             write_off);
         ] )
   in
   let shift = Bitfield.shift ~bit_order ~total ~bits_used ~width in
   let read = build_bf_reader base base_off shift width in
-  let raw_reader runtime base = read (Types.eval_bytes runtime) base in
+  let raw_reader _runtime buf base = read buf base in
   let raw_writer_inner = build_bf_writer base 0 shift width in
   let get = fld.get in
   let back, advance =
     if is_continuation then (base_byte_size, 0) else (0, base_byte_size)
   in
-  let raw_writer v runtime _base write_off =
-    raw_writer_inner (Types.eval_bytes runtime) (write_off - back) (get v);
+  let raw_writer v _runtime buf _base write_off =
+    raw_writer_inner buf (write_off - back) (get v);
     write_off + advance
   in
   {
@@ -1876,20 +1888,22 @@ let compile_bits : type r.
 let compile_codec_variable : type a r.
     layout_ctx ->
     get:(r -> a) ->
-    codec_decode:(runtime -> int -> a) ->
-    codec_encode:(a -> runtime -> int -> int) ->
-    codec_size_of:(runtime -> int -> int) ->
+    codec_decode:(runtime -> bytes -> int -> a) ->
+    codec_encode:(a -> runtime -> bytes -> int -> int) ->
+    codec_size_of:(runtime -> bytes -> int -> int) ->
     nested_readers:field_reader list ->
     (a, r) compiled_field =
  fun ctx ~get ~codec_decode ~codec_encode ~codec_size_of ~nested_readers ->
   let off_fn, (field_access : field_access), validator_off =
     match ctx.next_off with
     | Static n ->
-        let size_fn buf base = codec_size_of buf (base + n) in
-        ((fun _buf _base -> n), Variable { off = n; size_fn }, n)
+        let size_fn runtime buf base = codec_size_of runtime buf (base + n) in
+        ((fun _runtime _buf _base -> n), Variable { off = n; size_fn }, n)
     | Dynamic prev_end ->
-        let off_fn buf base = prev_end buf base - base in
-        let size_fn buf base = codec_size_of buf (base + off_fn buf base) in
+        let off_fn runtime buf base = prev_end runtime buf base - base in
+        let size_fn runtime buf base =
+          codec_size_of runtime buf (base + off_fn runtime buf base)
+        in
         (off_fn, Variable_dynamic { off_fn; size_fn }, -1)
   in
   let size_fn =
@@ -1899,14 +1913,19 @@ let compile_codec_variable : type a r.
     | _ -> assert false
   in
   {
-    raw_reader = (fun buf base -> codec_decode buf (base + off_fn buf base));
+    raw_reader =
+      (fun runtime buf base ->
+        codec_decode runtime buf (base + off_fn runtime buf base));
     raw_writer =
-      (fun v buf _base write_off -> codec_encode (get v) buf write_off);
+      (fun v runtime buf _base write_off ->
+        codec_encode (get v) runtime buf write_off);
     extra_writers = [];
     field_access;
     size_delta = 0;
     next_off =
-      Dynamic (fun buf base -> base + off_fn buf base + size_fn buf base);
+      Dynamic
+        (fun runtime buf base ->
+          base + off_fn runtime buf base + size_fn runtime buf base);
     bf_after = None;
     int_reader = null_int_reader;
     nested_readers;
@@ -1917,10 +1936,10 @@ let compile_codec_variable : type a r.
 let compile_codec : type a r.
     layout_ctx ->
     (a, r) field ->
-    codec_decode:(runtime -> int -> a) ->
-    codec_encode:(a -> runtime -> int -> int) ->
+    codec_decode:(runtime -> bytes -> int -> a) ->
+    codec_encode:(a -> runtime -> bytes -> int -> int) ->
     codec_fixed_size:int option ->
-    codec_size_of:(runtime -> int -> int) ->
+    codec_size_of:(runtime -> bytes -> int -> int) ->
     codec_field_readers:field_reader list ->
     (a, r) compiled_field =
  fun ctx fld ~codec_decode ~codec_encode ~codec_fixed_size ~codec_size_of
@@ -1930,8 +1949,8 @@ let compile_codec : type a r.
   match codec_fixed_size with
   | Some fsize ->
       let raw_reader, inner_writer = inner_codec_accessors fld.typ ctx in
-      let raw_writer v buf _base write_off =
-        inner_writer buf write_off (get v)
+      let raw_writer v runtime buf _base write_off =
+        inner_writer runtime buf write_off (get v)
       in
       {
         raw_reader;
@@ -1959,25 +1978,27 @@ let compile_codec : type a r.
 let dynamic_optional_next_off ctx present_fn fsize =
   let base_off = ctx.next_off in
   Dynamic
-    (fun buf base ->
+    (fun runtime buf base ->
       let off =
-        match base_off with Static n -> base + n | Dynamic f -> f buf base
+        match base_off with
+        | Static n -> base + n
+        | Dynamic f -> f runtime buf base
       in
-      if present_fn buf base then off + fsize else off)
+      if present_fn runtime buf base then off + fsize else off)
 
 (* Absolute byte position a [next_off] points at, given the record [base]. *)
-let next_off_pos : next_off -> runtime -> int -> int = function
-  | Static n -> fun _runtime base -> base + n
+let next_off_pos : next_off -> runtime -> bytes -> int -> int = function
+  | Static n -> fun _runtime _buf base -> base + n
   | Dynamic f -> f
 
 let optional_compiled : type a r.
     layout_ctx ->
-    ?int_reader:(runtime -> int -> int) ->
-    raw_reader:(runtime -> int -> a) ->
-    raw_writer:(r -> runtime -> int -> int -> int) ->
+    ?int_reader:(runtime -> bytes -> int -> int) ->
+    raw_reader:(runtime -> bytes -> int -> a) ->
+    raw_writer:(r -> runtime -> bytes -> int -> int -> int) ->
     size_delta:int ->
     next_off:next_off ->
-    populate:(slots -> runtime -> int -> unit) ->
+    populate:(slots -> runtime -> bytes -> int -> unit) ->
     unit ->
     (a, r) compiled_field =
  fun ctx ?(int_reader = null_int_reader) ~raw_reader ~raw_writer ~size_delta
@@ -2004,15 +2025,15 @@ let repeat_raw_fixed : type elt seq.
     (elt, seq) seq_map ->
     elt typ ->
     int ->
-    off_fn:(runtime -> int -> int) ->
-    size_fn:(runtime -> int -> int) ->
+    off_fn:(runtime -> bytes -> int -> int) ->
+    size_fn:(runtime -> bytes -> int -> int) ->
     runtime ->
+    bytes ->
     int ->
     seq =
- fun (Seq_map seq) elem esz ~off_fn ~size_fn runtime base ->
-  let buf = Types.eval_bytes runtime in
-  let budget = size_fn runtime base in
-  let start = base + off_fn runtime base in
+ fun (Seq_map seq) elem esz ~off_fn ~size_fn runtime buf base ->
+  let budget = size_fn runtime buf base in
+  let start = base + off_fn runtime buf base in
   (* The budget comes from a length field, i.e. untrusted input. Bound it to the
      buffer before reading so an oversized length fails cleanly instead of
      crashing [read_elem] with an out-of-range [Bytes.sub]. *)
@@ -2024,32 +2045,33 @@ let repeat_raw_fixed : type elt seq.
   let n = if esz > 0 then budget / esz else 0 in
   let rec loop acc i =
     if i >= n then seq.finish acc
-    else loop (seq.add acc (read_elem elem runtime (start + (i * esz)))) (i + 1)
+    else
+      loop (seq.add acc (read_elem elem runtime buf (start + (i * esz)))) (i + 1)
   in
   loop seq.empty 0
 
 let repeat_raw_variable : type elt seq.
     (elt, seq) seq_map ->
     elt typ ->
-    off_fn:(runtime -> int -> int) ->
-    size_fn:(runtime -> int -> int) ->
+    off_fn:(runtime -> bytes -> int -> int) ->
+    size_fn:(runtime -> bytes -> int -> int) ->
     runtime ->
+    bytes ->
     int ->
     seq =
- fun (Seq_map seq) elem ~off_fn ~size_fn runtime base ->
-  let buf = Types.eval_bytes runtime in
-  let budget = size_fn runtime base in
-  let start = base + off_fn runtime base in
+ fun (Seq_map seq) elem ~off_fn ~size_fn runtime buf base ->
+  let budget = size_fn runtime buf base in
+  let start = base + off_fn runtime buf base in
   (* Bound the untrusted budget to the buffer (see [repeat_raw_fixed]). *)
   if budget < 0 || start + budget > Bytes.length buf then
     raise_eof ~at:start ~expected:(start + budget) ~got:(Bytes.length buf);
   let rec loop acc pos remaining =
     if remaining <= 0 then seq.finish acc
     else
-      let esz = elem_size_of elem runtime pos in
+      let esz = elem_size_of elem runtime buf pos in
       if esz <= 0 || esz > remaining then
         raise_eof ~at:pos ~expected:esz ~got:remaining;
-      let v = read_elem elem runtime pos in
+      let v = read_elem elem runtime buf pos in
       loop (seq.add acc v) (pos + esz) (remaining - esz)
   in
   loop seq.empty start budget
@@ -2058,9 +2080,10 @@ let repeat_raw_reader : type elt seq.
     (elt, seq) seq_map ->
     elt typ ->
     elem_size:int option ->
-    off_fn:(runtime -> int -> int) ->
-    size_fn:(runtime -> int -> int) ->
+    off_fn:(runtime -> bytes -> int -> int) ->
+    size_fn:(runtime -> bytes -> int -> int) ->
     runtime ->
+    bytes ->
     int ->
     seq =
  fun seq elem ~elem_size ~off_fn ~size_fn ->
@@ -2080,16 +2103,18 @@ let compile_repeat : type elt seq r.
      when a [Repeat] sits after a variable-size field, the running offset is
      [Dynamic] and is resolved at runtime rather than from a static offset. *)
   let off_fn, (field_access : field_access), validator_off =
-    let sizeof_this : runtime -> int -> int =
+    let sizeof_this : runtime -> bytes -> int -> int =
       match ctx.next_off with
-      | Static n -> fun _buf _base -> n
-      | Dynamic prev_end -> fun buf base -> prev_end buf base - base
+      | Static n -> fun _runtime _buf _base -> n
+      | Dynamic prev_end ->
+          fun runtime buf base -> prev_end runtime buf base - base
     in
     let size_fn = compile_expr ~sizeof_this ctx.field_readers size_expr in
     match ctx.next_off with
-    | Static n -> ((fun _buf _base -> n), Variable { off = n; size_fn }, n)
+    | Static n ->
+        ((fun _runtime _buf _base -> n), Variable { off = n; size_fn }, n)
     | Dynamic prev_end ->
-        let off_fn buf base = prev_end buf base - base in
+        let off_fn runtime buf base = prev_end runtime buf base - base in
         (off_fn, Variable_dynamic { off_fn; size_fn }, -1)
   in
   let size_fn =
@@ -2101,9 +2126,9 @@ let compile_repeat : type elt seq r.
   let elem_size = field_wire_size elem in
   let raw_reader = repeat_raw_reader seq elem ~elem_size ~off_fn ~size_fn in
   let get = fld.get in
-  let raw_writer v runtime base write_off =
+  let raw_writer v runtime buf base write_off =
     let items = get v in
-    let expected = size_fn runtime base in
+    let expected = size_fn runtime buf base in
     let sized_items =
       Types.exact_repeat_elements seq ~expected
         ~size_of:(Types.size_of_typ_value elem)
@@ -2112,7 +2137,7 @@ let compile_repeat : type elt seq r.
     let pos = Stdlib.ref write_off in
     List.iter
       (fun (item, size) ->
-        write_elem elem runtime !pos item;
+        write_elem elem runtime buf !pos item;
         pos := !pos + size)
       sized_items;
     !pos
@@ -2124,7 +2149,9 @@ let compile_repeat : type elt seq r.
     field_access;
     size_delta = 0;
     next_off =
-      Dynamic (fun buf base -> base + off_fn buf base + size_fn buf base);
+      Dynamic
+        (fun runtime buf base ->
+          base + off_fn runtime buf base + size_fn runtime buf base);
     bf_after = None;
     int_reader = null_int_reader;
     nested_readers = [];
@@ -2137,15 +2164,15 @@ let compile_repeat : type elt seq r.
    terminator is found -- a truncated / unterminated zero-terminated string. *)
 let var_bytes_reader : type a.
     a typ ->
-    (runtime -> int -> int) ->
-    (runtime -> int -> int) ->
+    (runtime -> bytes -> int -> int) ->
+    (runtime -> bytes -> int -> int) ->
     runtime ->
+    bytes ->
     int ->
     a =
- fun typ off_fn size_fn runtime base ->
-  let buf = Types.eval_bytes runtime in
-  let fo = off_fn runtime base in
-  let sz = size_fn runtime base in
+ fun typ off_fn size_fn runtime buf base ->
+  let fo = off_fn runtime buf base in
+  let sz = size_fn runtime buf base in
   let first = base + fo in
   (* [fo] and [sz] derive from length fields, i.e. untrusted input. A field
      sized past the buffer (or a negative size from an overrun offset) would
@@ -2181,19 +2208,19 @@ let var_bytes_reader : type a.
           if c <> '\000' then raise_non_zero_padding ~at:(base + fo + i))
         s;
       s
-  | Casetype _ -> read_elem typ runtime (base + fo)
+  | Casetype _ -> read_elem typ runtime buf (base + fo)
   | Single_elem { elem; at_most; _ } ->
       let first = base + fo in
-      let consumed = elem_size_of elem runtime first in
+      let consumed = elem_size_of elem runtime buf first in
       if consumed > sz || ((not at_most) && consumed <> sz) then
         raise_eof ~at:(first + min consumed sz) ~expected:sz ~got:consumed;
-      read_elem elem runtime first
+      read_elem elem runtime buf first
   | _ -> assert false
 
 (* Kept at top level: as local closures they would be heap-allocated on
    every call (two allocations per variable-bytes field on each encode). *)
-let var_bytes_check_len size_fn runtime base ~actual =
-  let expected = size_fn runtime base in
+let var_bytes_check_len size_fn runtime buf base ~actual =
+  let expected = size_fn runtime buf base in
   if actual <> expected then
     Fmt.invalid_arg
       "Codec.encode: byte field length %d does not match expected %d \
@@ -2208,29 +2235,29 @@ let var_bytes_write_str buf write_off s =
 let var_bytes_writer : type a r.
     a typ ->
     (r -> a) ->
-    (runtime -> int -> int) ->
+    (runtime -> bytes -> int -> int) ->
     r ->
     runtime ->
+    bytes ->
     int ->
     int ->
     int =
- fun typ get size_fn v runtime base write_off ->
-  let buf = Types.eval_bytes runtime in
+ fun typ get size_fn v runtime buf base write_off ->
   let value = get v in
   match typ with
   | Byte_slice _ ->
       let src = (value : Slice.t) in
       let len = Slice.length src in
-      var_bytes_check_len size_fn runtime base ~actual:len;
+      var_bytes_check_len size_fn runtime buf base ~actual:len;
       Bytes.blit (Slice.bytes src) (Slice.first src) buf write_off len;
       write_off + len
   | Byte_array _ ->
       let s = (value : string) in
-      var_bytes_check_len size_fn runtime base ~actual:(String.length s);
+      var_bytes_check_len size_fn runtime buf base ~actual:(String.length s);
       var_bytes_write_str buf write_off s
   | Byte_array_where _ ->
       let s = (value : string) in
-      var_bytes_check_len size_fn runtime base ~actual:(String.length s);
+      var_bytes_check_len size_fn runtime buf base ~actual:(String.length s);
       var_bytes_write_str buf write_off s
   | All_bytes -> var_bytes_write_str buf write_off (value : string)
   | All_zeros -> var_bytes_write_str buf write_off (value : string)
@@ -2245,7 +2272,7 @@ let var_bytes_writer : type a r.
       let s = (value : string) in
       if String.contains s '\000' then
         invalid_arg "Codec.encode: zeroterm string contains a NUL byte";
-      let region = size_fn runtime base in
+      let region = size_fn runtime buf base in
       let len = String.length s in
       if len + 1 > region then
         Fmt.invalid_arg
@@ -2257,7 +2284,7 @@ let var_bytes_writer : type a r.
       write_off + region
   | Casetype _ -> build_field_encoder_ctx typ runtime buf write_off value
   | Single_elem { elem; at_most; _ } ->
-      let n = size_fn runtime base in
+      let n = size_fn runtime buf base in
       let actual = Types.size_of_typ_value elem value in
       Types.check_nested_size ~at_most ~expected:n ~actual;
       let inner_end =
@@ -2271,8 +2298,9 @@ let var_bytes_writer : type a r.
 let compile_var_size_fn : type a.
     layout_ctx ->
     a typ ->
-    off_fn:(runtime -> int -> int) ->
+    off_fn:(runtime -> bytes -> int -> int) ->
     runtime ->
+    bytes ->
     int ->
     int =
  fun ctx typ ~off_fn ->
@@ -2282,19 +2310,17 @@ let compile_var_size_fn : type a.
          current offset. The OCaml decoder gets the buffer length via
          [Bytes.length buf]; the 3D projection emits [all_bytes], which
          3D handles natively. *)
-      fun runtime base ->
-        Bytes.length (Types.eval_bytes runtime) - (base + off_fn runtime base)
+      fun runtime buf base -> Bytes.length buf - (base + off_fn runtime buf base)
   | Casetype _ ->
       (* Tag is decoded first; the case body's size is whatever the
          selected case's inner typ reports. *)
-      fun runtime base -> elem_size_of typ runtime (base + off_fn runtime base)
+      fun runtime buf base ->
+        elem_size_of typ runtime buf (base + off_fn runtime buf base)
   | Zeroterm ->
       (* Consumed bytes = string length plus the one-byte NUL terminator. *)
-      fun runtime base ->
-        let first = base + off_fn runtime base in
-        zeroterm_nul_pos (Types.eval_bytes runtime) ~first
-          ~limit:(Bytes.length (Types.eval_bytes runtime))
-        - first + 1
+      fun runtime buf base ->
+        let first = base + off_fn runtime buf base in
+        zeroterm_nul_pos buf ~first ~limit:(Bytes.length buf) - first + 1
   | _ ->
       let size_expr =
         match typ with
@@ -2306,10 +2332,11 @@ let compile_var_size_fn : type a.
         | Zeroterm_at_most { size } -> size
         | _ -> invalid_arg "add_field: unsupported variable-size field type"
       in
-      let sizeof_this : runtime -> int -> int =
+      let sizeof_this : runtime -> bytes -> int -> int =
         match ctx.next_off with
-        | Static n -> fun _buf _base -> n
-        | Dynamic prev_end -> fun buf base -> prev_end buf base - base
+        | Static n -> fun _runtime _buf _base -> n
+        | Dynamic prev_end ->
+            fun runtime buf base -> prev_end runtime buf base - base
       in
       compile_expr ~sizeof_this ctx.field_readers size_expr
 
@@ -2319,8 +2346,10 @@ let compile_var_bytes : type a r.
   let typ = fld.typ in
   let off_fn, validator_off =
     match ctx.next_off with
-    | Static n -> ((fun (_runtime : runtime) (_base : int) -> n), n)
-    | Dynamic prev_end -> ((fun buf base -> prev_end buf base - base), -1)
+    | Static n ->
+        ((fun (_runtime : runtime) (_buf : bytes) (_base : int) -> n), n)
+    | Dynamic prev_end ->
+        ((fun runtime buf base -> prev_end runtime buf base - base), -1)
   in
   let size_fn = compile_var_size_fn ctx typ ~off_fn in
   let field_access : field_access =
@@ -2332,24 +2361,28 @@ let compile_var_bytes : type a r.
     match typ with
     | Uint_var { endian; _ } ->
         let get = fld.get in
-        let raw_reader : runtime -> int -> a =
-         fun runtime base ->
-          let fo = off_fn runtime base in
-          let sz = size_fn runtime base in
-          Uint_var.read endian (Types.eval_bytes runtime) (base + fo) sz
+        let raw_reader : runtime -> bytes -> int -> a =
+         fun runtime buf base ->
+          let fo = off_fn runtime buf base in
+          let sz = size_fn runtime buf base in
+          Uint_var.read endian buf (base + fo) sz
         in
-        let raw_writer : r -> runtime -> int -> int -> int =
-         fun v runtime base write_off ->
-          let sz = size_fn runtime base in
-          Uint_var.write endian (Types.eval_bytes runtime) write_off sz (get v);
+        let raw_writer : r -> runtime -> bytes -> int -> int -> int =
+         fun v runtime buf base write_off ->
+          let sz = size_fn runtime buf base in
+          Uint_var.write endian buf write_off sz (get v);
           write_off + sz
         in
-        let int_reader buf base = int_of_typ_value typ (raw_reader buf base) in
+        let int_reader runtime buf base =
+          int_of_typ_value typ (raw_reader runtime buf base)
+        in
         (raw_reader, raw_writer, int_reader)
     | _ ->
         let raw_reader = var_bytes_reader typ off_fn size_fn in
         let raw_writer = var_bytes_writer typ fld.get size_fn in
-        let int_reader buf base = int_of_typ_value typ (raw_reader buf base) in
+        let int_reader runtime buf base =
+          int_of_typ_value typ (raw_reader runtime buf base)
+        in
         (raw_reader, raw_writer, int_reader)
   in
   let populate = build_populate typ ctx.n_fields raw_reader in
@@ -2361,9 +2394,9 @@ let compile_var_bytes : type a r.
     size_delta = 0;
     next_off =
       Dynamic
-        (fun buf base ->
-          let fo = off_fn buf base in
-          base + fo + size_fn buf base);
+        (fun runtime buf base ->
+          let fo = off_fn runtime buf base in
+          base + fo + size_fn runtime buf base);
     bf_after = None;
     int_reader;
     nested_readers = [];
@@ -2384,20 +2417,21 @@ let compile_scalar_or_var : type a r.
         match field_off_static with
         | Some _ ->
             let reader = build_field_reader_ctx typ field_off in
-            fun runtime base -> reader runtime base
+            fun runtime buf base -> reader runtime buf base
         | None ->
             let reader_at_0 = build_field_reader_ctx typ 0 in
-            fun runtime base ->
-              let off = field_off_fn runtime base in
-              reader_at_0 runtime (base + off)
+            fun runtime buf base ->
+              let off = field_off_fn runtime buf base in
+              reader_at_0 runtime buf (base + off)
       in
       let get = fld.get in
-      let raw_writer : r -> runtime -> int -> int -> int =
-       fun v runtime _base write_off ->
-        build_field_encoder_ctx typ runtime (Types.eval_bytes runtime) write_off
-          (get v)
+      let raw_writer : r -> runtime -> bytes -> int -> int -> int =
+       fun v runtime buf _base write_off ->
+        build_field_encoder_ctx typ runtime buf write_off (get v)
       in
-      let int_reader buf base = int_of_typ_value typ (raw_reader buf base) in
+      let int_reader runtime buf base =
+        int_of_typ_value typ (raw_reader runtime buf base)
+      in
       let populate = build_populate typ ctx.n_fields raw_reader in
       {
         raw_reader;
@@ -2414,6 +2448,17 @@ let compile_scalar_or_var : type a r.
       }
   | None -> compile_var_bytes ctx fld
 
+(* An [optional] field whose value disagrees with its presence predicate cannot
+   be encoded: reject it rather than write a record decode cannot read back. *)
+let optional_presence_mismatch : type a. bool -> a =
+ fun present ->
+  if present then
+    invalid_arg
+      "Codec.encode: optional field absent but presence predicate is true"
+  else
+    invalid_arg
+      "Codec.encode: optional field present but presence predicate is false"
+
 let rec compile_field : type a r.
     layout_ctx -> (a, r) field -> (a, r) compiled_field =
  fun ctx fld ->
@@ -2427,11 +2472,12 @@ let rec compile_field : type a r.
       let check = enum_check cases closed in
       {
         cf with
-        raw_reader = (fun buf off -> check ~at:off (cf.raw_reader buf off));
+        raw_reader =
+          (fun runtime buf off -> check ~at:off (cf.raw_reader runtime buf off));
         populate =
-          (fun arr buf base ->
-            cf.populate arr buf base;
-            ignore (check ~at:base (cf.int_reader buf base)));
+          (fun arr runtime buf base ->
+            cf.populate arr runtime buf base;
+            ignore (check ~at:base (cf.int_reader runtime buf base)));
       }
   | Where { inner; _ } -> compile_field ctx { fld with typ = inner }
   | Bits { width; base; bit_order } -> compile_bits ctx fld width base bit_order
@@ -2472,7 +2518,7 @@ and compile_map : type a w r.
     }
   in
   let cf = compile_field ctx inner_fld in
-  let checked_reader buf off = decode (cf.raw_reader buf off) in
+  let checked_reader runtime buf off = decode (cf.raw_reader runtime buf off) in
   {
     cf with
     raw_reader = checked_reader;
@@ -2480,9 +2526,9 @@ and compile_map : type a w r.
        populate too so [Codec.validate] enforces the bound decode does. The inner
        populate still fills the int slot from the raw value. *)
     populate =
-      (fun arr buf base ->
-        cf.populate arr buf base;
-        ignore (checked_reader buf base));
+      (fun arr runtime buf base ->
+        cf.populate arr runtime buf base;
+        ignore (checked_reader runtime buf base));
   }
 
 and compile_optional : type a r.
@@ -2500,18 +2546,19 @@ and compile_optional : type a r.
       let inner_populate = build_populate inner nfields inner_reader in
       let get = fld.get in
       optional_compiled ctx
-        ~raw_reader:(fun buf base -> Some (inner_reader buf base))
-        ~raw_writer:(fun v buf _base write_off ->
+        ~raw_reader:(fun runtime buf base ->
+          Some (inner_reader runtime buf base))
+        ~raw_writer:(fun v runtime buf _base write_off ->
           match get v with
-          | Some iv -> inner_writer buf write_off iv
+          | Some iv -> inner_writer runtime buf write_off iv
           | None -> write_off + fsize)
         ~size_delta:fsize
         ~next_off:(advance_next_off ctx.next_off fsize)
         ~populate:inner_populate ()
   | Bool false, _ ->
       optional_compiled ctx
-        ~raw_reader:(fun _buf _base -> None)
-        ~raw_writer:(fun _v _buf _base write_off -> write_off)
+        ~raw_reader:(fun _runtime _buf _base -> None)
+        ~raw_writer:(fun _v _runtime _buf _base write_off -> write_off)
         ~size_delta:0 ~next_off:ctx.next_off ~populate:no_populate ()
   | _, Some fsize ->
       let present_fn = compile_bool_expr ctx.field_readers present in
@@ -2519,24 +2566,20 @@ and compile_optional : type a r.
       let inner_populate = build_populate inner nfields inner_reader in
       let get = fld.get in
       optional_compiled ctx
-        ~raw_reader:(fun buf base ->
-          if present_fn buf base then Some (inner_reader buf base) else None)
-        ~raw_writer:(fun v buf base write_off ->
-          match (present_fn buf base, get v) with
-          | true, Some iv -> inner_writer buf write_off iv
+        ~raw_reader:(fun runtime buf base ->
+          if present_fn runtime buf base then
+            Some (inner_reader runtime buf base)
+          else None)
+        ~raw_writer:(fun v runtime buf base write_off ->
+          match (present_fn runtime buf base, get v) with
+          | true, Some iv -> inner_writer runtime buf write_off iv
           | false, None -> write_off
-          | true, None ->
-              invalid_arg
-                "Codec.encode: optional field absent but presence predicate is \
-                 true"
-          | false, Some _ ->
-              invalid_arg
-                "Codec.encode: optional field present but presence predicate \
-                 is false")
+          | present, _ -> optional_presence_mismatch present)
         ~size_delta:0
         ~next_off:(dynamic_optional_next_off ctx present_fn fsize)
-        ~populate:(fun arr buf base ->
-          if present_fn buf base then inner_populate arr buf base)
+        ~populate:(fun arr runtime buf base ->
+          if present_fn runtime buf base then
+            inner_populate arr runtime buf base)
         ()
   | _ -> compile_optional_variable ctx fld present inner
 
@@ -2564,35 +2607,28 @@ and compile_optional_variable : type a r.
         (fun v ->
           match get v with
           | Some iv -> iv
-          | None ->
-              invalid_arg
-                "Codec.encode: optional field absent but presence predicate is \
-                 true");
+          | None -> optional_presence_mismatch true);
     }
   in
   let cf = compile_field ctx inner_fld in
   optional_compiled ctx
-    ~raw_reader:(fun buf base ->
-      if present_fn buf base then Some (cf.raw_reader buf base) else None)
-    ~raw_writer:(fun v buf base write_off ->
-      match (present_fn buf base, get v) with
-      | true, Some _ -> cf.raw_writer v buf base write_off
+    ~raw_reader:(fun runtime buf base ->
+      if present_fn runtime buf base then Some (cf.raw_reader runtime buf base)
+      else None)
+    ~raw_writer:(fun v runtime buf base write_off ->
+      match (present_fn runtime buf base, get v) with
+      | true, Some _ -> cf.raw_writer v runtime buf base write_off
       | false, None -> write_off
-      | true, None ->
-          invalid_arg
-            "Codec.encode: optional field absent but presence predicate is true"
-      | false, Some _ ->
-          invalid_arg
-            "Codec.encode: optional field present but presence predicate is \
-             false")
+      | present, _ -> optional_presence_mismatch present)
     ~size_delta:0
     ~next_off:
       (Dynamic
-         (fun buf base ->
-           if present_fn buf base then next_off_pos cf.next_off buf base
-           else next_off_pos ctx.next_off buf base))
-    ~populate:(fun arr buf base ->
-      if present_fn buf base then cf.populate arr buf base)
+         (fun runtime buf base ->
+           if present_fn runtime buf base then
+             next_off_pos cf.next_off runtime buf base
+           else next_off_pos ctx.next_off runtime buf base))
+    ~populate:(fun arr runtime buf base ->
+      if present_fn runtime buf base then cf.populate arr runtime buf base)
     ()
 
 and compile_optional_or : type a r.
@@ -2610,25 +2646,26 @@ and compile_optional_or : type a r.
       let get = fld.get in
       let populate = build_populate fld.typ ctx.n_fields inner_reader in
       optional_compiled ctx ~raw_reader:inner_reader
-        ~int_reader:(fun buf base ->
-          int_of_typ_value inner (inner_reader buf base))
-        ~raw_writer:(fun v buf _base write_off ->
-          inner_writer buf write_off (get v))
+        ~int_reader:(fun runtime buf base ->
+          int_of_typ_value inner (inner_reader runtime buf base))
+        ~raw_writer:(fun v runtime buf _base write_off ->
+          inner_writer runtime buf write_off (get v))
         ~size_delta:fsize
         ~next_off:(advance_next_off ctx.next_off fsize)
         ~populate ()
   | Bool false, _ ->
       optional_compiled ctx
-        ~raw_reader:(fun _buf _base -> default)
-        ~int_reader:(fun _buf _base -> int_of_typ_value inner default)
-        ~raw_writer:(fun _v _buf _base write_off -> write_off)
+        ~raw_reader:(fun _runtime _buf _base -> default)
+        ~int_reader:(fun _runtime _buf _base -> int_of_typ_value inner default)
+        ~raw_writer:(fun _v _runtime _buf _base write_off -> write_off)
         ~size_delta:0 ~next_off:ctx.next_off ~populate:no_populate ()
   | _, Some fsize ->
       let present_fn = compile_bool_expr ctx.field_readers present in
       let inner_reader, inner_writer = inner_codec_accessors inner ctx in
       let get = fld.get in
-      let raw_reader buf base =
-        if present_fn buf base then inner_reader buf base else default
+      let raw_reader runtime buf base =
+        if present_fn runtime buf base then inner_reader runtime buf base
+        else default
       in
       let populate = build_populate fld.typ ctx.n_fields raw_reader in
       (* Encode is value-driven: the user always has a value, so always
@@ -2638,12 +2675,12 @@ and compile_optional_or : type a r.
          choice; if the user sets the gate to [absent] while the value
          differs from [default], decoding loses the value and falls
          back to [default]. *)
-      let raw_writer v buf _base write_off =
-        inner_writer buf write_off (get v)
+      let raw_writer v runtime buf _base write_off =
+        inner_writer runtime buf write_off (get v)
       in
       optional_compiled ctx ~raw_reader
-        ~int_reader:(fun buf base ->
-          int_of_typ_value inner (raw_reader buf base))
+        ~int_reader:(fun runtime buf base ->
+          int_of_typ_value inner (raw_reader runtime buf base))
         ~raw_writer ~size_delta:fsize
         ~next_off:(advance_next_off ctx.next_off fsize)
         ~populate ()
@@ -2673,9 +2710,11 @@ and compile_optional_or_variable : type a r.
   in
   let cf = compile_field ctx inner_fld in
   optional_compiled ctx
-    ~raw_reader:(fun buf base ->
-      if present_fn buf base then cf.raw_reader buf base else default)
-    ~raw_writer:(fun v buf base write_off -> cf.raw_writer v buf base write_off)
+    ~raw_reader:(fun runtime buf base ->
+      if present_fn runtime buf base then cf.raw_reader runtime buf base
+      else default)
+    ~raw_writer:(fun v runtime buf base write_off ->
+      cf.raw_writer v runtime buf base write_off)
     ~int_reader:cf.int_reader ~size_delta:0 ~next_off:cf.next_off
     ~populate:cf.populate ()
 
@@ -2741,13 +2780,13 @@ let rec field_reader_validates : type a. a Types.typ -> bool = function
    unwinds. Only fields that can raise an attributable error are wrapped; a plain
    scalar read raises only [Unexpected_eof] from the record's bounds check, which
    is recorded without a path. *)
-let prepend_field name f buf base =
-  try f buf base
+let prepend_field name f runtime buf base =
+  try f runtime buf base
   with Types.Parse_error e ->
     raise (Types.Parse_error { e with field = name :: e.field })
 
-let prepend_field_check name f arr buf base =
-  try f arr buf base
+let prepend_field_check name f arr runtime buf base =
+  try f arr runtime buf base
   with Types.Parse_error e ->
     raise (Types.Parse_error { e with field = name :: e.field })
 
@@ -2774,7 +2813,7 @@ let apply_compiled : type a f r.
   in
   let n_extra_vars = List.length action_vanames in
   let field_idx = r.n_fields in
-  let dummy_reader _buf _base = 0 in
+  let dummy_reader _runtime _buf _base = 0 in
   let cc_readers =
     let base = (fld.name, dummy_reader) :: r.field_readers in
     List.fold_left (fun acc vn -> (vn, dummy_reader) :: acc) base action_vanames
@@ -2786,16 +2825,16 @@ let apply_compiled : type a f r.
   in
   let check = compile_field_check cc fld in
   let act = compile_action cc fld.action in
-  let check_only arr buf base =
-    cf.populate arr buf base;
+  let check_only arr runtime buf base =
+    cf.populate arr runtime buf base;
     match check with
     | Some f when not (f arr) -> raise_field_constraint ~field_idx ~at:base arr
     | _ -> ()
   in
   (* The full validator is the read-and-check plus the field action. Decode and
      [Codec.validate] both run it, so an action never fires on one path only. *)
-  let full arr buf base =
-    check_only arr buf base;
+  let full arr runtime buf base =
+    check_only arr runtime buf base;
     match act with Some f -> f arr | None -> ()
   in
   let faction =
@@ -2867,7 +2906,7 @@ let add_field : type a f r. (a -> f, r) record -> (a, r) field -> (f, r) record
 type (_, _) readers_fwd =
   | FNil : ('r, 'r) readers_fwd
   | FCons :
-      (runtime -> int -> 'a) * ('rest, 'result) readers_fwd
+      (runtime -> bytes -> int -> 'a) * ('rest, 'result) readers_fwd
       -> ('a -> 'rest, 'result) readers_fwd
 
 (* Convert a [readers] snoc-list to a [readers_fwd] cons-list. O(n), runs
@@ -2898,111 +2937,118 @@ let to_fwd : type full result.
    patterns across ~500 lines; the flat table is both shorter and easier to
    read. *)
 let rec apply_fwd : type mid result.
-    mid -> (mid, result) readers_fwd -> runtime -> int -> result =
- fun f fwd buf off ->
+    mid -> (mid, result) readers_fwd -> runtime -> bytes -> int -> result =
+ fun f fwd runtime buf off ->
   match fwd with
   | FNil -> f
   | FCons (r1, FNil) ->
-      f (r1 buf off)
+      f (r1 runtime buf off)
   | FCons (r1, FCons (r2, FNil)) ->
-      f (r1 buf off) (r2 buf off)
+      f (r1 runtime buf off) (r2 runtime buf off)
   | FCons (r1, FCons (r2, FCons (r3, FNil))) ->
-      f (r1 buf off) (r2 buf off) (r3 buf off)
+      f (r1 runtime buf off) (r2 runtime buf off) (r3 runtime buf off)
   | FCons (r1, FCons (r2, FCons (r3, FCons (r4, FNil)))) ->
-      f (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off)
+      f (r1 runtime buf off) (r2 runtime buf off) (r3 runtime buf off) (r4 runtime buf off)
   | FCons (r1, FCons (r2, FCons (r3, FCons (r4, FCons (r5, FNil))))) ->
-      f (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off) (r5 buf off)
+      f (r1 runtime buf off) (r2 runtime buf off) (r3 runtime buf off) (r4 runtime buf off) (r5 runtime buf off)
   | FCons (r1, FCons (r2, FCons (r3, FCons (r4, FCons (r5, FCons (r6, FNil)))))) ->
-      f (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off) (r5 buf off) (r6 buf off)
+      f (r1 runtime buf off) (r2 runtime buf off) (r3 runtime buf off) (r4 runtime buf off) (r5 runtime buf off) (r6 runtime buf off)
   | FCons (r1, FCons (r2, FCons (r3, FCons (r4, FCons (r5, FCons (r6, FCons (r7, FNil))))))) ->
-      f (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off) (r5 buf off) (r6 buf off) (r7 buf off)
+      f (r1 runtime buf off) (r2 runtime buf off) (r3 runtime buf off) (r4 runtime buf off) (r5 runtime buf off) (r6 runtime buf off) (r7 runtime buf off)
   | FCons (r1, FCons (r2, FCons (r3, FCons (r4, FCons (r5, FCons (r6, FCons (r7, FCons (r8, FNil)))))))) ->
-      f (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off) (r5 buf off) (r6 buf off) (r7 buf off) (r8 buf off)
+      f (r1 runtime buf off) (r2 runtime buf off) (r3 runtime buf off) (r4 runtime buf off) (r5 runtime buf off) (r6 runtime buf off) (r7 runtime buf off) (r8 runtime buf off)
   | FCons (r1, FCons (r2, FCons (r3, FCons (r4, FCons (r5, FCons (r6, FCons (r7, FCons (r8, FCons (r9, FNil))))))))) ->
-      f (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off) (r5 buf off) (r6 buf off) (r7 buf off) (r8 buf off) (r9 buf off)
+      f (r1 runtime buf off) (r2 runtime buf off) (r3 runtime buf off) (r4 runtime buf off) (r5 runtime buf off) (r6 runtime buf off) (r7 runtime buf off) (r8 runtime buf off) (r9 runtime buf off)
   | FCons (r1, FCons (r2, FCons (r3, FCons (r4, FCons (r5, FCons (r6, FCons (r7, FCons (r8, FCons (r9, FCons (r10, FNil)))))))))) ->
-      f (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off) (r5 buf off) (r6 buf off) (r7 buf off) (r8 buf off) (r9 buf off) (r10 buf off)
+      f (r1 runtime buf off) (r2 runtime buf off) (r3 runtime buf off) (r4 runtime buf off) (r5 runtime buf off) (r6 runtime buf off) (r7 runtime buf off) (r8 runtime buf off) (r9 runtime buf off) (r10 runtime buf off)
   | FCons (r1, FCons (r2, FCons (r3, FCons (r4, FCons (r5, FCons (r6, FCons (r7, FCons (r8, FCons (r9, FCons (r10, FCons (r11, FNil))))))))))) ->
-      f (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off) (r5 buf off) (r6 buf off) (r7 buf off) (r8 buf off) (r9 buf off) (r10 buf off) (r11 buf off)
+      f (r1 runtime buf off) (r2 runtime buf off) (r3 runtime buf off) (r4 runtime buf off) (r5 runtime buf off) (r6 runtime buf off) (r7 runtime buf off) (r8 runtime buf off) (r9 runtime buf off) (r10 runtime buf off) (r11 runtime buf off)
   | FCons (r1, FCons (r2, FCons (r3, FCons (r4, FCons (r5, FCons (r6, FCons (r7, FCons (r8, FCons (r9, FCons (r10, FCons (r11, FCons (r12, FNil)))))))))))) ->
-      f (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off) (r5 buf off) (r6 buf off) (r7 buf off) (r8 buf off) (r9 buf off) (r10 buf off) (r11 buf off) (r12 buf off)
+      f (r1 runtime buf off) (r2 runtime buf off) (r3 runtime buf off) (r4 runtime buf off) (r5 runtime buf off) (r6 runtime buf off) (r7 runtime buf off) (r8 runtime buf off) (r9 runtime buf off) (r10 runtime buf off) (r11 runtime buf off) (r12 runtime buf off)
   | FCons (r1, FCons (r2, FCons (r3, FCons (r4, FCons (r5, FCons (r6, FCons (r7, FCons (r8, FCons (r9, FCons (r10, FCons (r11, FCons (r12, FCons (r13, FNil))))))))))))) ->
-      f (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off) (r5 buf off) (r6 buf off) (r7 buf off) (r8 buf off) (r9 buf off) (r10 buf off) (r11 buf off) (r12 buf off) (r13 buf off)
+      f (r1 runtime buf off) (r2 runtime buf off) (r3 runtime buf off) (r4 runtime buf off) (r5 runtime buf off) (r6 runtime buf off) (r7 runtime buf off) (r8 runtime buf off) (r9 runtime buf off) (r10 runtime buf off) (r11 runtime buf off) (r12 runtime buf off) (r13 runtime buf off)
   | FCons (r1, FCons (r2, FCons (r3, FCons (r4, FCons (r5, FCons (r6, FCons (r7, FCons (r8, FCons (r9, FCons (r10, FCons (r11, FCons (r12, FCons (r13, FCons (r14, FNil)))))))))))))) ->
-      f (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off) (r5 buf off) (r6 buf off) (r7 buf off) (r8 buf off) (r9 buf off) (r10 buf off) (r11 buf off) (r12 buf off) (r13 buf off) (r14 buf off)
+      f (r1 runtime buf off) (r2 runtime buf off) (r3 runtime buf off) (r4 runtime buf off) (r5 runtime buf off) (r6 runtime buf off) (r7 runtime buf off) (r8 runtime buf off) (r9 runtime buf off) (r10 runtime buf off) (r11 runtime buf off) (r12 runtime buf off) (r13 runtime buf off) (r14 runtime buf off)
   | FCons (r1, FCons (r2, FCons (r3, FCons (r4, FCons (r5, FCons (r6, FCons (r7, FCons (r8, FCons (r9, FCons (r10, FCons (r11, FCons (r12, FCons (r13, FCons (r14, FCons (r15, FNil))))))))))))))) ->
-      f (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off) (r5 buf off) (r6 buf off) (r7 buf off) (r8 buf off) (r9 buf off) (r10 buf off) (r11 buf off) (r12 buf off) (r13 buf off) (r14 buf off) (r15 buf off)
+      f (r1 runtime buf off) (r2 runtime buf off) (r3 runtime buf off) (r4 runtime buf off) (r5 runtime buf off) (r6 runtime buf off) (r7 runtime buf off) (r8 runtime buf off) (r9 runtime buf off) (r10 runtime buf off) (r11 runtime buf off) (r12 runtime buf off) (r13 runtime buf off) (r14 runtime buf off) (r15 runtime buf off)
   | FCons (r1, FCons (r2, FCons (r3, FCons (r4, FCons (r5, FCons (r6, FCons (r7, FCons (r8, FCons (r9, FCons (r10, FCons (r11, FCons (r12, FCons (r13, FCons (r14, FCons (r15, FCons (r16, FNil)))))))))))))))) ->
-      f (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off) (r5 buf off) (r6 buf off) (r7 buf off) (r8 buf off) (r9 buf off) (r10 buf off) (r11 buf off) (r12 buf off) (r13 buf off) (r14 buf off) (r15 buf off) (r16 buf off)
+      f (r1 runtime buf off) (r2 runtime buf off) (r3 runtime buf off) (r4 runtime buf off) (r5 runtime buf off) (r6 runtime buf off) (r7 runtime buf off) (r8 runtime buf off) (r9 runtime buf off) (r10 runtime buf off) (r11 runtime buf off) (r12 runtime buf off) (r13 runtime buf off) (r14 runtime buf off) (r15 runtime buf off) (r16 runtime buf off)
   | FCons (r1, FCons (r2, FCons (r3, FCons (r4, FCons (r5, FCons (r6, FCons (r7, FCons (r8, FCons (r9, FCons (r10, FCons (r11, FCons (r12, FCons (r13, FCons (r14, FCons (r15, FCons (r16, FCons (r17, FNil))))))))))))))))) ->
-      f (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off) (r5 buf off) (r6 buf off) (r7 buf off) (r8 buf off) (r9 buf off) (r10 buf off) (r11 buf off) (r12 buf off) (r13 buf off) (r14 buf off) (r15 buf off) (r16 buf off) (r17 buf off)
+      f (r1 runtime buf off) (r2 runtime buf off) (r3 runtime buf off) (r4 runtime buf off) (r5 runtime buf off) (r6 runtime buf off) (r7 runtime buf off) (r8 runtime buf off) (r9 runtime buf off) (r10 runtime buf off) (r11 runtime buf off) (r12 runtime buf off) (r13 runtime buf off) (r14 runtime buf off) (r15 runtime buf off) (r16 runtime buf off) (r17 runtime buf off)
   | FCons (r1, FCons (r2, FCons (r3, FCons (r4, FCons (r5, FCons (r6, FCons (r7, FCons (r8, FCons (r9, FCons (r10, FCons (r11, FCons (r12, FCons (r13, FCons (r14, FCons (r15, FCons (r16, FCons (r17, FCons (r18, FNil)))))))))))))))))) ->
-      f (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off) (r5 buf off) (r6 buf off) (r7 buf off) (r8 buf off) (r9 buf off) (r10 buf off) (r11 buf off) (r12 buf off) (r13 buf off) (r14 buf off) (r15 buf off) (r16 buf off) (r17 buf off) (r18 buf off)
+      f (r1 runtime buf off) (r2 runtime buf off) (r3 runtime buf off) (r4 runtime buf off) (r5 runtime buf off) (r6 runtime buf off) (r7 runtime buf off) (r8 runtime buf off) (r9 runtime buf off) (r10 runtime buf off) (r11 runtime buf off) (r12 runtime buf off) (r13 runtime buf off) (r14 runtime buf off) (r15 runtime buf off) (r16 runtime buf off) (r17 runtime buf off) (r18 runtime buf off)
   | FCons (r1, FCons (r2, FCons (r3, FCons (r4, FCons (r5, FCons (r6, FCons (r7, FCons (r8, FCons (r9, FCons (r10, FCons (r11, FCons (r12, FCons (r13, FCons (r14, FCons (r15, FCons (r16, FCons (r17, FCons (r18, FCons (r19, FNil))))))))))))))))))) ->
-      f (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off) (r5 buf off) (r6 buf off) (r7 buf off) (r8 buf off) (r9 buf off) (r10 buf off) (r11 buf off) (r12 buf off) (r13 buf off) (r14 buf off) (r15 buf off) (r16 buf off) (r17 buf off) (r18 buf off) (r19 buf off)
+      f (r1 runtime buf off) (r2 runtime buf off) (r3 runtime buf off) (r4 runtime buf off) (r5 runtime buf off) (r6 runtime buf off) (r7 runtime buf off) (r8 runtime buf off) (r9 runtime buf off) (r10 runtime buf off) (r11 runtime buf off) (r12 runtime buf off) (r13 runtime buf off) (r14 runtime buf off) (r15 runtime buf off) (r16 runtime buf off) (r17 runtime buf off) (r18 runtime buf off) (r19 runtime buf off)
   | FCons (r1, FCons (r2, FCons (r3, FCons (r4, FCons (r5, FCons (r6, FCons (r7, FCons (r8, FCons (r9, FCons (r10, FCons (r11, FCons (r12, FCons (r13, FCons (r14, FCons (r15, FCons (r16, FCons (r17, FCons (r18, FCons (r19, FCons (r20, FNil)))))))))))))))))))) ->
-      f (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off) (r5 buf off) (r6 buf off) (r7 buf off) (r8 buf off) (r9 buf off) (r10 buf off) (r11 buf off) (r12 buf off) (r13 buf off) (r14 buf off) (r15 buf off) (r16 buf off) (r17 buf off) (r18 buf off) (r19 buf off) (r20 buf off)
+      f (r1 runtime buf off) (r2 runtime buf off) (r3 runtime buf off) (r4 runtime buf off) (r5 runtime buf off) (r6 runtime buf off) (r7 runtime buf off) (r8 runtime buf off) (r9 runtime buf off) (r10 runtime buf off) (r11 runtime buf off) (r12 runtime buf off) (r13 runtime buf off) (r14 runtime buf off) (r15 runtime buf off) (r16 runtime buf off) (r17 runtime buf off) (r18 runtime buf off) (r19 runtime buf off) (r20 runtime buf off)
   | FCons (r1, FCons (r2, FCons (r3, FCons (r4, FCons (r5, FCons (r6, FCons (r7, FCons (r8, FCons (r9, FCons (r10, FCons (r11, FCons (r12, FCons (r13, FCons (r14, FCons (r15, FCons (r16, FCons (r17, FCons (r18, FCons (r19, FCons (r20, FCons (r21, FNil))))))))))))))))))))) ->
-      f (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off) (r5 buf off) (r6 buf off) (r7 buf off) (r8 buf off) (r9 buf off) (r10 buf off) (r11 buf off) (r12 buf off) (r13 buf off) (r14 buf off) (r15 buf off) (r16 buf off) (r17 buf off) (r18 buf off) (r19 buf off) (r20 buf off) (r21 buf off)
+      f (r1 runtime buf off) (r2 runtime buf off) (r3 runtime buf off) (r4 runtime buf off) (r5 runtime buf off) (r6 runtime buf off) (r7 runtime buf off) (r8 runtime buf off) (r9 runtime buf off) (r10 runtime buf off) (r11 runtime buf off) (r12 runtime buf off) (r13 runtime buf off) (r14 runtime buf off) (r15 runtime buf off) (r16 runtime buf off) (r17 runtime buf off) (r18 runtime buf off) (r19 runtime buf off) (r20 runtime buf off) (r21 runtime buf off)
   | FCons (r1, FCons (r2, FCons (r3, FCons (r4, FCons (r5, FCons (r6, FCons (r7, FCons (r8, FCons (r9, FCons (r10, FCons (r11, FCons (r12, FCons (r13, FCons (r14, FCons (r15, FCons (r16, FCons (r17, FCons (r18, FCons (r19, FCons (r20, FCons (r21, FCons (r22, FNil)))))))))))))))))))))) ->
-      f (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off) (r5 buf off) (r6 buf off) (r7 buf off) (r8 buf off) (r9 buf off) (r10 buf off) (r11 buf off) (r12 buf off) (r13 buf off) (r14 buf off) (r15 buf off) (r16 buf off) (r17 buf off) (r18 buf off) (r19 buf off) (r20 buf off) (r21 buf off) (r22 buf off)
+      f (r1 runtime buf off) (r2 runtime buf off) (r3 runtime buf off) (r4 runtime buf off) (r5 runtime buf off) (r6 runtime buf off) (r7 runtime buf off) (r8 runtime buf off) (r9 runtime buf off) (r10 runtime buf off) (r11 runtime buf off) (r12 runtime buf off) (r13 runtime buf off) (r14 runtime buf off) (r15 runtime buf off) (r16 runtime buf off) (r17 runtime buf off) (r18 runtime buf off) (r19 runtime buf off) (r20 runtime buf off) (r21 runtime buf off) (r22 runtime buf off)
   | FCons (r1, FCons (r2, FCons (r3, FCons (r4, FCons (r5, FCons (r6, FCons (r7, FCons (r8, FCons (r9, FCons (r10, FCons (r11, FCons (r12, FCons (r13, FCons (r14, FCons (r15, FCons (r16, FCons (r17, FCons (r18, FCons (r19, FCons (r20, FCons (r21, FCons (r22, FCons (r23, FNil))))))))))))))))))))))) ->
-      f (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off) (r5 buf off) (r6 buf off) (r7 buf off) (r8 buf off) (r9 buf off) (r10 buf off) (r11 buf off) (r12 buf off) (r13 buf off) (r14 buf off) (r15 buf off) (r16 buf off) (r17 buf off) (r18 buf off) (r19 buf off) (r20 buf off) (r21 buf off) (r22 buf off) (r23 buf off)
+      f (r1 runtime buf off) (r2 runtime buf off) (r3 runtime buf off) (r4 runtime buf off) (r5 runtime buf off) (r6 runtime buf off) (r7 runtime buf off) (r8 runtime buf off) (r9 runtime buf off) (r10 runtime buf off) (r11 runtime buf off) (r12 runtime buf off) (r13 runtime buf off) (r14 runtime buf off) (r15 runtime buf off) (r16 runtime buf off) (r17 runtime buf off) (r18 runtime buf off) (r19 runtime buf off) (r20 runtime buf off) (r21 runtime buf off) (r22 runtime buf off) (r23 runtime buf off)
   | FCons (r1, FCons (r2, FCons (r3, FCons (r4, FCons (r5, FCons (r6, FCons (r7, FCons (r8, FCons (r9, FCons (r10, FCons (r11, FCons (r12, FCons (r13, FCons (r14, FCons (r15, FCons (r16, FCons (r17, FCons (r18, FCons (r19, FCons (r20, FCons (r21, FCons (r22, FCons (r23, FCons (r24, FNil)))))))))))))))))))))))) ->
-      f (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off) (r5 buf off) (r6 buf off) (r7 buf off) (r8 buf off) (r9 buf off) (r10 buf off) (r11 buf off) (r12 buf off) (r13 buf off) (r14 buf off) (r15 buf off) (r16 buf off) (r17 buf off) (r18 buf off) (r19 buf off) (r20 buf off) (r21 buf off) (r22 buf off) (r23 buf off) (r24 buf off)
+      f (r1 runtime buf off) (r2 runtime buf off) (r3 runtime buf off) (r4 runtime buf off) (r5 runtime buf off) (r6 runtime buf off) (r7 runtime buf off) (r8 runtime buf off) (r9 runtime buf off) (r10 runtime buf off) (r11 runtime buf off) (r12 runtime buf off) (r13 runtime buf off) (r14 runtime buf off) (r15 runtime buf off) (r16 runtime buf off) (r17 runtime buf off) (r18 runtime buf off) (r19 runtime buf off) (r20 runtime buf off) (r21 runtime buf off) (r22 runtime buf off) (r23 runtime buf off) (r24 runtime buf off)
   | FCons (r1, FCons (r2, FCons (r3, FCons (r4, FCons (r5, FCons (r6, FCons (r7, FCons (r8, FCons (r9, FCons (r10, FCons (r11, FCons (r12, FCons (r13, FCons (r14, FCons (r15, FCons (r16, FCons (r17, FCons (r18, FCons (r19, FCons (r20, FCons (r21, FCons (r22, FCons (r23, FCons (r24, FCons (r25, FNil))))))))))))))))))))))))) ->
-      f (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off) (r5 buf off) (r6 buf off) (r7 buf off) (r8 buf off) (r9 buf off) (r10 buf off) (r11 buf off) (r12 buf off) (r13 buf off) (r14 buf off) (r15 buf off) (r16 buf off) (r17 buf off) (r18 buf off) (r19 buf off) (r20 buf off) (r21 buf off) (r22 buf off) (r23 buf off) (r24 buf off) (r25 buf off)
+      f (r1 runtime buf off) (r2 runtime buf off) (r3 runtime buf off) (r4 runtime buf off) (r5 runtime buf off) (r6 runtime buf off) (r7 runtime buf off) (r8 runtime buf off) (r9 runtime buf off) (r10 runtime buf off) (r11 runtime buf off) (r12 runtime buf off) (r13 runtime buf off) (r14 runtime buf off) (r15 runtime buf off) (r16 runtime buf off) (r17 runtime buf off) (r18 runtime buf off) (r19 runtime buf off) (r20 runtime buf off) (r21 runtime buf off) (r22 runtime buf off) (r23 runtime buf off) (r24 runtime buf off) (r25 runtime buf off)
   | FCons (r1, FCons (r2, FCons (r3, FCons (r4, FCons (r5, FCons (r6, FCons (r7, FCons (r8, FCons (r9, FCons (r10, FCons (r11, FCons (r12, FCons (r13, FCons (r14, FCons (r15, FCons (r16, FCons (r17, FCons (r18, FCons (r19, FCons (r20, FCons (r21, FCons (r22, FCons (r23, FCons (r24, FCons (r25, FCons (r26, FNil)))))))))))))))))))))))))) ->
-      f (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off) (r5 buf off) (r6 buf off) (r7 buf off) (r8 buf off) (r9 buf off) (r10 buf off) (r11 buf off) (r12 buf off) (r13 buf off) (r14 buf off) (r15 buf off) (r16 buf off) (r17 buf off) (r18 buf off) (r19 buf off) (r20 buf off) (r21 buf off) (r22 buf off) (r23 buf off) (r24 buf off) (r25 buf off) (r26 buf off)
+      f (r1 runtime buf off) (r2 runtime buf off) (r3 runtime buf off) (r4 runtime buf off) (r5 runtime buf off) (r6 runtime buf off) (r7 runtime buf off) (r8 runtime buf off) (r9 runtime buf off) (r10 runtime buf off) (r11 runtime buf off) (r12 runtime buf off) (r13 runtime buf off) (r14 runtime buf off) (r15 runtime buf off) (r16 runtime buf off) (r17 runtime buf off) (r18 runtime buf off) (r19 runtime buf off) (r20 runtime buf off) (r21 runtime buf off) (r22 runtime buf off) (r23 runtime buf off) (r24 runtime buf off) (r25 runtime buf off) (r26 runtime buf off)
   | FCons (r1, FCons (r2, FCons (r3, FCons (r4, FCons (r5, FCons (r6, FCons (r7, FCons (r8, FCons (r9, FCons (r10, FCons (r11, FCons (r12, FCons (r13, FCons (r14, FCons (r15, FCons (r16, FCons (r17, FCons (r18, FCons (r19, FCons (r20, FCons (r21, FCons (r22, FCons (r23, FCons (r24, FCons (r25, FCons (r26, FCons (r27, FNil))))))))))))))))))))))))))) ->
-      f (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off) (r5 buf off) (r6 buf off) (r7 buf off) (r8 buf off) (r9 buf off) (r10 buf off) (r11 buf off) (r12 buf off) (r13 buf off) (r14 buf off) (r15 buf off) (r16 buf off) (r17 buf off) (r18 buf off) (r19 buf off) (r20 buf off) (r21 buf off) (r22 buf off) (r23 buf off) (r24 buf off) (r25 buf off) (r26 buf off) (r27 buf off)
+      f (r1 runtime buf off) (r2 runtime buf off) (r3 runtime buf off) (r4 runtime buf off) (r5 runtime buf off) (r6 runtime buf off) (r7 runtime buf off) (r8 runtime buf off) (r9 runtime buf off) (r10 runtime buf off) (r11 runtime buf off) (r12 runtime buf off) (r13 runtime buf off) (r14 runtime buf off) (r15 runtime buf off) (r16 runtime buf off) (r17 runtime buf off) (r18 runtime buf off) (r19 runtime buf off) (r20 runtime buf off) (r21 runtime buf off) (r22 runtime buf off) (r23 runtime buf off) (r24 runtime buf off) (r25 runtime buf off) (r26 runtime buf off) (r27 runtime buf off)
   | FCons (r1, FCons (r2, FCons (r3, FCons (r4, FCons (r5, FCons (r6, FCons (r7, FCons (r8, FCons (r9, FCons (r10, FCons (r11, FCons (r12, FCons (r13, FCons (r14, FCons (r15, FCons (r16, FCons (r17, FCons (r18, FCons (r19, FCons (r20, FCons (r21, FCons (r22, FCons (r23, FCons (r24, FCons (r25, FCons (r26, FCons (r27, FCons (r28, FNil)))))))))))))))))))))))))))) ->
-      f (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off) (r5 buf off) (r6 buf off) (r7 buf off) (r8 buf off) (r9 buf off) (r10 buf off) (r11 buf off) (r12 buf off) (r13 buf off) (r14 buf off) (r15 buf off) (r16 buf off) (r17 buf off) (r18 buf off) (r19 buf off) (r20 buf off) (r21 buf off) (r22 buf off) (r23 buf off) (r24 buf off) (r25 buf off) (r26 buf off) (r27 buf off) (r28 buf off)
+      f (r1 runtime buf off) (r2 runtime buf off) (r3 runtime buf off) (r4 runtime buf off) (r5 runtime buf off) (r6 runtime buf off) (r7 runtime buf off) (r8 runtime buf off) (r9 runtime buf off) (r10 runtime buf off) (r11 runtime buf off) (r12 runtime buf off) (r13 runtime buf off) (r14 runtime buf off) (r15 runtime buf off) (r16 runtime buf off) (r17 runtime buf off) (r18 runtime buf off) (r19 runtime buf off) (r20 runtime buf off) (r21 runtime buf off) (r22 runtime buf off) (r23 runtime buf off) (r24 runtime buf off) (r25 runtime buf off) (r26 runtime buf off) (r27 runtime buf off) (r28 runtime buf off)
   | FCons (r1, FCons (r2, FCons (r3, FCons (r4, FCons (r5, FCons (r6, FCons (r7, FCons (r8, FCons (r9, FCons (r10, FCons (r11, FCons (r12, FCons (r13, FCons (r14, FCons (r15, FCons (r16, FCons (r17, FCons (r18, FCons (r19, FCons (r20, FCons (r21, FCons (r22, FCons (r23, FCons (r24, FCons (r25, FCons (r26, FCons (r27, FCons (r28, FCons (r29, FNil))))))))))))))))))))))))))))) ->
-      f (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off) (r5 buf off) (r6 buf off) (r7 buf off) (r8 buf off) (r9 buf off) (r10 buf off) (r11 buf off) (r12 buf off) (r13 buf off) (r14 buf off) (r15 buf off) (r16 buf off) (r17 buf off) (r18 buf off) (r19 buf off) (r20 buf off) (r21 buf off) (r22 buf off) (r23 buf off) (r24 buf off) (r25 buf off) (r26 buf off) (r27 buf off) (r28 buf off) (r29 buf off)
+      f (r1 runtime buf off) (r2 runtime buf off) (r3 runtime buf off) (r4 runtime buf off) (r5 runtime buf off) (r6 runtime buf off) (r7 runtime buf off) (r8 runtime buf off) (r9 runtime buf off) (r10 runtime buf off) (r11 runtime buf off) (r12 runtime buf off) (r13 runtime buf off) (r14 runtime buf off) (r15 runtime buf off) (r16 runtime buf off) (r17 runtime buf off) (r18 runtime buf off) (r19 runtime buf off) (r20 runtime buf off) (r21 runtime buf off) (r22 runtime buf off) (r23 runtime buf off) (r24 runtime buf off) (r25 runtime buf off) (r26 runtime buf off) (r27 runtime buf off) (r28 runtime buf off) (r29 runtime buf off)
   | FCons (r1, FCons (r2, FCons (r3, FCons (r4, FCons (r5, FCons (r6, FCons (r7, FCons (r8, FCons (r9, FCons (r10, FCons (r11, FCons (r12, FCons (r13, FCons (r14, FCons (r15, FCons (r16, FCons (r17, FCons (r18, FCons (r19, FCons (r20, FCons (r21, FCons (r22, FCons (r23, FCons (r24, FCons (r25, FCons (r26, FCons (r27, FCons (r28, FCons (r29, FCons (r30, FNil)))))))))))))))))))))))))))))) ->
-      f (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off) (r5 buf off) (r6 buf off) (r7 buf off) (r8 buf off) (r9 buf off) (r10 buf off) (r11 buf off) (r12 buf off) (r13 buf off) (r14 buf off) (r15 buf off) (r16 buf off) (r17 buf off) (r18 buf off) (r19 buf off) (r20 buf off) (r21 buf off) (r22 buf off) (r23 buf off) (r24 buf off) (r25 buf off) (r26 buf off) (r27 buf off) (r28 buf off) (r29 buf off) (r30 buf off)
+      f (r1 runtime buf off) (r2 runtime buf off) (r3 runtime buf off) (r4 runtime buf off) (r5 runtime buf off) (r6 runtime buf off) (r7 runtime buf off) (r8 runtime buf off) (r9 runtime buf off) (r10 runtime buf off) (r11 runtime buf off) (r12 runtime buf off) (r13 runtime buf off) (r14 runtime buf off) (r15 runtime buf off) (r16 runtime buf off) (r17 runtime buf off) (r18 runtime buf off) (r19 runtime buf off) (r20 runtime buf off) (r21 runtime buf off) (r22 runtime buf off) (r23 runtime buf off) (r24 runtime buf off) (r25 runtime buf off) (r26 runtime buf off) (r27 runtime buf off) (r28 runtime buf off) (r29 runtime buf off) (r30 runtime buf off)
   | FCons (r1, FCons (r2, FCons (r3, FCons (r4, FCons (r5, FCons (r6, FCons (r7, FCons (r8, FCons (r9, FCons (r10, FCons (r11, FCons (r12, FCons (r13, FCons (r14, FCons (r15, FCons (r16, FCons (r17, FCons (r18, FCons (r19, FCons (r20, FCons (r21, FCons (r22, FCons (r23, FCons (r24, FCons (r25, FCons (r26, FCons (r27, FCons (r28, FCons (r29, FCons (r30, FCons (r31, FNil))))))))))))))))))))))))))))))) ->
-      f (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off) (r5 buf off) (r6 buf off) (r7 buf off) (r8 buf off) (r9 buf off) (r10 buf off) (r11 buf off) (r12 buf off) (r13 buf off) (r14 buf off) (r15 buf off) (r16 buf off) (r17 buf off) (r18 buf off) (r19 buf off) (r20 buf off) (r21 buf off) (r22 buf off) (r23 buf off) (r24 buf off) (r25 buf off) (r26 buf off) (r27 buf off) (r28 buf off) (r29 buf off) (r30 buf off) (r31 buf off)
+      f (r1 runtime buf off) (r2 runtime buf off) (r3 runtime buf off) (r4 runtime buf off) (r5 runtime buf off) (r6 runtime buf off) (r7 runtime buf off) (r8 runtime buf off) (r9 runtime buf off) (r10 runtime buf off) (r11 runtime buf off) (r12 runtime buf off) (r13 runtime buf off) (r14 runtime buf off) (r15 runtime buf off) (r16 runtime buf off) (r17 runtime buf off) (r18 runtime buf off) (r19 runtime buf off) (r20 runtime buf off) (r21 runtime buf off) (r22 runtime buf off) (r23 runtime buf off) (r24 runtime buf off) (r25 runtime buf off) (r26 runtime buf off) (r27 runtime buf off) (r28 runtime buf off) (r29 runtime buf off) (r30 runtime buf off) (r31 runtime buf off)
   | FCons (r1, FCons (r2, FCons (r3, FCons (r4, FCons (r5, FCons (r6, FCons (r7, FCons (r8, FCons (r9, FCons (r10, FCons (r11, FCons (r12, FCons (r13, FCons (r14, FCons (r15, FCons (r16, FCons (r17, FCons (r18, FCons (r19, FCons (r20, FCons (r21, FCons (r22, FCons (r23, FCons (r24, FCons (r25, FCons (r26, FCons (r27, FCons (r28, FCons (r29, FCons (r30, FCons (r31, FCons (r32, rest)))))))))))))))))))))))))))))))) ->
-      apply_fwd (f (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off) (r5 buf off) (r6 buf off) (r7 buf off) (r8 buf off) (r9 buf off) (r10 buf off) (r11 buf off) (r12 buf off) (r13 buf off) (r14 buf off) (r15 buf off) (r16 buf off) (r17 buf off) (r18 buf off) (r19 buf off) (r20 buf off) (r21 buf off) (r22 buf off) (r23 buf off) (r24 buf off) (r25 buf off) (r26 buf off) (r27 buf off) (r28 buf off) (r29 buf off) (r30 buf off) (r31 buf off) (r32 buf off)) rest buf off
+      apply_fwd (f (r1 runtime buf off) (r2 runtime buf off) (r3 runtime buf off) (r4 runtime buf off) (r5 runtime buf off) (r6 runtime buf off) (r7 runtime buf off) (r8 runtime buf off) (r9 runtime buf off) (r10 runtime buf off) (r11 runtime buf off) (r12 runtime buf off) (r13 runtime buf off) (r14 runtime buf off) (r15 runtime buf off) (r16 runtime buf off) (r17 runtime buf off) (r18 runtime buf off) (r19 runtime buf off) (r20 runtime buf off) (r21 runtime buf off) (r22 runtime buf off) (r23 runtime buf off) (r24 runtime buf off) (r25 runtime buf off) (r26 runtime buf off) (r27 runtime buf off) (r28 runtime buf off) (r29 runtime buf off) (r30 runtime buf off) (r31 runtime buf off) (r32 runtime buf off)) rest runtime buf off
 [@@ocamlformat "disable"]
 
-let build_decode : type full r. full -> (full, r) readers -> runtime -> int -> r
-    =
+let build_decode : type full r.
+    full -> (full, r) readers -> runtime -> bytes -> int -> r =
  fun make readers ->
   match readers with
-  | Nil -> fun _buf _off -> make
-  | Snoc (Nil, r1) -> fun buf off -> make (r1 buf off)
-  | Snoc (Snoc (Nil, r1), r2) -> fun buf off -> make (r1 buf off) (r2 buf off)
+  | Nil -> fun _runtime _buf _off -> make
+  | Snoc (Nil, r1) -> fun runtime buf off -> make (r1 runtime buf off)
+  | Snoc (Snoc (Nil, r1), r2) ->
+      fun runtime buf off -> make (r1 runtime buf off) (r2 runtime buf off)
   | Snoc (Snoc (Snoc (Nil, r1), r2), r3) ->
-      fun buf off -> make (r1 buf off) (r2 buf off) (r3 buf off)
+      fun runtime buf off ->
+        make (r1 runtime buf off) (r2 runtime buf off) (r3 runtime buf off)
   | Snoc (Snoc (Snoc (Snoc (Nil, r1), r2), r3), r4) ->
-      fun buf off -> make (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off)
+      fun runtime buf off ->
+        make (r1 runtime buf off) (r2 runtime buf off) (r3 runtime buf off)
+          (r4 runtime buf off)
   | Snoc (Snoc (Snoc (Snoc (Snoc (Nil, r1), r2), r3), r4), r5) ->
-      fun buf off ->
-        make (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off) (r5 buf off)
+      fun runtime buf off ->
+        make (r1 runtime buf off) (r2 runtime buf off) (r3 runtime buf off)
+          (r4 runtime buf off) (r5 runtime buf off)
   | Snoc (Snoc (Snoc (Snoc (Snoc (Snoc (Nil, r1), r2), r3), r4), r5), r6) ->
-      fun buf off ->
-        make (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off) (r5 buf off)
-          (r6 buf off)
+      fun runtime buf off ->
+        make (r1 runtime buf off) (r2 runtime buf off) (r3 runtime buf off)
+          (r4 runtime buf off) (r5 runtime buf off) (r6 runtime buf off)
   | Snoc
       (Snoc (Snoc (Snoc (Snoc (Snoc (Snoc (Nil, r1), r2), r3), r4), r5), r6), r7)
     ->
-      fun buf off ->
-        make (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off) (r5 buf off)
-          (r6 buf off) (r7 buf off)
+      fun runtime buf off ->
+        make (r1 runtime buf off) (r2 runtime buf off) (r3 runtime buf off)
+          (r4 runtime buf off) (r5 runtime buf off) (r6 runtime buf off)
+          (r7 runtime buf off)
   | Snoc
       ( Snoc
           ( Snoc (Snoc (Snoc (Snoc (Snoc (Snoc (Nil, r1), r2), r3), r4), r5), r6),
             r7 ),
         r8 ) ->
-      fun buf off ->
-        make (r1 buf off) (r2 buf off) (r3 buf off) (r4 buf off) (r5 buf off)
-          (r6 buf off) (r7 buf off) (r8 buf off)
+      fun runtime buf off ->
+        make (r1 runtime buf off) (r2 runtime buf off) (r3 runtime buf off)
+          (r4 runtime buf off) (r5 runtime buf off) (r6 runtime buf off)
+          (r7 runtime buf off) (r8 runtime buf off)
   | readers ->
       let fwd = to_fwd readers in
-      fun buf off -> apply_fwd make fwd buf off
+      fun runtime buf off -> apply_fwd make fwd runtime buf off
 
 let lookup_reader_idx rev_readers name =
   let rec find i = function
@@ -3046,13 +3092,12 @@ let seed_param_slots arr n_total = function
       let n = Array.length slots in
       Array.blit slots 0 arr.ints (n_total - n) n
 
-let validation_runtime param_slots arr buf =
+let validation_runtime param_slots arr =
   Types.eval_ctx
     ~set_param:(fun name value ->
       match Hashtbl.find_opt param_slots name with
       | Some idx -> arr.ints.(idx) <- value
       | None -> ())
-    buf
     (fun name ->
       match Hashtbl.find_opt param_slots name with
       | Some idx -> arr.ints.(idx)
@@ -3062,9 +3107,9 @@ let build_validators validators_rev checkers_rev compiled_where struct_fields
     param_slots n_total =
   let validator_fns = Array.of_list (List.map snd validators_rev) in
   let n_validators = Array.length validator_fns in
-  let validate_arr arr runtime off =
+  let validate_arr arr runtime buf off =
     for i = 0 to n_validators - 1 do
-      validator_fns.(i) arr runtime off
+      validator_fns.(i) arr runtime buf off
     done;
     match compiled_where with
     | Some f when not (f arr) -> raise_constraint ~at:off ~which:Where ()
@@ -3072,9 +3117,9 @@ let build_validators validators_rev checkers_rev compiled_where struct_fields
   in
   let checker_fns = Array.of_list (List.map snd checkers_rev) in
   let n_checkers = Array.length checker_fns in
-  let populate arr runtime off =
+  let populate arr runtime buf off =
     for i = 0 to n_checkers - 1 do
-      checker_fns.(i) arr runtime off
+      checker_fns.(i) arr runtime buf off
     done
   in
   (* Run the validator pass only when the struct actually has something to
@@ -3093,8 +3138,8 @@ let build_validators validators_rev checkers_rev compiled_where struct_fields
         (* Seed param slots so [where] clauses referencing [Param.input]
            evaluate correctly. *)
         seed_param_slots arr n_total env_slots;
-        let runtime = validation_runtime param_slots arr buf in
-        validate_or_eof buf (fun () -> validate_arr arr runtime off)
+        let runtime = validation_runtime param_slots arr in
+        validate_or_eof buf (fun () -> validate_arr arr runtime buf off)
   in
   (validate_arr, populate, validate)
 
@@ -3126,15 +3171,14 @@ let fill_param_slots tbl param_base handles =
    must hold at least [min_size] bytes, and the codec's resolved wire size must
    fit. Shared with [validate] so a constraint-free codec is still bounds-checked
    before a zero-copy [get] reads its fields. *)
-let check_decode_bounds wire_size_info min_size runtime off =
-  let buf = Types.eval_bytes runtime in
+let check_decode_bounds wire_size_info min_size runtime buf off =
   if off + min_size > Bytes.length buf then
     raise_eof ~at:off ~expected:min_size ~got:(Bytes.length buf - off);
   match wire_size_info with
   | Fixed _ -> ()
   | Variable { compute; _ } ->
       let end_off =
-        try compute runtime off
+        try compute runtime buf off
         with Invalid_argument _ ->
           raise_eof ~at:off ~expected:min_size ~got:(Bytes.length buf - off)
       in
@@ -3144,9 +3188,9 @@ let check_decode_bounds wire_size_info min_size runtime off =
         raise_eof ~at:off ~expected:(end_off - off) ~got:(Bytes.length buf - off)
 
 let build_checked_decode raw_decode wire_size_info min_size =
- fun runtime off ->
-  check_decode_bounds wire_size_info min_size runtime off;
-  raw_decode runtime off
+ fun runtime buf off ->
+  check_decode_bounds wire_size_info min_size runtime buf off;
+  raw_decode runtime buf off
 
 (* [Codec.validate] is the safety gate before a batch of zero-copy [get] calls on
    untrusted input, so it must run decode's structural bounds check even for a
@@ -3157,14 +3201,14 @@ let validate_with_bounds wire_size_info min_size param_slots param_base
  fun ?env_slots buf off ->
   let runtime =
     match env_slots with
-    | None -> no_runtime buf
+    | None -> no_runtime
     | Some slots ->
-        Types.eval_ctx buf (fun name ->
+        Types.eval_ctx (fun name ->
             match Hashtbl.find_opt param_slots name with
             | Some idx -> slots.(idx - param_base)
             | None -> 0)
   in
-  check_decode_bounds wire_size_info min_size runtime off;
+  check_decode_bounds wire_size_info min_size runtime buf off;
   validate_checks ?env_slots buf off
 
 (* Whether a field consumes the rest of the buffer: a greedy leaf ([all_bytes] /
@@ -3397,8 +3441,7 @@ let build_size_of_value size_funcs =
 
 let build_record_encoder name writers size_of_value =
   let n = Array.length writers in
-  fun value runtime off ->
-    let buf = Types.eval_bytes runtime in
+  fun value runtime buf off ->
     let need = size_of_value value in
     if off + need > Bytes.length buf then
       Fmt.invalid_arg "Codec.encode %s: buffer too short (need %d, got %d)" name
@@ -3406,7 +3449,7 @@ let build_record_encoder name writers size_of_value =
         (Bytes.length buf - off);
     let write_off = Stdlib.ref off in
     for i = 0 to n - 1 do
-      write_off := writers.(i) value runtime off !write_off
+      write_off := writers.(i) value runtime buf off !write_off
     done;
     !write_off
 
@@ -3478,13 +3521,13 @@ type validator = {
   min_size : int;
   wire_size : wire_size_info;
   validate : bytes -> int -> unit;
-  validate_ctx : runtime -> int -> unit;
+  validate_ctx : runtime -> bytes -> int -> unit;
 }
 
 (* Internal accumulator -- the validator-relevant subset of [record]. *)
 type validator_acc = {
-  validators_rev : (int * (slots -> runtime -> int -> unit)) list;
-  checkers_rev : (int * (slots -> runtime -> int -> unit)) list;
+  validators_rev : (int * (slots -> runtime -> bytes -> int -> unit)) list;
+  checkers_rev : (int * (slots -> runtime -> bytes -> int -> unit)) list;
   field_readers : field_reader list;
   n_fields : int;
   n_array_slots : int;
@@ -3529,14 +3572,14 @@ let layout_ctx_of_validator_acc acc =
 (* Common access patterns over [next_off]: a fresh-buffer offset
    function and a "previous end" helper that hides the static/dynamic
    split. *)
-let acc_off_fn (acc : validator_acc) : runtime -> int -> int =
+let acc_off_fn (acc : validator_acc) : runtime -> bytes -> int -> int =
   match acc.next_off with
-  | Static n -> fun _buf _base -> n
-  | Dynamic f -> fun buf base -> f buf base - base
+  | Static n -> fun _runtime _buf _base -> n
+  | Dynamic f -> fun runtime buf base -> f runtime buf base - base
 
-let acc_prev_end (acc : validator_acc) : runtime -> int -> int =
+let acc_prev_end (acc : validator_acc) : runtime -> bytes -> int -> int =
   match acc.next_off with
-  | Static n -> fun _buf base -> base + n
+  | Static n -> fun _runtime _buf base -> base + n
   | Dynamic f -> f
 
 (* Validator step for a [Struct]-typed field. [compile_field] doesn't
@@ -3555,7 +3598,7 @@ let build_field_checks acc ~populate ~validator_off ~name ~action ~constraint_ =
     | Some (Types.Success stmts | Types.Act stmts) ->
         List.fold_left action_vars [] stmts
   in
-  let dummy_reader _buf _base = 0 in
+  let dummy_reader _runtime _buf _base = 0 in
   let cc_readers =
     let base = (name, dummy_reader) :: acc.field_readers in
     List.fold_left
@@ -3572,15 +3615,15 @@ let build_field_checks acc ~populate ~validator_off ~name ~action ~constraint_ =
   let raise_check_failed arr base =
     raise_field_constraint ~field_idx:acc.n_fields ~at:base arr
   in
-  let full arr buf base =
-    populate arr buf base;
+  let full arr runtime buf base =
+    populate arr runtime buf base;
     (match check with
     | Some f when not (f arr) -> raise_check_failed arr base
     | _ -> ());
     Option.iter (fun f -> f arr) act
   in
-  let check_only arr buf base =
-    populate arr buf base;
+  let check_only arr runtime buf base =
+    populate arr runtime buf base;
     match check with
     | Some f when not (f arr) -> raise_check_failed arr base
     | _ -> ()
@@ -3591,16 +3634,20 @@ let rec apply_struct_field acc inner_struct =
   let inner_v = validator_of_struct inner_struct in
   let static_off = match acc.next_off with Static n -> n | Dynamic _ -> -1 in
   let off_fn = acc_off_fn acc in
-  let validator _arr runtime base =
-    inner_v.validate_ctx runtime (base + off_fn runtime base)
+  let validator _arr runtime buf base =
+    inner_v.validate_ctx runtime buf (base + off_fn runtime buf base)
   in
   let prev_end = acc_prev_end acc in
   let size_delta, next_off =
     match (acc.next_off, inner_v.wire_size) with
     | Static n, Fixed sz -> (sz, Static (n + sz))
-    | _, Fixed sz -> (sz, Dynamic (fun buf base -> prev_end buf base + sz))
+    | _, Fixed sz ->
+        (sz, Dynamic (fun runtime buf base -> prev_end runtime buf base + sz))
     | _, Variable { min_size; compute } ->
-        (min_size, Dynamic (fun buf base -> compute buf (prev_end buf base)))
+        ( min_size,
+          Dynamic
+            (fun runtime buf base ->
+              compute runtime buf (prev_end runtime buf base)) )
   in
   {
     validators_rev = (static_off, validator) :: acc.validators_rev;
@@ -3680,16 +3727,16 @@ and validator_of_struct (s : Types.struct_) : validator =
      actions). [validate_arr] runs full validators against a per-domain
      scratch, zeroed on entry. *)
   let get_arr = domain_local_slots n_total in
-  let validate_ctx runtime off =
+  let validate_ctx runtime buf off =
     let arr = get_arr () in
     if n_total > 0 then clear_slots arr n_total;
     List.iteri
       (fun i (Param.Pack p) ->
         arr.ints.(param_base + i) <- Types.eval_param runtime p.Types.name)
       param_handles;
-    validate_arr arr runtime off
+    validate_arr arr runtime buf off
   in
-  let validate buf off = validate_ctx (no_runtime buf) off in
+  let validate buf off = validate_ctx no_runtime buf off in
   {
     min_size = acc.min_size;
     wire_size = wire_size_info;
@@ -3702,7 +3749,7 @@ let validate_struct (v : validator) buf off = v.validate buf off
 let struct_size_of (v : validator) buf off =
   match v.wire_size with
   | Fixed n -> n
-  | Variable { compute; _ } -> compute (no_runtime buf) off - off
+  | Variable { compute; _ } -> compute no_runtime buf off - off
 
 let struct_min_size (v : validator) = v.min_size
 
@@ -3710,7 +3757,7 @@ let wire_size_info_of_validator (v : validator) =
   match v.wire_size with
   | Fixed n -> `Fixed n
   | Variable { compute; _ } ->
-      `Variable (fun buf off -> compute (no_runtime buf) off)
+      `Variable (fun buf off -> compute no_runtime buf off)
 
 (* Heterogeneous field list. [] seals the view; (::) adds a field.
    Tracks the constructor type: ('a -> 'b -> 'r, 'r) matches a
@@ -3744,14 +3791,14 @@ let min_wire_size (t : _ t) =
 let wire_size_at (t : _ t) buf off =
   match t.wire_size with
   | Fixed n -> n
-  | Variable { compute; _ } -> compute (no_runtime buf) off - off
+  | Variable { compute; _ } -> compute no_runtime buf off - off
 
 let size_of_value (t : _ t) v = t.size_of_value v
 
 let is_fixed (t : _ t) =
   match t.wire_size with Fixed _ -> true | Variable _ -> false
 
-let raw_decode (t : _ t) buf off = t.decode (no_runtime buf) off
+let raw_decode (t : _ t) buf off = t.decode no_runtime buf off
 
 (* Reject [encode] on a parametric codec without an env, and reject envs
    that left an input param unbound. Either case would silently resolve
@@ -3798,45 +3845,43 @@ let require_env ~op t = function
 
 let raw_encode ?env:e t v buf off =
   require_env ~op:"encode" t e;
-  t.encode v (runtime ?env:e buf) off
+  t.encode v (runtime ?env:e ()) buf off
 
-let embed_encode_ctx (t : 'r t) v runtime off = t.encode v runtime off
+let embed_encode_ctx (t : 'r t) v runtime buf off = t.encode v runtime buf off
+let embed_encode (t : 'r t) v buf off = embed_encode_ctx t v no_runtime buf off
 
-let embed_encode (t : 'r t) v buf off =
-  embed_encode_ctx t v (no_runtime buf) off
-
-let validate_runtime t runtime off =
+let validate_runtime t runtime buf off =
   let arr = t.decode_scratch () in
   clear_slots arr t.n_array_slots;
   List.iteri
     (fun i (Param.Pack p) ->
       arr.ints.(t.param_base + i) <- Types.eval_param runtime p.Types.name)
     t.param_handles;
-  t.validate_arr arr runtime off;
+  t.validate_arr arr runtime buf off;
   List.iteri
     (fun i (Param.Pack p) ->
       if p.Types.mutable_ then
         Types.eval_set_param runtime p.name arr.ints.(t.param_base + i))
     t.param_handles
 
-let embed_decode_ctx (t : 'r t) runtime off =
-  let v = t.decode runtime off in
-  validate_runtime t runtime off;
+let embed_decode_ctx (t : 'r t) runtime buf off =
+  let v = t.decode runtime buf off in
+  validate_runtime t runtime buf off;
   v
 
-let embed_decode (t : 'r t) buf off = embed_decode_ctx t (no_runtime buf) off
+let embed_decode (t : 'r t) buf off = embed_decode_ctx t no_runtime buf off
 
 let wire_size_info_ctx (t : _ t) =
   match t.wire_size with
   | Fixed n -> `Fixed n
   | Variable { compute; _ } ->
-      `Variable (fun runtime off -> compute runtime off - off)
+      `Variable (fun runtime buf off -> compute runtime buf off - off)
 
 let wire_size_info (t : _ t) =
   match t.wire_size with
   | Fixed n -> `Fixed n
   | Variable { compute; _ } ->
-      `Variable (fun buf off -> compute (no_runtime buf) off - off)
+      `Variable (fun buf off -> compute no_runtime buf off - off)
 
 let env (t : _ t) : Param.env =
   {
@@ -3854,15 +3899,15 @@ let decode_exn ?env:e t buf off =
      and misaligning the rest of the record. This is a usage error, not malformed
      input, so it raises [Invalid_argument] rather than returning a parse error. *)
   require_env ~op:"decode" t e;
-  let runtime = runtime ?env:e buf in
-  let v = t.decode runtime off in
+  let runtime = runtime ?env:e () in
+  let v = t.decode runtime buf off in
   let arr = t.decode_scratch () in
   clear_slots arr t.n_array_slots;
   (match e with
   | Some (e : Param.env) when t.n_params > 0 ->
       Array.blit e.slots 0 arr.ints t.param_base t.n_params
   | _ -> ());
-  t.validate_arr arr runtime off;
+  t.validate_arr arr runtime buf off;
   (match e with
   | Some (e : Param.env) ->
       (* Array slot of [param_handles.(i)] is [param_base + i]; its env slot is
@@ -3881,7 +3926,7 @@ let decode ?env t buf off =
 let encode ?env:e t v buf off =
   require_env ~op:"encode" t e;
   let expected = t.size_of_value v in
-  let actual = t.encode v (runtime ?env:e buf) off - off in
+  let actual = t.encode v (runtime ?env:e ()) buf off - off in
   (* Underrun = silent data corruption: the trailing bytes the caller
      allocated stay uninitialised and the decoder reads them as part
      of the value. Overrun is loud already. *)
@@ -3912,57 +3957,55 @@ let validate ?env:e (t : _ t) buf off =
    For Bitfield: the GADT ensures 'a = int via Bits constructor.
    For Dynamic: compute offset at read time. *)
 let rec build_staged_reader : type a.
-    a typ -> field_access -> runtime -> int -> a =
+    a typ -> field_access -> runtime -> bytes -> int -> a =
  fun typ access ->
   match (typ, access) with
   | Bits _, Bitfield { base; byte_off; shift; width } ->
       let read = build_bf_reader base byte_off shift width in
-      fun runtime base -> read (Types.eval_bytes runtime) base
+      fun _runtime buf base -> read buf base
   | _, Fixed off ->
       let read = build_field_reader_ctx typ off in
-      fun runtime base -> read runtime base
+      fun runtime buf base -> read runtime buf base
   | _, Dynamic fn ->
       let reader_at_0 = build_field_reader_ctx typ 0 in
-      fun runtime base ->
-        let off = fn runtime base in
-        reader_at_0 runtime (base + off)
+      fun runtime buf base ->
+        let off = fn runtime buf base in
+        reader_at_0 runtime buf (base + off)
   | Byte_slice _, Variable { off; size_fn } ->
-      fun runtime base ->
-        let sz = size_fn runtime base in
-        Slice.make_or_eod (Types.eval_bytes runtime) ~first:(base + off)
-          ~length:sz
+      fun runtime buf base ->
+        let sz = size_fn runtime buf base in
+        Slice.make_or_eod buf ~first:(base + off) ~length:sz
   | Byte_array _, Variable { off; size_fn } ->
-      fun runtime base ->
-        let sz = size_fn runtime base in
-        Bytes.sub_string (Types.eval_bytes runtime) (base + off) sz
+      fun runtime buf base ->
+        let sz = size_fn runtime buf base in
+        Bytes.sub_string buf (base + off) sz
   | Byte_array_where _, Variable { off; size_fn } ->
-      fun runtime base ->
-        let sz = size_fn runtime base in
-        Bytes.sub_string (Types.eval_bytes runtime) (base + off) sz
+      fun runtime buf base ->
+        let sz = size_fn runtime buf base in
+        Bytes.sub_string buf (base + off) sz
   | Byte_slice _, Variable_dynamic { off_fn; size_fn } ->
-      fun runtime base ->
-        let fo = off_fn runtime base in
-        let sz = size_fn runtime base in
-        Slice.make_or_eod (Types.eval_bytes runtime) ~first:(base + fo)
-          ~length:sz
+      fun runtime buf base ->
+        let fo = off_fn runtime buf base in
+        let sz = size_fn runtime buf base in
+        Slice.make_or_eod buf ~first:(base + fo) ~length:sz
   | Byte_array _, Variable_dynamic { off_fn; size_fn } ->
-      fun runtime base ->
-        let fo = off_fn runtime base in
-        let sz = size_fn runtime base in
-        Bytes.sub_string (Types.eval_bytes runtime) (base + fo) sz
+      fun runtime buf base ->
+        let fo = off_fn runtime buf base in
+        let sz = size_fn runtime buf base in
+        Bytes.sub_string buf (base + fo) sz
   | Byte_array_where _, Variable_dynamic { off_fn; size_fn } ->
-      fun runtime base ->
-        let fo = off_fn runtime base in
-        let sz = size_fn runtime base in
-        Bytes.sub_string (Types.eval_bytes runtime) (base + fo) sz
+      fun runtime buf base ->
+        let fo = off_fn runtime buf base in
+        let sz = size_fn runtime buf base in
+        Bytes.sub_string buf (base + fo) sz
   | Where { inner; _ }, _ -> build_staged_reader inner access
   | Enum { base; cases; closed; _ }, _ ->
       let read = build_staged_reader base access in
       let check = enum_check cases closed in
-      fun buf base -> check ~at:base (read buf base)
+      fun runtime buf base -> check ~at:base (read runtime buf base)
   | Map { inner; decode; _ }, _ ->
       let read = build_staged_reader inner access in
-      fun buf base -> decode (read buf base)
+      fun runtime buf base -> decode (read runtime buf base)
   | _, Bitfield _ ->
       invalid_arg "Codec.get: non-bitfield type with bitfield access"
   | _, Variable _ | _, Variable_dynamic _ ->
@@ -3970,63 +4013,57 @@ let rec build_staged_reader : type a.
 
 (* Build a staged writer from field type and access info. *)
 let rec build_staged_writer : type a.
-    a typ -> field_access -> runtime -> int -> a -> unit =
+    a typ -> field_access -> runtime -> bytes -> int -> a -> unit =
  fun typ access ->
   match (typ, access) with
   | Bits _, Bitfield { base; byte_off; shift; width } ->
       let write = build_bf_accessor_writer base byte_off shift width in
-      fun runtime base value -> write (Types.eval_bytes runtime) base value
+      fun _runtime buf base value -> write buf base value
   | _, Fixed off ->
       let encode = build_field_encoder_ctx typ in
-      fun runtime base value ->
-        let _ = encode runtime (Types.eval_bytes runtime) (base + off) value in
+      fun runtime buf base value ->
+        let _ = encode runtime buf (base + off) value in
         ()
   | _, Dynamic fn ->
       let encode = build_field_encoder_ctx typ in
-      fun runtime base value ->
-        let off = fn runtime base in
-        let _ = encode runtime (Types.eval_bytes runtime) (base + off) value in
+      fun runtime buf base value ->
+        let off = fn runtime buf base in
+        let _ = encode runtime buf (base + off) value in
         ()
   | Byte_slice _, Variable { off; _ } ->
-      fun runtime base value ->
-        let buf = Types.eval_bytes runtime in
+      fun _runtime buf base value ->
         let src = (value : Slice.t) in
         let len = Slice.length src in
         Bytes.blit (Slice.bytes src) (Slice.first src) buf (base + off) len
   | Byte_array _, Variable { off; _ } ->
-      fun runtime base value ->
-        let buf = Types.eval_bytes runtime in
+      fun _runtime buf base value ->
         let s = (value : string) in
         Bytes.blit_string s 0 buf (base + off) (String.length s)
   | Byte_array_where _, Variable { off; _ } ->
-      fun runtime base value ->
-        let buf = Types.eval_bytes runtime in
+      fun _runtime buf base value ->
         let s = (value : string) in
         Bytes.blit_string s 0 buf (base + off) (String.length s)
   | Byte_slice _, Variable_dynamic { off_fn; _ } ->
-      fun runtime base value ->
-        let buf = Types.eval_bytes runtime in
-        let fo = off_fn runtime base in
+      fun runtime buf base value ->
+        let fo = off_fn runtime buf base in
         let src = (value : Slice.t) in
         let len = Slice.length src in
         Bytes.blit (Slice.bytes src) (Slice.first src) buf (base + fo) len
   | Byte_array _, Variable_dynamic { off_fn; _ } ->
-      fun runtime base value ->
-        let buf = Types.eval_bytes runtime in
-        let fo = off_fn runtime base in
+      fun runtime buf base value ->
+        let fo = off_fn runtime buf base in
         let s = (value : string) in
         Bytes.blit_string s 0 buf (base + fo) (String.length s)
   | Byte_array_where _, Variable_dynamic { off_fn; _ } ->
-      fun runtime base value ->
-        let buf = Types.eval_bytes runtime in
-        let fo = off_fn runtime base in
+      fun runtime buf base value ->
+        let fo = off_fn runtime buf base in
         let s = (value : string) in
         Bytes.blit_string s 0 buf (base + fo) (String.length s)
   | Where { inner; _ }, _ -> build_staged_writer inner access
   | Enum { base; _ }, _ -> build_staged_writer base access
   | Map { inner; encode; _ }, _ ->
       let write = build_staged_writer inner access in
-      fun buf base value -> write buf base (encode value)
+      fun runtime buf base value -> write runtime buf base (encode value)
   | _, Bitfield _ ->
       invalid_arg "Codec.set: non-bitfield type with bitfield access"
   | _, Variable _ | _, Variable_dynamic _ ->
@@ -4087,11 +4124,14 @@ let[@inline] get (type a r) ?env (codec : r t) (f : (a, r) field) :
   Option.iter (check_env_owner ~op:"get" codec) env;
   let access = field_access codec f.name in
   let read = build_staged_reader f.typ access in
+  (* The context no longer carries the buffer, so [env] resolves once here
+     instead of per staged call. *)
+  let rt = runtime ?env () in
   match List.assoc_opt f.name codec.field_actions with
   | None -> (
       match build_immediate_staged_reader f.typ access with
       | Some read -> Staged.stage read
-      | None -> Staged.stage (fun buf off -> read (runtime ?env buf) off))
+      | None -> Staged.stage (fun buf off -> read rt buf off))
   | Some act ->
       (* Reuse the codec's own domain-local scratch rather than minting another
          [Domain.DLS] key here: [get] returns a staged reader, but a caller that
@@ -4119,12 +4159,11 @@ let[@inline] get (type a r) ?env (codec : r t) (f : (a, r) field) :
                   Array.blit e.slots 0 arr.ints param_base n_params )
       in
       Staged.stage (fun buf off ->
-          let runtime = runtime ?env buf in
-          let v = read runtime off in
+          let v = read rt buf off in
           let arr = get_arr () in
           clear_slots arr n;
           blit_input arr;
-          populate arr runtime off;
+          populate arr rt buf off;
           act arr;
           sync arr;
           v)
@@ -4135,7 +4174,7 @@ let[@inline] set (type a r) (codec : r t) (f : (a, r) field) :
   let write = build_staged_writer f.typ access in
   match build_immediate_staged_writer f.typ access with
   | Some write -> Staged.stage write
-  | None -> Staged.stage (fun buf off value -> write (no_runtime buf) off value)
+  | None -> Staged.stage (fun buf off value -> write no_runtime buf off value)
 
 let name (t : _ t) = t.name
 let rename new_name (t : _ t) = { t with name = new_name }
@@ -4144,7 +4183,7 @@ let field_readers_ctx (t : _ t) = t.field_readers
 
 let field_readers (t : _ t) =
   List.map
-    (fun (name, read) -> (name, fun buf off -> read (no_runtime buf) off))
+    (fun (name, read) -> (name, fun buf off -> read no_runtime buf off))
     t.field_readers
 
 let pp ppf (t : _ t) = Fmt.string ppf t.name
@@ -4168,10 +4207,10 @@ let[@inline] slice_offset (type r) (codec : r t) (f : (Slice.t, r) field) :
     (bytes -> int -> int) Staged.t =
   match field_access codec f.name with
   | Fixed off -> Staged.stage (fun _buf base -> base + off)
-  | Dynamic fn -> Staged.stage (fun buf base -> base + fn (no_runtime buf) base)
+  | Dynamic fn -> Staged.stage (fun buf base -> base + fn no_runtime buf base)
   | Variable { off; _ } -> Staged.stage (fun _buf base -> base + off)
   | Variable_dynamic { off_fn; _ } ->
-      Staged.stage (fun buf base -> base + off_fn (no_runtime buf) base)
+      Staged.stage (fun buf base -> base + off_fn no_runtime buf base)
   | Bitfield _ ->
       Fmt.invalid_arg
         "Codec.slice_offset: field %S is a bitfield, not a byte slice" f.name
@@ -4189,7 +4228,7 @@ let[@inline] slice_length (type r) (codec : r t) (f : (Slice.t, r) field) :
              -- internal inconsistency"
             f.name)
   | _, Variable { size_fn; _ } | _, Variable_dynamic { size_fn; _ } ->
-      Staged.stage (fun buf base -> size_fn (no_runtime buf) base)
+      Staged.stage (fun buf base -> size_fn no_runtime buf base)
   | _, (Fixed _ | Dynamic _) ->
       Fmt.invalid_arg "Codec.slice_length: field %S is not a byte slice" f.name
   | _, Bitfield _ ->

--- a/lib/codec.mli
+++ b/lib/codec.mli
@@ -168,7 +168,7 @@ val embed_encode : 'r t -> 'r -> bytes -> int -> int
 (** Encode a parameter-free sub-codec embedded as a field/element, skipping the
     env check {!encode} performs. Internal use. *)
 
-val embed_encode_ctx : 'r t -> 'r -> Types.eval_ctx -> int -> int
+val embed_encode_ctx : 'r t -> 'r -> Types.eval_ctx -> bytes -> int -> int
 (** Context-threaded embedded encode. Internal use. *)
 
 val embed_decode : 'r t -> bytes -> int -> 'r
@@ -176,14 +176,14 @@ val embed_decode : 'r t -> bytes -> int -> 'r
     field constraints against param values seeded by the enclosing codec.
     Internal use. *)
 
-val embed_decode_ctx : 'r t -> Types.eval_ctx -> int -> 'r
+val embed_decode_ctx : 'r t -> Types.eval_ctx -> bytes -> int -> 'r
 (** Context-threaded embedded decode. Internal use. *)
 
 val wire_size_info : 'r t -> [ `Fixed of int | `Variable of bytes -> int -> int ]
 (** Wire size information for embedding. *)
 
 val wire_size_info_ctx :
-  'r t -> [ `Fixed of int | `Variable of Types.eval_ctx -> int -> int ]
+  'r t -> [ `Fixed of int | `Variable of Types.eval_ctx -> bytes -> int -> int ]
 (** Context-threaded wire size information for embedding. Internal use. *)
 
 val name : 'r t -> string
@@ -205,7 +205,8 @@ val field_readers : 'r t -> (string * (bytes -> int -> int)) list
     field name. Used for cross-codec name resolution when [c] is embedded as a
     sub-codec via {!Wire.codec}. *)
 
-val field_readers_ctx : 'r t -> (string * (Types.eval_ctx -> int -> int)) list
+val field_readers_ctx :
+  'r t -> (string * (Types.eval_ctx -> bytes -> int -> int)) list
 (** Context-threaded field readers for embedding. Internal use. *)
 
 val pp : Format.formatter -> 'r t -> unit

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -25,36 +25,22 @@ type ('elt, 'seq) seq_map =
 (* Param handles -- defined here so expr and action_stmt can reference them *)
 type param_input
 type param_output
+type bindings = { param : string -> int; set_param : string -> int -> unit }
 
-type bound_eval_ctx = {
-  bytes : bytes;
-  param : string -> int;
-  set_param : string -> int -> unit;
-}
+(* The buffer travels as its own argument rather than inside the context, so
+   the parameter-free hot path is the constant constructor [Unbound]. Being a
+   constant, it is an immediate: an encode or decode without parameters builds
+   no context block and allocates nothing. *)
+type eval_ctx = Unbound | Bound of bindings
 
-type eval_ctx = Obj.t
+let unbound_eval_ctx = Unbound
+let eval_ctx ?(set_param = fun _ _ -> ()) param = Bound { param; set_param }
 
-(* A parameter-free operation is the common hot path. Represent its context by
-   the bytes block itself (whose runtime tag is [String_tag]) so introducing an
-   explicit context does not add an allocation to every encode/decode. A bound
-   context is a normal record and therefore has tag 0. The type stays abstract
-   outside this module, containing the representation distinction here. *)
-let empty_eval_ctx bytes : eval_ctx = Obj.repr bytes
+let eval_param ctx name =
+  match ctx with Unbound -> 0 | Bound b -> b.param name
 
-let eval_ctx ?(set_param = fun _ _ -> ()) bytes param : eval_ctx =
-  Obj.repr { bytes; param; set_param }
-
-let eval_bytes (ctx : eval_ctx) : bytes =
-  if Obj.tag ctx = Obj.string_tag then Obj.obj ctx
-  else (Obj.obj ctx : bound_eval_ctx).bytes
-
-let eval_param (ctx : eval_ctx) name =
-  if Obj.tag ctx = Obj.string_tag then 0
-  else (Obj.obj ctx : bound_eval_ctx).param name
-
-let eval_set_param (ctx : eval_ctx) name value =
-  if Obj.tag ctx <> Obj.string_tag then
-    (Obj.obj ctx : bound_eval_ctx).set_param name value
+let eval_set_param ctx name value =
+  match ctx with Unbound -> () | Bound b -> b.set_param name value
 
 (* Parse errors, defined before [typ] so [typ]'s own [Where] / [Field]
    constructors win type-directed disambiguation everywhere below; the
@@ -240,18 +226,18 @@ and _ typ =
   | Apply : { typ : 'a typ; args : packed_expr list } -> 'a typ
   | Codec : {
       codec_name : string;
-      codec_decode : eval_ctx -> int -> 'r;
-      codec_encode : 'r -> eval_ctx -> int -> int;
+      codec_decode : eval_ctx -> bytes -> int -> 'r;
+      codec_encode : 'r -> eval_ctx -> bytes -> int -> int;
           (* Returns the offset after the bytes the encoder wrote. *)
       codec_fixed_size : int option;
-      codec_size_of : eval_ctx -> int -> int;
+      codec_size_of : eval_ctx -> bytes -> int -> int;
       codec_size_of_value : 'r -> int;
           (* Encoded byte length of a value, computed from the value rather
              than by re-reading the buffer. The buffer-driven [codec_size_of]
              is wrong for variable-size codecs ending in [all_bytes] /
              [rest_bytes] / [all_zeros]: it reads "remaining buffer space",
              not the value's actual tail length. *)
-      codec_field_readers : (string * (eval_ctx -> int -> int)) list;
+      codec_field_readers : (string * (eval_ctx -> bytes -> int -> int)) list;
       codec_struct : struct_;
           (** Structural representation of the codec. Mirrors [codec_decode] /
               [codec_encode] but in a form 3D projection can walk. *)

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -7,18 +7,16 @@ val equal_endian : endian -> endian -> bool
 (** [equal_endian a b] is [true] when [a] and [b] are the same byte order. *)
 
 type eval_ctx
-(** Explicit runtime context for buffer and parameter expression evaluation.
-    Internal to the direct and compiled interpreters. *)
+(** Parameter bindings for expression evaluation. Internal to the direct and
+    compiled interpreters. The buffer is not part of the context: it travels as
+    its own argument so that {!unbound_eval_ctx} is a constant, and a
+    parameter-free encode or decode allocates no context. *)
 
-val empty_eval_ctx : bytes -> eval_ctx
-(** A runtime context with no parameter bindings. *)
+val unbound_eval_ctx : eval_ctx
+(** The context with no parameter bindings. Internal use. *)
 
-val eval_ctx :
-  ?set_param:(string -> int -> unit) -> bytes -> (string -> int) -> eval_ctx
-(** A runtime context with explicit parameter lookup. Internal use. *)
-
-val eval_bytes : eval_ctx -> bytes
-(** The context's input/output buffer. Internal use. *)
+val eval_ctx : ?set_param:(string -> int -> unit) -> (string -> int) -> eval_ctx
+(** A context with explicit parameter lookup. Internal use. *)
 
 val eval_param : eval_ctx -> string -> int
 (** Look up a parameter, returning 0 in an unbound context. Internal use. *)
@@ -260,14 +258,14 @@ and _ typ =
       (** Parameterised type application. *)
   | Codec : {
       codec_name : string;
-      codec_decode : eval_ctx -> int -> 'r;
-      codec_encode : 'r -> eval_ctx -> int -> int;
+      codec_decode : eval_ctx -> bytes -> int -> 'r;
+      codec_encode : 'r -> eval_ctx -> bytes -> int -> int;
       codec_fixed_size : int option;
-      codec_size_of : eval_ctx -> int -> int;
+      codec_size_of : eval_ctx -> bytes -> int -> int;
       codec_size_of_value : 'r -> int;
           (** Encoded byte length of a value, computed from the value rather
               than by re-reading the buffer. *)
-      codec_field_readers : (string * (eval_ctx -> int -> int)) list;
+      codec_field_readers : (string * (eval_ctx -> bytes -> int -> int)) list;
       codec_struct : struct_;
           (** Structural form of the codec, used by the 3D projection. *)
     }

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -79,7 +79,7 @@ let codec (c : 'r Codec.t) : 'r typ =
           codec_decode;
           codec_encode;
           codec_fixed_size = Some n;
-          codec_size_of = (fun _buf _off -> n);
+          codec_size_of = (fun _ctx _buf _off -> n);
           codec_size_of_value;
           codec_field_readers;
           codec_struct;
@@ -307,11 +307,10 @@ let rec parse_direct : type a. a typ -> bytes -> int -> int -> a * int =
       check_enum_membership ~at:off ~closed cases v;
       (v, off')
   | Codec { codec_decode; codec_fixed_size; codec_size_of; _ } ->
-      let runtime = Types.empty_eval_ctx buf in
       parse_codec_typ
-        (fun _buf off -> codec_decode runtime off)
+        (codec_decode Types.unbound_eval_ctx)
         codec_fixed_size
-        (fun _buf off -> codec_size_of runtime off)
+        (codec_size_of Types.unbound_eval_ctx)
         buf off len
   | Struct s -> parse_struct_typ s buf off len
   | Casetype { cases; tag; _ } -> parse_casetype tag cases buf off len
@@ -766,7 +765,7 @@ let rec encode_into : type a. a typ -> a -> encoder -> unit =
   | Map { inner; encode; _ } -> encode_into inner (encode v) enc
   | Codec { codec_encode; codec_fixed_size; codec_size_of_value; _ } ->
       encode_codec
-        ~encode:(fun v buf off -> codec_encode v (Types.empty_eval_ctx buf) off)
+        ~encode:(fun v buf off -> codec_encode v Types.unbound_eval_ctx buf off)
         ~fixed_size:codec_fixed_size ~size_of_value:codec_size_of_value v enc
   | Optional { present; inner } ->
       if Eval.expr Eval.empty present then encode_into inner (Option.get v) enc
@@ -902,7 +901,7 @@ let rec encode_direct : type a. a typ -> bytes -> int -> a -> int =
   | Map { inner; encode; _ } -> encode_direct inner buf off (encode v)
   | Where { inner; _ } -> encode_direct inner buf off v
   | Enum { base; _ } -> encode_direct base buf off v
-  | Codec { codec_encode; _ } -> codec_encode v (Types.empty_eval_ctx buf) off
+  | Codec { codec_encode; _ } -> codec_encode v Types.unbound_eval_ctx buf off
   | _ -> encode_via_writer typ buf off v
 
 let to_bytes typ v =

--- a/merlint.toml
+++ b/merlint.toml
@@ -2,10 +2,3 @@
 [[rules]]
 files = "examples/net/net.ml"
 exclude = ["E350"]
-
-# A parameter-free evaluation context is represented directly by its bytes
-# block so the explicit context does not regress allocation-free codec paths.
-# The unsafe representation is confined to this module and hidden by its mli.
-[[rules]]
-files = "lib/types.ml"
-exclude = ["E100"]


### PR DESCRIPTION
The expression evaluation context discriminated its unbound and bound shapes with `Obj.tag`, and `merlint.toml` carried an E100 exclusion to silence the finding; both are now gone.

Taking the buffer out of the context makes the parameter-free case a constant constructor, so the committed zero-allocation tests still measure the same word counts as before.