### PR TITLE
codec: bound-check field reads on the validate path

### DIFF
--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -2852,40 +2852,85 @@ let wrap_field_errors ~validates ~check ~act name raw_reader full check_only =
       prepend_field_check name check_only )
   else (raw_reader, full, check_only)
 
-(* Size, offset, presence and [where] expressions read earlier fields through
-   these readers. Unlike a plain decode, such a read can be asked for a field
-   the buffer does not reach: an earlier variable-size field pushes it past the
-   end, or the enclosing record is short. Check the field's byte extent first
-   so truncation is reported as end-of-input at the span that was missing.
+(* The bounds check a field's read needs before it touches the buffer, or
+   [None] when the read guards itself. Such a read can be asked for a field the
+   buffer does not reach: an earlier variable-size field pushes it past the end,
+   or the enclosing record is short. Checking the field's byte extent first
+   reports truncation as end-of-input at the span that was missing.
 
-   Only accesses with a known extent are wrapped. A variable-width field reads
+   Only accesses with a known extent get a guard. A variable-width field reads
    through [var_bytes_reader], which bounds-checks itself, and a field whose
    footprint differs from its wire size (an optional, a bitfield continuation)
    is left alone: it may legitimately occupy no bytes. *)
-let expr_reader : type a r. (a, r) compiled_field -> a typ -> _ =
+let read_guard : type a r.
+    (a, r) compiled_field -> a typ -> (runtime -> bytes -> int -> unit) option =
  fun cf typ ->
-  let reader = cf.int_reader in
   match cf.field_access with
   | Bitfield { base = word; byte_off; _ } ->
       let width = Bitfield.byte_size word in
-      fun runtime buf base ->
-        check_read_bounds buf ~at:(base + byte_off) ~width;
-        reader runtime buf base
+      Some
+        (fun _runtime buf base ->
+          check_read_bounds buf ~at:(base + byte_off) ~width)
   | Fixed off -> (
       match field_wire_size typ with
       | Some width when width = cf.size_delta ->
-          fun runtime buf base ->
-            check_read_bounds buf ~at:(base + off) ~width;
-            reader runtime buf base
-      | _ -> reader)
+          Some
+            (fun _runtime buf base ->
+              check_read_bounds buf ~at:(base + off) ~width)
+      | _ -> None)
   | Dynamic off_fn -> (
       match field_wire_size typ with
       | Some width when width = cf.size_delta ->
-          fun runtime buf base ->
-            check_read_bounds buf ~at:(base + off_fn runtime buf base) ~width;
-            reader runtime buf base
-      | _ -> reader)
-  | Variable _ | Variable_dynamic _ -> reader
+          Some
+            (fun runtime buf base ->
+              check_read_bounds buf ~at:(base + off_fn runtime buf base) ~width)
+      | _ -> None)
+  | Variable _ | Variable_dynamic _ -> None
+
+(* Size, offset, presence and [where] expressions read earlier fields through
+   these readers. *)
+let expr_reader : type a r. (a, r) compiled_field -> a typ -> _ =
+ fun cf typ ->
+  let reader = cf.int_reader in
+  match read_guard cf typ with
+  | None -> reader
+  | Some guard ->
+      fun runtime buf base ->
+        guard runtime buf base;
+        reader runtime buf base
+
+(* [Codec.validate] reaches a field's bytes only through its populate: unlike
+   decode, it never walks the record field by field, so a field pushed past the
+   end by an overlong variable-size predecessor is read at its computed offset
+   with nothing in between to notice. Guard it with the same extent check the
+   expression readers use, so validating truncated input ends in a located
+   end-of-input rather than a raw out-of-bounds [Invalid_argument]. *)
+let guarded_populate : type a r.
+    (a, r) compiled_field -> a typ -> slots -> runtime -> bytes -> int -> unit =
+ fun cf typ ->
+  let populate = cf.populate in
+  match read_guard cf typ with
+  | None -> populate
+  | Some guard ->
+      fun arr runtime buf base ->
+        guard runtime buf base;
+        populate arr runtime buf base
+
+(* A field's two validators. [check_only] fills the field's int slot and tests
+   its constraint; [full] adds the field action. Decode and [Codec.validate]
+   both run [full], so an action never fires on one path only. *)
+let field_validators ~field_idx ~populate ~check ~act =
+  let check_only arr runtime buf base =
+    populate arr runtime buf base;
+    match check with
+    | Some f when not (f arr) -> raise_field_constraint ~field_idx ~at:base arr
+    | _ -> ()
+  in
+  let full arr runtime buf base =
+    check_only arr runtime buf base;
+    match act with Some f -> f arr | None -> ()
+  in
+  (check_only, full)
 
 let apply_compiled : type a f r.
     (a -> f, r) record -> (a, r) field -> (a, r) compiled_field -> (f, r) record
@@ -2911,17 +2956,10 @@ let apply_compiled : type a f r.
   in
   let check = compile_field_check cc fld in
   let act = compile_action cc fld.action in
-  let check_only arr runtime buf base =
-    cf.populate arr runtime buf base;
-    match check with
-    | Some f when not (f arr) -> raise_field_constraint ~field_idx ~at:base arr
-    | _ -> ()
-  in
-  (* The full validator is the read-and-check plus the field action. Decode and
-     [Codec.validate] both run it, so an action never fires on one path only. *)
-  let full arr runtime buf base =
-    check_only arr runtime buf base;
-    match act with Some f -> f arr | None -> ()
+  let check_only, full =
+    field_validators ~field_idx
+      ~populate:(guarded_populate cf fld.typ)
+      ~check ~act
   in
   let faction =
     match act with None -> None | Some act_fn -> Some (fld.name, act_fn)

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -926,6 +926,85 @@ let test_repeat_oversized_length_rejected () =
   Alcotest.(check bool)
     "length past buffer fails cleanly" true (decodes "\x00\x10abc")
 
+(* [Codec.validate] never walks a record field by field the way decode does: it
+   reaches each field's bytes through that field's populate, at the offset the
+   layout computes. An overlong [Field.repeat] budget pushes every following
+   field past the end of the buffer, and the populate used to read there
+   unguarded. The trailing [all_zeros] keeps the record greedy, so the top-level
+   bounds check resolves the record's span to the whole buffer and lets it
+   through; the constrained fields make [validate] run the populate pass at all.
+   Shape and bytes come from the composer's [(rep:fint,i8,uv3le,(bnd,i16,az))]
+   sample. *)
+let validate_overrun_codec =
+  let f_a = Field.v "a" uint8 in
+  let f_b =
+    Field.v "b" uint8 ~self_constraint:(fun b ->
+        Expr.(Field.int f_a + b < int 10))
+  in
+  let pair =
+    Codec.v "Pair" (fun a b -> (a, b)) Codec.[ f_a $ fst; f_b $ snd ]
+  in
+  let f_total = Field.v "total" uint16be in
+  let rep =
+    Codec.v "Rep"
+      (fun _ xs -> xs)
+      Codec.
+        [
+          (f_total $ fun _ -> 0);
+          ( Field.repeat "items" ~size:(Field.ref f_total) (codec pair)
+          $ fun xs -> xs );
+        ]
+  in
+  let bounded =
+    Codec.v "Bounded"
+      (fun v -> v)
+      Codec.
+        [
+          ( Field.v "v" uint8 ~self_constraint:(fun r ->
+                Expr.(r >= int 10 && r <= int 100))
+          $ fun v -> v );
+        ]
+  in
+  let tail =
+    Codec.v "Tail"
+      (fun x y z -> (x, y, z))
+      Codec.
+        [
+          (Field.v "bnd" (codec bounded) $ fun (x, _, _) -> x);
+          (Field.v "i16" int16be $ fun (_, y, _) -> y);
+          (Field.v "az" all_zeros $ fun (_, _, z) -> z);
+        ]
+  in
+  Codec.v "Overrun"
+    (fun w x y z -> (w, x, y, z))
+    Codec.
+      [
+        (Field.v "rep" (codec rep) $ fun (w, _, _, _) -> w);
+        (Field.v "i8" int8 $ fun (_, x, _, _) -> x);
+        ( Field.v "uv" (uint ~endian:Wire.Little (Wire.int 3))
+        $ fun (_, _, y, _) -> y );
+        (Field.v "tail" (codec tail) $ fun (_, _, _, z) -> z);
+      ]
+
+(* The composer's sample: a 0xAA0F byte budget on a 64-byte buffer. *)
+let validate_overrun_input =
+  "\xaa\x0f\x9bFZ\x12\xef\x99\x05\xc5<\xac\xcfx\xd4Q\xfai\xf1RE\xb7S\xe6\xb0\xb8\xdfLjO\xbc\xc9\xfb\xf1\xf1\xc6\xa2\xcaS\xba\x0f\xda\x8e=/\xceC?\x8d\x0cG\x92%\xa1\xbc\xaf\xf6\x18\x9d\x90\x82:\xbd\xac"
+
+let test_validate_overrun_field_offset () =
+  let buf = Bytes.of_string validate_overrun_input in
+  (match Codec.validate validate_overrun_codec buf 0 with
+  | () ->
+      Alcotest.fail "validate accepted a record whose fields run off the end"
+  | exception Wire.Parse_error _ -> ()
+  | exception Invalid_argument m ->
+      Alcotest.failf "validate crashed instead of failing cleanly: %s" m);
+  match Codec.decode validate_overrun_codec buf 0 with
+  | Ok _ ->
+      Alcotest.fail "decode accepted a record whose fields run off the end"
+  | Error _ -> ()
+  | exception Invalid_argument m ->
+      Alcotest.failf "decode crashed instead of failing cleanly: %s" m
+
 (* A byte_slice whose resolved size goes negative (here a [Sub] on an untrusted
    length field) must fail cleanly: [make_or_eod] would otherwise raise a raw
    [Invalid_argument] that escapes the decode result. A large variable field
@@ -7130,6 +7209,8 @@ let suite =
         test_repeat_oversized_length_rejected;
       Alcotest.test_case "byte_slice negative size fails cleanly" `Quick
         test_byte_slice_negative_size;
+      Alcotest.test_case "validate: field past end fails cleanly" `Quick
+        test_validate_overrun_field_offset;
       Alcotest.test_case "repeat/array reject bitfield element" `Quick
         test_repeat_array_reject_bitfield;
       Alcotest.test_case "array/repeat reject zero-width element" `Quick


### PR DESCRIPTION
`Codec.validate` raised `Invalid_argument` instead of returning a parse error when an overlong variable-size field pushed later fields past the end of the buffer, which matters because it is the documented gate to run on untrusted bytes before zero-copy reads. It now reports end-of-input cleanly, as `Codec.decode` already did; the defect predates #267.