### PR TITLE
ci: run the test lanes that no job reached

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,18 @@ jobs:
 
       - run: opam install . --deps-only --with-test
       - run: opam exec -- dune build @install
+
+      # Seed the property tests from the run id so each run explores a
+      # different input set instead of replaying alcobar's constant seed.
+      # Alcobar prints the counterexample on failure but not the seed, so a red
+      # run is replayed with the one recorded here:
+      #   WIRE_FUZZ_SEED=<run id> dune runtest
+      # 20000 iterations rather than alcobar's 5000, because 5000 was not
+      # enough to find the defects that are there.
       - run: opam exec -- dune runtest
+        env:
+          WIRE_FUZZ_SEED: ${{ github.run_id }}
+          WIRE_FUZZ_REPEAT: 20000
 
   # OCaml's TSan runtime does not currently build on the macOS/arm64 runner
   # (runtime/weak.c), so keep this race-detection lane on Linux. The core test
@@ -241,6 +252,10 @@ jobs:
   # 3d.exe both are skipped, so a shape that builds but does not project to a
   # validator EverParse verifies (a composite-over-composite gap) would slip
   # past the plain build job, which only string-checks the projection.
+  #
+  # The job also runs the suites gated on BUILD_EVERPARSE=1, which nothing else
+  # reaches: fuzz-afl-diff sets the variable but builds only @fuzz/diff/fuzz
+  # under --profile afl, and those rules require a non-afl profile.
   everparse-3d:
     runs-on: ubuntu-latest
     steps:
@@ -263,3 +278,17 @@ jobs:
         run: opam exec -- dune runtest
         env:
           WIRE_3D_BATCH: 1
+          WIRE_FUZZ_SEED: ${{ github.run_id }}
+          WIRE_FUZZ_REPEAT: 20000
+
+      # Named one alias at a time rather than through dune runtest, because
+      # BUILD_EVERPARSE=1 also enables test/bench's own executable, and that one
+      # does not link on Linux: the bench C tier's archives reach the linker in
+      # an order GNU ld will not resolve. Add @test/bench/runtest here once that
+      # is fixed.
+      - name: Run the suites that need EverParse-generated C
+        run: |
+          opam exec -- dune build \
+            @test/stubs/runtest @fuzz/diff/runtest @test/bench-diff/runtest
+        env:
+          BUILD_EVERPARSE: 1

--- a/fuzz/dune
+++ b/fuzz/dune
@@ -2,13 +2,35 @@
  (name fuzz)
  (libraries wire alcobar fuzz_gen))
 
+; Alcobar seeds its PRNG from a constant and never self-inits, so a run with no
+; [-s] replays one fixed input set, and the seed each test gets is drawn in test
+; order, so re-running a single failing test does not replay what the suite ran.
+; Passing [-s] explicitly fixes both: every test uses that seed, and
+; [fuzz.exe test wire <n> -s <seed>] is an exact replay. Alcobar prints the
+; counterexample on failure but never the seed, so the seed has to be one the
+; caller chose and recorded; CI passes the run id.
+;
+; The defaults keep the per-commit loop short and deterministic; CI overrides
+; only the seed. To widen the search, locally or there:
+;   WIRE_FUZZ_SEED=$RANDOM WIRE_FUZZ_REPEAT=20000 dune runtest
+; [WIRE_FUZZ_BUDGET] is alcobar's per-test wall-clock cap, which binds well
+; before the default repeat is exhausted, so a raised repeat only buys its full
+; increase with the budget raised or set to 0 alongside it.
+
 (rule
  (alias runtest)
  (enabled_if
   (<> %{profile} afl))
  (deps fuzz.exe afl.dict)
  (action
-  (run %{exe:fuzz.exe})))
+  (run
+   %{exe:fuzz.exe}
+   -s
+   %{env:WIRE_FUZZ_SEED=42}
+   -r
+   %{env:WIRE_FUZZ_REPEAT=5000}
+   --budget
+   %{env:WIRE_FUZZ_BUDGET=2})))
 
 ; afl-fuzz searches PATH for a target with no '/', so pass [./fuzz.exe] (the
 ; cwd is this dir in the build tree, where fuzz.exe is built).


### PR DESCRIPTION
`test/stubs`, `fuzz/diff` and `test/bench-diff` are gated on `BUILD_EVERPARSE=1`, which no job set in a way those rules accept, and the property tests replayed one fixed 5000-input prefix; `everparse-3d` now runs all three, and CI seeds the fuzzer from the run id at 20000 iterations. Searching that deep finds real defects, so runs that draw one are red: #277 fixes the first, and `repeat` over a dynamic-span `optional` still round-trips wrong (`test wire 164 -s 555 -r 8000`). The gated step adds 13m37s, taking `everparse-3d` to about 42 minutes.
