### PR TITLE
types: fix a zero-width array element and a racy name counter

### DIFF
--- a/lib/types.ml
+++ b/lib/types.ml
@@ -787,12 +787,11 @@ let array_seq seq ~len elem =
   Array { len = fold_size len; elem; seq }
 
 let byte_array ~size = Byte_array { size = fold_size size }
-let byte_array_where_counter = Stdlib.ref 0
+let byte_array_where_counter = Atomic.make 0
 let elt_var_prefix = "__elt_"
 
 let byte_array_where ~size ~per_byte =
-  let n = !byte_array_where_counter in
-  Stdlib.incr byte_array_where_counter;
+  let n = Atomic.fetch_and_add byte_array_where_counter 1 in
   let elt_var = elt_var_prefix ^ string_of_int n in
   let cond = per_byte (Ref (I, elt_var)) in
   Byte_array_where { size = fold_size size; elt_var; cond }

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -694,9 +694,12 @@ let rec is_array_element : type a. a typ -> bool = function
   | Int8 | Int16 _ | Int32 _ | Int64 _ -> true
   | Float32 _ | Float64 _ -> true
   (* [Unit] is 0-width: an array of it carries no bytes and projects to a
-     zero-size 3D array EverParse rejects, so it is not a valid element. *)
+     zero-size 3D array EverParse rejects, so it is not a valid element. A byte
+     span whose declared size is a literal zero (or less) is 0-width for the
+     same reason, so admit only a positive one. [uint] already refuses a
+     non-positive literal size, and a symbolic one is not [Int _]. *)
   | Uint_var { size = Int _; _ } -> true
-  | Byte_array { size = Int _ } | Byte_slice { size = Int _ } -> true
+  | Byte_array { size = Int n } | Byte_slice { size = Int n } -> n > 0
   | Codec { codec_fixed_size; codec_struct; _ } ->
       codec_fixed_size <> None && struct_nz codec_struct
   | Map { inner; _ } -> is_array_element inner
@@ -708,10 +711,10 @@ let reject_non_array_element ~combinator t =
   if not (is_array_element t) then
     Fmt.invalid_arg
       "Wire.%s: element type is not a fixed-width array element -- 3D projects \
-       %s as a count of fixed-size elements (a scalar, a fixed byte span, or a \
-       fixed-size sub-codec with at least one fixed-size field); a nested \
-       region, refined span, variable inner, or a sub-codec made only of \
-       byte-span fields has no array projection."
+       %s as a count of fixed-size elements (a scalar, a byte span of at least \
+       one byte, or a fixed-size sub-codec with at least one fixed-size \
+       field); a nested region, refined span, zero-width span, variable inner, \
+       or a sub-codec made only of byte-span fields has no array projection."
       combinator combinator
 
 (* A self-delimiting inner carries its own length / structure, so it decodes a

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -995,6 +995,56 @@ let test_reject_zero_width_element () =
     "repeat over empty rejected" true
     (raises_invalid (fun () -> Field.repeat "r" ~size:(int 3) empty))
 
+(* A byte span of literal size zero is 0-width too: EverParse refuses to extract
+   a zero-size element, so an [array] over one has no projection even though the
+   fixed count keeps the decode loop terminating. Refused at construction like
+   [empty], matching the [Field.repeat] guard. *)
+let array_rejects elem =
+  match array ~len:(int 2) elem with
+  | _ -> false
+  | exception Invalid_argument _ -> true
+
+let test_array_rejects_zero_width_span () =
+  Alcotest.(check bool)
+    "byte_array of size 0" true
+    (array_rejects (byte_array ~size:(int 0)));
+  Alcotest.(check bool)
+    "byte_slice of size 0" true
+    (array_rejects (byte_slice ~size:(int 0)));
+  Alcotest.(check bool)
+    "byte_array of negative size" true
+    (array_rejects (byte_array ~size:(int (-1))));
+  Alcotest.(check bool)
+    "byte_array of size 0 under a map" true
+    (array_rejects
+       (map ~decode:String.length
+          ~encode:(fun _ -> "")
+          (byte_array ~size:(int 0))));
+  Alcotest.(check bool)
+    "byte_array of a folded zero size" true
+    (array_rejects (byte_array ~size:Expr.(int 1 - int 1)));
+  Alcotest.(check bool)
+    "array_seq over byte_array of size 0" true
+    (match array_seq seq_list ~len:(int 2) (byte_array ~size:(int 0)) with
+    | _ -> false
+    | exception Invalid_argument _ -> true);
+  (* A varint sized by [sizeof] stays symbolic (constant folding leaves [Sizeof]
+     alone), so it never reaches the literal-size case and [array] already
+     refuses it. *)
+  Alcotest.(check bool)
+    "uint sized by sizeof empty" true
+    (array_rejects (uint (sizeof empty)))
+
+(* The guard must still admit a legitimate fixed-size byte element: a positive
+   literal span projects to a count of fixed-size elements. *)
+let test_array_accepts_fixed_byte_span () =
+  Alcotest.(check bool)
+    "byte_array of size 4 allowed" false
+    (array_rejects (byte_array ~size:(int 4)));
+  Alcotest.(check bool)
+    "byte_slice of size 1 allowed" false
+    (array_rejects (byte_slice ~size:(int 1)))
+
 (* Wire.array over a fixed sub-record (Codec element): a fixed-count list of
    structs. Decoding raised Failure "build_field_reader: unsupported type"
    because the array element reader had no Codec case. The schema projects the
@@ -6831,6 +6881,10 @@ let suite =
         test_repeat_array_reject_bitfield;
       Alcotest.test_case "array/repeat reject zero-width element" `Quick
         test_reject_zero_width_element;
+      Alcotest.test_case "array: rejects zero-width byte span" `Quick
+        test_array_rejects_zero_width_span;
+      Alcotest.test_case "array: accepts fixed-size byte span" `Quick
+        test_array_accepts_fixed_byte_span;
       Alcotest.test_case "array: record element roundtrip" `Quick
         test_array_record_element;
       Alcotest.test_case "array: record element projection" `Quick


### PR DESCRIPTION
`array` used to accept a `byte_array` or `byte_slice` element declared with a size of zero, a shape EverParse refuses to extract, so the OCaml side built a codec the 3D side cannot express; `Field.repeat` got the same fix in #256.

The second commit makes the counter behind `byte_array_where`'s synthesised element name atomic, so two domains building schemas at once cannot mint the same name. Stacked on #263.
