### PR TITLE
codec: refuse to encode values decode rejects

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,12 @@
 
 ### Added
 
+- The fuzz suite now feeds hostile values to `Codec.encode`, not only hostile
+  bytes to `Codec.decode`. Every generated value must either be refused with
+  `Invalid_argument` or encode to bytes that decode back unchanged, so an
+  encoder that emits a frame its own decoder rejects fails the suite (#263,
+  @samoht)
+
 - `Field.optional` over a sub-codec now documents how to make a whole field
   group conditional, keeping the group's byte-length prefix and dependent
   `Field.repeat` local to the group while later fields stay in the parent
@@ -23,7 +29,7 @@
   value, an `all_zeros` padding field given a non-zero byte, a
   `byte_array_where` byte that fails its `~per_byte` refinement, and a record
   whose `where` clause or field `~constraint_` does not hold for the values
-  supplied. Encoding a well-formed value is unchanged (@samoht)
+  supplied. Encoding a well-formed value is unchanged (#263, @samoht)
 
 - **Breaking:** encoding a `byte_array`, `byte_array_where` or `byte_slice`
   whose length differs from its declared `~size` now raises

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,14 @@
 
 ### Changed
 
+- **Breaking:** `Codec.encode` and `Wire.to_string` now raise
+  `Invalid_argument` on a value their own decoder rejects, instead of writing
+  bytes that fail to read back. This covers a closed `enum` given an unlisted
+  value, an `all_zeros` padding field given a non-zero byte, a
+  `byte_array_where` byte that fails its `~per_byte` refinement, and a record
+  whose `where` clause or field `~constraint_` does not hold for the values
+  supplied. Encoding a well-formed value is unchanged (@samoht)
+
 - **Breaking:** encoding a `byte_array`, `byte_array_where` or `byte_slice`
   whose length differs from its declared `~size` now raises
   `Invalid_argument`. It used to silently truncate a longer value, zero-pad a

--- a/fuzz/gen/fuzz_gen.ml
+++ b/fuzz/gen/fuzz_gen.ml
@@ -26,6 +26,13 @@ type 'a t = {
       (* When the codec references [Param.input], the test driver pulls
          a fresh env from [positive] for the round-trip case and from
          the [fuzz] gen for random and adversarial streams. *)
+  adversarial_value : 'a Alcobar.gen option;
+      (* Hostile VALUES, the counterpart of the hostile BYTES in [random] /
+         [adversarial]. Each is a well-typed value of the codec's own OCaml
+         type that violates something decode enforces: enum membership,
+         all-zero padding, a per-byte span predicate, a declared byte length,
+         a where cond or a field constraint. [None] where the shape has no
+         refinement left to violate (a plain scalar, an open enum). *)
 }
 
 and env_strategy = {
@@ -65,6 +72,8 @@ let string_of_slice s =
     (Bytesrw.Bytes.Slice.first s)
     (Bytesrw.Bytes.Slice.length s)
 
+let slice_equal a b = String.equal (string_of_slice a) (string_of_slice b)
+
 let bytes_of_octets xs =
   let b = Bytes.create (List.length xs) in
   List.iteri (fun i x -> Bytes.set_uint8 b i (x land 0xFF)) xs;
@@ -88,6 +97,28 @@ let encode_via_codec codec v =
   Wire.Codec.encode codec v buf 0;
   buf
 
+(* Hostile-value streams. [check_encode_safety] requires encode to refuse each
+   of these outright or to write bytes that decode back unchanged, so each
+   stream must yield values that violate a refinement decode enforces. *)
+
+(* A value a closed enum does not list. Steps up from the drawn number until it
+   lands outside the case set, so the stream is hostile by construction rather
+   than by luck. *)
+let unlisted_enum_gen ~mask valid =
+  let rec step n tries =
+    if tries > mask || not (List.mem n valid) then n
+    else step ((n + 1) land mask) (tries + 1)
+  in
+  Alcobar.map Alcobar.[ Alcobar.int ] (fun n -> step (n land mask) 0)
+
+(* A byte string of one of the lengths around [n], for a byte span whose
+   declared size is [n]: only the exact length may encode. *)
+let byte_lengths_around n =
+  Alcobar.choose
+    (List.map
+       (fun k -> Alcobar.bytes_fixed k)
+       (List.sort_uniq Int.compare [ 0; max 0 (n - 1); n; n + 1; n * 2 ]))
+
 (* Build a leaf [t] from a typ and three Alcobar generators. *)
 let leaf ~equal ~typ ~value_gen ~random ~adversarial =
   let codec = codec_of_typ typ in
@@ -105,6 +136,7 @@ let leaf ~equal ~typ ~value_gen ~random ~adversarial =
     adversarial = adversarial_bytes;
     equal;
     env = None;
+    adversarial_value = None;
   }
 
 (* A leaf whose positives draw a value from [value_gen] and encode it through
@@ -116,7 +148,16 @@ let enum_like ~typ ~value_gen ~random ~adversarial =
   let positive =
     Alcobar.map Alcobar.[ value_gen ] (fun v -> (v, encode_via_codec codec v))
   in
-  { codec; typ; positive; random; adversarial; equal = ( = ); env = None }
+  {
+    codec;
+    typ;
+    positive;
+    random;
+    adversarial;
+    equal = ( = );
+    env = None;
+    adversarial_value = None;
+  }
 
 (* {1 Leaves} *)
 
@@ -281,6 +322,8 @@ let byte_array n =
     adversarial;
     equal = String.equal;
     env = None;
+    (* A fixed-size byte span is exact: any other length must be refused. *)
+    adversarial_value = Some (byte_lengths_around n);
   }
 
 let byte_slice n =
@@ -305,10 +348,6 @@ let byte_slice n =
       (min n (Bytesrw.Bytes.Slice.length s));
     buf
   in
-  let slice_of_string s =
-    let b = Bytes.of_string s in
-    Bytesrw.Bytes.Slice.make_or_eod b ~first:0 ~length:(Bytes.length b)
-  in
   let value_gen = Alcobar.bytes_fixed n in
   let positive =
     Alcobar.map
@@ -317,26 +356,18 @@ let byte_slice n =
         let slice = slice_of_string s in
         (slice, encode slice))
   in
-  let slice_equal a b =
-    let la = Bytesrw.Bytes.Slice.length a
-    and lb = Bytesrw.Bytes.Slice.length b in
-    la = lb
-    &&
-    let sa =
-      Bytes.sub_string
-        (Bytesrw.Bytes.Slice.bytes a)
-        (Bytesrw.Bytes.Slice.first a)
-        la
-    in
-    let sb =
-      Bytes.sub_string
-        (Bytesrw.Bytes.Slice.bytes b)
-        (Bytesrw.Bytes.Slice.first b)
-        lb
-    in
-    String.equal sa sb
-  in
-  { codec; typ; positive; random; adversarial; equal = slice_equal; env = None }
+  {
+    codec;
+    typ;
+    positive;
+    random;
+    adversarial;
+    equal = slice_equal;
+    env = None;
+    (* Same exact-span rule as [byte_array], through the zero-copy slice. *)
+    adversarial_value =
+      Some (Alcobar.map Alcobar.[ byte_lengths_around n ] slice_of_string);
+  }
 
 let all_bytes =
   let typ = Wire.all_bytes in
@@ -359,6 +390,7 @@ let all_bytes =
     adversarial = bytes_any;
     equal = String.equal;
     env = None;
+    adversarial_value = None;
   }
 
 let all_zeros =
@@ -393,6 +425,12 @@ let all_zeros =
     adversarial;
     equal = String.equal;
     env = None;
+    (* Padding decode only accepts as zeros: a non-zero byte must be refused. *)
+    adversarial_value =
+      Some
+        (Alcobar.map
+           Alcobar.[ Alcobar.range ~min:1 16; Alcobar.range ~min:1 255 ]
+           (fun n byte -> String.make n (Char.chr byte)));
   }
 
 (* NUL-free string: a [zeroterm] value cannot contain its own terminator. *)
@@ -426,6 +464,9 @@ let zeroterm =
     adversarial;
     equal = String.equal;
     env = None;
+    (* A value carrying its own terminator cannot round-trip. *)
+    adversarial_value =
+      Some (Alcobar.map Alcobar.[ Alcobar.bytes ] (fun s -> s ^ "\000x"));
   }
 
 let zeroterm_at_most n =
@@ -455,6 +496,16 @@ let zeroterm_at_most n =
     adversarial = bytes_fixed n;
     equal = String.equal;
     env = None;
+    (* Too long for the region once the terminator is counted, or carrying its
+       own terminator. *)
+    adversarial_value =
+      Some
+        (Alcobar.choose
+           [
+             Alcobar.bytes_fixed n;
+             Alcobar.bytes_fixed (n + 1);
+             Alcobar.map Alcobar.[ Alcobar.bytes_fixed n ] (fun s -> s ^ "\000");
+           ]);
   }
 
 let byte_array_where n ~per_byte =
@@ -483,6 +534,9 @@ let byte_array_where n ~per_byte =
     adversarial;
     equal = String.equal;
     env = None;
+    (* Arbitrary bytes at the declared length and around it: most violate the
+       refinement, the rest exercise the exact-length rule. *)
+    adversarial_value = Some (byte_lengths_around n);
   }
 
 (* [nested] and [nested_at_most] differ only in the typ constructor; the
@@ -517,6 +571,7 @@ let nested_sized make_typ n inner =
     adversarial;
     equal = inner.equal;
     env = None;
+    adversarial_value = None;
   }
 
 let nested n inner = nested_sized Wire.nested n inner
@@ -535,6 +590,7 @@ let map ~decode ~encode inner =
     adversarial = inner.adversarial;
     equal = (fun a b -> inner.equal (encode a) (encode b));
     env = None;
+    adversarial_value = None;
   }
 
 let uint_var ~endian size =
@@ -568,6 +624,7 @@ let uint_var ~endian size =
     adversarial;
     equal = ( = );
     env = None;
+    adversarial_value = None;
   }
 
 let exact_cases ~typ ~equal cases =
@@ -586,6 +643,7 @@ let exact_cases ~typ ~equal cases =
       Alcobar.choose (List.map (fun (_, bs) -> Alcobar.const bs) cases);
     equal;
     env = None;
+    adversarial_value = None;
   }
 
 let exact_int typ cases = exact_cases ~typ ~equal:Int.equal cases
@@ -766,6 +824,7 @@ let optional ?(present = true) inner =
     adversarial = inner.adversarial;
     equal = Option.equal inner.equal;
     env = None;
+    adversarial_value = None;
   }
 
 let optional_or ?(present = true) ~default inner =
@@ -791,6 +850,7 @@ let optional_or ?(present = true) ~default inner =
     adversarial = inner.adversarial;
     equal = inner.equal;
     env = None;
+    adversarial_value = None;
   }
 
 let list_equal eq a b = List.length a = List.length b && List.for_all2 eq a b
@@ -843,6 +903,7 @@ let repeat_sized name make_items ~bytes:total_bytes inner =
     adversarial = bytes_any;
     equal = list_equal inner.equal;
     env = None;
+    adversarial_value = None;
   }
 
 let repeat ~bytes inner =
@@ -867,6 +928,7 @@ let codec_wrap (c : 'a Wire.Codec.t) ~value_gen ~equal =
     adversarial = bytes_any;
     equal;
     env = None;
+    adversarial_value = None;
   }
 
 let nested_at_most n inner = nested_sized Wire.nested_at_most n inner
@@ -911,6 +973,13 @@ let array_sized make_typ n inner =
       Alcobar.[ sample_array_of_positives inner.positive n ]
       (fun (vs, bss) -> (vs, concat_bytes_list bss))
   in
+  (* An [array ~len:n] is an exact cardinality, so a shorter or longer list must
+     be refused rather than silently clipped or padded. *)
+  let wrong_cardinality k =
+    Alcobar.map
+      Alcobar.[ sample_array_of_positives inner.positive k ]
+      (fun (vs, _) -> vs)
+  in
   {
     codec;
     typ;
@@ -919,6 +988,11 @@ let array_sized make_typ n inner =
     adversarial = bytes_any;
     equal = list_equal inner.equal;
     env = None;
+    adversarial_value =
+      Some
+        (Alcobar.choose
+           (List.map wrong_cardinality
+              (List.sort_uniq Int.compare [ 0; max 0 (n - 1); n + 1 ])));
   }
 
 let array n inner = array_sized Wire.array n inner
@@ -947,6 +1021,7 @@ let enum name cases =
     adversarial = bytes_fixed 1;
     equal = Int.equal;
     env = None;
+    adversarial_value = Some (unlisted_enum_gen ~mask:0xFF valid_values);
   }
 
 (* [Wire.enum_open]: names known codes for documentation but accepts any value,
@@ -972,6 +1047,7 @@ let enum_open =
     adversarial = bytes_fixed 1;
     equal = Int.equal;
     env = None;
+    adversarial_value = None;
   }
 
 let enum_base ~typ ~size name cases =
@@ -994,6 +1070,8 @@ let enum_base ~typ ~size name cases =
     adversarial = bytes_fixed size;
     equal = Int.equal;
     env = None;
+    adversarial_value =
+      Some (unlisted_enum_gen ~mask:((1 lsl (size * 8)) - 1) valid_values);
   }
 
 let enum_open_base ~typ ~size name cases =
@@ -1017,6 +1095,7 @@ let enum_open_base ~typ ~size name cases =
     adversarial = bytes_fixed size;
     equal = Int.equal;
     env = None;
+    adversarial_value = None;
   }
 
 let enum_u16be =
@@ -1050,6 +1129,7 @@ let variants_u16be =
     adversarial = bytes_fixed 2;
     equal = ( = );
     env = None;
+    adversarial_value = None;
   }
 
 (* Single-field record holding a [Wire.uint8] constrained via the field's
@@ -1094,6 +1174,14 @@ let bounded_u8 ~min ~max =
     adversarial = boundary_bytes;
     equal = Int.equal;
     env = None;
+    (* Out-of-range on both sides of the field's [~self_constraint]. *)
+    adversarial_value =
+      Some
+        (Alcobar.choose
+           (List.map Alcobar.const
+              (List.filter
+                 (fun n -> n >= 0 && n <= 0xFF && (n < min || n > max))
+                 [ min - 1; max + 1; 0; 0xFF ])));
   }
 
 (* [bounded_u8] generalised to any unsigned integer [inner_typ] of [size] bytes
@@ -1138,6 +1226,7 @@ let bounded_int ~inner_typ ~size ~set ~max_val ~min ~max ~of_int ~equal =
     adversarial = boundary_bytes;
     equal;
     env = None;
+    adversarial_value = None;
   }
 
 let bounded_u16be =
@@ -1192,6 +1281,10 @@ let codec_where =
     adversarial = boundary;
     equal = ( = );
     env = None;
+    (* [a = b] fails the codec-level [~where] [a < b]. *)
+    adversarial_value =
+      Some
+        (Alcobar.map Alcobar.[ Alcobar.range ~min:0 0x100 ] (fun a -> (a, a)));
   }
 
 let u8_pair_bytes a b =
@@ -1205,18 +1298,27 @@ let u8_pair_positive gen =
 
 let u8_pair_adversarial gen = Alcobar.map gen (fun a b -> u8_pair_bytes a b)
 
+(* The same out-of-contract pair the decoder is handed, read back as a value so
+   encode is put through it too. *)
+let u8_pair_hostile bytes_gen =
+  Alcobar.map
+    Alcobar.[ bytes_gen ]
+    (fun b -> (Bytes.get_uint8 b 0, Bytes.get_uint8 b 1))
+
 let u8_pair_record name f_a f_b ~positive ~adversarial =
   let codec =
     Wire.Codec.v name (fun a b -> (a, b)) Wire.Codec.[ f_a $ fst; f_b $ snd ]
   in
+  let adversarial_bytes = u8_pair_adversarial adversarial in
   {
     codec;
     typ = Wire.codec codec;
     positive = u8_pair_positive positive;
     random = bytes_fixed 2;
-    adversarial = u8_pair_adversarial adversarial;
+    adversarial = adversarial_bytes;
     equal = ( = );
     env = None;
+    adversarial_value = Some (u8_pair_hostile adversarial_bytes);
   }
 
 (* A field whose typ carries a [Wire.where] cond ([d : where (len < 2) uint8]).
@@ -1296,6 +1398,7 @@ let self_int64 =
     adversarial;
     equal = Int64.equal;
     env = None;
+    adversarial_value = None;
   }
 
 (* {1 More leaves and wrappers} *)
@@ -1322,6 +1425,7 @@ let where inner =
     adversarial = inner.adversarial;
     equal = inner.equal;
     env = None;
+    adversarial_value = None;
   }
 
 let bits ?bit_order ~width base =
@@ -1398,6 +1502,7 @@ let bitpack3 name ~base ~bit_order (w_a, w_b, w_c) =
     adversarial = bytes_fixed (total / 8);
     equal = ( = );
     env = None;
+    adversarial_value = None;
   }
 
 let bitpack2_spill name ~base ~bit_order (w_a, w_b) =
@@ -1423,6 +1528,7 @@ let bitpack2_spill name ~base ~bit_order (w_a, w_b) =
     adversarial = bytes_fixed (2 * (total / 8));
     equal = ( = );
     env = None;
+    adversarial_value = None;
   }
 
 let bitpack_split_orders =
@@ -1450,6 +1556,7 @@ let bitpack_split_orders =
     adversarial = bytes_fixed 2;
     equal = ( = );
     env = None;
+    adversarial_value = None;
   }
 
 let bitpack_u8_msb =
@@ -1516,6 +1623,7 @@ let bit inner =
     adversarial = inner.adversarial;
     equal = Bool.equal;
     env = None;
+    adversarial_value = None;
   }
 
 let array_seq n inner = array_sized (Wire.array_seq Wire.seq_list) n inner
@@ -1559,6 +1667,7 @@ let field_anon =
     adversarial = bytes_fixed 2;
     equal = ( = );
     env = None;
+    adversarial_value = None;
   }
 
 (* Codec referencing [Param.input] in its [~where]. Each test run binds
@@ -1599,6 +1708,7 @@ let param_input =
     adversarial = bytes_fixed 1;
     equal = Int.equal;
     env = Some strategy;
+    adversarial_value = None;
   }
 
 (* A 1-byte positive: a uint8 value written to a single-byte buffer. *)
@@ -1624,6 +1734,7 @@ let action_codec name action =
     adversarial = bytes_fixed 1;
     equal = Int.equal;
     env = Some { positive = Fun.id; fuzz = Alcobar.const Fun.id };
+    adversarial_value = None;
   }
 
 (* Codec with [Action.on_success [assign out (Field.ref f); abort?]]
@@ -1663,6 +1774,7 @@ let action_abort =
     adversarial = bytes_fixed 1;
     equal = Int.equal;
     env = None;
+    adversarial_value = None;
   }
 
 (* Same as [action] but using [Action.on_act] in place of
@@ -1720,6 +1832,7 @@ let nan_float64 =
     adversarial;
     equal = float64_bits_equal;
     env = None;
+    adversarial_value = None;
   }
 
 (* Single-field float codec with [~self_constraint:is_finite]. Adversarial
@@ -1762,6 +1875,7 @@ let finite_float64 =
     adversarial;
     equal = float64_bits_equal;
     env = None;
+    adversarial_value = None;
   }
 
 (* Codec whose constraint exercises every integer Expr operator
@@ -1815,6 +1929,7 @@ let expr_ops =
     adversarial = bytes_fixed 2;
     equal = ( = );
     env = None;
+    adversarial_value = None;
   }
 
 (* Codec ending in [rest_bytes] whose tail length is computed from a
@@ -1856,6 +1971,7 @@ let rest_bytes =
     adversarial = bytes_fixed (1 + tail_len);
     equal = ( = );
     env = Some strategy;
+    adversarial_value = None;
   }
 
 (* A [byte_array] whose [~size] is a bound [Param.input], bound through
@@ -1893,6 +2009,7 @@ let param_size =
     adversarial = bytes_any;
     equal = String.equal;
     env = Some strategy;
+    adversarial_value = None;
   }
 
 (* [Wire.Expr.if_then_else] driving a field size: the [len] byte selects the
@@ -1934,6 +2051,7 @@ let if_then_else =
     adversarial = bytes_any;
     equal = ( = );
     env = None;
+    adversarial_value = None;
   }
 
 (* Two-field codec whose second field's [~self_constraint] references
@@ -1970,6 +2088,7 @@ let sizeof =
     adversarial = bytes_fixed 2;
     equal = ( = );
     env = None;
+    adversarial_value = None;
   }
 
 (* A uint8 [gate] field followed by a [mk_payload]-built payload field that
@@ -1990,6 +2109,7 @@ let gate_codec name mk_payload positive =
     adversarial = bytes_any;
     equal = ( = );
     env = None;
+    adversarial_value = None;
   }
 
 let gate_present f_gate = Wire.Expr.(Wire.Field.ref f_gate <> Wire.int 0)
@@ -2128,6 +2248,7 @@ let casetype_u8 name cases =
     adversarial = bytes_any;
     equal;
     env = env_strategy;
+    adversarial_value = None;
   }
 
 (* A direct [Wire.casetype] over a wider discriminator, with a default branch
@@ -2174,6 +2295,7 @@ let casetype_u16be_default =
     adversarial = bytes_any;
     equal = ( = );
     env = None;
+    adversarial_value = None;
   }
 
 (* {1 Record composition} *)
@@ -2284,6 +2406,31 @@ module Codec = struct
     | [] -> []
     | f :: rest -> f.gen.env :: field_envs rest
 
+  (* Hostile values compose the same "one bad slot" way the hostile bytes do:
+     slot [i] draws from its own [adversarial_value], every other slot draws a
+     positive value, so the record is well-formed apart from the one field
+     under test. *)
+  let rec hostile_value_at : type f r.
+      int -> f -> (f, r) fields -> r Alcobar.gen =
+   fun slot partial fields ->
+    match fields with
+    | [] -> Alcobar.const partial
+    | f :: rest ->
+        let gen =
+          match f.gen.adversarial_value with
+          | Some g when slot = 0 -> g
+          | _ -> Alcobar.map Alcobar.[ f.gen.positive ] fst
+        in
+        Alcobar.dynamic_bind gen (fun v ->
+            hostile_value_at (slot - 1) (partial v) rest)
+
+  let rec hostile_slots : type f r. int -> (f, r) fields -> int list =
+   fun i -> function
+    | [] -> []
+    | f :: rest ->
+        let tail = hostile_slots (i + 1) rest in
+        if Option.is_some f.gen.adversarial_value then i :: tail else tail
+
   let v : type f r.
       string -> ?equal:(r -> r -> bool) -> f -> (f, r) fields -> r t =
    fun name ?(equal = ( = )) builder fields ->
@@ -2324,6 +2471,14 @@ module Codec = struct
       if per_slot = [] then Alcobar.const Bytes.empty
       else Alcobar.choose per_slot
     in
+    let adversarial_value =
+      match hostile_slots 0 fields with
+      | [] -> None
+      | slots ->
+          Some
+            (Alcobar.choose
+               (List.map (fun i -> hostile_value_at i builder fields) slots))
+    in
     {
       codec;
       typ;
@@ -2332,6 +2487,7 @@ module Codec = struct
       adversarial;
       equal;
       env = combine_env_strategies (field_envs fields);
+      adversarial_value;
     }
 end
 
@@ -2876,6 +3032,46 @@ let check_decode_safety label kind ?env g bs =
   try ignore (Wire.Codec.decode ?env g.codec bs 0)
   with Invalid_argument _ -> Alcobar.failf "%s %s crashed decoder" label kind
 
+(* The bytes a hostile value encodes to, or [None] when encode refused it, which
+   is one of the two outcomes [check_encode_safety] allows. *)
+let hostile_encoding label ?env g value =
+  match Wire.Codec.size_of_value g.codec value with
+  | exception Invalid_argument _ -> None
+  | sz -> (
+      match Bytes.create sz with
+      | exception Invalid_argument _ ->
+          Alcobar.failf "%s encode safety: size_of_value returned %d" label sz
+      | buf -> (
+          match Wire.Codec.encode ?env g.codec value buf 0 with
+          | exception Invalid_argument _ -> None
+          | () -> Some buf))
+
+(* The encode-side twin of [check_decode_safety]. Decode is handed hostile bytes
+   and must not crash; encode is handed a hostile value and must not put a frame
+   on the wire that its own decoder throws out. Exactly two outcomes are
+   allowed: encode refuses the value with [Invalid_argument], or the bytes it
+   writes decode back to an equal value. Anything else means the OCaml encoder
+   and the EverParse validator built from the same schema disagree on a frame
+   this library produced itself. *)
+let check_encode_safety label ?env g value =
+  match hostile_encoding label ?env g value with
+  | None -> ()
+  | Some buf -> (
+      match Wire.Codec.decode ?env g.codec buf 0 with
+      | Ok back ->
+          if not (g.equal back value) then
+            Alcobar.failf
+              "%s encode safety: encode wrote bytes that decode to a different \
+               value"
+              label
+      | Error e ->
+          Alcobar.failf
+            "%s encode safety: encode wrote bytes its own decoder rejects (%a)"
+            label Wire.pp_parse_error e
+      | exception Invalid_argument _ ->
+          Alcobar.failf
+            "%s encode safety: encode wrote bytes that crash the decoder" label)
+
 let decode_accepts ?env g bs =
   try
     match Wire.Codec.decode ?env g.codec bs 0 with
@@ -2899,6 +3095,14 @@ let check_decode_validate_agree label kind ?env g bs =
   | `Reject, `Accept ->
       Alcobar.failf "%s %s validate accepted but decode rejected" label kind
 
+(* One sample of the hostile-value stream, or [None] for a shape with no
+   refinement to violate. Kept as an [option] stream so every gen presents the
+   same test-case arity whether or not it has hostile values. *)
+let hostile_value_stream g =
+  match g.adversarial_value with
+  | None -> Alcobar.const None
+  | Some gen -> Alcobar.map Alcobar.[ gen ] (fun v -> Some v)
+
 let test_cases ?(validate = true) label g =
   let check_positive_stream ((_, bs) as sample) =
     check_positive label g sample;
@@ -2911,26 +3115,44 @@ let test_cases ?(validate = true) label g =
       check_decode_validate_agree label kind ?env g bs
     end
   in
+  let check_hostile_stream ?env = function
+    | None -> ()
+    | Some value -> check_encode_safety label ?env g value
+  in
   match g.env with
   | None ->
       [
         Alcobar.test_case (label ^ " all")
-          Alcobar.[ g.positive; g.random; g.adversarial ]
-          (fun positive random adversarial ->
+          Alcobar.
+            [ g.positive; g.random; g.adversarial; hostile_value_stream g ]
+          (fun positive random adversarial hostile ->
             check_positive_stream positive;
             check_safety_stream "random" random;
-            check_safety_stream "adversarial" adversarial);
+            check_safety_stream "adversarial" adversarial;
+            check_hostile_stream hostile);
       ]
   | Some s ->
       [
         Alcobar.test_case (label ^ " all")
-          Alcobar.[ g.positive; g.random; g.adversarial; s.fuzz; s.fuzz ]
-          (fun positive random adversarial random_env adversarial_env ->
+          Alcobar.
+            [
+              g.positive;
+              g.random;
+              g.adversarial;
+              s.fuzz;
+              s.fuzz;
+              hostile_value_stream g;
+            ]
+          (fun positive random adversarial random_env adversarial_env hostile ->
             check_positive_stream positive;
             let env = Some (random_env (Wire.Codec.env g.codec)) in
             check_safety_stream "random" ?env random;
             let env = Some (adversarial_env (Wire.Codec.env g.codec)) in
-            check_safety_stream "adversarial" ?env adversarial);
+            check_safety_stream "adversarial" ?env adversarial;
+            (* The hostile value is the thing under test, so bind the params the
+               way a positive would: a random env would make encode fail for an
+               unrelated reason. *)
+            check_hostile_stream ?env:(positive_env g) hostile);
       ]
 
 (* Cross-field sizes: a [byte_array] whose [~size] reads a preceding int field.
@@ -2975,6 +3197,7 @@ let sized_source name make_len bytes_of_len =
     adversarial = bytes_any;
     equal = ( = );
     env = None;
+    adversarial_value = None;
   }
 
 let sized_cases group =
@@ -4097,6 +4320,7 @@ let check_all_zeros_semantic label () =
       adversarial = bytes_any;
       equal = String.equal;
       env = None;
+      adversarial_value = None;
     }
   in
   check_decode_validate_agree label "all_zeros" g
@@ -4123,6 +4347,7 @@ let signed_slice_semantic_codec () =
           Int.equal l1 l2
           && String.equal (string_of_slice s1) (string_of_slice s2));
       env = None;
+      adversarial_value = None;
     }
   in
   (g, codec, cf_data)

--- a/fuzz/gen/fuzz_gen.ml
+++ b/fuzz/gen/fuzz_gen.ml
@@ -4412,7 +4412,16 @@ let check_metadata_helpers () =
     (Wire.Everparse.project ~mode:`Ffi renamed).Wire.Everparse.name;
   if Wire.Codec.doc codec <> None then
     Alcobar.failf "Codec.doc unexpectedly set";
-  let pp_value = Fmt.str "%a" (pp_value codec) (7, 1) in
+  (* [pp_value] encodes the value to read its fields back, and encode refuses a
+     record that fails its own where clause. It threads no [Param.env], so the
+     param-gated [codec] above cannot satisfy its cond here; print through the
+     same fields with no param in the clause. *)
+  let pp_codec =
+    Wire.Codec.v "ApiPp"
+      (fun src copy -> (src, copy))
+      Wire.Codec.[ f_src $ fst; f_copy $ snd ]
+  in
+  let pp_value = Fmt.str "%a" (pp_value pp_codec) (7, 1) in
   if not (String.contains pp_value 'S') then
     Alcobar.failf "pp_value did not include field output: %S" pp_value;
   let _ = Wire.Codec.field_ref Wire.Codec.(f_src $ fst) in

--- a/fuzz/gen/fuzz_gen.mli
+++ b/fuzz/gen/fuzz_gen.mli
@@ -1,12 +1,14 @@
 (** Fuzz generators that mirror Wire's surface.
 
-    Each [t] bundles a codec with three Alcobar generators: [positive] produces
-    a value together with bytes that decode to it, [random] produces arbitrary
-    bytes the decoder must handle without raising, and [adversarial] produces
-    bytes at the boundary of every constraint the codec checks (lengths, gate
-    flips, bit-pattern extremes). {!Codec.v} composes leaves into record gens
-    with the same shape as {!Wire.Codec.v} composes typs into record codecs -- a
-    record gen is itself a [t], so composition is recursive. *)
+    Each [t] bundles a codec with four Alcobar generators: [positive] produces a
+    value together with bytes that decode to it, [random] produces arbitrary
+    bytes the decoder must handle without raising, [adversarial] produces bytes
+    at the boundary of every constraint the codec checks (lengths, gate flips,
+    bit-pattern extremes), and a hostile-value stream produces well-typed values
+    that violate one of those constraints, which encode must refuse rather than
+    write out. {!Codec.v} composes leaves into record gens with the same shape
+    as {!Wire.Codec.v} composes typs into record codecs -- a record gen is
+    itself a [t], so composition is recursive. *)
 
 type 'a t
 (** A fuzz generator paired with the codec it tests. *)
@@ -20,10 +22,13 @@ val file_input_mode : unit -> bool
     AFL-provided file input. *)
 
 val test_cases : ?validate:bool -> string -> 'a t -> Alcobar.test_case list
-(** [test_cases label g] batches [g.positive], [g.random], and [g.adversarial]
-    into one Alcobar case: positives check codec round-trip plus validation, and
-    random/adversarial streams check codec/validator crash-safety. [validate]
-    defaults to [true]. Direct typ-level entry points are covered by
+(** [test_cases label g] batches [g]'s four streams into one Alcobar case:
+    positives check codec round-trip plus validation, random/adversarial bytes
+    check codec/validator crash-safety, and hostile values check encode safety.
+    Encode safety is the mirror of decode crash-safety: a hostile value must
+    either be refused with [Invalid_argument] or encode to bytes that decode
+    back to an equal value, never to bytes the codec's own decoder rejects.
+    [validate] defaults to [true]. Direct typ-level entry points are covered by
     {!entry_point_cases} so this hot path stays cheap. *)
 
 val afl_cases : ?max_len:int -> string -> Alcobar.test_case list

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -12,6 +12,26 @@ let blit_slice_exact n buf off src =
   Bytes.blit (Slice.bytes src) (Slice.first src) buf off n;
   off + n
 
+(* A refinement decode enforces has to gate encode too, or the encoder emits
+   bytes its own decoder (and the EverParse validator built from the same
+   schema) rejects. One helper per refined type, so the encoder dispatch below
+   stays a flat table. *)
+let refined_bytes_encoder n ~elt_var ~cond buf off v =
+  Eval.check_byte_refinement ~elt_var ~cond v;
+  blit_string_exact n buf off v
+
+let where_field_encoder cond enc runtime buf off v =
+  Types.check_where_encode cond (Eval.expr Eval.empty cond);
+  enc runtime buf off v
+
+let enum_field_encoder ~name ~cases ~closed enc =
+  if not closed then enc
+  else
+    let valid = Types.enum_values cases in
+    fun runtime buf off v ->
+      Types.check_enum_encode ~name ~valid v;
+      enc runtime buf off v
+
 (* Pack a fixed-width integer setter into a [bytes -> int -> int -> int]
    field encoder that returns the offset advance. Used by the scalar cases
    in [build_field_encoder] / [build_field_reader]. *)
@@ -145,10 +165,13 @@ and build_field_encoder_ctx : type a.
   | Uint_var { size = Int n; endian } ->
       fun _runtime -> uint_var_field_encoder endian n
   | Byte_array { size = Int n } -> fun _runtime -> blit_string_exact n
-  | Byte_array_where { size = Int n; _ } -> fun _runtime -> blit_string_exact n
+  | Byte_array_where { size = Int n; elt_var; cond } ->
+      fun _runtime -> refined_bytes_encoder n ~elt_var ~cond
   | Byte_slice { size = Int n } -> fun _runtime -> blit_slice_exact n
-  | Where { inner; _ } -> build_field_encoder_ctx inner
-  | Enum { base; _ } -> build_field_encoder_ctx base
+  | Where { cond; inner } ->
+      where_field_encoder cond (build_field_encoder_ctx inner)
+  | Enum { name; base; cases; closed } ->
+      enum_field_encoder ~name ~cases ~closed (build_field_encoder_ctx base)
   | Map { inner; encode; _ } ->
       let enc = build_field_encoder_ctx inner in
       fun runtime buf off v -> enc runtime buf off (encode v)
@@ -217,6 +240,15 @@ let enum_checker cases =
    document known members, so decode does not reject the rest. *)
 let enum_check cases closed =
   if closed then enum_checker cases else fun ~at:_ v -> v
+
+(* Encode-side twin of [enum_check], gated on [closed] by the same rule so the
+   two halves admit exactly the same values. Encoding an unlisted value raises
+   [Invalid_argument]: it is a caller error, not malformed input. *)
+let enum_encode_check ~name ~cases ~closed =
+  if not closed then fun (_ : int) -> ()
+  else
+    let valid = Types.enum_values cases in
+    fun v -> Types.check_enum_encode ~name ~valid v
 
 (** Build a direct field reader that reads at a fixed offset. No tuples, no refs
     \- just pure value read. Caller must ensure the buffer is large enough. *)
@@ -2237,12 +2269,16 @@ let var_bytes_writer : type a r.
       let s = (value : string) in
       var_bytes_check_len size_fn runtime buf base ~actual:(String.length s);
       var_bytes_write_str buf write_off s
-  | Byte_array_where _ ->
+  | Byte_array_where { elt_var; cond; _ } ->
       let s = (value : string) in
       var_bytes_check_len size_fn runtime buf base ~actual:(String.length s);
+      Eval.check_byte_refinement ~elt_var ~cond s;
       var_bytes_write_str buf write_off s
   | All_bytes -> var_bytes_write_str buf write_off (value : string)
-  | All_zeros -> var_bytes_write_str buf write_off (value : string)
+  | All_zeros ->
+      let s = (value : string) in
+      Types.check_all_zeros_encode s;
+      var_bytes_write_str buf write_off s
   | Zeroterm ->
       let s = (value : string) in
       if String.contains s '\000' then
@@ -2446,16 +2482,22 @@ let rec compile_field : type a r.
  fun ctx fld ->
   match fld.typ with
   | Map { inner; decode; encode; _ } -> compile_map ctx fld inner decode encode
-  | Enum { base; cases; closed; _ } ->
+  | Enum { name; base; cases; closed } ->
       (* Compile as the base integer, then validate the decoded value is one of
          the named cases. [compile_field] would otherwise strip the cases and
          accept any base value, unlike the EverParse validator. *)
       let cf = compile_field ctx { fld with typ = base } in
       let check = enum_check cases closed in
+      let get = fld.get in
+      let encode_check = enum_encode_check ~name ~cases ~closed in
       {
         cf with
         raw_reader =
           (fun runtime buf off -> check ~at:off (cf.raw_reader runtime buf off));
+        raw_writer =
+          (fun v runtime buf base write_off ->
+            encode_check (get v);
+            cf.raw_writer v runtime buf base write_off);
         populate =
           (fun arr runtime buf base ->
             cf.populate arr runtime buf base;
@@ -3421,7 +3463,41 @@ let build_size_of_value size_funcs =
     done;
     !total
 
-let build_record_encoder name writers size_of_value =
+(* Whether encode has to re-read the record it just wrote. A [Wire.where] cond
+   or a field [~constraint_] reads sibling fields, so neither can be judged from
+   one field's value in isolation -- only against the assembled bytes.
+   [struct_field] folds a typ-level [where] into the field's [constraint_], so
+   both arrive here as one predicate. A cond that is constantly true restricts
+   nothing and does not arm the pass. *)
+let is_real_cond : bool Types.expr -> bool = function
+  | Types.Bool true -> false
+  | _ -> true
+
+let has_encode_checks struct_fields where =
+  Option.fold ~none:false ~some:is_real_cond where
+  || List.exists
+       (fun (Types.Field f) ->
+         Option.fold ~none:false ~some:is_real_cond f.constraint_)
+       struct_fields
+
+(* Replay the decode-side check pass over the record encode just assembled, so a
+   cond that reads sibling fields is enforced on both halves. Field actions are
+   deliberately excluded: [populate] runs the check-only validators, so encoding
+   never fires an [~action]'s side effects. *)
+let encode_checker ~scratch ~n_total ~param_base ~param_handles ~populate
+    ~compiled_where runtime buf off =
+  let arr = scratch () in
+  clear_slots arr n_total;
+  List.iteri
+    (fun i (Param.Pack p) ->
+      arr.ints.(param_base + i) <- Types.eval_param runtime p.Types.name)
+    param_handles;
+  populate arr runtime buf off;
+  match compiled_where with
+  | Some f when not (f arr) -> raise_constraint ~at:off ~which:Where ()
+  | _ -> ()
+
+let build_record_encoder name writers size_of_value ~check =
   let n = Array.length writers in
   fun value runtime buf off ->
     let need = size_of_value value in
@@ -3433,6 +3509,15 @@ let build_record_encoder name writers size_of_value =
     for i = 0 to n - 1 do
       write_off := writers.(i) value runtime buf off !write_off
     done;
+    (match check with
+    | None -> ()
+    | Some f -> (
+        try f runtime buf off
+        with Types.Parse_error e ->
+          Fmt.invalid_arg
+            "Codec.encode %s: the encoded record is rejected by its own \
+             constraints (%a)"
+            name Types.pp_parse_error e));
     !write_off
 
 let seal : type r. (r, r) record -> r t =
@@ -3463,6 +3548,14 @@ let seal : type r. (r, r) record -> r t =
     build_validators validators (List.rev r.checkers_rev) compiled_where
       struct_fields r.param_slots n_total
   in
+  let scratch = domain_local_slots n_total in
+  let encode_check =
+    if not (has_encode_checks struct_fields r.where) then None
+    else
+      Some
+        (encode_checker ~scratch ~n_total ~param_base ~param_handles ~populate
+           ~compiled_where)
+  in
   (* Per-field action runners *)
   let field_actions = List.rev r.field_actions_rev in
   let size_funcs = Array.of_list (List.rev r.size_of_value_rev) in
@@ -3475,7 +3568,8 @@ let seal : type r. (r, r) record -> r t =
     field_readers = List.rev r.field_readers;
     field_actions;
     decode = build_checked_decode raw_decode wire_size_info min_size;
-    encode = build_record_encoder r.name writers size_of_value;
+    encode =
+      build_record_encoder r.name writers size_of_value ~check:encode_check;
     wire_size = wire_size_info;
     struct_fields;
     validate =
@@ -3484,7 +3578,7 @@ let seal : type r. (r, r) record -> r t =
     validate_arr;
     populate;
     n_array_slots = n_total;
-    decode_scratch = domain_local_slots n_total;
+    decode_scratch = scratch;
     param_base;
     n_params;
     param_handles;

--- a/lib/codec.mli
+++ b/lib/codec.mli
@@ -124,7 +124,14 @@ val encode : ?env:Param.env -> 'r t -> 'r -> bytes -> int -> unit
     when the codec has parameters and no env is supplied, when the env left any
     input param unbound (the error names the offending param), when the
     destination buffer is too short, or when a parametric byte field's value
-    length does not match its env-bound size. *)
+    length does not match its env-bound size.
+
+    Also raises [Invalid_argument] on a record {!decode} would reject: a closed
+    enum field carrying an unlisted value, an [all_zeros] field carrying a
+    non-zero byte, a [byte_array_where] byte failing its refinement, or a
+    [where] clause or field [~constraint_] that does not hold for the values
+    given. Encode never emits bytes its own decoder refuses. Field [~action]s
+    are not run by encode. *)
 
 val to_struct : 'r t -> Types.struct_
 (** Project to a {!Types.struct_} declaration. *)

--- a/lib/eval.ml
+++ b/lib/eval.ml
@@ -170,3 +170,18 @@ and compare_expr : type a. ctx -> a expr -> a expr -> int =
 
 and compare_int64_expr ctx (a : int64 expr) (b : int64 expr) =
   Int64.unsigned_compare (expr ctx a) (expr ctx b)
+
+(* [byte_array_where] refines every byte of the span. Decode rejects the first
+   offending byte, so encode must refuse the same value rather than emit a span
+   its own decoder (and the EverParse validator built from the same schema)
+   rejects. *)
+let check_byte_refinement ~elt_var ~cond s =
+  String.iteri
+    (fun i c ->
+      let n = Char.code c in
+      if not (expr (bind elt_var n empty) cond) then
+        Fmt.invalid_arg
+          "Wire.encode: byte_array_where byte %d = 0x%02x violates its \
+           per-byte constraint %a"
+          i n Types.pp_expr cond)
+    s

--- a/lib/eval.mli
+++ b/lib/eval.mli
@@ -36,3 +36,10 @@ val expr : ctx -> 'a Types.expr -> 'a
 (** [expr ctx e] evaluates a top-level expression. Raises on [Ref] (cross-field
     references are only valid inside a struct). [Sizeof_this] and [Field_pos]
     return 0. *)
+
+val check_byte_refinement :
+  elt_var:string -> cond:bool Types.expr -> string -> unit
+(** [check_byte_refinement ~elt_var ~cond s] raises [Invalid_argument] on the
+    first byte of [s] that fails [cond], the per-byte refinement of a
+    [byte_array_where]. Encode-side counterpart of the decode check, so both
+    halves reject the same spans. *)

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -1776,6 +1776,40 @@ and pp_typ : type a. a typ Fmt.t =
 
 and pp_packed_expr ppf (Pack_expr e) = pp_expr ppf e
 
+(* Encode-side guards. Decode rejects each of these values, so emitting one
+   would put bytes on the wire that this library's own decoder, and the
+   EverParse validator generated from the same schema, refuse. Each raises
+   [Invalid_argument]: an unencodable value is a caller error, not malformed
+   input. *)
+
+(* Membership in a closed [enum]: the single rule both halves use, so decode and
+   encode agree on which values a closed enum admits. An open enum names known
+   codes without restricting the set, so it has no encode guard at all. *)
+let enum_values cases = List.map snd cases
+let enum_member valid v = List.exists (Int.equal v) valid
+
+let check_enum_encode ~name ~valid v =
+  if not (enum_member valid v) then
+    Fmt.invalid_arg "Wire.encode: enum %s expected one of [%a], got %d" name
+      Fmt.(list ~sep:comma int)
+      valid v
+
+(* [all_zeros] decodes only zero bytes, so a padding value carrying anything
+   else round-trips to [Non_zero_padding]. *)
+let check_all_zeros_encode s =
+  String.iteri
+    (fun i c ->
+      if c <> '\000' then
+        Fmt.invalid_arg
+          "Wire.encode: all_zeros expected a zero byte at offset %d, got 0x%02x"
+          i (Char.code c))
+    s
+
+let check_where_encode cond ok =
+  if not ok then
+    Fmt.invalid_arg "Wire.encode: value violates its where constraint %a"
+      pp_expr cond
+
 (* 3D's [var x = a; p] requires [a] to be an atomic action (extern call,
    field_ptr, ...), not an arbitrary expression. Wire's [Action.var name e]
    binds a name to a pure expression, so we lower it by substituting

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -120,6 +120,23 @@ val check_nested_size : at_most:bool -> expected:int -> actual:int -> unit
 (** Check an inner value against an exact or at-most nested region. Internal
     helper shared by sizing and encoders. *)
 
+val enum_values : (string * int) list -> int list
+(** The value set of an enum's named cases. *)
+
+val enum_member : int list -> int -> bool
+(** [enum_member valid v] is [true] when [v] is one of [valid]. The single
+    membership rule decode and encode share, so the two halves agree on what a
+    closed enum admits. *)
+
+val check_enum_encode : name:string -> valid:int list -> int -> unit
+(** Check a value against a closed enum's case set before encoding it. An
+    unlisted value raises [Invalid_argument]: decode rejects it, so emitting it
+    would produce bytes this library cannot read back. *)
+
+val check_all_zeros_encode : string -> unit
+(** Check an {!val-all_zeros} padding value is all zero bytes before encoding
+    it. A non-zero byte raises [Invalid_argument]. *)
+
 (** {1 Param handles} *)
 
 type param_input
@@ -847,6 +864,11 @@ val pp_expr : Format.formatter -> 'a expr -> unit
 
 val pp_typ : Format.formatter -> 'a typ -> unit
 (** Pretty-print a type. *)
+
+val check_where_encode : bool expr -> bool -> unit
+(** [check_where_encode cond ok] raises [Invalid_argument] when [ok] is [false],
+    naming [cond] in the message. Used by the encoders to refuse a value its own
+    [where] refinement rejects. *)
 
 val pp_action : Format.formatter -> action -> unit
 (** Pretty-print an action block. *)

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -716,7 +716,9 @@ let rec encode_into : type a. a typ -> a -> encoder -> unit =
             (Int32.shift_left (Int32.of_int (v land mask)) shift))
   | Unit -> ()
   | All_bytes -> write_string enc v
-  | All_zeros -> write_string enc v
+  | All_zeros ->
+      Types.check_all_zeros_encode v;
+      write_string enc v
   | Zeroterm ->
       if String.contains v '\000' then
         invalid_arg "Wire.encode: zeroterm string contains a NUL byte";
@@ -736,7 +738,9 @@ let rec encode_into : type a. a typ -> a -> encoder -> unit =
       for _ = len to n - 1 do
         write_byte enc 0
       done
-  | Where { inner; _ } -> encode_into inner v enc
+  | Where { cond; inner } ->
+      Types.check_where_encode cond (Eval.expr Eval.empty cond);
+      encode_into inner v enc
   | Array { len; elem; seq } ->
       let expected = Eval.expr Eval.empty len in
       Types.exact_array_elements seq ~expected v
@@ -746,13 +750,7 @@ let rec encode_into : type a. a typ -> a -> encoder -> unit =
       write_string enc v
   | Byte_array_where { size; elt_var; cond } ->
       check_byte_field_size size ~actual:(String.length v);
-      String.iteri
-        (fun i c ->
-          let n = Char.code c in
-          if not (Eval.expr (Eval.bind elt_var n Eval.empty) cond) then
-            Fmt.invalid_arg
-              "byte_array_where: byte %d=0x%02x violates constraint" i n)
-        v;
+      Eval.check_byte_refinement ~elt_var ~cond v;
       write_string enc v
   | Byte_slice { size } ->
       let src = Slice.bytes v in
@@ -768,7 +766,10 @@ let rec encode_into : type a. a typ -> a -> encoder -> unit =
       for _ = inner_sz to n - 1 do
         write_byte enc 0
       done
-  | Enum { base; _ } -> encode_into base v enc
+  | Enum { name; base; cases; closed } ->
+      if closed then
+        Types.check_enum_encode ~name ~valid:(Types.enum_values cases) v;
+      encode_into base v enc
   | Map { inner; encode; _ } -> encode_into inner (encode v) enc
   | Codec { codec_encode; codec_fixed_size; codec_size_of_value; _ } ->
       encode_codec
@@ -894,6 +895,7 @@ let rec encode_direct : type a. a typ -> bytes -> int -> a -> int =
       Bytes.blit_string v 0 buf off n;
       off + n
   | All_zeros ->
+      Types.check_all_zeros_encode v;
       let n = String.length v in
       Bytes.blit_string v 0 buf off n;
       off + n
@@ -906,8 +908,13 @@ let rec encode_direct : type a. a typ -> bytes -> int -> a -> int =
       if off' < off + n then Bytes.fill buf off' (off + n - off') '\x00';
       off + n
   | Map { inner; encode; _ } -> encode_direct inner buf off (encode v)
-  | Where { inner; _ } -> encode_direct inner buf off v
-  | Enum { base; _ } -> encode_direct base buf off v
+  | Where { cond; inner } ->
+      Types.check_where_encode cond (Eval.expr Eval.empty cond);
+      encode_direct inner buf off v
+  | Enum { name; base; cases; closed } ->
+      if closed then
+        Types.check_enum_encode ~name ~valid:(Types.enum_values cases) v;
+      encode_direct base buf off v
   | Codec { codec_encode; _ } -> codec_encode v Types.unbound_eval_ctx buf off
   | _ -> encode_via_writer typ buf off v
 

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -652,7 +652,9 @@ val all_zeros : string typ
     of them to be zero.
 
     This is mainly useful as the final field of a struct or record-shaped
-    layout. *)
+    layout. Encoding a value with a non-zero byte raises [Invalid_argument]:
+    decode reports it as {!constructor-Non_zero_padding}, so writing it would
+    produce bytes that fail to read back. *)
 
 val zeroterm : string typ
 (** [zeroterm] is a NUL-terminated string: the bytes up to (but excluding) the
@@ -674,7 +676,10 @@ val zeroterm_at_most : size:int expr -> string typ
     see [EverParse3d.Prelude.fsti]. *)
 
 val where : bool expr -> 'a typ -> 'a typ
-(** Refine a description with a boolean constraint. *)
+(** Refine a description with a boolean constraint.
+
+    Encoding a value the constraint rejects raises [Invalid_argument] rather
+    than emitting bytes decode would refuse. *)
 
 (** Builder for sequence accumulation (Jsont-style). *)
 type ('elt, 'seq) seq_map = ('elt, 'seq) Types.seq_map =
@@ -760,10 +765,11 @@ val nested_at_most : size:int expr -> 'a typ -> 'a typ
 
 val enum : string -> (string * int) list -> int typ -> int typ
 (** [enum name cases base] validates that the decoded integer is one of the
-    named values. The result is still an OCaml integer -- use {!variants}
-    instead if you want to decode to proper OCaml values. [enum] is mainly
-    useful for 3D projection where the name and cases appear in the generated
-    [.3d] file. *)
+    named values, on encode as well as on decode: encoding an unlisted value
+    raises [Invalid_argument]. The result is still an OCaml integer -- use
+    {!variants} instead if you want to decode to proper OCaml values. [enum] is
+    mainly useful for 3D projection where the name and cases appear in the
+    generated [.3d] file. *)
 
 val enum_open : string -> (string * int) list -> int typ -> int typ
 (** [enum_open name cases base] is like {!enum} but for an open value set: the
@@ -1164,7 +1170,12 @@ type 'r codec = 'r Codec.t
 val pp_value : 'r codec -> 'r Fmt.t
 (** [pp_value c] is a formatter that prints a record field-by-field through
     codec [c]. Integer-valued fields show as [name = value]; non-integer fields
-    are skipped. Use with [%a]: [Fmt.pr "%a@." (Wire.pp_value c) v]. *)
+    are skipped. Use with [%a]: [Fmt.pr "%a@." (Wire.pp_value c) v].
+
+    It encodes the value to read the fields back and threads no {!Param.env}, so
+    on a codec whose sizes or constraints reference a {!Param.input} it raises
+    [Invalid_argument]: with no binding those params read as zero, and the
+    record that comes out is not one the codec accepts. *)
 
 (** {1 Nested Codec Combinators}
 

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -1850,6 +1850,114 @@ let test_exact_byte_field_expression_size () =
   Codec.encode exact_vb_codec (4, "abcd") buf 0;
   Alcotest.(check string) "exact string" "\x04abcd" (Bytes.sub_string buf 0 5)
 
+(* Encode must not emit a value its own decoder rejects: a refinement the
+   decoder enforces (enum membership, all-zero padding, a per-byte span
+   predicate, a where cond) has to gate encode too, or the record ships bytes
+   that fail to read back. Each case pins the bytes on the accepted value and
+   the [Invalid_argument] on the rejected one, and confirms decode agrees. *)
+let expect_encode_rejects label ~names f =
+  match f () with
+  | () -> Alcotest.failf "%s: encode accepted a value decode rejects" label
+  | exception Invalid_argument msg ->
+      List.iter
+        (fun sub ->
+          Alcotest.(check bool)
+            (Fmt.str "%s: message names %S" label sub)
+            true (contains ~sub msg))
+        names
+
+let expect_decode_rejects label codec s =
+  match Codec.decode codec (Bytes.of_string s) 0 with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.failf "%s: decode accepted %S" label s
+
+let closed_enum_codec =
+  Codec.v "ClosedEnum" Fun.id
+    Codec.[ Field.v "E" (enum "Code" [ ("A", 1); ("B", 2) ] uint8) $ Fun.id ]
+
+let open_enum_codec =
+  Codec.v "OpenEnum" Fun.id
+    Codec.
+      [ Field.v "E" (enum_open "Code" [ ("A", 1); ("B", 2) ] uint8) $ Fun.id ]
+
+let test_encode_rejects_unlisted_enum () =
+  let buf = Bytes.create 1 in
+  expect_encode_rejects "closed enum" ~names:[ "Code"; "got 99" ] (fun () ->
+      Codec.encode closed_enum_codec 99 buf 0);
+  expect_decode_rejects "closed enum" closed_enum_codec "\099";
+  Codec.encode closed_enum_codec 2 buf 0;
+  Alcotest.(check string) "listed value" "\002" (Bytes.to_string buf);
+  (* An open enum documents its codes without restricting them, so encode
+     stays permissive exactly where decode does. *)
+  Codec.encode open_enum_codec 99 buf 0;
+  Alcotest.(check string) "open enum" "\099" (Bytes.to_string buf)
+
+let zeros_codec =
+  Codec.v "Padded"
+    (fun tag pad -> (tag, pad))
+    Codec.[ Field.v "Tag" uint8 $ fst; Field.v "Pad" all_zeros $ snd ]
+
+let test_encode_rejects_non_zero_padding () =
+  let buf = Bytes.create 4 in
+  expect_encode_rejects "all_zeros" ~names:[ "all_zeros"; "0x61" ] (fun () ->
+      Codec.encode zeros_codec (1, "abc") buf 0);
+  expect_decode_rejects "all_zeros" zeros_codec "\001abc";
+  Codec.encode zeros_codec (1, "\000\000\000") buf 0;
+  Alcotest.(check string)
+    "zero padding" "\001\000\000\000" (Bytes.to_string buf)
+
+let per_byte_codec =
+  Codec.v "Printable" Fun.id
+    Codec.
+      [
+        Field.v "B"
+          (byte_array_where ~size:(int 3) ~per_byte:(fun b ->
+               Expr.(b >= int 0x20 && b <= int 0x7e)))
+        $ Fun.id;
+      ]
+
+let test_encode_rejects_refined_byte () =
+  let buf = Bytes.create 3 in
+  expect_encode_rejects "byte_array_where" ~names:[ "byte 1"; "0xff" ]
+    (fun () -> Codec.encode per_byte_codec "a\xffb" buf 0);
+  Codec.encode per_byte_codec "abc" buf 0;
+  Alcotest.(check string) "printable span" "abc" (Bytes.to_string buf)
+
+(* The cond of a [Wire.where] reads sibling fields, so it can only be decided
+   against the assembled record; encode replays the decode-side check pass over
+   the bytes it just wrote. *)
+let where_len = Field.v "Len" uint8
+
+let where_codec =
+  Codec.v "TypWhereEncode"
+    (fun len d -> (len, d))
+    Codec.
+      [
+        where_len $ fst;
+        Field.v "D" (where Expr.(Field.ref where_len < int 2) uint8) $ snd;
+      ]
+
+let codec_where_codec =
+  Codec.v "CodecWhereEncode"
+    ~where:Expr.(Field.ref where_len < int 2)
+    (fun len d -> (len, d))
+    Codec.[ where_len $ fst; Field.v "D" uint8 $ snd ]
+
+let test_encode_rejects_where_violation () =
+  let buf = Bytes.create 2 in
+  expect_encode_rejects "typ where" ~names:[ "TypWhereEncode"; "constraint" ]
+    (fun () -> Codec.encode where_codec (6, 0) buf 0);
+  expect_decode_rejects "typ where" where_codec "\006\000";
+  Codec.encode where_codec (1, 0) buf 0;
+  Alcotest.(check string) "satisfied cond" "\001\000" (Bytes.to_string buf);
+  expect_encode_rejects "codec where"
+    ~names:[ "CodecWhereEncode"; "constraint" ] (fun () ->
+      Codec.encode codec_where_codec (6, 0) buf 0);
+  expect_decode_rejects "codec where" codec_where_codec "\006\000";
+  Codec.encode codec_where_codec (1, 0) buf 0;
+  Alcotest.(check string)
+    "satisfied codec where" "\001\000" (Bytes.to_string buf)
+
 (* [Codec.set] writes in place, so a byte field whose size is only known at
    run time still owns exactly that many bytes: an oversized value that fits in
    the buffer would otherwise land on the fields that follow, with nothing to
@@ -6799,6 +6907,14 @@ let suite =
         test_exact_byte_field_literal_size;
       Alcotest.test_case "exact byte field: expression size" `Quick
         test_exact_byte_field_expression_size;
+      Alcotest.test_case "encode rejects: unlisted enum value" `Quick
+        test_encode_rejects_unlisted_enum;
+      Alcotest.test_case "encode rejects: non-zero all_zeros" `Quick
+        test_encode_rejects_non_zero_padding;
+      Alcotest.test_case "encode rejects: refined byte span" `Quick
+        test_encode_rejects_refined_byte;
+      Alcotest.test_case "encode rejects: where violation" `Quick
+        test_encode_rejects_where_violation;
       Alcotest.test_case "constant size expression folds" `Quick
         test_constant_size_expression_folds;
       Alcotest.test_case "exact byte field: set var byte_array" `Quick

--- a/test/test_wire.ml
+++ b/test/test_wire.ml
@@ -1014,6 +1014,59 @@ let test_exact_byte_field_writer () =
     "exact slice" "wxyz"
     (encode_chunked ~chunk_size:1 bs (slice "wxyz"))
 
+(* The typ-level encoders ([to_string], and the streaming writer behind it) must
+   refuse a value [of_string] rejects: emitting bytes this library cannot read
+   back is the divergence the EverParse-generated validator would also flag.
+   Each case pins the accepted bytes as well as the rejection. *)
+let expect_typ_encode_rejects label ~names f =
+  match f () with
+  | (_ : string) ->
+      Alcotest.failf "%s: encode accepted a value decode rejects" label
+  | exception Invalid_argument msg ->
+      List.iter
+        (fun sub ->
+          Alcotest.(check bool)
+            (Fmt.str "%s: message names %S" label sub)
+            true (contains ~sub msg))
+        names
+
+let expect_typ_decode_rejects label typ s =
+  match of_string typ s with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.failf "%s: decode accepted %S" label s
+
+let test_encode_rejects_unlisted_enum () =
+  let closed = enum "Code" [ ("A", 1); ("B", 2) ] uint8 in
+  let open_ = enum_open "Code" [ ("A", 1); ("B", 2) ] uint8 in
+  expect_typ_encode_rejects "closed enum" ~names:[ "Code"; "got 99" ] (fun () ->
+      to_string closed 99);
+  expect_typ_decode_rejects "closed enum" closed "\099";
+  Alcotest.(check string) "listed value" "\002" (to_string closed 2);
+  (* An open enum names known codes without restricting them. *)
+  Alcotest.(check string) "open enum" "\099" (to_string open_ 99);
+  (* The streaming writer shares the kernel, so it rejects the same value. *)
+  expect_typ_encode_rejects "closed enum streamed" ~names:[ "got 99" ]
+    (fun () -> encode_chunked ~chunk_size:1 closed 99)
+
+let test_encode_rejects_non_zero_padding () =
+  expect_typ_encode_rejects "all_zeros" ~names:[ "all_zeros"; "0x61" ]
+    (fun () -> to_string all_zeros "abc");
+  expect_typ_decode_rejects "all_zeros" all_zeros "abc";
+  Alcotest.(check string)
+    "zero padding" "\000\000"
+    (to_string all_zeros "\000\000");
+  expect_typ_encode_rejects "all_zeros streamed" ~names:[ "0x61" ] (fun () ->
+      encode_chunked ~chunk_size:1 all_zeros "abc")
+
+let test_encode_rejects_where_violation () =
+  let t = where Expr.(int 3 = int 7) uint8 in
+  expect_typ_encode_rejects "where" ~names:[ "where constraint" ] (fun () ->
+      to_string t 3);
+  expect_typ_decode_rejects "where" t "\003";
+  Alcotest.(check string)
+    "satisfied cond" "\003"
+    (to_string (where Expr.(int 7 = int 7) uint8) 3)
+
 (* -- Streaming: cross-slice boundary tests -- *)
 
 (* Parse roundtrip with every chunk size forcing boundary straddles *)
@@ -1419,6 +1472,12 @@ let suite =
         test_roundtrip_byte_array;
       Alcotest.test_case "exact byte field: streaming writer" `Quick
         test_exact_byte_field_writer;
+      Alcotest.test_case "encode rejects: unlisted enum value" `Quick
+        test_encode_rejects_unlisted_enum;
+      Alcotest.test_case "encode rejects: non-zero all_zeros" `Quick
+        test_encode_rejects_non_zero_padding;
+      Alcotest.test_case "encode rejects: where violation" `Quick
+        test_encode_rejects_where_violation;
       (* streaming: cross-slice boundary *)
       Alcotest.test_case "stream: uint8 chunk=1" `Quick test_stream_uint8;
       Alcotest.test_case "stream: uint16 chunk=1" `Quick


### PR DESCRIPTION
A closed `enum` given an unlisted value, an `all_zeros` field given a non-zero byte, a `byte_array_where` byte failing its refinement and a record failing its own `where` clause all used to encode happily and then fail to read back, so the OCaml encoder and the EverParse validator built from the same schema disagreed on a frame this library produced itself.
The second commit closes the harness gap that allowed the class: the fuzz suite fed hostile bytes to decode but only well-formed values to encode. Stacked on #262.