### PR TITLE
codec: enforce byte_array_where refinements when decoding

### DIFF
--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -32,6 +32,15 @@ let const_span_reader ~field_off n read =
   else fun _runtime _buf base ->
     raise_out_of_range ~at:(base + field_off) (Int64.of_int n)
 
+(* The refinement of a [byte_array_where] lives in its reader: every compiled
+   path that yields the span runs it, so [Codec.decode] and [Codec.validate]
+   reject the same bytes as [Wire.of_string] and as the EverParse validator
+   built from the same schema. *)
+let refined_span_reader ~elt_var ~cond buf ~first ~len =
+  let bad = Eval.bad_byte ~elt_var ~cond buf ~first ~len in
+  if bad >= 0 then raise_constraint ~at:(first + bad) ~which:Per_byte ();
+  Bytes.sub_string buf first len
+
 (* A refinement decode enforces has to gate encode too, or the encoder emits
    bytes its own decoder (and the EverParse validator built from the same
    schema) rejects. One helper per refined type, so the encoder dispatch below
@@ -321,9 +330,10 @@ let rec build_field_reader_ctx : type a.
   | Byte_array { size = Int n } ->
       const_span_reader ~field_off n (fun _runtime buf base ->
           Bytes.sub_string buf (base + field_off) n)
-  | Byte_array_where { size = Int n; _ } ->
+  | Byte_array_where { size = Int n; elt_var; cond } ->
       const_span_reader ~field_off n (fun _runtime buf base ->
-          Bytes.sub_string buf (base + field_off) n)
+          refined_span_reader ~elt_var ~cond buf ~first:(base + field_off)
+            ~len:n)
   | Byte_slice { size = Int n } ->
       const_span_reader ~field_off n (fun _runtime buf base ->
           Slice.make_or_eod buf ~first:(base + field_off) ~length:n)
@@ -1553,7 +1563,8 @@ let rec read_elem : type a. a typ -> runtime -> bytes -> int -> a =
   (* Fixed-size byte spans as repeat / array elements: a list of n-byte
      chunks. The size is the element's own constant width. *)
   | Byte_array { size = Int n } -> Bytes.sub_string buf off n
-  | Byte_array_where { size = Int n; _ } -> Bytes.sub_string buf off n
+  | Byte_array_where { size = Int n; elt_var; cond } ->
+      refined_span_reader ~elt_var ~cond buf ~first:off ~len:n
   | Byte_slice { size = Int n } -> Slice.make_or_eod buf ~first:off ~length:n
   (* A lone bitfield occupies its base word; extract the value at its bit
      offset. *)
@@ -2237,7 +2248,8 @@ let var_bytes_reader : type a.
   match typ with
   | Byte_slice _ -> Slice.make_or_eod buf ~first:(base + fo) ~length:sz
   | Byte_array _ -> Bytes.sub_string buf (base + fo) sz
-  | Byte_array_where _ -> Bytes.sub_string buf (base + fo) sz
+  | Byte_array_where { elt_var; cond; _ } ->
+      refined_span_reader ~elt_var ~cond buf ~first:(base + fo) ~len:sz
   | All_bytes -> Bytes.sub_string buf (base + fo) sz
   (* [sz] already counts the terminator (see [compile_var_size_fn]). *)
   | Zeroterm -> Bytes.sub_string buf (base + fo) (sz - 1)
@@ -4104,10 +4116,10 @@ let rec build_staged_reader : type a.
       fun runtime buf base ->
         let sz = size_fn runtime buf base in
         Bytes.sub_string buf (base + off) sz
-  | Byte_array_where _, Variable { off; size_fn } ->
+  | Byte_array_where { elt_var; cond; _ }, Variable { off; size_fn } ->
       fun runtime buf base ->
         let sz = size_fn runtime buf base in
-        Bytes.sub_string buf (base + off) sz
+        refined_span_reader ~elt_var ~cond buf ~first:(base + off) ~len:sz
   | Byte_slice _, Variable_dynamic { off_fn; size_fn } ->
       fun runtime buf base ->
         let fo = off_fn runtime buf base in
@@ -4118,11 +4130,12 @@ let rec build_staged_reader : type a.
         let fo = off_fn runtime buf base in
         let sz = size_fn runtime buf base in
         Bytes.sub_string buf (base + fo) sz
-  | Byte_array_where _, Variable_dynamic { off_fn; size_fn } ->
+  | Byte_array_where { elt_var; cond; _ }, Variable_dynamic { off_fn; size_fn }
+    ->
       fun runtime buf base ->
         let fo = off_fn runtime buf base in
         let sz = size_fn runtime buf base in
-        Bytes.sub_string buf (base + fo) sz
+        refined_span_reader ~elt_var ~cond buf ~first:(base + fo) ~len:sz
   | Where { inner; _ }, _ -> build_staged_reader inner access
   | Enum { base; cases; closed; _ }, _ ->
       let read = build_staged_reader base access in

--- a/lib/eval.ml
+++ b/lib/eval.ml
@@ -10,10 +10,21 @@
 
 open Types
 
-type ctx = (string * int) list
+(* The binding is mutable so a per-byte refinement can be decided in place: a
+   fresh association per byte would make scanning a [byte_array_where] allocate
+   in proportion to the span it is protecting. *)
+type binding = { name : string; mutable value : int }
+type ctx = binding list
 
 let empty : ctx = []
-let bind name v ctx = (name, v) :: ctx
+let bind name value ctx = { name; value } :: ctx
+
+let rec lookup name = function
+  | [] ->
+      failwith
+        ("Eval.expr: unbound field " ^ name
+       ^ " (cross-field references are only valid inside a struct)")
+  | b :: tl -> if String.equal b.name name then b.value else lookup name tl
 
 (* Convert a typed value to [int]. Returns [None] for types that don't
    fit in OCaml int (uint64 over 2^63, non-numeric). *)
@@ -113,13 +124,7 @@ let rec expr : type a. ctx -> a expr -> a =
   | Int n -> n
   | Int64 n -> n
   | Bool b -> b
-  | Ref (I, name) -> (
-      match List.assoc_opt name ctx with
-      | Some v -> v
-      | None ->
-          failwith
-            ("Eval.expr: unbound field " ^ name
-           ^ " (cross-field references are only valid inside a struct)"))
+  | Ref (I, name) -> lookup name ctx
   | Ref (I64, name) ->
       failwith
         ("Eval.expr: unbound int64 field " ^ name
@@ -171,17 +176,30 @@ and compare_expr : type a. ctx -> a expr -> a expr -> int =
 and compare_int64_expr ctx (a : int64 expr) (b : int64 expr) =
   Int64.unsigned_compare (expr ctx a) (expr ctx b)
 
-(* [byte_array_where] refines every byte of the span. Decode rejects the first
-   offending byte, so encode must refuse the same value rather than emit a span
-   its own decoder (and the EverParse validator built from the same schema)
-   rejects. *)
+(* [byte_array_where] refines every byte of the span, and every path that reads
+   or writes one decides it here: the compiled codec, the direct parser, both
+   encoders and the EverParse validator built from the same schema all admit
+   exactly the same bytes. The loop stays at top level rather than closing over
+   the span, so a scan allocates only its single binding. *)
+let rec scan_bytes ctx elt cond buf ~first ~len i =
+  if i >= len then -1
+  else begin
+    elt.value <- Bytes.get_uint8 buf (first + i);
+    if expr ctx cond then scan_bytes ctx elt cond buf ~first ~len (i + 1) else i
+  end
+
+let bad_byte ~elt_var ~cond buf ~first ~len =
+  let elt = { name = elt_var; value = 0 } in
+  scan_bytes [ elt ] elt cond buf ~first ~len 0
+
 let check_byte_refinement ~elt_var ~cond s =
-  String.iteri
-    (fun i c ->
-      let n = Char.code c in
-      if not (expr (bind elt_var n empty) cond) then
-        Fmt.invalid_arg
-          "Wire.encode: byte_array_where byte %d = 0x%02x violates its \
-           per-byte constraint %a"
-          i n Types.pp_expr cond)
-    s
+  let len = String.length s in
+  (* [bad_byte] only reads, so the aliased bytes never escape as mutable. *)
+  let i = bad_byte ~elt_var ~cond (Bytes.unsafe_of_string s) ~first:0 ~len in
+  if i >= 0 then
+    Fmt.invalid_arg
+      "Wire.encode: byte_array_where byte %d = 0x%02x violates its per-byte \
+       constraint %a"
+      i
+      (Char.code s.[i])
+      Types.pp_expr cond

--- a/lib/eval.mli
+++ b/lib/eval.mli
@@ -37,6 +37,16 @@ val expr : ctx -> 'a Types.expr -> 'a
     references are only valid inside a struct). [Sizeof_this] and [Field_pos]
     return 0. *)
 
+val bad_byte :
+  elt_var:string -> cond:bool Types.expr -> bytes -> first:int -> len:int -> int
+(** [bad_byte ~elt_var ~cond buf ~first ~len] is the index within
+    [buf.[first .. first + len - 1]] of the first byte that fails [cond], the
+    per-byte refinement of a [byte_array_where], or [-1] when every byte
+    satisfies it. Single source of truth for the refinement: the direct parser,
+    the compiled codec and both encoders all decide it here, so they admit
+    exactly the same spans as the EverParse validator built from the same
+    schema. *)
+
 val check_byte_refinement :
   elt_var:string -> cond:bool Types.expr -> string -> unit
 (** [check_byte_refinement ~elt_var ~cond s] raises [Invalid_argument] on the

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -281,11 +281,8 @@ let rec parse_direct : type a. a typ -> bytes -> int -> int -> a * int =
   | Byte_array_where { size; elt_var; cond } ->
       let n = Eval.expr Eval.empty size in
       check_span len ~off ~n;
-      for i = 0 to n - 1 do
-        let v = Bytes.get_uint8 buf (off + i) in
-        if not (Eval.expr (Eval.bind elt_var v Eval.empty) cond) then
-          raise_constraint ~at:(off + i) ~which:Per_byte ()
-      done;
+      let bad = Eval.bad_byte ~elt_var ~cond buf ~first:off ~len:n in
+      if bad >= 0 then raise_constraint ~at:(off + bad) ~which:Per_byte ();
       (Bytes.sub_string buf off n, off + n)
   | Byte_slice { size } ->
       let n = Eval.expr Eval.empty size in

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -1906,15 +1906,24 @@ let test_encode_rejects_non_zero_padding () =
   Alcotest.(check string)
     "zero padding" "\001\000\000\000" (Bytes.to_string buf)
 
-let per_byte_codec =
-  Codec.v "Printable" Fun.id
-    Codec.
-      [
-        Field.v "B"
-          (byte_array_where ~size:(int 3) ~per_byte:(fun b ->
-               Expr.(b >= int 0x20 && b <= int 0x7e)))
-        $ Fun.id;
-      ]
+let per_byte_typ =
+  byte_array_where ~size:(int 3) ~per_byte:(fun b ->
+      Expr.(b >= int 0x20 && b <= int 0x7e))
+
+let per_byte_cf = Codec.(Field.v "B" per_byte_typ $ Fun.id)
+let per_byte_codec = Codec.v "Printable" Fun.id [ per_byte_cf ]
+
+(* Same refinement over a length-prefixed span, which takes the variable-size
+   reader rather than the constant-offset one. *)
+let per_byte_var_codec =
+  let open Codec in
+  let f_len = Field.v "Len" uint8 in
+  let f_b =
+    Field.v "B"
+      (byte_array_where ~size:(Field.ref f_len) ~per_byte:(fun b ->
+           Expr.(b >= int 0x20 && b <= int 0x7e)))
+  in
+  v "PrintableVar" (fun len b -> (len, b)) [ f_len $ fst; f_b $ snd ]
 
 let test_encode_rejects_refined_byte () =
   let buf = Bytes.create 3 in
@@ -1922,6 +1931,92 @@ let test_encode_rejects_refined_byte () =
     (fun () -> Codec.encode per_byte_codec "a\xffb" buf 0);
   Codec.encode per_byte_codec "abc" buf 0;
   Alcotest.(check string) "printable span" "abc" (Bytes.to_string buf)
+
+let decode_accepts codec s =
+  Result.is_ok (Codec.decode codec (Bytes.of_string s) 0)
+
+let validate_result codec s =
+  match Codec.validate codec (Bytes.of_string s) 0 with
+  | () -> Ok ()
+  | exception Parse_error e -> Error e
+
+let expect_per_byte label ~at = function
+  | Error { kind = Constraint_failed { which = Per_byte; _ }; at = off; _ } ->
+      Alcotest.(check int) (label ^ ": offset") at off
+  | Error e ->
+      Alcotest.failf "%s: expected a per-byte refusal, got %a" label
+        pp_parse_error e
+  | Ok () -> Alcotest.failf "%s: accepted a byte violating the refinement" label
+
+(* The refinement belongs to the span itself, so the compiled reader has to
+   apply it: a [Codec.decode] more permissive than [Wire.of_string] is also more
+   permissive than the EverParse validator built from the same schema, and
+   [Codec.validate] is the gate a caller runs before reading untrusted bytes
+   zero-copy. *)
+let test_decode_rejects_refined_byte () =
+  expect_per_byte "decode" ~at:1
+    (Result.map ignore
+       (Codec.decode per_byte_codec (Bytes.of_string "a\xffb") 0));
+  expect_per_byte "validate" ~at:1 (validate_result per_byte_codec "a\xffb");
+  expect_per_byte "decode var" ~at:2
+    (Result.map ignore
+       (Codec.decode per_byte_var_codec (Bytes.of_string "\002a\xff") 0));
+  expect_per_byte "validate var" ~at:2
+    (validate_result per_byte_var_codec "\002a\xff");
+  (* [get] is documented as unchecked for other fields' constraints, but the
+     span's own refinement travels with the reader, as a closed enum's does. *)
+  let get = Staged.unstage (Codec.get per_byte_codec per_byte_cf) in
+  (match get (Bytes.of_string "a\xffb") 0 with
+  | s -> Alcotest.failf "get returned %S past the refinement" s
+  | exception
+      Parse_error { kind = Constraint_failed { which = Per_byte; _ }; _ } ->
+      ());
+  (* The direct parser has always rejected this; it must keep doing so. *)
+  match of_string per_byte_typ "a\xffb" with
+  | Error { kind = Constraint_failed { which = Per_byte; _ }; at; _ } ->
+      Alcotest.(check int) "of_string offset" 1 at
+  | Error e -> Alcotest.failf "of_string: wrong error %a" pp_parse_error e
+  | Ok _ -> Alcotest.fail "of_string accepted a byte violating the refinement"
+
+let test_decode_accepts_conforming_refined_byte () =
+  Alcotest.(check (result string string))
+    "of_string" (Ok "abc")
+    (Result.map_error
+       (Fmt.str "%a" pp_parse_error)
+       (of_string per_byte_typ "abc"));
+  Alcotest.(check bool) "decode" true (decode_accepts per_byte_codec "abc");
+  Alcotest.(check (result unit string))
+    "validate" (Ok ())
+    (Result.map_error
+       (Fmt.str "%a" pp_parse_error)
+       (validate_result per_byte_codec "abc"));
+  Alcotest.(check string)
+    "get" "abc"
+    ((Staged.unstage (Codec.get per_byte_codec per_byte_cf))
+       (Bytes.of_string "abc") 0)
+
+(* The fuzz harness holds [decode] and [validate] to the same verdict; pin that
+   here against the verdict the refinement calls for, so a later change can
+   neither drop the check nor move one path without the other. *)
+let test_refined_byte_decode_validate_agree () =
+  List.iter
+    (fun (s, accept) ->
+      Alcotest.(check bool)
+        (Fmt.str "decode of %S" s) accept
+        (decode_accepts per_byte_codec s);
+      Alcotest.(check bool)
+        (Fmt.str "validate of %S" s)
+        accept
+        (Result.is_ok (validate_result per_byte_codec s)))
+    [
+      ("abc", true);
+      (" ~!", true);
+      ("a\xffb", false);
+      ("\000bc", false);
+      ("ab\x7f", false);
+      ("ab\x80", false);
+      ("\x1fbc", false);
+    ]
 
 (* The cond of a [Wire.where] reads sibling fields, so it can only be decided
    against the assembled record; encode replays the decode-side check pass over
@@ -7003,6 +7098,12 @@ let suite =
         test_encode_rejects_non_zero_padding;
       Alcotest.test_case "encode rejects: refined byte span" `Quick
         test_encode_rejects_refined_byte;
+      Alcotest.test_case "decode rejects: refined byte span" `Quick
+        test_decode_rejects_refined_byte;
+      Alcotest.test_case "decode accepts: conforming refined byte span" `Quick
+        test_decode_accepts_conforming_refined_byte;
+      Alcotest.test_case "refined byte span: decode and validate agree" `Quick
+        test_refined_byte_decode_validate_agree;
       Alcotest.test_case "encode rejects: where violation" `Quick
         test_encode_rejects_where_violation;
       Alcotest.test_case "constant size expression folds" `Quick


### PR DESCRIPTION
`Codec.decode` and `Codec.validate` used to read a `byte_array_where` span without applying its per-byte refinement, so they accepted bytes that `Wire.of_string` and the EverParse validator built from the same schema both reject; they now fail with `Constraint_failed { which = Per_byte }` at the offending byte, as the other paths already did.
Stacked on #267.