### PR TITLE
codec: stop using Invalid_argument as the truncation signal

### DIFF
--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -12,6 +12,26 @@ let blit_slice_exact n buf off src =
   Bytes.blit (Slice.bytes src) (Slice.first src) buf off n;
   off + n
 
+(* A read of [width] bytes at [at] that must stay inside [buf]. Reads whose
+   position was itself computed from the buffer can land past the end on
+   truncated input; reporting the span here keeps the failure a precise
+   end-of-input instead of a raw out-of-bounds [Invalid_argument], which a
+   caller cannot tell apart from a misuse or from a user [map] callback. *)
+let[@inline] check_read_bounds buf ~at ~width =
+  if at < 0 || at + width > Bytes.length buf then
+    raise_eof ~at ~expected:width ~got:(max 0 (Bytes.length buf - at))
+
+(* Reader for a byte span of constant width. A negative width comes from a size
+   expression that underflows or names a negative literal, so it is data rather
+   than a span the codec can read: report it at the field instead of crashing
+   [Bytes.sub] with an [Invalid_argument] that escapes the decode result. The
+   width is resolved once, while the reader is staged, so the read itself keeps
+   no test. *)
+let const_span_reader ~field_off n read =
+  if n >= 0 then read
+  else fun _runtime _buf base ->
+    raise_out_of_range ~at:(base + field_off) (Int64.of_int n)
+
 (* A refinement decode enforces has to gate encode too, or the encoder emits
    bytes its own decoder (and the EverParse validator built from the same
    schema) rejects. One helper per refined type, so the encoder dispatch below
@@ -299,12 +319,14 @@ let rec build_field_reader_ctx : type a.
   | Uint_var { size = Int n; endian } ->
       fun _runtime buf base -> Uint_var.read endian buf (base + field_off) n
   | Byte_array { size = Int n } ->
-      fun _runtime buf base -> Bytes.sub_string buf (base + field_off) n
+      const_span_reader ~field_off n (fun _runtime buf base ->
+          Bytes.sub_string buf (base + field_off) n)
   | Byte_array_where { size = Int n; _ } ->
-      fun _runtime buf base -> Bytes.sub_string buf (base + field_off) n
+      const_span_reader ~field_off n (fun _runtime buf base ->
+          Bytes.sub_string buf (base + field_off) n)
   | Byte_slice { size = Int n } ->
-      fun _runtime buf base ->
-        Slice.make_or_eod buf ~first:(base + field_off) ~length:n
+      const_span_reader ~field_off n (fun _runtime buf base ->
+          Slice.make_or_eod buf ~first:(base + field_off) ~length:n)
   | Where { inner; _ } -> build_field_reader_ctx inner field_off
   | Enum { base; cases; closed; _ } ->
       let read = build_field_reader_ctx base field_off in
@@ -1636,6 +1658,9 @@ let rec elem_size_of : type a. a typ -> runtime -> bytes -> int -> int =
   | Codec { codec_size_of; _ } -> codec_size_of runtime buf off
   | Casetype { tag; cases; _ } ->
       let tag_size = tag_byte_size tag in
+      (* The position comes from a preceding length field, so a truncated
+         buffer can put the tag past the end. *)
+      check_read_bounds buf ~at:off ~width:tag_size;
       let tag_val = read_elem tag runtime buf off in
       tag_size
       + size_case_body ~at:off ~tag cases tag_val runtime buf (off + tag_size)
@@ -2825,6 +2850,41 @@ let wrap_field_errors ~validates ~check ~act name raw_reader full check_only =
       prepend_field_check name check_only )
   else (raw_reader, full, check_only)
 
+(* Size, offset, presence and [where] expressions read earlier fields through
+   these readers. Unlike a plain decode, such a read can be asked for a field
+   the buffer does not reach: an earlier variable-size field pushes it past the
+   end, or the enclosing record is short. Check the field's byte extent first
+   so truncation is reported as end-of-input at the span that was missing.
+
+   Only accesses with a known extent are wrapped. A variable-width field reads
+   through [var_bytes_reader], which bounds-checks itself, and a field whose
+   footprint differs from its wire size (an optional, a bitfield continuation)
+   is left alone: it may legitimately occupy no bytes. *)
+let expr_reader : type a r. (a, r) compiled_field -> a typ -> _ =
+ fun cf typ ->
+  let reader = cf.int_reader in
+  match cf.field_access with
+  | Bitfield { base = word; byte_off; _ } ->
+      let width = Bitfield.byte_size word in
+      fun runtime buf base ->
+        check_read_bounds buf ~at:(base + byte_off) ~width;
+        reader runtime buf base
+  | Fixed off -> (
+      match field_wire_size typ with
+      | Some width when width = cf.size_delta ->
+          fun runtime buf base ->
+            check_read_bounds buf ~at:(base + off) ~width;
+            reader runtime buf base
+      | _ -> reader)
+  | Dynamic off_fn -> (
+      match field_wire_size typ with
+      | Some width when width = cf.size_delta ->
+          fun runtime buf base ->
+            check_read_bounds buf ~at:(base + off_fn runtime buf base) ~width;
+            reader runtime buf base
+      | _ -> reader)
+  | Variable _ | Variable_dynamic _ -> reader
+
 let apply_compiled : type a f r.
     (a -> f, r) record -> (a, r) field -> (a, r) compiled_field -> (f, r) record
     =
@@ -2867,7 +2927,7 @@ let apply_compiled : type a f r.
   let byte_off = cf.validator_off in
   let new_writers_rev = (cf.raw_writer :: cf.extra_writers) @ r.writers_rev in
   let new_field_readers =
-    cf.nested_readers @ ((fld.name, cf.int_reader) :: r.field_readers)
+    cf.nested_readers @ ((fld.name, expr_reader cf fld.typ) :: r.field_readers)
   in
   let field_typ = fld.typ in
   let field_get = fld.get in
@@ -3091,17 +3151,6 @@ let compile_where_clause param_slots field_readers where =
       let cc = mk_ctx ~param_slots idx in
       Some (compile_bool_arr cc cond)
 
-(* Run a validation pass, turning an out-of-bounds read into a clean eof. A
-   check may read a field whose offset depends on a length read from the buffer;
-   on a buffer too short to hold it that read is out of bounds. [decode] runs
-   [t.decode] first (which bounds-checks), but [Codec.validate] runs the check
-   kernel directly, so this keeps a short buffer a clean failure, not a crash. *)
-let validate_or_eof buf f =
-  try f ()
-  with Invalid_argument _ ->
-    let len = Bytes.length buf in
-    raise_eof ~at:len ~expected:(len + 1) ~got:len
-
 let has_validation_checks compiled_where struct_fields =
   compiled_where <> None
   || List.exists
@@ -3163,7 +3212,7 @@ let build_validators validators_rev checkers_rev compiled_where struct_fields
            evaluate correctly. *)
         seed_param_slots arr n_total env_slots;
         let runtime = validation_runtime param_slots arr in
-        validate_or_eof buf (fun () -> validate_arr arr runtime buf off)
+        validate_arr arr runtime buf off
   in
   (validate_arr, populate, validate)
 
@@ -3201,11 +3250,11 @@ let check_decode_bounds wire_size_info min_size runtime buf off =
   match wire_size_info with
   | Fixed _ -> ()
   | Variable { compute; _ } ->
-      let end_off =
-        try compute runtime buf off
-        with Invalid_argument _ ->
-          raise_eof ~at:off ~expected:min_size ~got:(Bytes.length buf - off)
-      in
+      (* [compute] reads the length fields the codec's span depends on. Those
+         reads bound-check themselves ([expr_reader]), so a buffer too short to
+         hold them already surfaces as end-of-input here; anything else they
+         raise is a real error and propagates. *)
+      let end_off = compute runtime buf off in
       if end_off < off + min_size then
         raise_eof ~at:off ~expected:min_size ~got:(Bytes.length buf - off);
       if end_off > Bytes.length buf then

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -137,6 +137,14 @@ module Slice = Bytesrw.Bytes.Slice
 let[@inline] check_eof len need =
   if need > len then raise_eof ~at:len ~expected:need ~got:len
 
+(* A span of [n] bytes starting at [off]. [n] comes from a size expression, so
+   an underflowing subtraction or a negative literal reaches here as data: a
+   bare [check_eof] would wave it through and [Bytes.sub] would then raise an
+   [Invalid_argument] that escapes [of_string]'s result. *)
+let[@inline] check_span len ~off ~n =
+  if n < 0 then raise_out_of_range ~at:off (Int64.of_int n);
+  check_eof len (off + n)
+
 (* The single decoder kernel. Bytes-based, returns [(value, end_off)].
    All types handled here -- no fallback. Expressions are evaluated in
    [Eval.empty] (no field bindings); types using [Ref]/[Sizeof_this]/
@@ -156,20 +164,13 @@ let parse_all_zeros buf off len =
   (check 0, len)
 
 let parse_codec_typ codec_decode fixed_size size_of buf off len =
-  let sz =
-    match fixed_size with
-    | Some n -> n
-    | None -> (
-        (* A variable-size codec computes its span by reading length / gate
-           fields from the buffer; on a buffer too short to hold them, that read
-           is out of bounds. Convert the [Invalid_argument] into a clean eof, the
-           same guard [Codec.decode]'s checked path applies, so [of_string] on a
-           truncated input returns [Error _] instead of crashing. *)
-        try size_of buf off
-        with Invalid_argument _ ->
-          raise_eof ~at:off ~expected:(len + 1) ~got:len)
-  in
-  check_eof len (off + sz);
+  (* A variable-size codec computes its span by reading length / gate fields
+     from the buffer. Those reads bound-check themselves, so a buffer too short
+     to hold them already fails as end-of-input at the field that was missing;
+     a misuse in the size expression, or an exception from a user [map]
+     callback, reaches the caller unchanged. *)
+  let sz = match fixed_size with Some n -> n | None -> size_of buf off in
+  check_span len ~off ~n:sz;
   (codec_decode buf off, off + sz)
 
 (* Only a closed enum enforces membership; an open enum names known codes but
@@ -205,7 +206,7 @@ let validator_for_struct s =
 let parse_struct_typ s buf off len =
   let v = validator_for_struct s in
   let sz = Codec.struct_size_of v buf off in
-  check_eof len (off + sz);
+  check_span len ~off ~n:sz;
   Codec.validate_struct v buf off;
   ((), off + sz)
 
@@ -245,7 +246,7 @@ let rec parse_direct : type a. a typ -> bytes -> int -> int -> a * int =
   | Float64 Big -> parse_fixed 8 float64_be buf off len
   | Uint_var { size; endian } ->
       let n = Eval.expr Eval.empty size in
-      check_eof len (off + n);
+      check_span len ~off ~n;
       (Uint_var.read endian buf off n, off + n)
   | Bits { width; base; bit_order } ->
       let sz = Bitfield.byte_size base in
@@ -270,16 +271,16 @@ let rec parse_direct : type a. a typ -> bytes -> int -> int -> a * int =
       (Bytes.sub_string buf off (nul - off), nul + 1)
   | Zeroterm_at_most { size } ->
       let n = Eval.expr Eval.empty size in
-      check_eof len (off + n);
+      check_span len ~off ~n;
       let nul = Codec.zeroterm_nul_pos buf ~first:off ~limit:(off + n) in
       (Bytes.sub_string buf off (nul - off), off + n)
   | Byte_array { size } ->
       let n = Eval.expr Eval.empty size in
-      check_eof len (off + n);
+      check_span len ~off ~n;
       (Bytes.sub_string buf off n, off + n)
   | Byte_array_where { size; elt_var; cond } ->
       let n = Eval.expr Eval.empty size in
-      check_eof len (off + n);
+      check_span len ~off ~n;
       for i = 0 to n - 1 do
         let v = Bytes.get_uint8 buf (off + i) in
         if not (Eval.expr (Eval.bind elt_var v Eval.empty) cond) then
@@ -288,11 +289,11 @@ let rec parse_direct : type a. a typ -> bytes -> int -> int -> a * int =
       (Bytes.sub_string buf off n, off + n)
   | Byte_slice { size } ->
       let n = Eval.expr Eval.empty size in
-      check_eof len (off + n);
+      check_span len ~off ~n;
       (Slice.make_or_eod buf ~first:off ~length:n, off + n)
   | Single_elem { size; elem; at_most } ->
       let n = Eval.expr Eval.empty size in
-      check_eof len (off + n);
+      check_span len ~off ~n;
       let v, inner_end = parse_direct elem buf off (off + n) in
       let consumed = inner_end - off in
       if (not at_most) && consumed <> n then
@@ -525,10 +526,6 @@ let of_reader_incremental typ reader =
     | exception Parse_error e ->
         push_back_bytes reader bytes 0 len;
         raise (Parse_error e)
-    | exception Invalid_argument _ ->
-        read_more (fun () ->
-            push_back_bytes reader bytes 0 len;
-            raise_eof ~at:len ~expected:(len + 1) ~got:len)
   in
   loop ()
 

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -228,7 +228,8 @@ val field_pos : int expr
     description.
 
     Like {!sizeof_this}, this is context-dependent and is mainly used inside
-    dependent field constraints and projections. *)
+    dependent field constraints and projections. It has no meaning in a size
+    expression, where decoding it raises [Invalid_argument]. *)
 
 module Expr : sig
   (** Arithmetic, bitwise, and comparison operators on expressions.
@@ -888,7 +889,13 @@ val eof :
 
     Use {!Codec} instead when the format is record-shaped and the main goal is
     repeated access to individual fields in an existing buffer, without
-    allocating an OCaml record for each read. *)
+    allocating an OCaml record for each read.
+
+    The [parse_error] result covers failures of the input: truncation,
+    constraint violations, a byte span the data sizes out of range. A
+    description that cannot be decoded whatever the input, such as {!field_pos}
+    in a size expression, is a programmer error and raises [Invalid_argument],
+    the same way encoding does. *)
 
 val of_reader : 'a typ -> Bytesrw.Bytes.Reader.t -> ('a, parse_error) result
 (** Decodes one value from the current reader position.

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -6733,6 +6733,96 @@ let test_set_no_allocation () =
   check_no_per_call_allocation "set int32be" (fun () -> set_i32 buf 0 70_000);
   check_no_per_call_allocation "set map" (fun () -> set_priority buf 0 High)
 
+(* Decode diagnostics: end of input is reported only for a read that actually
+   ran off the end of the buffer. A misuse in a size expression keeps its own
+   error, and a byte span the data sizes below zero stays inside the result
+   type. *)
+
+let f_diag_len = Field.v "len" uint8
+
+let field_pos_size_codec =
+  Codec.v "FieldPosSize"
+    (fun _len body -> body)
+    Codec.
+      [
+        f_diag_len $ String.length;
+        Field.v "body"
+          (byte_array ~size:Expr.(Field.ref f_diag_len + field_pos))
+        $ Fun.id;
+      ]
+
+let test_size_misuse_reports_itself () =
+  let check name decode =
+    match decode () with
+    | Ok _ -> Alcotest.failf "%s: decoded a value" name
+    | Error e ->
+        Alcotest.failf "%s: misreported as a parse error: %a" name
+          pp_parse_error e
+    | exception Invalid_argument msg ->
+        if not (contains ~sub:"[field_pos] only valid inside an action" msg)
+        then Alcotest.failf "%s: unexpected message %S" name msg
+  in
+  check "Codec.decode" (fun () ->
+      Codec.decode field_pos_size_codec (Bytes.of_string "\001ab") 0);
+  check "of_string" (fun () -> of_string (codec field_pos_size_codec) "\001ab")
+
+let dep_size_codec =
+  Codec.v "DepSizeTrunc"
+    (fun _len body -> body)
+    Codec.
+      [
+        f_diag_len $ String.length;
+        Field.v "body" (byte_array ~size:(Field.ref f_diag_len)) $ Fun.id;
+      ]
+
+(* The length field of the second span sits past the first span, so a short
+   buffer cannot even reach it: computing the record's size is the read that
+   runs off the end. *)
+let two_span_codec =
+  let f_n = Field.v "n" uint8 in
+  Codec.v "TwoSpanTrunc"
+    (fun _len a n b -> (a, n, b))
+    Codec.
+      [
+        (f_diag_len $ fun (a, _, _) -> String.length a);
+        ( Field.v "a" (byte_array ~size:(Field.ref f_diag_len))
+        $ fun (a, _, _) -> a );
+        (f_n $ fun (_, n, _) -> n);
+        (Field.v "b" (byte_array ~size:(Field.ref f_n)) $ fun (_, _, b) -> b);
+      ]
+
+let expect_eof name = function
+  | Ok _ -> Alcotest.failf "%s: decoded a truncated buffer" name
+  | Error { kind = Unexpected_eof _; _ } -> ()
+  | Error e ->
+      Alcotest.failf "%s: expected an eof, got %a" name pp_parse_error e
+
+let test_truncated_still_reports_eof () =
+  expect_eof "Codec.decode"
+    (Codec.decode dep_size_codec (Bytes.of_string "\010ab") 0);
+  expect_eof "of_string" (of_string (codec dep_size_codec) "\010ab");
+  expect_eof "Codec.decode two-span"
+    (Codec.decode two_span_codec (Bytes.of_string "\010X") 0);
+  expect_eof "of_string two-span" (of_string (codec two_span_codec) "\010X")
+
+let test_negative_span_is_parse_error () =
+  let neg_codec =
+    Codec.v "NegSpan" Fun.id
+      Codec.[ Field.v "b" (byte_array ~size:(int (-1))) $ Fun.id ]
+  in
+  let expect name = function
+    | Ok _ -> Alcotest.failf "%s: accepted a negative span" name
+    | Error { kind = Value_out_of_range _; _ } -> ()
+    | Error e ->
+        Alcotest.failf "%s: expected Value_out_of_range, got %a" name
+          pp_parse_error e
+  in
+  expect "Codec.decode" (Codec.decode neg_codec (Bytes.of_string "abc") 0);
+  expect "of_string codec" (of_string (codec neg_codec) "abc");
+  expect "of_string typ" (of_string (byte_array ~size:(int (-1))) "abc");
+  expect "of_bytes typ"
+    (of_bytes (byte_array ~size:(int (-1))) (Bytes.of_string "abc"))
+
 (* -- Suite -- *)
 
 let suite =
@@ -7290,4 +7380,11 @@ let suite =
         test_get_no_allocation;
       Alcotest.test_case "set: immediate fields allocate nothing" `Quick
         test_set_no_allocation;
+      (* decode diagnostics *)
+      Alcotest.test_case "diag: field_pos in a size expression reports itself"
+        `Quick test_size_misuse_reports_itself;
+      Alcotest.test_case "diag: truncated buffer still reports eof" `Quick
+        test_truncated_still_reports_eof;
+      Alcotest.test_case "diag: negative span is a parse error" `Quick
+        test_negative_span_is_parse_error;
     ] )


### PR DESCRIPTION
A size or offset expression that cannot be evaluated, such as one using field_pos, was reported as a truncation of a buffer that was in fact long enough; the reads whose position comes from the buffer now bound-check themselves and raise the end-of-input directly, so a programmer error keeps its own message.
A byte span a size expression puts below zero no longer escapes Codec.decode / Wire.of_string as Invalid_argument "String.sub / Bytes.sub".