### PR TITLE
fuzz: compare the typ-level and codec-level paths

### DIFF
--- a/fuzz/diff/dune
+++ b/fuzz/diff/dune
@@ -27,7 +27,7 @@
  (modules fuzz stubs diff_index)
  (enabled_if
   (= %{env:BUILD_EVERPARSE=} "1"))
- (libraries wire fuzz_gen diff_codecs alcobar)
+ (libraries wire fuzz_gen diff_codecs alcobar fmt)
  (foreign_archives diffcodecs)
  (foreign_stubs
   (language c)

--- a/fuzz/diff/fuzz.ml
+++ b/fuzz/diff/fuzz.ml
@@ -1,13 +1,14 @@
-(** Differential AFL fuzzer: OCaml wire codec vs EverParse C validator, driven
-    by the registry.
+(** Differential AFL fuzzer: OCaml wire codec vs EverParse C validator.
 
-    For each codec EverParse could generate a validator for
-    ({!Diff_index.covered}, looked up in {!Fuzz_gen.registry} by label), feed
-    the AFL input to both the OCaml {!Wire.Codec.validate} and the generated C
-    validator and flag any accept/reject divergence: both decoders must agree on
-    which inputs are valid. Codecs the candidate filter dropped (variable-size,
-    parameterised, casetype, or a shared-name duplicate of an already-included
-    codec) are reported via {!Diff_codecs.excluded}. *)
+    The codecs come from {!Diff_codecs.included}, the in-scope part of the
+    Boltzmann {!Fuzz_gen.sample} -- not from {!Fuzz_gen.registry}, which the
+    OCaml-only suites drive off. For each codec EverParse could generate a
+    validator for ({!Diff_index.covered}, looked up in {!Diff_codecs.included}
+    by label), feed the AFL input to both the OCaml {!Wire.Codec.validate} and
+    the generated C validator and flag any accept/reject divergence: both
+    decoders must agree on which inputs are valid. Codecs the candidate filter
+    dropped (variable-size, zero-size, parameterised or casetype) are reported
+    via {!Diff_codecs.excluded}. *)
 
 open Fuzz_gen
 
@@ -38,7 +39,7 @@ let covered_cases =
 
 (* Normal [dune test]: one case per covered codec, each on its own random bytes,
    so a single run touches every codec. *)
-let registry_case (label, (p, c_check)) =
+let sample_case (label, (p, c_check)) =
   Alcobar.test_case label [ Alcobar.bytes ] (fun buf ->
       diff_check label p c_check (Bytes.of_string buf))
 
@@ -50,13 +51,12 @@ let afl_case ?(max_len = 256) () =
       diff_check label p c_check input.payload)
 
 let cases =
-  if file_input_mode () then afl_case ()
-  else List.map registry_case covered_cases
+  if file_input_mode () then afl_case () else List.map sample_case covered_cases
 
 let () =
   List.iter
     (fun (label, _, reason) ->
-      Printf.eprintf "diff: skipping %s (%s)\n" label
+      Fmt.epr "diff: skipping %s (%s)@." label
         (Diff_codecs.string_of_exclusion reason))
     Diff_codecs.excluded;
   Alcobar.run "diff" [ ("diff", cases) ]

--- a/fuzz/diff/gen/diff_codecs.ml
+++ b/fuzz/diff/gen/diff_codecs.ml
@@ -1,7 +1,11 @@
 (** The codecs the differential fuzzer compares against the EverParse-generated
     C validator: a deterministic, well-distributed Boltzmann {!Fuzz_gen.sample}
-    of the shape space (not a handpicked list), filtered to the ones with a
-    standalone fixed-size validator.
+    of the shape space (not a handpicked list, and not {!Fuzz_gen.registry},
+    which the OCaml-only suites drive off), filtered to the ones with a
+    standalone fixed-size validator. The sampled vocabulary spans scalars of
+    every width and endianness, bitfields, enums and lookups, and the fixed-size
+    refined shapes -- byte spans with and without a per-byte predicate, range
+    bounds, cross-field constraints, variable-width integers.
 
     A codec is includable iff it has a positive fixed wire size (variable-size
     codecs have no standalone validator; zero-size unit codecs hit a setter

--- a/fuzz/diff/gen/diff_codecs.mli
+++ b/fuzz/diff/gen/diff_codecs.mli
@@ -1,5 +1,6 @@
-(** The registry subset the differential fuzzer compares against the
-    EverParse-generated C validator. See {!included}. *)
+(** The codecs the differential fuzzer compares against the EverParse-generated
+    C validator: the in-scope part of the Boltzmann {!Fuzz_gen.sample}, not of
+    {!Fuzz_gen.registry}. See {!included}. *)
 
 (** Why a candidate is out of the differential's scope. *)
 type exclusion =
@@ -12,12 +13,12 @@ val string_of_exclusion : exclusion -> string
 (** A short human-readable reason, for logs. *)
 
 val included : (string * Fuzz_gen.packed) list
-(** Registry codecs the differential fuzzer covers: fixed-size, parameter-free
-    projections of a single uniquely-named validator, in registry order. *)
+(** Sampled codecs the differential fuzzer covers: fixed-size, parameter-free
+    projections of a single uniquely-named validator, in sample order. *)
 
 val excluded : (string * Fuzz_gen.packed * exclusion) list
-(** Registry codecs skipped, each with the reason it is out of scope, so
-    coverage stays explicit. *)
+(** Sampled codecs skipped, each with the reason it is out of scope, so coverage
+    stays explicit. *)
 
 val summary : string
 (** One-line tally: total candidates, included count, and excluded count broken

--- a/fuzz/gen/fuzz_gen.ml
+++ b/fuzz/gen/fuzz_gen.ml
@@ -2920,6 +2920,82 @@ let positive_env g =
   | Some s -> Some (s.positive (Wire.Codec.env g.codec))
   | None -> None
 
+(* Typ-level vs codec-level agreement. [Wire.of_string] (typ level) and
+   [Codec.decode] (codec level) are two independent reader constructions over
+   the same schema, so they can drift apart: a refinement enforced by one and
+   dropped by the other accepts input the other -- and the EverParse C built
+   from the same schema -- rejects. The two may legitimately report different
+   errors (offsets and kinds are not part of the contract), so only the
+   accept/reject verdict is compared, plus the decoded value where both
+   accept. *)
+
+let direct_decodes g bs =
+  match Wire.of_string g.typ (string_of_bytes bs) with
+  | Ok v -> `Accept v
+  | Error _ -> `Reject
+  | exception Invalid_argument _ -> `Crash
+
+let codec_decodes g bs =
+  match Wire.Codec.decode g.codec bs 0 with
+  | Ok v -> `Accept v
+  | Error _ -> `Reject
+  | exception Invalid_argument _ -> `Crash
+
+(* Decode the same bytes both ways and require the same verdict. Codecs that
+   bind a [Param.env] are skipped: the typ-level entry points cannot thread
+   one. *)
+let check_direct_codec_agree label kind g bs =
+  if Option.is_none g.env then
+    match (direct_decodes g bs, codec_decodes g bs) with
+    | `Crash, _ -> Alcobar.failf "%s %s of_string crashed" label kind
+    | _, `Crash -> Alcobar.failf "%s %s Codec.decode crashed" label kind
+    | `Reject, `Reject -> ()
+    | `Accept direct, `Accept codec ->
+        if not (g.equal direct codec) then
+          Alcobar.failf "%s %s of_string and Codec.decode decoded differently"
+            label kind
+    | `Accept _, `Reject ->
+        Alcobar.failf "%s %s of_string accepted but Codec.decode rejected" label
+          kind
+    | `Reject, `Accept _ ->
+        Alcobar.failf "%s %s Codec.decode accepted but of_string rejected" label
+          kind
+
+(* The encode-side twin. [Wire.to_bytes] (typ level) and [Codec.encode] (codec
+   level) are, like the two decoders, separate constructions over one schema:
+   they must refuse the same values and, when they accept, write the same bytes.
+   A value one path writes and the other refuses is a frame the library produces
+   through one entry point and rejects through the other. *)
+
+let direct_encodes g value =
+  match Wire.to_bytes g.typ value with
+  | bs -> `Wrote (string_of_bytes bs)
+  | exception Invalid_argument _ -> `Refused
+
+let codec_encodes g value =
+  match Wire.Codec.size_of_value g.codec value with
+  | exception Invalid_argument _ -> `Refused
+  | sz -> (
+      let buf = Bytes.create sz in
+      match Wire.Codec.encode g.codec value buf 0 with
+      | () -> `Wrote (string_of_bytes buf)
+      | exception Invalid_argument _ -> `Refused)
+
+let check_direct_codec_encode_agree label kind g value =
+  if Option.is_none g.env then
+    match (direct_encodes g value, codec_encodes g value) with
+    | `Refused, `Refused -> ()
+    | `Wrote direct, `Wrote codec ->
+        if not (String.equal direct codec) then
+          Alcobar.failf "%s %s to_bytes and Codec.encode wrote different bytes"
+            label kind
+    | `Wrote _, `Refused ->
+        Alcobar.failf "%s %s to_bytes wrote a value Codec.encode refuses" label
+          kind
+    | `Refused, `Wrote _ ->
+        Alcobar.failf "%s %s Codec.encode wrote a value to_bytes refuses" label
+          kind
+
 (* Round-trip one positive sample: decode the canonical bytes back to the
    value, then re-encode into a buffer sized from [size_of_value] and require
    the two to agree. Sizing from [size_of_value] (rather than from the
@@ -2985,6 +3061,7 @@ let check_positive_encode label g value bs env sz =
 let check_positive label g (value, bs) =
   let env = positive_env g in
   check_positive_decode label g value bs env;
+  check_direct_codec_encode_agree label "positive" g value;
   let sz = check_positive_size label g value bs in
   check_positive_size_metadata label g bs;
   check_positive_encode label g value bs env sz
@@ -3110,6 +3187,7 @@ let test_cases ?(validate = true) label g =
   in
   let check_safety_stream kind ?env bs =
     check_decode_safety label kind ?env g bs;
+    check_direct_codec_agree label kind g bs;
     if validate then begin
       check_validate_safety label kind ?env g bs;
       check_decode_validate_agree label kind ?env g bs
@@ -3117,7 +3195,9 @@ let test_cases ?(validate = true) label g =
   in
   let check_hostile_stream ?env = function
     | None -> ()
-    | Some value -> check_encode_safety label ?env g value
+    | Some value ->
+        check_direct_codec_encode_agree label "hostile" g value;
+        check_encode_safety label ?env g value
   in
   match g.env with
   | None ->
@@ -3273,7 +3353,8 @@ let nested_cases label depth =
           let nested_label = Fmt.str "%s [%s]" label comp in
           let env = Option.map (fun f -> f (Wire.Codec.env g.codec)) mk in
           check_decode_safety nested_label kind ?env g bs;
-          check_validate_safety nested_label kind ?env g bs
+          check_validate_safety nested_label kind ?env g bs;
+          check_direct_codec_agree nested_label kind g bs
         in
         check "random" random;
         check "adversarial" adversarial);
@@ -4924,6 +5005,11 @@ let afl_everparse_cases ?max_len label =
 let registry_pick =
   Alcobar.choose (List.map (fun (_, p) -> Alcobar.const p) registry)
 
+(* Same pick, keeping the entry name so a failure says which registry codec
+   diverged (and so the agreement quarantine can be looked up by name). *)
+let registry_pick_named =
+  Alcobar.choose (List.map (fun (name, p) -> Alcobar.const (name, p)) registry)
+
 let ep_direct label =
   Alcobar.dynamic_bind registry_pick (fun (Pack g) ->
       Alcobar.map
@@ -4960,17 +5046,17 @@ let ep_direct label =
           end))
 
 let ep_direct_safety label kind adversarial =
-  Alcobar.dynamic_bind registry_pick (fun (Pack g) ->
+  Alcobar.dynamic_bind registry_pick_named (fun (name, Pack g) ->
       let stream = if adversarial then g.adversarial else g.random in
       Alcobar.map
         Alcobar.[ stream ]
         (fun bs () ->
-          if Option.is_none g.env then
-            try
-              ignore (Wire.of_string g.typ (string_of_bytes bs));
-              ignore (Wire.of_bytes g.typ bs)
-            with Invalid_argument _ ->
-              Alcobar.failf "%s direct %s crashed decoder" label kind))
+          if Option.is_none g.env then begin
+            (try ignore (Wire.of_bytes g.typ bs)
+             with Invalid_argument _ ->
+               Alcobar.failf "%s %s direct %s crashed decoder" label name kind);
+            check_direct_codec_agree name ("direct " ^ kind) g bs
+          end))
 
 let ep_streaming label =
   Alcobar.dynamic_bind registry_pick (fun (Pack g) ->

--- a/fuzz/gen/fuzz_gen.ml
+++ b/fuzz/gen/fuzz_gen.ml
@@ -2718,9 +2718,8 @@ let pair_of (Any a) (Any b) =
     }
 
 (* Flat records of arity 3 and 4: like [pair_of] but for more fields, so the
-   Boltzmann sampler can emit single-typedef records wider than a pair. Each
-   unpacks its [Any] elements and seals a flat [Codec.v] (no nesting, so the 3D
-   projection stays a single typedef). *)
+   Boltzmann sampler can emit records wider than a pair. Each unpacks its [Any]
+   elements and seals a flat [Codec.v]. *)
 let rec3_of (Any a) (Any b) (Any c) =
   let g =
     Codec.v "R3"
@@ -3824,15 +3823,14 @@ let afl_env_cases ?max_len label =
    a record is geometric (the Boltzmann distribution for a sequence, tuned to a
    small expected size via [continue]), and each field is drawn from a fixed
    leaf vocabulary that deliberately over-samples weird / adversarial shapes.
-   It stays in the single-typedef, fixed-size fragment (flat records and
-   homogeneous arrays of leaves) so the differential fuzzer can compile every
-   sample to a standalone C validator. Driven by a
-   [Random.State.t], so a [seed] reproduces the exact set: the differential's
-   generator and its runner both call [sample] with the same seed and agree on
-   the shapes. *)
+   It stays in the fixed-size fragment (flat records and homogeneous arrays of
+   leaves) so the differential fuzzer can compile every sample to a standalone C
+   validator. Driven by a [Random.State.t], so a [seed] reproduces the exact
+   set: the differential's generator and its runner both call [sample] with the
+   same seed and agree on the shapes. *)
 
-(* Single-typedef, fixed-size leaf vocabulary: each projects to one EverParse
-   field, so a flat record of them stays a single typedef. The sampler chooses
+(* Fixed-size leaf vocabulary: every leaf has a standalone validator, so a flat
+   record or array of them compiles to one C entrypoint. The sampler chooses
    from [sampler_adversarial_leaves] three times more often than from
    [sampler_regular_leaves]; bugs have clustered around these odd shapes. *)
 let sampler_regular_leaves : any list =
@@ -3855,7 +3853,7 @@ let sampler_regular_leaves : any list =
     Any { g = float64be; size = Some 8; label = "f64be" };
   ]
 
-let sampler_adversarial_leaves : any list =
+let sampler_weird_leaves : any list =
   [
     Any { g = bits ~width:3 Wire.U8; size = Some 1; label = "bits3" };
     Any
@@ -3888,6 +3886,30 @@ let sampler_adversarial_leaves : any list =
       { g = lookup [ 'a'; 'b'; 'c'; 'd' ] uint8; size = Some 1; label = "lkp" };
   ]
 
+(* Refined and byte-span shapes. Every one is fixed-size and parameter-free, so
+   the differential's scope filter takes them unchanged -- and they are where
+   the refinements live: a per-byte span predicate, a range bound, a cross-field
+   constraint, a variable-width integer. A decoder that drops one of those
+   accepts bytes the generated C rejects, which is exactly what the differential
+   is for. *)
+let sampler_refined_leaves : any list =
+  [
+    Any { g = byte_array 3; size = Some 3; label = "ba3" };
+    Any
+      {
+        g = byte_array_where 3 ~per_byte:printable_byte;
+        size = Some 3;
+        label = "baw3";
+      };
+    Any { g = uint_var ~endian:Wire.Big 3; size = Some 3; label = "uv3" };
+    Any { g = uint_var ~endian:Wire.Little 3; size = Some 3; label = "uv3le" };
+    Any { g = bounded_u16be; size = Some 2; label = "bnd16" };
+    Any { g = bounded_u32be; size = Some 4; label = "bnd32" };
+    Any { g = typ_where; size = Some 2; label = "twhere" };
+    Any { g = field_constraint; size = Some 2; label = "fconstraint" };
+  ]
+
+let sampler_adversarial_leaves = sampler_weird_leaves @ sampler_refined_leaves
 let sampler_leaves = sampler_regular_leaves @ sampler_adversarial_leaves
 
 (* Geometric arity in [1, max_arity]: keep adding a field with probability
@@ -3900,11 +3922,11 @@ let sample_arity rng ~continue ~max_arity =
   go 1
 
 (* The shape of one sampled codec, paired with the leaf-vocabulary labels it
-   draws (in draw order). The sampler stays in the single-typedef, fixed-size
-   fragment, so a composition is only a flat record of leaves or an array of one
-   leaf -- "depth" here is record arity and array presence, not arbitrary
-   nesting. Exposed alongside each sample so coverage metrics read the structure
-   directly rather than parsing the debug label. *)
+   draws (in draw order). The sampler stays in the fixed-size fragment, so a
+   composition is only a flat record of leaves or an array of one leaf --
+   "depth" here is record arity and array presence, not arbitrary nesting.
+   Exposed alongside each sample so coverage metrics read the structure directly
+   rather than parsing the debug label. *)
 type sample_shape = Leaf | Array | Record of int
 type sample_meta = { shape : sample_shape; leaves : string list }
 
@@ -4212,6 +4234,14 @@ let expected_sampler_labels =
     "enum";
     "enum_open";
     "lkp";
+    "ba3";
+    "baw3";
+    "uv3";
+    "uv3le";
+    "bnd16";
+    "bnd32";
+    "twhere";
+    "fconstraint";
   ]
 
 let check_registry_invariants () =
@@ -4325,6 +4355,11 @@ let check_sampler_distribution () =
       ("no 8-bit bitpack", has_any [ "bp8m"; "bp8l" ]);
       ("no 16-bit bitpack", has "bp16bel");
       ("no 32-bit bitpack", has_any [ "bp32m"; "bp32bel" ]);
+      ("no byte span", has "ba3");
+      ("no refined byte span", has "baw3");
+      ("no variable-width uint", has_any [ "uv3"; "uv3le" ]);
+      ("no wide bounded int", has_any [ "bnd16"; "bnd32" ]);
+      ("no refined sub-codec", has_any [ "twhere"; "fconstraint" ]);
     ]
   in
   List.iter

--- a/fuzz/gen/fuzz_gen.mli
+++ b/fuzz/gen/fuzz_gen.mli
@@ -28,8 +28,13 @@ val test_cases : ?validate:bool -> string -> 'a t -> Alcobar.test_case list
     Encode safety is the mirror of decode crash-safety: a hostile value must
     either be refused with [Invalid_argument] or encode to bytes that decode
     back to an equal value, never to bytes the codec's own decoder rejects.
-    [validate] defaults to [true]. Direct typ-level entry points are covered by
-    {!entry_point_cases} so this hot path stays cheap. *)
+    Every stream also cross-checks the typ-level entry points against the codec
+    ones: {!Wire.of_string} and {!Wire.Codec.decode} must reach the same
+    accept/reject verdict on the same bytes (and the same value where both
+    accept), and {!Wire.to_bytes} and {!Wire.Codec.encode} must refuse the same
+    values and write the same bytes. A refinement one path enforces and the
+    other drops shows up here rather than in the generated C. [validate]
+    defaults to [true]. *)
 
 val afl_cases : ?max_len:int -> string -> Alcobar.test_case list
 (** [afl_cases label] is the fast file-input AFL smoke suite. It reuses a
@@ -183,8 +188,9 @@ val entry_point_cases : string -> Alcobar.test_case list
     ([of_string] / [of_bytes] / [of_reader] / [to_string] / [to_bytes] /
     [to_writer] / [_exn] variants / [validate]) over a {!registry} gen picked at
     random each sample, so they cover the whole registry instead of a pinned
-    subset. Direct decode crash-safety is sampled on random/adversarial streams.
-    Direct checks skip codecs that bind a [Param.env]. *)
+    subset. Random and adversarial streams check that the direct decoder does
+    not crash and reaches the same verdict as {!Wire.Codec.decode}. Direct
+    checks skip codecs that bind a [Param.env]. *)
 
 val sized_cases : string -> Alcobar.test_case list
 (** [sized_cases group] round-trips a two-field length/data codec whose data

--- a/fuzz/gen/fuzz_gen.mli
+++ b/fuzz/gen/fuzz_gen.mli
@@ -108,14 +108,15 @@ val codec : 'a t -> 'a Wire.Codec.t
 
 val sample : seed:int -> count:int -> (string * packed) list
 (** [sample ~seed ~count] is a deterministic, well-distributed Boltzmann sample
-    of [count] codecs in the single-typedef, fixed-size fragment (flat records
-    and homogeneous arrays of leaves), each renamed to a unique struct name.
-    Record arity follows a geometric (Boltzmann-for-sequence) law and each leaf
-    is drawn from a fixed vocabulary that deliberately oversamples the weird /
-    adversarial shapes (3:1 over the regular leaves), since bugs cluster there;
-    {!val-invariant_cases} asserts the resulting spread across the grammar. The
-    same [seed] yields the same set, so a code generator and its consumer can
-    agree on the shapes. *)
+    of [count] codecs in the fixed-size fragment (flat records and homogeneous
+    arrays of leaves), each renamed to a unique struct name. Record arity
+    follows a geometric (Boltzmann-for-sequence) law and each leaf is drawn from
+    a fixed vocabulary that deliberately oversamples the weird / adversarial
+    shapes (3:1 over the regular leaves) -- refined byte spans, range bounds,
+    cross-field constraints and variable-width integers included, since bugs
+    cluster there; {!val-invariant_cases} asserts the resulting spread across
+    the grammar. The same [seed] yields the same set, so a code generator and
+    its consumer can agree on the shapes. *)
 
 val binds_env : packed -> bool
 (** [binds_env p] is [true] when [p]'s codec references a [Param.input] /

--- a/test/3d/test_wire_3d.ml
+++ b/test/3d/test_wire_3d.ml
@@ -8,6 +8,12 @@ let simple_struct =
 
 let simple_module = module_ [ typedef ~entrypoint:true simple_struct ]
 
+(* Everything below that shells out to EverParse needs [3d.exe]. Reporting those
+   cases as [OK] when the binary is absent would print a green tick for an
+   assertion that never ran, so they skip instead: the four default [dune
+   runtest] lanes have no EverParse and must say so. *)
+let needs_3d_exe () = if not (Wire_3d.has_3d_exe ()) then Alcotest.skip ()
+
 let test_everparse_name () =
   (* All-caps names get lowercased with first letter capitalized *)
   Alcotest.(check string) "CLCW -> Clcw" "Clcw" (Wire_3d.everparse_name "CLCW");
@@ -136,8 +142,8 @@ let read_file path =
   Bytes.unsafe_to_string buf
 
 let test_generate_c () =
-  (* generate_c requires 3d.exe; skip when not available *)
-  if Wire_3d.has_3d_exe () then begin
+  needs_3d_exe ();
+  begin
     let tmpdir = Filename.temp_dir "wire_3d_gen_c" "" in
     let s = Wire.Everparse.Raw.project_struct ~mode:`Ffi simple_struct in
     Wire_3d.generate_3d ~outdir:tmpdir [ s ];
@@ -336,8 +342,8 @@ let test_generate_dune_standalone_context_policy () =
     (List.length host_gated >= 1)
 
 let test_generate_standalone () =
-  (* generate_standalone needs 3d.exe; skip when not available. *)
-  if Wire_3d.has_3d_exe () then begin
+  needs_3d_exe ();
+  begin
     let tmpdir = Filename.temp_dir "wire_3d_gen_doc" "" in
     Wire_3d.generate_standalone ~outdir:tmpdir ~package:"my-pkg"
       [ Wire_3d.pack (doc_codec "Pkt"); Wire_3d.pack (doc_codec "Pkt2") ];
@@ -446,63 +452,59 @@ let differential_ok ~name ~package ~corpus codecs =
   | _ -> Alcotest.failf "differential %s terminated abnormally:\n%s" name output
 
 let test_doc_differential () =
-  if not (Wire_3d.has_3d_exe ()) then ()
-  else
-    differential_ok ~name:"protospec" ~package:"demo-doc" ~corpus:(`Fuzz 400)
-      [
-        Wire_3d.pack diff_enum_codec;
-        Wire_3d.pack diff_range_codec;
-        Wire_3d.pack diff_bits_codec;
-        Wire_3d.pack diff_param_codec;
-      ]
+  needs_3d_exe ();
+  differential_ok ~name:"protospec" ~package:"demo-doc" ~corpus:(`Fuzz 400)
+    [
+      Wire_3d.pack diff_enum_codec;
+      Wire_3d.pack diff_range_codec;
+      Wire_3d.pack diff_bits_codec;
+      Wire_3d.pack diff_param_codec;
+    ]
 
 let test_doc_differential_no_params () =
   (* Regression: an all-non-parameterized package must still compile. The agree
      harness must not emit an unused [parse_params] helper (a -Werror under the
      strict flags) when no codec takes parameters. *)
-  if not (Wire_3d.has_3d_exe ()) then ()
-  else
-    differential_ok ~name:"plainspec" ~package:"plain-doc" ~corpus:(`Fuzz 100)
-      [ Wire_3d.pack diff_enum_codec; Wire_3d.pack diff_range_codec ]
+  needs_3d_exe ();
+  differential_ok ~name:"plainspec" ~package:"plain-doc" ~corpus:(`Fuzz 100)
+    [ Wire_3d.pack diff_enum_codec; Wire_3d.pack diff_range_codec ]
 
 let test_doc_differential_nested_regions () =
-  if not (Wire_3d.has_3d_exe ()) then ()
-  else
-    differential_ok ~name:"nestedspec" ~package:"nested-doc"
-      ~corpus:
-        (`Lines
-           [
-             "NestedExact - 41000000 0";
-             "NestedExact - 41424300 1";
-             "NestedAtMost - 41000000 1";
-             "NestedAtMost - 41424300 1";
-           ])
-      [
-        Wire_3d.pack diff_nested_exact_codec;
-        Wire_3d.pack diff_nested_at_most_codec;
-      ]
+  needs_3d_exe ();
+  differential_ok ~name:"nestedspec" ~package:"nested-doc"
+    ~corpus:
+      (`Lines
+         [
+           "NestedExact - 41000000 0";
+           "NestedExact - 41424300 1";
+           "NestedAtMost - 41000000 1";
+           "NestedAtMost - 41424300 1";
+         ])
+    [
+      Wire_3d.pack diff_nested_exact_codec;
+      Wire_3d.pack diff_nested_at_most_codec;
+    ]
 
 let test_doc_differential_region_cardinality () =
-  if not (Wire_3d.has_3d_exe ()) then ()
-  else
-    differential_ok ~name:"invariantspec" ~package:"invariant-doc"
-      ~corpus:
-        (`Lines
-           [
-             "ArrayExact - 010203 1";
-             "ArrayExact - 0102 0";
-             "ArrayExact - 01020304 0";
-             "RepeatExact - 00010002 1";
-             "RepeatExact - 0001 0";
-             "RepeatExact - 000100020003 0";
-             "NestedExact - 41424300 1";
-             "NestedExact - 41000000 0";
-           ])
-      [
-        Wire_3d.pack diff_array_exact_codec;
-        Wire_3d.pack diff_repeat_exact_codec;
-        Wire_3d.pack diff_nested_exact_codec;
-      ]
+  needs_3d_exe ();
+  differential_ok ~name:"invariantspec" ~package:"invariant-doc"
+    ~corpus:
+      (`Lines
+         [
+           "ArrayExact - 010203 1";
+           "ArrayExact - 0102 0";
+           "ArrayExact - 01020304 0";
+           "RepeatExact - 00010002 1";
+           "RepeatExact - 0001 0";
+           "RepeatExact - 000100020003 0";
+           "NestedExact - 41424300 1";
+           "NestedExact - 41000000 0";
+         ])
+    [
+      Wire_3d.pack diff_array_exact_codec;
+      Wire_3d.pack diff_repeat_exact_codec;
+      Wire_3d.pack diff_nested_exact_codec;
+    ]
 
 (* The installed standalone archive must export only the checked
    [<Base>CheckWire<Codec>] wrappers, not the raw [<Base>Validate*] entry points
@@ -512,8 +514,8 @@ let test_doc_differential_region_cardinality () =
    symbol. This runs the platform's real link step on CI (macOS and Linux). Needs
    3d.exe for the C. *)
 let test_archive_hides_raw_validators () =
-  if not (Wire_3d.has_3d_exe ()) then ()
-  else begin
+  needs_3d_exe ();
+  begin
     let name = "symspec" and package = "sym-doc" in
     let codec =
       Codec.v "Sample"
@@ -579,10 +581,9 @@ let diff_signed_codec =
   Codec.v "SignedMsg" (fun v -> v) [ Codec.( $ ) f (fun v -> v) ]
 
 let test_doc_differential_signed () =
-  if not (Wire_3d.has_3d_exe ()) then ()
-  else
-    differential_ok ~name:"signedspec" ~package:"signed-doc" ~corpus:(`Fuzz 256)
-      [ Wire_3d.pack diff_signed_codec ]
+  needs_3d_exe ();
+  differential_ok ~name:"signedspec" ~package:"signed-doc" ~corpus:(`Fuzz 256)
+    [ Wire_3d.pack diff_signed_codec ]
 
 (* An 8192-byte payload makes each corpus line 16384 hex chars; the agree
    reader's hex buffer must hold the line, or it truncates and the verdict
@@ -594,10 +595,9 @@ let diff_large_payload_codec =
     [ Codec.( $ ) (Field.v "data" (byte_array ~size:(int 8192))) (fun d -> d) ]
 
 let test_doc_differential_large_payload () =
-  if not (Wire_3d.has_3d_exe ()) then ()
-  else
-    differential_ok ~name:"sharedspec" ~package:"shared-doc" ~corpus:(`Fuzz 40)
-      [ Wire_3d.pack diff_large_payload_codec ]
+  needs_3d_exe ();
+  differential_ok ~name:"sharedspec" ~package:"shared-doc" ~corpus:(`Fuzz 40)
+    [ Wire_3d.pack diff_large_payload_codec ]
 
 (* Interior consecutive caps: EverParse normalizes the validator symbol to
    [SpacewireCheckSpaceOsframe], so agree.c must build the same name through
@@ -609,10 +609,9 @@ let diff_caps_name_codec =
     [ Codec.( $ ) (Field.v "v" uint8) (fun v -> v) ]
 
 let test_doc_differential_caps_name () =
-  if not (Wire_3d.has_3d_exe ()) then ()
-  else
-    differential_ok ~name:"spacewire" ~package:"space-wire" ~corpus:(`Fuzz 40)
-      [ Wire_3d.pack diff_caps_name_codec ]
+  needs_3d_exe ();
+  differential_ok ~name:"spacewire" ~package:"space-wire" ~corpus:(`Fuzz 40)
+    [ Wire_3d.pack diff_caps_name_codec ]
 
 (* A valid record followed by trailing bytes must be rejected. EverParse's
    stock [Check] wrapper returns TRUE on any successful validation -- success
@@ -621,13 +620,11 @@ let test_doc_differential_caps_name () =
    exact boundary: the 2-byte RangeMsg accepts exactly-sized input and rejects
    both one byte over and one byte short. *)
 let test_doc_differential_trailing_bytes () =
-  if not (Wire_3d.has_3d_exe ()) then ()
-  else
-    differential_ok ~name:"trailspec" ~package:"trail-doc"
-      ~corpus:
-        (`Lines
-           [ "RangeMsg - 0102 1"; "RangeMsg - 010203 0"; "RangeMsg - 01 0" ])
-      [ Wire_3d.pack diff_range_codec ]
+  needs_3d_exe ();
+  differential_ok ~name:"trailspec" ~package:"trail-doc"
+    ~corpus:
+      (`Lines [ "RangeMsg - 0102 1"; "RangeMsg - 010203 0"; "RangeMsg - 01 0" ])
+    [ Wire_3d.pack diff_range_codec ]
 
 (* End-to-end compile+run. Generates C for a schema, invokes the same
    cc command [generate_dune] emits, runs the resulting binary. This is
@@ -639,8 +636,8 @@ let test_doc_differential_trailing_bytes () =
    Parameterised over the schema so tricky names (underscores, all-
    caps prefixes, mixed case) each exercise the pipeline end-to-end. *)
 let compile_and_run ~name codec =
-  if not (Wire_3d.has_3d_exe ()) then ()
-  else begin
+  needs_3d_exe ();
+  begin
     let tmpdir = Filename.temp_dir ("wire_3d_e2e_" ^ name) "" in
     let schema = Everparse.project ~mode:`Ffi codec in
     Wire_3d.generate_3d ~outdir:tmpdir [ schema ];
@@ -1025,10 +1022,19 @@ let test_uses_wire_ctx () =
     "raw module without extern WireCtx" false
     (Wire.Everparse.uses_wire_ctx raw)
 
+(* [has_3d_exe] is the gate every EverParse-dependent case reads, so it is
+   checked against the search it documents -- PATH, then the
+   [~/.local/everparse/bin] fallback -- resolved here independently of
+   [Wire_3d]'s own lookup. *)
 let test_has_3d_exe () =
-  (* Just check the function is callable and returns a bool *)
-  let result = Wire_3d.has_3d_exe () in
-  Alcotest.(check bool) "has_3d_exe returns bool" result result
+  let on_path = Sys.command "command -v 3d.exe > /dev/null 2>&1" = 0 in
+  let fallback =
+    Sys.file_exists
+      (Filename.concat (Sys.getenv "HOME") ".local/everparse/bin/3d.exe")
+  in
+  Alcotest.(check bool)
+    "has_3d_exe agrees with PATH plus the ~/.local/everparse fallback"
+    (on_path || fallback) (Wire_3d.has_3d_exe ())
 
 let test_main_exists () =
   (* main dispatches on Sys.argv; calling it in tests would exit, so we only
@@ -1412,8 +1418,8 @@ let test_field_optional_byte_array () =
    extraction here: rendering alone would not catch an invalid casetype or
    dependent repeat in the generated F*. *)
 let test_optional_length_prefixed_group_projects () =
-  if not (Wire_3d.has_3d_exe ()) then ()
-  else begin
+  needs_3d_exe ();
+  begin
     let f_ext_len = Field.v "ext_items_len" uint8 in
     let extensions =
       Codec.v "ProjectedTransferExtensions"
@@ -1455,8 +1461,8 @@ let test_optional_length_prefixed_group_projects () =
    and raises if EverParse rejects the module, so this pins the shape rather
    than only its rendering. *)
 let test_bare_uint64_projects () =
-  if not (Wire_3d.has_3d_exe ()) then ()
-  else begin
+  needs_3d_exe ();
+  begin
     let codec =
       Codec.v "BareUint64"
         (fun value -> value)
@@ -1478,8 +1484,8 @@ let test_bare_uint64_projects () =
    [generate_c] runs [3d.exe] and raises if the .3d is rejected, so this is the
    regression guard. *)
 let test_nested_field_projects () =
-  if not (Wire_3d.has_3d_exe ()) then ()
-  else begin
+  needs_3d_exe ();
+  begin
     let inner =
       Codec.v "NInner"
         (fun a b -> (a, b))


### PR DESCRIPTION
The `byte_array_where` divergence fixed in #268 left the entire default suite green, because nothing compares the typ-level and codec-level paths against each other. They are now compared on every registry entry, the differential sampler covers refined and variable-size shapes, and `test/3d` skips rather than silently passing when EverParse is absent.