### PR TITLE
chore: anchor the generated .3d ignore rule to the repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,10 +12,10 @@ c_stubs.ml
 .DS_Store
 prof.txt
 prof.trace/
-*.3d
-# Except the committed RFC-documented protocol spec (kept in sync by a runtest
-# diff against examples/net/gen_spec).
-!examples/net/Net.3d
+# Generated schemas land in _build (dune rules) or in the repo root (a
+# generator run by hand from there). Anchoring keeps a committed schema
+# elsewhere in the tree visible, such as examples/net/Net.3d.
+/*.3d
 schemas/
 AGENTS.md
 .agents/


### PR DESCRIPTION
A blanket `*.3d` made any newly committed schema invisible to `git status`, so a contributor adding one had to notice the rule and add a second negation or watch the file silently never land. Generated schemas only reach `_build` or the repo root, so the rule now covers just the root and `examples/net/Net.3d` no longer needs its negation.