### PR TITLE
wire: name uint's result type Optint.Int63.t

### DIFF
--- a/fuzz/gen/fuzz_gen.ml
+++ b/fuzz/gen/fuzz_gen.ml
@@ -600,7 +600,7 @@ let uint_var ~endian size =
   let value_gen =
     Alcobar.map
       Alcobar.[ Alcobar.int ]
-      (fun n -> Wire.Private.UInt63.of_int (n land max_v))
+      (fun n -> Optint.Int63.of_int (n land max_v))
   in
   let encode v =
     let buf = Bytes.create size in
@@ -608,9 +608,7 @@ let uint_var ~endian size =
     buf
   in
   let positive = Alcobar.map Alcobar.[ value_gen ] (fun v -> (v, encode v)) in
-  let boundaries =
-    List.map Wire.Private.UInt63.of_int [ 0; 1; max_v; max_v - 1 ]
-  in
+  let boundaries = List.map Optint.Int63.of_int [ 0; 1; max_v; max_v - 1 ] in
   let adversarial =
     Alcobar.map
       Alcobar.[ Alcobar.choose (List.map Alcobar.const boundaries) ]
@@ -761,9 +759,7 @@ let int64be_endian_edges =
     ]
 
 let uint_var_endian_edges ~endian size cases =
-  let cases =
-    List.map (fun (v, bs) -> (Wire.Private.UInt63.of_int v, bs)) cases
-  in
+  let cases = List.map (fun (v, bs) -> (Optint.Int63.of_int v, bs)) cases in
   exact_cases ~typ:(Wire.uint ~endian (Wire.int size)) ~equal:( = ) cases
 
 let uint_var3_little_edges =
@@ -4287,8 +4283,8 @@ let construction_guard_cases label =
             Wire.casetype "BadDynTag"
               (Wire.uint ~endian:Wire.Big (Wire.int 2))
               [
-                Wire.case ~index:(Wire.Private.UInt63.of_int 0)
-                  Wire.uint8 ~inject:Fun.id ~project:(fun v -> Some v);
+                Wire.case ~index:(Optint.Int63.of_int 0) Wire.uint8
+                  ~inject:Fun.id ~project:(fun v -> Some v);
               ]));
     const_case (label ^ " casetype enum tag") (fun () ->
         expect_invalid "casetype enum tag" (fun () ->

--- a/fuzz/gen/fuzz_gen.mli
+++ b/fuzz/gen/fuzz_gen.mli
@@ -274,7 +274,7 @@ val bits : ?bit_order:Wire.bit_order -> width:int -> Wire.bitfield -> int t
 val bit : int t -> bool t
 (** [bit inner] generates for [Wire.bit inner.typ]. *)
 
-val uint_var : endian:Wire.endian -> int -> Wire.Private.UInt63.t t
+val uint_var : endian:Wire.endian -> int -> Optint.Int63.t t
 (** [uint_var ~endian size] generates for [Wire.uint ~endian (Wire.int size)].
 *)
 

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -606,11 +606,12 @@ val is_nan : float Field.t -> bool expr
 (** [is_nan f] holds iff [f] decodes to a NaN bit pattern (exponent all-ones AND
     mantissa non-zero). *)
 
-val uint : ?endian:endian -> int expr -> UInt63.t typ
+val uint : ?endian:endian -> int expr -> Optint.Int63.t typ
 (** [uint size] is an unsigned integer of [size] bytes (1-7) with the given byte
     order (default {!Big}). The size may be a dynamic expression for
-    parameter-driven widths. Decodes to a [UInt63.t]: a 7-byte value needs 56
-    bits, which does not fit an int on a narrow-int target (js/wasm). *)
+    parameter-driven widths. Decodes to an [Optint.Int63.t]: a 7-byte value
+    needs 56 bits, which does not fit an int on a narrow-int target (js/wasm).
+*)
 
 val bits : ?bit_order:bit_order -> width:int -> bitfield -> int typ
 (** [bits ~width base] declares a bitfield of [width] bits inside [base].

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -1615,9 +1615,7 @@ let test_casetype_reject_unprojectable_tag () =
          casetype "CtTag"
            (uint (int 2))
            [
-             case
-               ~index:(Wire.Private.UInt63.of_int 1)
-               uint8
+             case ~index:(Optint.Int63.of_int 1) uint8
                ~inject:(fun s -> s)
                ~project:Option.some;
            ]));
@@ -5853,7 +5851,9 @@ let test_repeat_after_var_slice () =
 
 (* -- uint: variable-width unsigned integer -- *)
 
-module UInt63 = Wire.Private.UInt63
+(* [uint] decodes to an [Optint.Int63.t]. Aliasing [Optint.Int63] rather than
+   [Wire.Private.UInt63] keeps these tests within the public API. *)
+module UInt63 = Optint.Int63
 
 let u63 = Alcotest.testable UInt63.pp ( = )
 
@@ -5899,7 +5899,7 @@ let test_uint_5byte_le () =
       [ (Field.v "V" (uint ~endian:Wire.Little (Wire.int 5)) $ fun v -> v) ]
   in
   (* 40 bits: holds on every platform because the value lives in a
-     [UInt63.t], not a native int. *)
+     [Optint.Int63.t], not a native int. *)
   let value = Optint.Int63.of_int64 0x01_02_03_04_05L in
   let buf = Bytes.create 5 in
   Codec.encode codec value buf 0;


### PR DESCRIPTION
`Wire.uint` declared its result as `UInt63.t`, so naming the type meant reaching into `Wire.Private`, which the same interface introduces as unstable internals not to be depended on. It now spells it `Optint.Int63.t`, as its four neighbours in `wire.mli` already do; the two types are definitionally equal, so existing code is unaffected.