### PR TITLE
3d, stubs: fix silently wrong generated output

### DIFF
--- a/lib/3d/wire_3d.ml
+++ b/lib/3d/wire_3d.ml
@@ -88,6 +88,42 @@ let pascal_case name =
 let file_base (s : t) = String.capitalize_ascii s.name
 let c_ident (s : t) = everparse_name s.name
 
+(* Both mangles are many-to-one, so two codecs with different names can land
+   on one generated artifact and overwrite each other in silence. [file_base]
+   collides whenever the names differ only in the leading capital ([header]
+   and [Header] both write [Header.3d], and the second write wins: the
+   verified C, the plug and the provenance stamp then describe one codec while
+   the OCaml side still parses with both, so the shadowed codec's FFI stubs
+   validate against the other codec's spec). [c_ident] collides more widely,
+   since [everparse_name] also strips underscores and collapses uppercase runs
+   ([TMFrame] and [Tmframe] write two [_Fields.h] files that share the
+   [TMFRAME_FIELDS_H] include guard and the [TmframeFields] struct tag, so a
+   translation unit including both takes one schema's plug layout for the
+   other's). The standalone pipeline already rejects a name collision in
+   [Wire.Everparse.merge]; do the same for the per-schema pipeline, up front
+   and naming both codecs. Its remaining collapse, two codecs sharing one
+   [pascal_case] wrapper symbol ([TPM2B] and [Tpm2b]), is left to the C
+   compiler: the merged module puts both definitions in one translation unit,
+   so it fails loudly at build time rather than substituting one for the
+   other. *)
+let check_name_collisions schemas =
+  let check what key =
+    let seen = Hashtbl.create 16 in
+    List.iter
+      (fun (s : t) ->
+        let k = key s in
+        match Hashtbl.find_opt seen k with
+        | Some first ->
+            Fmt.invalid_arg
+              "Wire_3d: codecs %S and %S both generate %s %S; rename one of \
+               them"
+              first s.name what k
+        | None -> Hashtbl.add seen k s.name)
+      schemas
+  in
+  check "the file" (fun s -> file_base s ^ ".3d");
+  check "the C identifier" c_ident
+
 (* EverParse normalizes extern callback names in ways that are awkward to
    mirror exactly (runs of uppercase after a digit get lowercased, trailing
    uppercase runs get lowercased, ...). Rather than re-implement EverParse's
@@ -170,7 +206,9 @@ let read_validate_name ~outdir s =
   | Some n -> n
   | None -> Fmt.failwith "could not find Validate function name in %s" path
 
-let write_3d ~outdir schemas = Wire.Everparse.write ~mode:`Ffi ~outdir schemas
+let write_3d ~outdir schemas =
+  check_name_collisions schemas;
+  Wire.Everparse.write ~mode:`Ffi ~outdir schemas
 
 let absolute_path path =
   if Filename.is_relative path then Filename.concat (Sys.getcwd ()) path
@@ -376,6 +414,7 @@ let has_3d_exe () = locate_3d_exe () <> None
    a different WIRECTX definition; they must then also omit the default
    [<Name>_Fields.c] from their link. *)
 let write_external_typedefs ~outdir schemas =
+  check_name_collisions schemas;
   List.iter
     (fun s ->
       if Wire.Everparse.uses_wire_ctx s then begin
@@ -490,6 +529,7 @@ let write_fields_impl ~outdir s =
   close_out oc
 
 let write_fields ~outdir schemas =
+  check_name_collisions schemas;
   List.iter
     (fun s ->
       if Wire.Everparse.uses_wire_ctx s then begin
@@ -893,6 +933,7 @@ let batch_check ?max_jobs ~outdir schemas =
       match errors with [] -> Ok () | _ -> Error (String.concat "\n" errors))
 
 let generate_c ?(quiet = true) ~outdir schemas =
+  check_name_collisions schemas;
   ensure_dir outdir;
   if has_3d_exe () then begin
     run_everparse ~quiet ~outdir schemas;
@@ -1011,6 +1052,7 @@ let emit_install_stanza ppf ~package ~three_d_files ~c_files ~ctx_files
   pr "  (EverParseEndianness.h as c/EverParseEndianness.h)))\n"
 
 let generate_dune_file ~filename ~outdir ~package schemas =
+  check_name_collisions schemas;
   let oc = open_out (Filename.concat outdir filename) in
   let ppf = Format.formatter_of_out_channel oc in
   let names = List.map file_base schemas in

--- a/lib/3d/wire_3d.ml
+++ b/lib/3d/wire_3d.ml
@@ -379,31 +379,60 @@ let endianness_freestanding_branch =
 
 |}
 
-(* The EverParse anchor the freestanding branch is spliced before: the fallthrough
-   that rejects an unrecognized platform. *)
-let endianness_unsupported_anchor = "#else\n\n#error \"Unsupported platform\""
+(* The EverParse anchor the freestanding branch is spliced before: the
+   fallthrough that rejects an unrecognized platform. EverParse ships this
+   header with CRLF line endings, so the blank line between the two directives
+   is matched as a run of newline characters rather than pinned to [\n]. *)
+let endianness_unsupported_anchor =
+  Re.compile
+    (Re.seq
+       [
+         Re.str "#else";
+         Re.rep1 (Re.set "\r\n");
+         Re.str "#error \"Unsupported platform\"";
+       ])
+
+(* Says the freestanding branch is already spliced in, so a second pass over
+   the same file does not add it twice. *)
+let endianness_freestanding_marker =
+  Re.compile (Re.str "defined(__BYTE_ORDER__)")
 
 let with_freestanding_endianness content =
-  let anchor = Re.compile (Re.str endianness_unsupported_anchor) in
-  Re.replace_string ~all:false anchor
-    ~by:(endianness_freestanding_branch ^ endianness_unsupported_anchor)
-    content
+  if Re.execp endianness_freestanding_marker content then content
+  else if not (Re.execp endianness_unsupported_anchor content) then
+    failwith
+      "EverParseEndianness.h: no \"Unsupported platform\" fallthrough to \
+       splice the freestanding byte-order branch before; EverParse's header \
+       layout changed"
+  else
+    Re.replace ~all:false endianness_unsupported_anchor
+      ~f:(fun g -> endianness_freestanding_branch ^ Re.Group.get g 0)
+      content
 
-let copy_everparse_endianness ~outdir =
+(* Patch the [EverParseEndianness.h] in [outdir] so it also compiles for a
+   target with no OS <endian.h>. 3d.exe writes its own copy of this header on
+   every run, overwriting whatever is there, so the branch has to be spliced
+   into that copy after 3d.exe has run: patching a file that is not there yet,
+   or skipping the patch because the file already exists, both leave the
+   shipped header [#error]ing on the cross target the standalone C archive is
+   meant to serve. Falls back to EverParse's source copy when there is nothing
+   in [outdir] to patch. *)
+let patch_everparse_endianness ~outdir =
   let dst = Filename.concat outdir "EverParseEndianness.h" in
-  if not (Sys.file_exists dst) then begin
-    let ep_dir = everparse_dir () in
-    let src = Filename.concat ep_dir "src/3d/EverParseEndianness.h" in
-    if not (Sys.file_exists src) then
-      Fmt.failwith "Cannot find EverParseEndianness.h at %s" src;
-    let ic = open_in_bin src in
-    let n = in_channel_length ic in
-    let buf = really_input_string ic n in
-    close_in ic;
-    let oc = open_out_bin dst in
-    output_string oc (with_freestanding_endianness buf);
-    close_out oc
-  end
+  let src =
+    if Sys.file_exists dst then dst
+    else begin
+      let src =
+        Filename.concat (everparse_dir ()) "src/3d/EverParseEndianness.h"
+      in
+      if not (Sys.file_exists src) then
+        Fmt.failwith "Cannot find EverParseEndianness.h at %s" src;
+      src
+    end
+  in
+  let content = In_channel.with_open_bin src In_channel.input_all in
+  let patched = with_freestanding_endianness content in
+  Out_channel.with_open_bin dst (fun oc -> Out_channel.output_string oc patched)
 
 let has_3d_exe () = locate_3d_exe () <> None
 
@@ -627,7 +656,8 @@ let run_everparse_files ?(quiet = true) ~outdir files =
       harden_wrapper ~outdir (Filename.remove_extension (Filename.basename f));
       write_provenance ~outdir ~version f)
     files;
-  copy_everparse_endianness ~outdir
+  (* Last, because every 3d.exe run above rewrites this header. *)
+  patch_everparse_endianness ~outdir
 
 let run_everparse ?(quiet = true) ~outdir schemas =
   run_everparse_files ~quiet ~outdir (List.map Wire.Everparse.filename schemas)

--- a/lib/3d/wire_3d.mli
+++ b/lib/3d/wire_3d.mli
@@ -60,7 +60,15 @@ val pascal_case : string -> string
     [pascal_case "virtio_check_Virtq_desc"] is ["VirtioCheckVirtqDesc"]. *)
 
 val generate_3d : outdir:string -> Wire.Everparse.t list -> unit
-(** [generate_3d ~outdir schemas] generates [.3d] files from Wire modules. *)
+(** [generate_3d ~outdir schemas] generates [.3d] files from Wire modules.
+
+    Raises [Invalid_argument] if two schemas would generate the same [.3d] file
+    or the same C identifier, naming both codecs: the second write would
+    otherwise silently replace the first, leaving that codec's FFI stubs running
+    against another spec's verified C. Names collide after capitalization
+    ([header] and [Header]) and after EverParse's identifier mangling ([TMFrame]
+    and [Tmframe]). The same check guards {!generate_c}, {!generate_dune},
+    {!write_external_typedefs} and {!write_fields}. *)
 
 val generate_dune :
   outdir:string -> package:string -> Wire.Everparse.t list -> unit
@@ -138,8 +146,8 @@ val batch_check :
     [3d.exe --batch]. Each run uses a private directory. Returns [Ok ()] iff
     EverParse accepts every schema, else [Error] naming the offending schema(s)
     with their captured diagnostics. Schemas must have distinct names (one [.3d]
-    module each). Paths and filenames are passed without shell interpretation.
-    Requires [3d.exe] in PATH. *)
+    module each; {!generate_3d} rejects a collision). Paths and filenames are
+    passed without shell interpretation. Requires [3d.exe] in PATH. *)
 
 val write_external_typedefs : outdir:string -> Wire.Everparse.t list -> unit
 (** [write_external_typedefs ~outdir schemas] writes the default

--- a/lib/stubs/wire_stubs.ml
+++ b/lib/stubs/wire_stubs.ml
@@ -64,9 +64,18 @@ let pp_c_stub_output ppf ~lower ~ep ~validator (s : Wire.Everparse.Raw.struct_)
       lower;
     Fmt.pf ppf "  CAMLparam3(v_k, v_buf, v_off);@\n";
     Fmt.pf ppf "  CAMLlocal1(v_result);@\n";
+    (* [args] collects boxed values ([caml_copy_int64], [caml_copy_double]).
+       Each of those allocations can trigger a minor collection that moves or
+       reclaims the boxes already stored, and a bare [value args[N]] is
+       invisible to the GC, so the earlier slots go stale and the continuation
+       receives garbage field values. [CAMLlocalN] registers the array as a
+       root block and pre-fills it with [Val_unit], so every slot is a valid
+       root from the declaration on. It comes after the [CAMLparam3] /
+       [CAMLlocal1] declarations and before the first allocation, and the
+       single [CAMLreturn] unwinds all three root blocks. *)
+    Fmt.pf ppf "  CAMLlocalN(args, %d);@\n" n_fields;
     pp_c_stub_bounds ppf ~lower;
     c_stub_validate ppf ~lower ~ep ~validator;
-    Fmt.pf ppf "  value args[%d];@\n" n_fields;
     List.iteri
       (fun i kind -> Fmt.pf ppf "  args[%d] = %a;@\n" i pp_field_value kind)
       kinds;

--- a/test/3d/test_wire_3d.ml
+++ b/test/3d/test_wire_3d.ml
@@ -161,6 +161,51 @@ let test_generate_c () =
          contents)
   end
 
+(* Both the [.3d] file name and the C identifier are many-to-one mangles of
+   the codec name, so a collision has one codec's artifacts overwrite
+   another's with no diagnostic: the verified C then enforces the surviving
+   spec while the OCaml side still parses with both. *)
+let schema_named name =
+  Wire.Everparse.Raw.project_struct ~mode:`Ffi
+    (struct_ name [ field "x" uint8 ])
+
+let test_name_collision () =
+  let tmpdir = Filename.temp_dir "wire_3d_collision" "" in
+  let rejects what generate names substrings =
+    match generate (List.map schema_named names) with
+    | () -> Alcotest.failf "%s: collision accepted" what
+    | exception Invalid_argument msg ->
+        List.iter
+          (fun sub ->
+            if not (Re.execp (Re.compile (Re.str sub)) msg) then
+              Alcotest.failf "%s: error %S does not mention %S" what msg sub)
+          substrings
+  in
+  let generate_3d schemas = Wire_3d.generate_3d ~outdir:tmpdir schemas in
+  let generate_dune schemas =
+    Wire_3d.generate_dune ~outdir:tmpdir ~package:"pkg" schemas
+  in
+  (* [header] and [Header] both write [Header.3d]. *)
+  rejects "same .3d file" generate_3d [ "header"; "Header" ]
+    [ "\"header\""; "\"Header\""; "Header.3d" ];
+  rejects "same .3d file (dune)" generate_dune [ "header"; "Header" ]
+    [ "Header.3d" ];
+  (* [TMFrame] and [Tmframe] write two files that share the [TmframeFields]
+     plug struct tag and the [TMFRAME_FIELDS_H] include guard, so a
+     translation unit including both takes one plug layout for the other. *)
+  rejects "same C identifier" generate_3d [ "TMFrame"; "Tmframe" ]
+    [ "\"TMFrame\""; "\"Tmframe\""; "Tmframe" ];
+  rejects "same C identifier (plug)"
+    (fun schemas -> Wire_3d.write_fields ~outdir:tmpdir schemas)
+    [ "TMFrame"; "Tmframe" ] [ "Tmframe" ];
+  (* Distinct names still generate. *)
+  generate_3d [ schema_named "Alpha"; schema_named "Beta" ];
+  Alcotest.(check bool)
+    "distinct names generate" true
+    (Sys.file_exists (Filename.concat tmpdir "Alpha.3d")
+    && Sys.file_exists (Filename.concat tmpdir "Beta.3d"));
+  Wire_3d.rm_rf tmpdir
+
 let raises_failure f =
   match f () with () -> false | exception Failure _ -> true
 
@@ -1528,6 +1573,7 @@ let suite =
       Alcotest.test_case "schema_of_struct" `Quick test_schema_of_struct;
       Alcotest.test_case "ensure_dir" `Quick test_ensure_dir;
       Alcotest.test_case "generate_c (needs 3d.exe)" `Quick test_generate_c;
+      Alcotest.test_case "generated-name collision" `Quick test_name_collision;
       Alcotest.test_case "check_provenance" `Quick test_check_provenance;
       Alcotest.test_case "generate_dune_standalone" `Quick
         test_generate_dune_standalone;

--- a/test/3d/test_wire_3d.ml
+++ b/test/3d/test_wire_3d.ml
@@ -161,6 +161,54 @@ let test_generate_c () =
          contents)
   end
 
+(* 3d.exe writes its own [EverParseEndianness.h] on every run, so the
+   freestanding byte-order branch is only useful if it is spliced into that
+   copy afterwards. Without it the shipped header stops at [#error
+   "Unsupported platform"] for any target that is neither Linux/glibc nor
+   Apple, which is the OS-less cross target the standalone C archive exists to
+   serve. *)
+let test_endianness_freestanding () =
+  if not (Wire_3d.has_3d_exe ()) then ()
+  else begin
+    let tmpdir = Filename.temp_dir "wire_3d_endianness" "" in
+    let s = Wire.Everparse.Raw.project_struct ~mode:`Ffi simple_struct in
+    Wire_3d.generate_3d ~outdir:tmpdir [ s ];
+    Wire_3d.generate_c ~outdir:tmpdir [ s ];
+    let header = read_file (Filename.concat tmpdir "EverParseEndianness.h") in
+    let has sub = Re.execp (Re.compile (Re.str sub)) header in
+    Alcotest.(check bool)
+      "byte order comes from the compiler" true (has "__BYTE_ORDER__");
+    Alcotest.(check bool)
+      "byte swapping uses compiler builtins" true (has "__builtin_bswap32");
+    (* The [#error] fallthrough stays as the last resort for a compiler that
+       exposes neither an OS nor [__BYTE_ORDER__]; what matters is that a
+       freestanding GCC or Clang target no longer reaches it. Compile one to
+       prove it, undefining the two OS macros the header keys on. Skip the
+       compile where the host's own system headers do not survive those
+       undefines: the text assertions above still stand. *)
+    let write path contents =
+      Out_channel.with_open_bin path (fun oc ->
+          Out_channel.output_string oc contents)
+    in
+    write (Filename.concat tmpdir "probe.c") "#include <stdint.h>\n";
+    write
+      (Filename.concat tmpdir "freestanding.c")
+      "#include \"EverParseEndianness.h\"\n\
+       uint32_t swap(uint32_t x);\n\
+       uint32_t swap(uint32_t x) { return be32toh(x); }\n";
+    let compile file =
+      Fmt.kstr Sys.command
+        "cd %s && cc -std=c11 -U__APPLE__ -U__linux__ -I . -c %s -o /dev/null \
+         > /dev/null 2>&1"
+        (Filename.quote tmpdir) file
+    in
+    let freestanding_host = compile "probe.c" = 0 in
+    let status = if freestanding_host then compile "freestanding.c" else 0 in
+    ignore (Fmt.kstr Sys.command "rm -rf %s" tmpdir);
+    if freestanding_host then
+      Alcotest.(check int) "compiles for a target with no OS endian.h" 0 status
+  end
+
 (* Both the [.3d] file name and the C identifier are many-to-one mangles of
    the codec name, so a collision has one codec's artifacts overwrite
    another's with no diagnostic: the verified C then enforces the surviving
@@ -1573,6 +1621,8 @@ let suite =
       Alcotest.test_case "schema_of_struct" `Quick test_schema_of_struct;
       Alcotest.test_case "ensure_dir" `Quick test_ensure_dir;
       Alcotest.test_case "generate_c (needs 3d.exe)" `Quick test_generate_c;
+      Alcotest.test_case "freestanding endianness header (needs 3d.exe)" `Quick
+        test_endianness_freestanding;
       Alcotest.test_case "generated-name collision" `Quick test_name_collision;
       Alcotest.test_case "check_provenance" `Quick test_check_provenance;
       Alcotest.test_case "generate_dune_standalone" `Quick

--- a/test/stubs/test_wire_stubs.ml
+++ b/test/stubs/test_wire_stubs.ml
@@ -255,6 +255,34 @@ let test_c_stubs_bounds_check () =
     "no unchecked length subtraction remains" false
     (contains ~sub:"caml_string_length(v_buf) - Int_val(v_off)" c)
 
+(* The values handed to [caml_callbackN] are freshly boxed
+   ([caml_copy_int64] / [caml_copy_double]) and every box can trigger a minor
+   collection, so the array holding them has to be a registered root block. A
+   bare [value args[N]] leaves the boxes already stored unrooted: the
+   continuation then sees moved-away or reclaimed values, silently, with no
+   crash. See the GC stress e2e below for the dynamic witness. *)
+let test_c_stubs_callback_args_rooted () =
+  let s =
+    struct_ "Quad"
+      [
+        field "a" uint64be;
+        field "b" uint64be;
+        field "c" uint64be;
+        field "d" uint64be;
+      ]
+  in
+  let c = Wire_stubs.to_c_stubs [ s ] in
+  Alcotest.(check bool)
+    "callback arguments live in a CAMLlocalN root block" true
+    (contains ~sub:"CAMLlocalN(args, 4)" c);
+  Alcotest.(check bool)
+    "no unrooted value array" false
+    (contains ~sub:"value args[" c);
+  let index sub = Re.Group.start (Re.exec (Re.compile (Re.str sub)) c) 0 in
+  Alcotest.(check bool)
+    "roots registered before the first allocation" true
+    (index "CAMLlocalN(args, 4)" < index "caml_copy_int64")
+
 (* -- to_ml_stub_name -- *)
 
 let test_name_camel () =
@@ -294,10 +322,31 @@ let write_file path contents =
   output_string oc contents;
   close_out oc
 
+let capture cmd =
+  let ic = Unix.open_process_in (cmd ^ " 2>/dev/null") in
+  let output = In_channel.input_all ic in
+  match Unix.close_process_in ic with
+  | Unix.WEXITED 0 -> Some (String.trim output)
+  | _ -> None
+
+(* The GC stress e2e links the debug runtime: it poisons the minor arena it
+   has just collected, which is what turns an unrooted argument into an
+   observably wrong value instead of a stale-but-usually-intact one. The
+   debug runtime ships with a standard OCaml install; on a switch built
+   without it the test has nothing to say, so it steps aside rather than
+   failing. *)
+let has_debug_runtime =
+  match capture "ocamlopt -config-var standard_library" with
+  | Some dir -> Sys.file_exists (Filename.concat dir "libasmrund.a")
+  | None -> false
+
 (** End-to-end: .3d -> EverParse -> C stubs -> ML stubs -> compile -> call.
     [test_ml] is the OCaml source that calls the generated stubs and exits 0 on
-    success, non-zero on failure. *)
-let e2e ~name ~structs ~module_ ~test_ml =
+    success, non-zero on failure. [ocamlopt_flags] are appended to the link
+    command and [run_env] prefixes the run of the resulting binary, so a test
+    can select a runtime variant and its parameters. *)
+let e2e ?(ocamlopt_flags = "") ?(run_env = "") ~name ~structs ~module_ ~test_ml
+    () =
   if not has_3d then ()
   else begin
     let dir = Filename.temp_dir ("wire_e2e_" ^ name) "" in
@@ -319,13 +368,14 @@ let e2e ~name ~structs ~module_ ~test_ml =
        provides (the stubs call the validator directly). *)
     let cmd =
       Fmt.str
-        "cd %s && ocamlfind ocamlopt -package wire,wire.stubs -linkpkg -ccopt \
-         '-I %s' $(ls *.c | grep -v Wrapper) stubs.ml main.ml -o test_e2e 2>&1"
-        dir dir
+        "cd %s && ocamlfind ocamlopt -package wire,wire.stubs -linkpkg %s \
+         -ccopt '-I %s' $(ls *.c | grep -v Wrapper) stubs.ml main.ml -o \
+         test_e2e 2>&1"
+        dir ocamlopt_flags dir
     in
     run cmd;
     (* 4. Run *)
-    run (Filename.concat dir "test_e2e")
+    Fmt.kstr run "%s %s" run_env (Filename.concat dir "test_e2e")
   end
 
 let test_e2e_no_params () =
@@ -349,6 +399,7 @@ let test_e2e_no_params () =
   assert (r.Stubs.version = 1);
   assert (r.Stubs.length = 42)
 |}
+    ()
 
 let test_e2e_offset_bounds () =
   let f_version = Wire.Field.v "version" uint8 in
@@ -380,6 +431,7 @@ let test_e2e_offset_bounds () =
    | _ -> assert false
    | exception Invalid_argument _ -> ())
 |}
+    ()
 
 let test_e2e_with_constraint () =
   let f_x_ref = Wire.Field.v "x" uint8 in
@@ -405,6 +457,7 @@ let test_e2e_with_constraint () =
   (try ignore (Stubs.constrained_parse buf 0); assert false
    with Failure _ -> ())
 |}
+    ()
 
 let test_e2e_bitfields () =
   (* Adversarial: drive the EverParse-generated C parser on a real IPv4-style
@@ -439,6 +492,58 @@ let test_e2e_bitfields () =
   assert (r.Stubs.flags = 5);
   assert (r.Stubs.length = 100)
 |}
+    ()
+
+(* GC stress: four [uint64be] fields, so the whole argument array is boxed
+   ([caml_copy_int64]) and full of young pointers by the time the last box is
+   allocated. A tiny minor heap under the debug runtime puts a minor
+   collection between two of those boxes on a large fraction of iterations,
+   and the debug runtime poisons what it collected, so an unrooted slot reads
+   back as garbage. With the argument array unrooted this reported over a
+   thousand corrupted parses out of the 200000; every field value must
+   survive. *)
+let test_e2e_gc_stress () =
+  if not has_debug_runtime then ()
+  else begin
+    let f n = Wire.Field.v n Wire.uint64be in
+    let codec =
+      let open Wire.Codec in
+      v "GcQuad"
+        (fun a b c d -> (a, b, c, d))
+        [
+          (f "a" $ fun (a, _, _, _) -> a);
+          (f "b" $ fun (_, b, _, _) -> b);
+          (f "c" $ fun (_, _, c, _) -> c);
+          (f "d" $ fun (_, _, _, d) -> d);
+        ]
+    in
+    let schema = Wire.Everparse.project ~mode:`Ffi codec in
+    let s = Wire.Everparse.Raw.struct_of_codec codec in
+    e2e ~ocamlopt_flags:"-runtime-variant d" ~run_env:"OCAMLRUNPARAM=s=1k,v=0"
+      ~name:"GcQuad" ~structs:[ s ] ~module_:schema.module_
+      ~test_ml:
+        {|let () =
+  let buf = Bytes.create 32 in
+  Bytes.set_int64_be buf 0 0x1122334455667788L;
+  Bytes.set_int64_be buf 8 0x2233445566778899L;
+  Bytes.set_int64_be buf 16 0x33445566778899aaL;
+  Bytes.set_int64_be buf 24 0x445566778899aabbL;
+  let bad = ref 0 in
+  for _ = 1 to 200_000 do
+    let r = Stubs.gcquad_parse buf 0 in
+    if r.Stubs.a <> 0x1122334455667788L
+       || r.Stubs.b <> 0x2233445566778899L
+       || r.Stubs.c <> 0x33445566778899aaL
+       || r.Stubs.d <> 0x445566778899aabbL
+    then incr bad
+  done;
+  if !bad <> 0 then begin
+    Printf.eprintf "%d corrupted parses out of 200000\n" !bad;
+    exit 1
+  end
+|}
+      ()
+  end
 
 (* -- Output pattern invariants --
 
@@ -810,6 +915,8 @@ let suite =
         `Quick test_normalised_fields_name;
       Alcotest.test_case "c stubs: offset bounds check" `Quick
         test_c_stubs_bounds_check;
+      Alcotest.test_case "c stubs: callback args are GC roots" `Quick
+        test_c_stubs_callback_args_rooted;
       (* stub name *)
       Alcotest.test_case "name: camelCase" `Quick test_name_camel;
       Alcotest.test_case "name: ALLCAPS" `Quick test_name_allcaps;
@@ -824,6 +931,8 @@ let suite =
       Alcotest.test_case "e2e: output parse" `Slow test_e2e_output_parse;
       Alcotest.test_case "e2e: full stack (eth+ipv4+tcp linked)" `Slow
         test_e2e_full_stack;
+      Alcotest.test_case "e2e: GC stress under the debug runtime" `Slow
+        test_e2e_gc_stress;
       (* output pattern invariants *)
       Alcotest.test_case "action forms: scalars" `Quick
         test_action_forms_scalars;


### PR DESCRIPTION
Three defects that made generated output silently wrong: the FFI stub left its boxed field values unrooted so a collection mid-parse could hand the caller garbage, two codecs whose generated names collide overwrote each other and left one validating against the wrong spec, and the freestanding byte-order branch never reached the emitted header so the standalone archive stopped at `#error "Unsupported platform"`. The three commits are independent and each carries a regression test that fails on the parent.