### PR TITLE
lib: share one zeroterm encode guard and tidy wire internals

### DIFF
--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -219,21 +219,16 @@ and build_field_encoder_ctx : type a.
      [zeroterm_at_most] pads the rest of its fixed [n]-byte region with zeros. *)
   | Zeroterm ->
       fun _runtime buf off v ->
+        Types.check_zeroterm_encode v;
         let n = String.length v in
-        if String.contains v '\000' then
-          invalid_arg "Codec.encode: zeroterm string contains a NUL byte";
         Bytes.blit_string v 0 buf off n;
         Bytes.set_uint8 buf (off + n) 0;
         off + n + 1
   | Zeroterm_at_most { size = Int region } ->
       fun _runtime buf off v ->
+        Types.check_zeroterm_encode v;
         let n = String.length v in
-        if String.contains v '\000' then
-          invalid_arg "Codec.encode: zeroterm string contains a NUL byte";
-        if n + 1 > region then
-          Fmt.invalid_arg
-            "Codec.encode: zeroterm string needs %d bytes but region is %d"
-            (n + 1) region;
+        Types.check_zeroterm_region ~region ~len:n;
         Bytes.blit_string v 0 buf off n;
         Bytes.fill buf (off + n) (region - n) '\x00';
         off + region
@@ -2318,21 +2313,16 @@ let var_bytes_writer : type a r.
       var_bytes_write_str buf write_off s
   | Zeroterm ->
       let s = (value : string) in
-      if String.contains s '\000' then
-        invalid_arg "Codec.encode: zeroterm string contains a NUL byte";
+      Types.check_zeroterm_encode s;
       let e = var_bytes_write_str buf write_off s in
       Bytes.set_uint8 buf e 0;
       e + 1
   | Zeroterm_at_most _ ->
       let s = (value : string) in
-      if String.contains s '\000' then
-        invalid_arg "Codec.encode: zeroterm string contains a NUL byte";
+      Types.check_zeroterm_encode s;
       let region = size_fn runtime buf base in
       let len = String.length s in
-      if len + 1 > region then
-        Fmt.invalid_arg
-          "Codec.encode: zeroterm string needs %d bytes but region is %d"
-          (len + 1) region;
+      Types.check_zeroterm_region ~region ~len;
       Bytes.blit_string s 0 buf write_off len;
       (* Single fill covers the NUL terminator and any trailing padding. *)
       Bytes.fill buf (write_off + len) (region - len) '\x00';

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -1810,6 +1810,21 @@ let check_where_encode cond ok =
     Fmt.invalid_arg "Wire.encode: value violates its where constraint %a"
       pp_expr cond
 
+(* A [zeroterm] string ends at its first NUL, so a value carrying one decodes
+   back truncated. Every encoder funnels through here, so the caller sees one
+   message whatever path produced the bytes. *)
+let check_zeroterm_encode s =
+  if String.contains s '\000' then
+    invalid_arg "Wire.encode: zeroterm string contains a NUL byte"
+
+(* [zeroterm_at_most] writes the string, its NUL and zero padding into a fixed
+   region, so the value has to leave room for the terminator. *)
+let check_zeroterm_region ~region ~len =
+  if len + 1 > region then
+    Fmt.invalid_arg
+      "Wire.encode: zeroterm string needs %d bytes but region is %d" (len + 1)
+      region
+
 (* 3D's [var x = a; p] requires [a] to be an atomic action (extern call,
    field_ptr, ...), not an arbitrary expression. Wire's [Action.var name e]
    binds a name to a pure expression, so we lower it by substituting

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -137,6 +137,17 @@ val check_all_zeros_encode : string -> unit
 (** Check an {!val-all_zeros} padding value is all zero bytes before encoding
     it. A non-zero byte raises [Invalid_argument]. *)
 
+val check_zeroterm_encode : string -> unit
+(** Check a {!val-zeroterm} value carries no NUL before encoding it. An embedded
+    NUL raises [Invalid_argument]: it terminates the string on the wire, so the
+    bytes would decode back short. Internal helper shared by every encoder path.
+*)
+
+val check_zeroterm_region : region:int -> len:int -> unit
+(** Check a {!val-zeroterm_at_most} value of [len] bytes leaves room for its NUL
+    terminator inside a [region]-byte span. Internal helper shared by every
+    encoder path. *)
+
 (** {1 Param handles} *)
 
 type param_input

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -714,19 +714,14 @@ let rec encode_into : type a. a typ -> a -> encoder -> unit =
       Types.check_all_zeros_encode v;
       write_string enc v
   | Zeroterm ->
-      if String.contains v '\000' then
-        invalid_arg "Wire.encode: zeroterm string contains a NUL byte";
+      Types.check_zeroterm_encode v;
       write_string enc v;
       write_byte enc 0
   | Zeroterm_at_most { size } ->
-      if String.contains v '\000' then
-        invalid_arg "Wire.encode: zeroterm string contains a NUL byte";
+      Types.check_zeroterm_encode v;
       let n = Eval.expr Eval.empty size in
       let len = String.length v in
-      if len + 1 > n then
-        Fmt.invalid_arg
-          "Wire.encode: zeroterm string needs %d bytes but region is %d"
-          (len + 1) n;
+      Types.check_zeroterm_region ~region:n ~len;
       write_string enc v;
       (* Remaining bytes = NUL terminator plus any trailing padding. *)
       for _ = len to n - 1 do

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -189,16 +189,32 @@ let check_enum_membership ~at ~closed cases v =
    domain-local, which keeps it lock-free (each domain compiles its structs
    once) and avoids sharing a validator, hence its scratch, across domains.
    Keyed by physical identity, so the usual case of a codec built once and
-   decoded in a loop hits the cache. *)
+   decoded in a loop hits the cache.
+
+   Entries are never evicted. The [Domain.DLS] key outlives the validator that
+   allocated it, so dropping an entry does not give the key back: the next
+   decode of that struct compiles again and burns a second key. Physical
+   identity is also unhashable here, since two structs built from one schema are
+   indistinguishable to any hash, so no table turns the lookup sublinear either.
+   What the cache costs is therefore one entry per distinct struct the domain
+   has decoded, which is what compiling those structs already cost. *)
 let struct_validators =
   Domain.DLS.new_key (fun () ->
       (Stdlib.ref [] : (Types.struct_ * Codec.validator) list Stdlib.ref))
 
+exception Uncached
+
+(* Raises rather than returning an option: a hit is on the decode path, and the
+   option would allocate on every decode of a struct type. *)
+let rec cached_validator s = function
+  | [] -> raise_notrace Uncached
+  | (k, v) :: rest -> if k == s then v else cached_validator s rest
+
 let validator_for_struct s =
   let cache = Domain.DLS.get struct_validators in
-  match List.find_opt (fun (k, _) -> k == s) !cache with
-  | Some (_, v) -> v
-  | None ->
+  match cached_validator s !cache with
+  | v -> v
+  | exception Uncached ->
       let v = Codec.validator_of_struct s in
       cache := (s, v) :: !cache;
       v

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -1475,8 +1475,55 @@ module Private : sig
   module UInt32 = UInt32
   module UInt63 = UInt63
   module Types = Types
-  module Eval = Eval
-  module Bitfield = Bitfield
+
+  (** Top-level expression evaluation, in a context with no field bindings. *)
+  module Eval : sig
+    type ctx
+    (** Evaluation context. *)
+
+    val empty : ctx
+    (** Context with no bindings. *)
+
+    val expr : ctx -> 'a Types.expr -> 'a
+    (** Evaluate a top-level expression. *)
+
+    val int_of : 'a Types.typ -> 'a -> int option
+    (** Convert a typed value to [int], [None] when it does not fit. *)
+
+    val int_of_exn : 'a Types.typ -> 'a -> int
+    (** {!val-int_of} without the option; raises {!Types.Parse_error}. *)
+  end
+
+  (** Packed bitfield base words. *)
+  module Bitfield : sig
+    val byte_size : Types.bitfield_base -> int
+    (** Bytes in one packed base word. *)
+
+    val total_bits : Types.bitfield_base -> int
+    (** Bits in one packed base word. *)
+
+    val equal : Types.bitfield_base -> Types.bitfield_base -> bool
+    (** Same base type and endianness. *)
+
+    val read_word : Types.bitfield_base -> bytes -> int -> int
+    (** Read a base word at a byte offset. *)
+
+    val write_word : Types.bitfield_base -> bytes -> int -> int -> unit
+    (** Write a base word at a byte offset. *)
+
+    val native_bit_order : Types.bitfield_base -> Types.bit_order
+    (** The bit order matching EverParse 3D's native packing for a base. *)
+
+    val extract :
+      bit_order:Types.bit_order ->
+      total:int ->
+      bits_used:int ->
+      width:int ->
+      int ->
+      int
+    (** Extract a field's bits from a base word. *)
+  end
+
   module Uint_var = Uint_var
 
   val param_name : param -> string

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -6193,6 +6193,74 @@ let test_zeroterm_embedded_nul_rejected () =
   | () -> Alcotest.fail "expected Invalid_argument for embedded NUL"
   | exception Invalid_argument _ -> ()
 
+(* A casetype case body is encoded by the element encoder rather than the field
+   encoder, so each zeroterm form has a second compiled path behind a case. *)
+type zt_case = Zt of string | Zt_at_most of string
+
+let zt_case_typ : zt_case typ =
+  casetype "ZtCase" uint8
+    [
+      case ~index:1 zeroterm
+        ~inject:(fun s -> Zt s)
+        ~project:(function Zt s -> Some s | _ -> None);
+      case ~index:2
+        (zeroterm_at_most ~size:(int 8))
+        ~inject:(fun s -> Zt_at_most s)
+        ~project:(function Zt_at_most s -> Some s | _ -> None);
+    ]
+
+let zt_case_codec =
+  Codec.v "ZtCaseRec"
+    (fun v -> v)
+    Codec.[ (Field.v "body" zt_case_typ $ fun v -> v) ]
+
+(* One guard behind every encoder, so the message does not depend on whether the
+   value went through [Wire.to_string] or [Codec.encode], nor on whether the
+   string sat in a field or in a casetype case body. *)
+let test_zeroterm_nul_message_shared () =
+  let expected = "Wire.encode: zeroterm string contains a NUL byte" in
+  let check label f =
+    match f () with
+    | () ->
+        Alcotest.failf "%s: expected Invalid_argument for embedded NUL" label
+    | exception Invalid_argument msg ->
+        Alcotest.(check string) label expected msg
+  in
+  let nul = "x\000y" in
+  check "Wire.to_string zeroterm" (fun () ->
+      ignore (Wire.to_string zeroterm nul));
+  check "Wire.to_string zeroterm_at_most" (fun () ->
+      ignore (Wire.to_string (zeroterm_at_most ~size:(int 8)) nul));
+  let field_buf = Bytes.create 15 in
+  check "Codec.encode zeroterm field" (fun () ->
+      Codec.encode zt_codec { name = nul; tag = ""; n = 0 } field_buf 0);
+  check "Codec.encode zeroterm_at_most field" (fun () ->
+      Codec.encode zt_codec { name = ""; tag = nul; n = 0 } field_buf 0);
+  let case_buf = Bytes.create 16 in
+  check "Codec.encode zeroterm case body" (fun () ->
+      Codec.encode zt_case_codec (Zt nul) case_buf 0);
+  check "Codec.encode zeroterm_at_most case body" (fun () ->
+      Codec.encode zt_case_codec (Zt_at_most nul) case_buf 0)
+
+(* The region guard is shared the same way: a value with no room for its
+   terminator reports one message from every [zeroterm_at_most] encoder. *)
+let test_zeroterm_region_message_shared () =
+  let expected = "Wire.encode: zeroterm string needs 9 bytes but region is 8" in
+  let check label f =
+    match f () with
+    | () ->
+        Alcotest.failf "%s: expected Invalid_argument for a full region" label
+    | exception Invalid_argument msg ->
+        Alcotest.(check string) label expected msg
+  in
+  let full = String.make 8 'x' in
+  check "Wire.to_string" (fun () ->
+      ignore (Wire.to_string (zeroterm_at_most ~size:(int 8)) full));
+  check "Codec.encode field" (fun () ->
+      Codec.encode zt_codec { name = ""; tag = full; n = 0 } (Bytes.create 15) 0);
+  check "Codec.encode case body" (fun () ->
+      Codec.encode zt_case_codec (Zt_at_most full) (Bytes.create 16) 0)
+
 let test_zeroterm_missing_terminator () =
   (* No NUL anywhere: decode must fail rather than read past the buffer. *)
   let buf = Bytes.make 6 'x' in
@@ -7431,6 +7499,10 @@ let suite =
       Alcotest.test_case "zeroterm: empty" `Quick test_zeroterm_empty;
       Alcotest.test_case "zeroterm: embedded NUL rejected" `Quick
         test_zeroterm_embedded_nul_rejected;
+      Alcotest.test_case "zeroterm: one NUL message on every encode path" `Quick
+        test_zeroterm_nul_message_shared;
+      Alcotest.test_case "zeroterm: one region message on every encode path"
+        `Quick test_zeroterm_region_message_shared;
       Alcotest.test_case "zeroterm: missing terminator" `Quick
         test_zeroterm_missing_terminator;
       Alcotest.test_case "repeat: with trailer" `Quick test_repeat_with_trailer;


### PR DESCRIPTION
The zeroterm NUL and region rules were open-coded at six encode sites under two message prefixes, so the same mistake reported as `Wire.encode` or as `Codec.encode` depending on which encoder the value reached; both now live in `Types` beside the other encode guards. The two later commits are independent of it and of each other: `Wire.of_bytes` on a struct type no longer allocates to look its validator up, and `Wire.Private` no longer exports `Eval` and `Bitfield` whole.
Stacked on #268.