### PR TITLE
codec: make fixed-size byte fields exact on encode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,7 +24,7 @@
   and desynchronise every following field, so the bytes on the wire could
   differ from the value a caller had signed, hashed or length-prefixed. For a
   short value in a fixed-size region use `zeroterm_at_most`, which is
-  NUL-terminated and round-trips (@samoht)
+  NUL-terminated and round-trips (#259, @samoht)
 
 - Generated `.3d` C struct tags are now named `Wire<Name>` rather than
   `_<Name>`. Public typedef names are unchanged, and standalone entrypoints
@@ -42,6 +42,12 @@
   word stays an unboxed int (#232, @samoht)
 
 ### Fixed
+
+- A constant size or length expression such as `Expr.(int 2 + int 2)` now
+  behaves exactly like the literal `int 4`. It used to slip past every check
+  and fast path that looks for a literal size, so such a field encoded
+  without its exact-length check, reported its codec as variable-size, and
+  bypassed the `uint` 1-7 size guard (#259, @samoht)
 
 - `Wire.Ascii` diagrams now render every expression a size or constraint can
   contain. Bitmasks, shifts, division, casts, conditionals, `sizeof` and

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,15 @@
 
 ### Changed
 
+- **Breaking:** encoding a `byte_array`, `byte_array_where` or `byte_slice`
+  whose length differs from its declared `~size` now raises
+  `Invalid_argument`. It used to silently truncate a longer value, zero-pad a
+  shorter one, or (through the streaming writer) write the value's own length
+  and desynchronise every following field, so the bytes on the wire could
+  differ from the value a caller had signed, hashed or length-prefixed. For a
+  short value in a fixed-size region use `zeroterm_at_most`, which is
+  NUL-terminated and round-trips (@samoht)
+
 - Generated `.3d` C struct tags are now named `Wire<Name>` rather than
   `_<Name>`. Public typedef names are unchanged, and standalone entrypoints
   follow as `<Base>CheckWire<Name>` (#235, @samoht)

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -2,23 +2,15 @@ open Types
 module Slice = Bytesrw.Bytes.Slice
 module Param = Param
 
-(** Generic blit-with-padding into a fixed [n]-byte window. The caller supplies
-    the source length and a copy callback that writes exactly [len] bytes
-    starting at the given destination offset; this helper handles bounding by
-    [n] and zeroing the tail. *)
-let blit_padded n buf off ~src_len ~blit =
-  let len = min n src_len in
-  blit ~dst_off:off ~len;
-  if len < n then Bytes.fill buf (off + len) (n - len) '\x00';
+let blit_string_exact n buf off v =
+  check_byte_field_size ~expected:n ~actual:(String.length v);
+  Bytes.blit_string v 0 buf off n;
   off + n
 
-let blit_string_padded n buf off v =
-  blit_padded n buf off ~src_len:(String.length v) ~blit:(fun ~dst_off ~len ->
-      Bytes.blit_string v 0 buf dst_off len)
-
-let blit_slice_padded n buf off src =
-  blit_padded n buf off ~src_len:(Slice.length src) ~blit:(fun ~dst_off ~len ->
-      Bytes.blit (Slice.bytes src) (Slice.first src) buf dst_off len)
+let blit_slice_exact n buf off src =
+  check_byte_field_size ~expected:n ~actual:(Slice.length src);
+  Bytes.blit (Slice.bytes src) (Slice.first src) buf off n;
+  off + n
 
 (* Pack a fixed-width integer setter into a [bytes -> int -> int -> int]
    field encoder that returns the offset advance. Used by the scalar cases
@@ -152,14 +144,9 @@ and build_field_encoder_ctx : type a.
   | Float64 Big -> fun _runtime -> float64_field_encoder Bytes.set_int64_be
   | Uint_var { size = Int n; endian } ->
       fun _runtime -> uint_var_field_encoder endian n
-  | Byte_array { size = Int n } -> fun _runtime -> blit_string_padded n
-  | Byte_array_where { size = Int n; _ } -> fun _runtime -> blit_string_padded n
-  | Byte_slice { size = Int n } ->
-      fun _runtime buf off v ->
-        let len = min n (Slice.length v) in
-        Bytes.blit (Slice.bytes v) (Slice.first v) buf off len;
-        if len < n then Bytes.fill buf (off + len) (n - len) '\x00';
-        off + n
+  | Byte_array { size = Int n } -> fun _runtime -> blit_string_exact n
+  | Byte_array_where { size = Int n; _ } -> fun _runtime -> blit_string_exact n
+  | Byte_slice { size = Int n } -> fun _runtime -> blit_slice_exact n
   | Where { inner; _ } -> build_field_encoder_ctx inner
   | Enum { base; _ } -> build_field_encoder_ctx base
   | Map { inner; encode; _ } ->
@@ -1601,8 +1588,8 @@ let rec write_elem : type a. a typ -> runtime -> bytes -> int -> a -> unit =
       let n = String.length v in
       Bytes.blit_string v 0 buf off n;
       Bytes.set_uint8 buf (off + n) 0
-  (* Fixed-size byte spans: the field encoder blits / pads the constant width
-     and returns the advanced offset, which the repeat loop recomputes. *)
+  (* Fixed-size byte spans: the field encoder blits the constant width and
+     returns the advanced offset, which the repeat loop recomputes. *)
   | Byte_array { size = Int _ } ->
       ignore (build_field_encoder typ buf off v : int)
   | Byte_slice { size = Int _ } ->
@@ -2220,12 +2207,7 @@ let var_bytes_reader : type a.
 (* Kept at top level: as local closures they would be heap-allocated on
    every call (two allocations per variable-bytes field on each encode). *)
 let var_bytes_check_len size_fn runtime buf base ~actual =
-  let expected = size_fn runtime buf base in
-  if actual <> expected then
-    Fmt.invalid_arg
-      "Codec.encode: byte field length %d does not match expected %d \
-       (parametric size, bind via ?env)"
-      actual expected
+  check_byte_field_size ~expected:(size_fn runtime buf base) ~actual
 
 let var_bytes_write_str buf write_off s =
   let len = String.length s in

--- a/lib/codec.mli
+++ b/lib/codec.mli
@@ -60,7 +60,8 @@ val size_of_value : 'r t -> 'r -> int
     whose tail is [all_bytes] / [rest_bytes] / [all_zeros], where the
     buffer-driven {!wire_size_at} cannot distinguish "value's tail" from
     "remaining buffer space". Fixed-size byte arrays and slices contribute their
-    declared region size, including any zero-padding or truncation. *)
+    declared region size, which {!encode} requires the value to match exactly.
+*)
 
 val is_fixed : 'r t -> bool
 (** [is_fixed c] is [true] iff the codec [c] has a fixed wire size. *)
@@ -280,12 +281,13 @@ val extract : bitfield -> Optint.t -> int
 (** [extract bf word] extracts the field from a pre-loaded word value. Pure
     shift+mask, no memory access. *)
 
-val blit_string_padded : int -> bytes -> int -> string -> int
-(** [blit_string_padded n buf off s] writes [s] into [buf] at [off], zero-pads
-    the trailing bytes if [String.length s < n], and returns [off + n]. Shared
-    helper for both record and top-level encoders. *)
+val blit_string_exact : int -> bytes -> int -> string -> int
+(** [blit_string_exact n buf off s] writes [s] into [buf] at [off] and returns
+    [off + n]. Raises [Invalid_argument] unless [String.length s = n]: a
+    fixed-size byte field is exact. Shared helper for both record and top-level
+    encoders. *)
 
-val blit_slice_padded : int -> bytes -> int -> Bytesrw.Bytes.Slice.t -> int
-(** [blit_slice_padded n buf off src] is like {!blit_string_padded} but copies
+val blit_slice_exact : int -> bytes -> int -> Bytesrw.Bytes.Slice.t -> int
+(** [blit_slice_exact n buf off src] is like {!blit_string_exact} but copies
     from a {!Bytesrw.Bytes.Slice.t}. Top-level [encode_direct] uses it for
     [byte_slice] fields. *)

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -362,6 +362,86 @@ module Expr = struct
   let to_uint64 e = Cast (`U64, e)
 end
 
+(* Constant size and length expressions are normalised to [Int n] at the
+   construction boundary below. The rest of the library keys its fast paths and
+   its range guards on a literal [Int n] size, so [Expr.(int 2 + int 2)] has to
+   arrive as the same node as [int 4] or it silently falls off every one of
+   them.
+
+   Only reference-free arithmetic folds. A [Ref], [Param_ref], [Sizeof_this] or
+   [Field_pos] resolves against a buffer at decode time, and [Sizeof] must stay
+   symbolic so the 3D projection keeps emitting [sizeof(T)] rather than a
+   baked-in width. *)
+
+(* Native-int arithmetic that reports overflow instead of wrapping: a constant
+   folded to a value its expression does not denote would be worse than leaving
+   the expression symbolic. *)
+let const_add a b =
+  let s = a + b in
+  if a lxor s land (b lxor s) < 0 then None else Some s
+
+let const_sub a b =
+  let d = a - b in
+  if a lxor b land (a lxor d) < 0 then None else Some d
+
+let const_mul a b =
+  if a = 0 then Some 0
+  else if a = -1 && b = min_int then None
+  else
+    let p = a * b in
+    if p / a = b then Some p else None
+
+(* [min_int / -1] is the one division whose true result is not representable;
+   OCaml returns [min_int] for it rather than trapping. *)
+let const_div a b =
+  if b = 0 || (a = min_int && b = -1) then None else Some (a / b)
+
+let const_rem a b =
+  if b = 0 || (a = min_int && b = -1) then None else Some (a mod b)
+
+let const_shift_left a b =
+  if b >= 0 && b < Sys.int_size && (a lsl b) asr b = a then Some (a lsl b)
+  else None
+
+let const_shift_right a b =
+  if b >= 0 && b < Sys.int_size then Some (a lsr b) else None
+
+let const_cast width v =
+  match width with
+  | `U8 -> v land 0xFF
+  | `U16 -> v land 0xFFFF
+  | `U32 -> v land UInt32.mask32
+  | `U64 -> v
+
+let rec const_int_expr : int expr -> int option = function
+  | Int n -> Some n
+  | Ref _ | Param_ref _ | Sizeof _ | Sizeof_this | Field_pos -> None
+  | Add (a, b) -> const_binop const_add a b
+  | Sub (a, b) -> const_binop const_sub a b
+  | Mul (a, b) -> const_binop const_mul a b
+  | Div (a, b) -> const_binop const_div a b
+  | Mod (a, b) -> const_binop const_rem a b
+  | Land (a, b) -> const_binop (fun a b -> Some (a land b)) a b
+  | Lor (a, b) -> const_binop (fun a b -> Some (a lor b)) a b
+  | Lxor (a, b) -> const_binop (fun a b -> Some (a lxor b)) a b
+  | Lnot a -> Option.map lnot (const_int_expr a)
+  | Lsl (a, b) -> const_binop const_shift_left a b
+  | Lsr (a, b) -> const_binop const_shift_right a b
+  | Cast (width, e) -> Option.map (const_cast width) (const_int_expr e)
+  (* A constant condition would need the same pass over [bool expr]; leave the
+     whole node symbolic. *)
+  | If_then_else _ -> None
+
+and const_binop f a b =
+  match (const_int_expr a, const_int_expr b) with
+  | Some a, Some b -> f a b
+  | None, _ | _, None -> None
+
+(* [fold_size e] is [e] with a reference-free constant folded to its literal.
+   Every smart constructor taking a size or length expression runs its argument
+   through it. *)
+let fold_size e = match const_int_expr e with Some n -> Int n | None -> e
+
 (* Type constructors *)
 let uint8 = Uint8
 let uint16 = Uint16 Little
@@ -385,6 +465,7 @@ let float64 = Float64 Little
 let float64be = Float64 Big
 
 let uint ?(endian = Big) size =
+  let size = fold_size size in
   (match size with
   | Int n when n < 1 || n > 7 ->
       Fmt.invalid_arg "uint: size must be 1-7, got %d" n
@@ -478,7 +559,7 @@ let unit = Unit
 let all_bytes = All_bytes
 let all_zeros = All_zeros
 let zeroterm = Zeroterm
-let zeroterm_at_most ~size = Zeroterm_at_most { size }
+let zeroterm_at_most ~size = Zeroterm_at_most { size = fold_size size }
 
 let where cond inner =
   reject_decoration ~combinator:"where" inner;
@@ -694,15 +775,15 @@ let array ~len elem =
   reject_decoration ~combinator:"array" elem;
   reject_bitfield_element ~combinator:"array" elem;
   reject_non_array_element ~combinator:"array" elem;
-  Array { len; elem; seq = seq_list }
+  Array { len = fold_size len; elem; seq = seq_list }
 
 let array_seq seq ~len elem =
   reject_decoration ~combinator:"array_seq" elem;
   reject_bitfield_element ~combinator:"array_seq" elem;
   reject_non_array_element ~combinator:"array_seq" elem;
-  Array { len; elem; seq }
+  Array { len = fold_size len; elem; seq }
 
-let byte_array ~size = Byte_array { size }
+let byte_array ~size = Byte_array { size = fold_size size }
 let byte_array_where_counter = Stdlib.ref 0
 let elt_var_prefix = "__elt_"
 
@@ -711,7 +792,7 @@ let byte_array_where ~size ~per_byte =
   Stdlib.incr byte_array_where_counter;
   let elt_var = elt_var_prefix ^ string_of_int n in
   let cond = per_byte (Ref (I, elt_var)) in
-  Byte_array_where { size; elt_var; cond }
+  Byte_array_where { size = fold_size size; elt_var; cond }
 
 (* The 3D synthesized typedef name derived from an elt_var. The element
    field inside the synthesized struct keeps the elt_var as its name so the
@@ -723,7 +804,7 @@ let synth_name_of_elt_var ev =
     "_RefByte_" ^ String.sub ev plen (String.length ev - plen)
   else "_RefByte_" ^ ev
 
-let byte_slice ~size = Byte_slice { size }
+let byte_slice ~size = Byte_slice { size = fold_size size }
 
 let optional present inner =
   reject_bitfield_element ~combinator:"optional" inner;
@@ -743,20 +824,20 @@ let optional_or present ~default inner =
 let repeat ~size elem =
   reject_decoration ~combinator:"repeat" elem;
   reject_bitfield_element ~combinator:"repeat" elem;
-  Repeat { size; elem; seq = seq_list }
+  Repeat { size = fold_size size; elem; seq = seq_list }
 
 let repeat_seq seq ~size elem =
   reject_decoration ~combinator:"repeat_seq" elem;
   reject_bitfield_element ~combinator:"repeat_seq" elem;
-  Repeat { size; elem; seq }
+  Repeat { size = fold_size size; elem; seq }
 
 let nested ~size elem =
   reject_bitfield_element ~combinator:"nested" elem;
-  Single_elem { size; elem; at_most = false }
+  Single_elem { size = fold_size size; elem; at_most = false }
 
 let nested_at_most ~size elem =
   reject_bitfield_element ~combinator:"nested_at_most" elem;
-  Single_elem { size; elem; at_most = true }
+  Single_elem { size = fold_size size; elem; at_most = true }
 
 let enum name cases base = Enum { name; cases; base; closed = true }
 let enum_open name cases base = Enum { name; cases; base; closed = false }

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -516,6 +516,16 @@ let exact_repeat_elements seq ~expected ~size_of values =
     Fmt.invalid_arg "Wire.repeat: expected %d bytes, got %d" expected actual;
   sized
 
+(* A fixed-size byte field is exact. Truncating a long value or zero-padding a
+   short one would make the bytes on the wire differ from the value the caller
+   signed, hashed or length-prefixed, with nothing to signal it. *)
+let check_byte_field_size ~expected ~actual =
+  if actual <> expected then
+    Fmt.invalid_arg
+      "Wire.encode: byte field expected %d bytes, got %d (a fixed-size byte \
+       field is exact; use zeroterm_at_most for a shorter value)"
+      expected actual
+
 let check_nested_size ~at_most ~expected ~actual =
   if actual > expected then
     Fmt.invalid_arg "Wire.nested%s: region is %d bytes, value needs %d"

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -111,6 +111,11 @@ val exact_repeat_elements :
 (** Materialise and size a repeat value after checking its byte budget. Internal
     helper shared by direct and compiled encoders. *)
 
+val check_byte_field_size : expected:int -> actual:int -> unit
+(** Check a byte-span value against its declared size. A fixed-size byte field
+    is exact, so any mismatch raises [Invalid_argument]. Internal helper shared
+    by every encoder path. *)
+
 val check_nested_size : at_most:bool -> expected:int -> actual:int -> unit
 (** Check an inner value against an exact or at-most nested region. Internal
     helper shared by sizing and encoders. *)
@@ -597,8 +602,8 @@ val array_seq : ('a, 'seq) seq_map -> len:int expr -> 'a typ -> 'seq typ
 (** Fixed-count array with custom builder. *)
 
 val byte_array : size:int expr -> string typ
-(** Byte span as a string. A fixed-size span zero-pads short values and
-    truncates long values on encode. *)
+(** Byte span as a string. Encoding a value whose length differs from [size]
+    raises [Invalid_argument]. *)
 
 val byte_array_where :
   size:int expr -> per_byte:(int expr -> bool expr) -> string typ
@@ -606,8 +611,8 @@ val byte_array_where :
     byte must satisfy [per_byte]. The argument to [per_byte] is an expression
     bound to the current byte's integer value. Decode raises
     {!exception:Parse_error} on the first byte that violates the constraint;
-    encode raises [Invalid_argument]. A fixed-size span otherwise zero-pads
-    short values and truncates long values on encode. *)
+    encode raises [Invalid_argument]. Encoding otherwise follows {!byte_array}:
+    the value's length must equal [size]. *)
 
 val synth_name_of_elt_var : string -> string
 (** [synth_name_of_elt_var ev] is the 3D-side synthesised refinement-typedef
@@ -622,8 +627,8 @@ val index_bound_elt : 'a typ -> (string * bool expr) option
     used by the EverParse projection. *)
 
 val byte_slice : size:int expr -> Bytesrw.Bytes.Slice.t typ
-(** Zero-copy byte span. A fixed-size span zero-pads short values and truncates
-    long values on encode. *)
+(** Zero-copy byte span. Encoding a slice whose length differs from [size]
+    raises [Invalid_argument]. *)
 
 val optional : bool expr -> 'a typ -> 'a option typ
 (** Conditionally present field. *)

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -663,6 +663,9 @@ let encode_codec ~encode ~fixed_size ~size_of_value v enc =
   let _ : int = encode v tmp 0 in
   write_string enc (Bytes.unsafe_to_string tmp)
 
+let check_byte_field_size size ~actual =
+  Types.check_byte_field_size ~expected:(Eval.expr Eval.empty size) ~actual
+
 (* The single encoder kernel. Writes [v] to [enc]. Top-level expressions
    are evaluated in [Eval.empty]; [Struct] is rejected (encode goes
    through [Codec.encode] for records). *)
@@ -738,8 +741,11 @@ let rec encode_into : type a. a typ -> a -> encoder -> unit =
       let expected = Eval.expr Eval.empty len in
       Types.exact_array_elements seq ~expected v
       |> List.iter (fun elem_v -> encode_into elem elem_v enc)
-  | Byte_array _ -> write_string enc v
-  | Byte_array_where { elt_var; cond; _ } ->
+  | Byte_array { size } ->
+      check_byte_field_size size ~actual:(String.length v);
+      write_string enc v
+  | Byte_array_where { size; elt_var; cond } ->
+      check_byte_field_size size ~actual:(String.length v);
       String.iteri
         (fun i c ->
           let n = Char.code c in
@@ -748,10 +754,11 @@ let rec encode_into : type a. a typ -> a -> encoder -> unit =
               "byte_array_where: byte %d=0x%02x violates constraint" i n)
         v;
       write_string enc v
-  | Byte_slice _ ->
+  | Byte_slice { size } ->
       let src = Slice.bytes v in
       let off = Slice.first v in
       let len = Slice.length v in
+      check_byte_field_size size ~actual:len;
       write_string enc (Bytes.sub_string src off len)
   | Single_elem { size; elem; at_most } ->
       let n = Eval.expr Eval.empty size in
@@ -890,8 +897,8 @@ let rec encode_direct : type a. a typ -> bytes -> int -> a -> int =
       let n = String.length v in
       Bytes.blit_string v 0 buf off n;
       off + n
-  | Byte_array { size = Int n } -> Codec.blit_string_padded n buf off v
-  | Byte_slice { size = Int n } -> Codec.blit_slice_padded n buf off v
+  | Byte_array { size = Int n } -> Codec.blit_string_exact n buf off v
+  | Byte_slice { size = Int n } -> Codec.blit_slice_exact n buf off v
   | Single_elem { size = Int n; elem; at_most } ->
       let inner_sz = Types.size_of_typ_value elem v in
       Types.check_nested_size ~at_most ~expected:n ~actual:inner_sz;

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -704,8 +704,11 @@ val array_seq : ('a, 'seq) seq_map -> len:int expr -> 'a typ -> 'seq typ
 val byte_array : size:int expr -> string typ
 (** Fixed-size byte sequence copied as a string.
 
-    Encoding zero-pads a string shorter than [size] and truncates one longer
-    than [size].
+    Encoding raises [Invalid_argument] unless the string is exactly [size]
+    bytes: the field is an exact byte span, so a shorter or longer value is a
+    caller error rather than something to pad or clip. For a short value in a
+    fixed-size region use {!zeroterm_at_most}, which is NUL-terminated and
+    round-trips.
 
     When [size] contains the simple product of a field and a literal, and that
     field has a simple [field <= bound] constraint, {!Codec.v} rejects the codec
@@ -721,13 +724,14 @@ val byte_array_where :
 
     Decode raises {!exception:Parse_error} on the first byte that violates the
     constraint; encode raises [Invalid_argument]. Encoding otherwise follows
-    {!byte_array}: short strings are zero-padded and long strings are truncated.
-    The motivating shape is SSH name-list payloads (RFC 4251 sec 5), where every
-    byte must be printable US-ASCII. *)
+    {!byte_array}: the string must be exactly [size] bytes. The motivating shape
+    is SSH name-list payloads (RFC 4251 sec 5), where every byte must be
+    printable US-ASCII. *)
 
 val byte_slice : size:int expr -> Bytesrw.Bytes.Slice.t typ
-(** Fixed-size byte sequence exposed as a zero-copy slice. Encoding zero-pads a
-    slice shorter than [size] and truncates one longer than [size]. *)
+(** Fixed-size byte sequence exposed as a zero-copy slice. Encoding raises
+    [Invalid_argument] unless the slice is exactly [size] bytes, as for
+    {!byte_array}. *)
 
 val rest_bytes : (int, _) Param.t -> string typ
 (** [rest_bytes total] is the trailing payload of a record whose total decoded

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -590,14 +590,16 @@ let test_record_byte_array_roundtrip () =
           Alcotest.(check int) "tag" original.tag decoded.tag
       | Error e -> Alcotest.failf "%a" pp_parse_error e)
 
-let test_record_byte_array_padding () =
-  (* Short string should be zero-padded *)
-  let original = { id = Optint.of_int 1; uuid = "short"; tag = 2 } in
+let test_record_byte_array_trailing_zeros () =
+  (* A caller wanting "short" in a 16-byte span supplies the zeros itself. *)
+  let original =
+    { id = Optint.of_int 1; uuid = "short" ^ String.make 11 '\x00'; tag = 2 }
+  in
   match encode_record ba_record_codec original with
   | Error e -> Alcotest.failf "encode: %a" pp_parse_error e
   | Ok encoded -> (
       Alcotest.(check int) "wire size" 22 (String.length encoded);
-      (* Verify zero padding: bytes 9..19 should be zero *)
+      (* Verify the trailing zeros survive: bytes 9..19 should be zero *)
       for i = 9 to 19 do
         Alcotest.(check int)
           (Fmt.str "padding byte %d" i)
@@ -606,7 +608,7 @@ let test_record_byte_array_padding () =
       done;
       match decode_record ba_record_codec encoded with
       | Ok decoded ->
-          (* Decoded uuid includes the zero padding *)
+          (* Decoded uuid includes the trailing zeros *)
           Alcotest.(check int) "uuid length" 16 (String.length decoded.uuid);
           Alcotest.(check string)
             "uuid prefix" "short"
@@ -1738,11 +1740,13 @@ let test_fixed_byte_region_size_of_value () =
         Alcotest.(check bytes) case (Bytes.of_string expected) buf)
       cases
   in
+  (* Every value is exactly the declared region width: a fixed byte field
+     neither pads nor truncates. *)
   let cases =
     [
-      ("short", "A", "A\x00\x00");
+      ("zeros", "A\x00\x00", "A\x00\x00");
       ("exact", "ABC", "ABC");
-      ("long", "ABCDE", "ABC");
+      ("high", "\xff\xfe\xfd", "\xff\xfe\xfd");
     ]
   in
   check_string "FixedBytes" (byte_array ~size:(int 3)) cases;
@@ -1766,6 +1770,85 @@ let test_fixed_byte_region_size_of_value () =
       Codec.encode codec slice buf 0;
       Alcotest.(check bytes) (case ^ " slice") (Bytes.of_string expected) buf)
     cases
+
+(* A fixed-size byte field is exact: a value whose length differs from the
+   declared size is a caller error, not something to truncate or zero-pad. *)
+let expect_exact_byte_error label ~expected ~actual f =
+  match f () with
+  | () -> Alcotest.failf "%s: expected an exact-size error" label
+  | exception Invalid_argument msg ->
+      Alcotest.(check bool)
+        (label ^ ": names the declared size")
+        true
+        (contains ~sub:(Fmt.str "expected %d bytes" expected) msg);
+      Alcotest.(check bool)
+        (label ^ ": names the value length")
+        true
+        (contains ~sub:(Fmt.str "got %d" actual) msg)
+
+let slice_of_string s =
+  let b = Bytes.of_string s in
+  Bytesrw.Bytes.Slice.make b ~first:0 ~length:(Bytes.length b)
+
+let exact_ba_codec =
+  Codec.v "ExactBa" Fun.id
+    Codec.[ Field.v "B" (byte_array ~size:(int 4)) $ Fun.id ]
+
+let exact_bs_codec =
+  Codec.v "ExactBs" Fun.id
+    Codec.[ Field.v "S" (byte_slice ~size:(int 4)) $ Fun.id ]
+
+let test_exact_byte_field_literal_size () =
+  let buf = Bytes.create 4 in
+  expect_exact_byte_error "byte_array long" ~expected:4 ~actual:6 (fun () ->
+      Codec.encode exact_ba_codec "abcdef" buf 0);
+  expect_exact_byte_error "byte_array short" ~expected:4 ~actual:2 (fun () ->
+      Codec.encode exact_ba_codec "ab" buf 0);
+  expect_exact_byte_error "byte_slice long" ~expected:4 ~actual:6 (fun () ->
+      Codec.encode exact_bs_codec (slice_of_string "abcdef") buf 0);
+  expect_exact_byte_error "byte_slice short" ~expected:4 ~actual:2 (fun () ->
+      Codec.encode exact_bs_codec (slice_of_string "ab") buf 0);
+  Codec.encode exact_ba_codec "abcd" buf 0;
+  Alcotest.(check string) "exact string" "abcd" (Bytes.to_string buf);
+  Codec.encode exact_bs_codec (slice_of_string "wxyz") buf 0;
+  Alcotest.(check string) "exact slice" "wxyz" (Bytes.to_string buf)
+
+(* The same contract on the variable-size encoder, where the declared size is a
+   cross-field reference rather than a literal. *)
+let exact_vb_len = Field.v "N" uint8
+
+let exact_vb_codec =
+  Codec.v "ExactVb"
+    (fun n b -> (n, b))
+    Codec.
+      [
+        exact_vb_len $ fst;
+        Field.v "B" (byte_array ~size:(Field.ref exact_vb_len)) $ snd;
+      ]
+
+let exact_vs_len = Field.v "N" uint8
+
+let exact_vs_codec =
+  Codec.v "ExactVs"
+    (fun n s -> (n, s))
+    Codec.
+      [
+        exact_vs_len $ fst;
+        Field.v "S" (byte_slice ~size:(Field.ref exact_vs_len)) $ snd;
+      ]
+
+let test_exact_byte_field_expression_size () =
+  let buf = Bytes.create 16 in
+  expect_exact_byte_error "byte_array long" ~expected:4 ~actual:6 (fun () ->
+      Codec.encode exact_vb_codec (4, "abcdef") buf 0);
+  expect_exact_byte_error "byte_array short" ~expected:4 ~actual:2 (fun () ->
+      Codec.encode exact_vb_codec (4, "ab") buf 0);
+  expect_exact_byte_error "byte_slice long" ~expected:4 ~actual:6 (fun () ->
+      Codec.encode exact_vs_codec (4, slice_of_string "abcdef") buf 0);
+  expect_exact_byte_error "byte_slice short" ~expected:4 ~actual:2 (fun () ->
+      Codec.encode exact_vs_codec (4, slice_of_string "ab") buf 0);
+  Codec.encode exact_vb_codec (4, "abcd") buf 0;
+  Alcotest.(check string) "exact string" "\x04abcd" (Bytes.sub_string buf 0 5)
 
 let test_packed_bf_size () =
   let f_a = Field.v "a" (bits ~width:1 U8) in
@@ -6418,8 +6501,8 @@ let suite =
       Alcotest.test_case "record: with_multi" `Quick test_record_with_multi;
       Alcotest.test_case "record: byte_array roundtrip" `Quick
         test_record_byte_array_roundtrip;
-      Alcotest.test_case "record: byte_array padding" `Quick
-        test_record_byte_array_padding;
+      Alcotest.test_case "record: byte_array trailing zeros" `Quick
+        test_record_byte_array_trailing_zeros;
       Alcotest.test_case "array: encode cardinality" `Quick
         test_codec_array_cardinality;
       Alcotest.test_case "repeat: zeroterm element roundtrip" `Quick
@@ -6528,6 +6611,10 @@ let suite =
         test_packed_mapped_bf_size;
       Alcotest.test_case "fixed byte regions: size_of_value" `Quick
         test_fixed_byte_region_size_of_value;
+      Alcotest.test_case "exact byte field: literal size" `Quick
+        test_exact_byte_field_literal_size;
+      Alcotest.test_case "exact byte field: expression size" `Quick
+        test_exact_byte_field_expression_size;
       (* action semantics *)
       Alcotest.test_case "action: fires on decode_env" `Quick
         test_action_fires_decode_env;

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -1850,6 +1850,68 @@ let test_exact_byte_field_expression_size () =
   Codec.encode exact_vb_codec (4, "abcd") buf 0;
   Alcotest.(check string) "exact string" "\x04abcd" (Bytes.sub_string buf 0 5)
 
+(* A reference-free constant size expression normalises to the literal form at
+   construction, so every [Int n] fast path and range guard in the library sees
+   it. Sizes that must stay symbolic, and arithmetic the fold cannot do
+   faithfully, are left as expressions. *)
+let byte_array_size label t =
+  let module T = Wire.Private.Types in
+  match t with
+  | T.Byte_array { size } -> size
+  | _ -> Alcotest.failf "%s: expected a byte_array" label
+
+let test_constant_size_expression_folds () =
+  let module T = Wire.Private.Types in
+  (match byte_array_size "constant" (byte_array ~size:Expr.(int 2 + int 2)) with
+  | T.Int 4 -> ()
+  | e -> Alcotest.failf "constant size did not fold: %a" T.pp_expr e);
+  (* A reference-bearing size stays symbolic: the 3D projection needs the
+     expression, not a baked-in width. *)
+  (match
+     byte_array_size "reference"
+       (byte_array ~size:Expr.(Field.ref exact_vb_len + int 1))
+   with
+  | T.Add (T.Ref _, T.Int 1) -> ()
+  | e -> Alcotest.failf "reference-bearing size was folded: %a" T.pp_expr e);
+  (* Overflowing arithmetic is left alone rather than folded to a wrong
+     value. *)
+  (match
+     byte_array_size "overflow" (byte_array ~size:Expr.(int max_int + int 1))
+   with
+  | T.Add (T.Int _, T.Int 1) -> ()
+  | e -> Alcotest.failf "overflowing size was folded: %a" T.pp_expr e);
+  (* 1. the encode contract *)
+  let codec name typ = Codec.v name Fun.id Codec.[ Field.v "B" typ $ Fun.id ] in
+  let lit = codec "FoldLiteral" (byte_array ~size:(int 4)) in
+  let folded = codec "FoldConstant" (byte_array ~size:Expr.(int 2 + int 2)) in
+  let buf = Bytes.create 4 in
+  expect_exact_byte_error "literal long" ~expected:4 ~actual:6 (fun () ->
+      Codec.encode lit "abcdef" buf 0);
+  expect_exact_byte_error "constant long" ~expected:4 ~actual:6 (fun () ->
+      Codec.encode folded "abcdef" buf 0);
+  expect_exact_byte_error "constant short" ~expected:4 ~actual:2 (fun () ->
+      Codec.encode folded "ab" buf 0);
+  Codec.encode folded "abcd" buf 0;
+  Alcotest.(check string) "constant exact" "abcd" (Bytes.to_string buf);
+  (* 2. is_fixed / wire_size *)
+  Alcotest.(check bool) "literal is_fixed" true (Codec.is_fixed lit);
+  Alcotest.(check bool) "constant is_fixed" true (Codec.is_fixed folded);
+  Alcotest.(check int) "literal wire_size" 4 (Codec.wire_size lit);
+  Alcotest.(check int) "constant wire_size" 4 (Codec.wire_size folded);
+  (* 3. the uint 1-7 range guard *)
+  let uint_rejects label size =
+    match uint size with
+    | _ -> Alcotest.failf "%s: expected uint to reject the size" label
+    | exception Invalid_argument msg ->
+        Alcotest.(check bool)
+          (label ^ ": names the bound")
+          true
+          (contains ~sub:"size must be 1-7" msg)
+  in
+  uint_rejects "literal 0" (int 0);
+  uint_rejects "constant 0" Expr.(int 1 - int 1);
+  uint_rejects "constant 8" Expr.(int 4 + int 4)
+
 let test_packed_bf_size () =
   let f_a = Field.v "a" (bits ~width:1 U8) in
   let f_b = Field.v "b" (bits ~width:7 U8) in
@@ -6615,6 +6677,8 @@ let suite =
         test_exact_byte_field_literal_size;
       Alcotest.test_case "exact byte field: expression size" `Quick
         test_exact_byte_field_expression_size;
+      Alcotest.test_case "constant size expression folds" `Quick
+        test_constant_size_expression_folds;
       (* action semantics *)
       Alcotest.test_case "action: fires on decode_env" `Quick
         test_action_fires_decode_env;

--- a/test/test_wire.ml
+++ b/test/test_wire.ml
@@ -976,6 +976,44 @@ let test_roundtrip_byte_array () =
     (byte_array ~size:(int 5))
     Alcotest.string "hello"
 
+(* The streaming writer enforces the same exact-size contract as the record
+   and direct encoders: it used to write the value's own length, whatever the
+   declared size. *)
+let expect_exact_byte_error label ~expected ~actual f =
+  match f () with
+  | (_ : string) -> Alcotest.failf "%s: expected an exact-size error" label
+  | exception Invalid_argument msg ->
+      Alcotest.(check bool)
+        (label ^ ": names the declared size")
+        true
+        (contains ~sub:(Fmt.str "expected %d bytes" expected) msg);
+      Alcotest.(check bool)
+        (label ^ ": names the value length")
+        true
+        (contains ~sub:(Fmt.str "got %d" actual) msg)
+
+let test_exact_byte_field_writer () =
+  let ba = byte_array ~size:(int 4) in
+  let bs = byte_slice ~size:(int 4) in
+  let slice s =
+    let b = Bytes.of_string s in
+    Bytesrw.Bytes.Slice.make b ~first:0 ~length:(Bytes.length b)
+  in
+  expect_exact_byte_error "byte_array long" ~expected:4 ~actual:6 (fun () ->
+      encode_chunked ~chunk_size:1 ba "abcdef");
+  expect_exact_byte_error "byte_array short" ~expected:4 ~actual:2 (fun () ->
+      encode_chunked ~chunk_size:1 ba "ab");
+  expect_exact_byte_error "byte_slice long" ~expected:4 ~actual:6 (fun () ->
+      encode_chunked ~chunk_size:1 bs (slice "abcdef"));
+  expect_exact_byte_error "byte_slice short" ~expected:4 ~actual:2 (fun () ->
+      encode_chunked ~chunk_size:1 bs (slice "ab"));
+  Alcotest.(check string)
+    "exact string" "abcd"
+    (encode_chunked ~chunk_size:1 ba "abcd");
+  Alcotest.(check string)
+    "exact slice" "wxyz"
+    (encode_chunked ~chunk_size:1 bs (slice "wxyz"))
+
 (* -- Streaming: cross-slice boundary tests -- *)
 
 (* Parse roundtrip with every chunk size forcing boundary straddles *)
@@ -1379,6 +1417,8 @@ let suite =
       Alcotest.test_case "roundtrip: array" `Quick test_roundtrip_array;
       Alcotest.test_case "roundtrip: byte_array" `Quick
         test_roundtrip_byte_array;
+      Alcotest.test_case "exact byte field: streaming writer" `Quick
+        test_exact_byte_field_writer;
       (* streaming: cross-slice boundary *)
       Alcotest.test_case "stream: uint8 chunk=1" `Quick test_stream_uint8;
       Alcotest.test_case "stream: uint16 chunk=1" `Quick


### PR DESCRIPTION
Encoding a `byte_array` or `byte_slice` used to truncate a longer value, zero-pad a shorter one, or (through the streaming writer) write the value's own length and desynchronise every following field, so the bytes sent could differ from the value a caller had signed or hashed; now any length other than the declared `~size` raises `Invalid_argument`. The second commit folds constant size expressions to literals, without which `Expr.(int 2 + int 2)` slips past that check and the other 63 literal-size fast paths and guards.

Stacked on #258.