### PR TITLE
codec: raise instead of truncating a value a field cannot hold

### DIFF
--- a/fuzz/gen/fuzz_gen.ml
+++ b/fuzz/gen/fuzz_gen.ml
@@ -111,6 +111,20 @@ let unlisted_enum_gen ~mask valid =
   in
   Alcobar.map Alcobar.[ Alcobar.int ] (fun n -> step (n land mask) 0)
 
+(* A value with bits set above [width], for a [bits ~width] field. Only the low
+   [width] bits reach the wire, and the masked remainder is itself a legal field
+   value, so encode has to refuse rather than truncate. *)
+let above_bit_width width =
+  let mask = (1 lsl width) - 1 in
+  Alcobar.map Alcobar.[ Alcobar.int ] (fun n -> n land mask lor (mask + 1))
+
+(* The [uint ~size] counterpart: a value needing more than [size] bytes. *)
+let above_byte_width size =
+  let max_v = (1 lsl (size * 8)) - 1 in
+  Alcobar.map
+    Alcobar.[ Alcobar.int ]
+    (fun n -> Wire.Private.UInt63.of_int (n land max_v lor (max_v + 1)))
+
 (* A byte string of one of the lengths around [n], for a byte span whose
    declared size is [n]: only the exact length may encode. *)
 let byte_lengths_around n =
@@ -622,7 +636,7 @@ let uint_var ~endian size =
     adversarial;
     equal = ( = );
     env = None;
-    adversarial_value = None;
+    adversarial_value = Some (above_byte_width size);
   }
 
 let exact_cases ~typ ~equal cases =
@@ -1432,7 +1446,8 @@ let bits ?bit_order ~width base =
   let mask = (1 lsl width) - 1 in
   let value_gen = Alcobar.map Alcobar.[ Alcobar.int ] (fun n -> n land mask) in
   let boundaries = [ 0; 1; mask; mask - 1; mask lsr 1 ] in
-  scalar_int typ base_size value_gen boundaries
+  let g = scalar_int typ base_size value_gen boundaries in
+  { g with adversarial_value = Some (above_bit_width width) }
 
 let bitfield_total = function
   | Wire.U8 -> 8

--- a/fuzz/gen/fuzz_gen.ml
+++ b/fuzz/gen/fuzz_gen.ml
@@ -111,12 +111,24 @@ let unlisted_enum_gen ~mask valid =
   in
   Alcobar.map Alcobar.[ Alcobar.int ] (fun n -> step (n land mask) 0)
 
-(* A value with bits set above [width], for a [bits ~width] field. Only the low
-   [width] bits reach the wire, and the masked remainder is itself a legal field
-   value, so encode has to refuse rather than truncate. *)
+(* A value with bits set above [width], for any unsigned [width]-bit field:
+   [uint8], [uint16] and [bits ~width] alike. Only the low [width] bits reach
+   the wire, and the masked remainder is itself a legal field value, so encode
+   has to refuse rather than truncate. *)
 let above_bit_width width =
   let mask = (1 lsl width) - 1 in
   Alcobar.map Alcobar.[ Alcobar.int ] (fun n -> n land mask lor (mask + 1))
+
+(* The signed counterpart, drawn from both ends: a signed [width]-bit field
+   holds [-2^(width-1) .. 2^(width-1) - 1], so 200 into an [int8] is as
+   unrepresentable as -200 even though its low byte is a legal one. *)
+let outside_signed_width width =
+  let limit = 1 lsl (width - 1) in
+  Alcobar.map
+    Alcobar.[ Alcobar.int ]
+    (fun n ->
+      let over = (n land (limit - 1)) + limit in
+      if n < 0 then -over - 1 else over)
 
 (* The [uint ~size] counterpart: a value needing more than [size] bytes. *)
 let above_byte_width size =
@@ -124,6 +136,22 @@ let above_byte_width size =
   Alcobar.map
     Alcobar.[ Alcobar.int ]
     (fun n -> Wire.Private.UInt63.of_int (n land max_v lor (max_v + 1)))
+
+(* [uint32] is carried in an [Optint.t], which on a wide-int host holds numbers
+   32 bits cannot. *)
+let above_uint32 =
+  let mask = Wire.Private.UInt32.mask32 in
+  Alcobar.map
+    Alcobar.[ Alcobar.int ]
+    (fun n -> Optint.of_int (n land mask lor (mask + 1)))
+
+(* [uint63] fills its carrier, so the only unrepresentable value left is a
+   negative one: [chunk] would drop its sign bit and leave a legal positive
+   number on the wire. *)
+let below_zero_uint63 =
+  Alcobar.map
+    Alcobar.[ Alcobar.int ]
+    (fun n -> Optint.Int63.of_int (-(n land max_int) - 1))
 
 (* A byte string of one of the lengths around [n], for a byte span whose
    declared size is [n]: only the exact length may encode. *)
@@ -175,21 +203,33 @@ let enum_like ~typ ~value_gen ~random ~adversarial =
 
 (* {1 Leaves} *)
 
-let scalar_int typ size value_gen boundaries =
-  leaf ~equal:Int.equal ~typ ~value_gen ~random:(bytes_fixed size)
-    ~adversarial:(Alcobar.choose (List.map Alcobar.const boundaries))
+let scalar_int ?hostile typ size value_gen boundaries =
+  let g =
+    leaf ~equal:Int.equal ~typ ~value_gen ~random:(bytes_fixed size)
+      ~adversarial:(Alcobar.choose (List.map Alcobar.const boundaries))
+  in
+  { g with adversarial_value = hostile }
 
+(* [uint64] and [int64] are carried in an [int64], which is exactly the eight
+   bytes written: every value of it is in range, so there is no hostile value to
+   draw and no guard for one to exercise. *)
 let scalar_int64 typ size value_gen boundaries =
   leaf ~equal:Int64.equal ~typ ~value_gen ~random:(bytes_fixed size)
     ~adversarial:(Alcobar.choose (List.map Alcobar.const boundaries))
 
-let scalar_optint typ size value_gen boundaries =
-  leaf ~equal:Optint.equal ~typ ~value_gen ~random:(bytes_fixed size)
-    ~adversarial:(Alcobar.choose (List.map Alcobar.const boundaries))
+let scalar_optint ~hostile typ size value_gen boundaries =
+  let g =
+    leaf ~equal:Optint.equal ~typ ~value_gen ~random:(bytes_fixed size)
+      ~adversarial:(Alcobar.choose (List.map Alcobar.const boundaries))
+  in
+  { g with adversarial_value = Some hostile }
 
-let scalar_optint63 typ size value_gen boundaries =
-  leaf ~equal:Optint.Int63.equal ~typ ~value_gen ~random:(bytes_fixed size)
-    ~adversarial:(Alcobar.choose (List.map Alcobar.const boundaries))
+let scalar_optint63 ~hostile typ size value_gen boundaries =
+  let g =
+    leaf ~equal:Optint.Int63.equal ~typ ~value_gen ~random:(bytes_fixed size)
+      ~adversarial:(Alcobar.choose (List.map Alcobar.const boundaries))
+  in
+  { g with adversarial_value = Some hostile }
 
 let u8_boundaries = [ 0; 1; 0x7F; 0x80; 0xFE; 0xFF ]
 let u16_boundaries = [ 0; 1; 0x7F; 0x80; 0x7FFF; 0x8000; 0xFFFE; 0xFFFF ]
@@ -206,11 +246,23 @@ let u64_boundaries_i64 =
 
 let s8_boundaries = [ -128; -1; 0; 1; 127 ]
 let s16_boundaries = [ -0x8000; -1; 0; 1; 0x7FFF ]
-let s32_boundaries = [ Int.min_int; -1; 0; 1; Int.max_int ]
+
+let s32_boundaries =
+  [ Int32.to_int Int32.min_int; -1; 0; 1; Int32.to_int Int32.max_int ]
+
 let s64_boundaries_i64 = Int64.[ min_int; -1L; zero; one; max_int ]
-let uint8 = scalar_int Wire.uint8 1 Alcobar.uint8 u8_boundaries
-let uint16 = scalar_int Wire.uint16 2 Alcobar.uint16 u16_boundaries
-let uint16be = scalar_int Wire.uint16be 2 Alcobar.uint16 u16_boundaries
+
+let uint8 =
+  scalar_int ~hostile:(above_bit_width 8) Wire.uint8 1 Alcobar.uint8
+    u8_boundaries
+
+let uint16 =
+  scalar_int ~hostile:(above_bit_width 16) Wire.uint16 2 Alcobar.uint16
+    u16_boundaries
+
+let uint16be =
+  scalar_int ~hostile:(above_bit_width 16) Wire.uint16be 2 Alcobar.uint16
+    u16_boundaries
 
 let masked_u32 =
   Alcobar.map
@@ -222,24 +274,43 @@ let masked_u63 =
     Alcobar.[ Alcobar.int ]
     (fun n -> Optint.Int63.of_int (n land max_int))
 
-let uint32 = scalar_optint Wire.uint32 4 masked_u32 u32_boundaries
-let uint32be = scalar_optint Wire.uint32be 4 masked_u32 u32_boundaries
-let uint63 = scalar_optint63 Wire.uint63 8 masked_u63 u63_boundaries
-let uint63be = scalar_optint63 Wire.uint63be 8 masked_u63 u63_boundaries
+let uint32 =
+  scalar_optint ~hostile:above_uint32 Wire.uint32 4 masked_u32 u32_boundaries
+
+let uint32be =
+  scalar_optint ~hostile:above_uint32 Wire.uint32be 4 masked_u32 u32_boundaries
+
+let uint63 =
+  scalar_optint63 ~hostile:below_zero_uint63 Wire.uint63 8 masked_u63
+    u63_boundaries
+
+let uint63be =
+  scalar_optint63 ~hostile:below_zero_uint63 Wire.uint63be 8 masked_u63
+    u63_boundaries
+
 let uint64 = scalar_int64 Wire.uint64 8 Alcobar.int64 u64_boundaries_i64
 let uint64be = scalar_int64 Wire.uint64be 8 Alcobar.int64 u64_boundaries_i64
-let int8 = scalar_int Wire.int8 1 Alcobar.int8 s8_boundaries
-let int16 = scalar_int Wire.int16 2 Alcobar.int16 s16_boundaries
-let int16be = scalar_int Wire.int16be 2 Alcobar.int16 s16_boundaries
+
+let int8 =
+  scalar_int ~hostile:(outside_signed_width 8) Wire.int8 1 Alcobar.int8
+    s8_boundaries
+
+let int16 =
+  scalar_int ~hostile:(outside_signed_width 16) Wire.int16 2 Alcobar.int16
+    s16_boundaries
+
+let int16be =
+  scalar_int ~hostile:(outside_signed_width 16) Wire.int16be 2 Alcobar.int16
+    s16_boundaries
+
+let int32_value_gen = Alcobar.map Alcobar.[ Alcobar.int32 ] Int32.to_int
 
 let int32 =
-  scalar_int Wire.int32 4
-    (Alcobar.map Alcobar.[ Alcobar.int32 ] Int32.to_int)
+  scalar_int ~hostile:(outside_signed_width 32) Wire.int32 4 int32_value_gen
     s32_boundaries
 
 let int32be =
-  scalar_int Wire.int32be 4
-    (Alcobar.map Alcobar.[ Alcobar.int32 ] Int32.to_int)
+  scalar_int ~hostile:(outside_signed_width 32) Wire.int32be 4 int32_value_gen
     s32_boundaries
 
 let int64 = scalar_int64 Wire.int64 8 Alcobar.int64 s64_boundaries_i64
@@ -604,7 +675,12 @@ let map ~decode ~encode inner =
     adversarial = inner.adversarial;
     equal = (fun a b -> inner.equal (encode a) (encode b));
     env = None;
-    adversarial_value = None;
+    (* [map] adds no encode path of its own, it hands the mapped value to the
+       inner typ, so a value the inner typ refuses must still be refused here. *)
+    adversarial_value =
+      Option.map
+        (fun g -> Alcobar.map Alcobar.[ g ] decode)
+        inner.adversarial_value;
   }
 
 let uint_var ~endian size =
@@ -1435,7 +1511,9 @@ let where inner =
     adversarial = inner.adversarial;
     equal = inner.equal;
     env = None;
-    adversarial_value = None;
+    (* The cond is [true_], so [where] narrows nothing: whatever the inner typ
+       refuses it must still refuse through the wrapper. *)
+    adversarial_value = inner.adversarial_value;
   }
 
 let bits ?bit_order ~width base =
@@ -1446,8 +1524,7 @@ let bits ?bit_order ~width base =
   let mask = (1 lsl width) - 1 in
   let value_gen = Alcobar.map Alcobar.[ Alcobar.int ] (fun n -> n land mask) in
   let boundaries = [ 0; 1; mask; mask - 1; mask lsr 1 ] in
-  let g = scalar_int typ base_size value_gen boundaries in
-  { g with adversarial_value = Some (above_bit_width width) }
+  scalar_int ~hostile:(above_bit_width width) typ base_size value_gen boundaries
 
 let bitfield_total = function
   | Wire.U8 -> 8

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -84,7 +84,7 @@ let bits_field_encoder ~width ~base ~bit_order buf off v =
   let total = Bitfield.total_bits base in
   let shift = Bitfield.shift ~bit_order ~total ~bits_used:0 ~width in
   let mask = (1 lsl width) - 1 in
-  Types.check_bits_encode ~width v;
+  Types.check_unsigned_encode ~bits:width v;
   (match base with
   | U32 Little when not Bitfield.int_holds_u32 ->
       Bitfield.u32_field_word_le buf off shift v
@@ -135,15 +135,15 @@ and build_field_encoder_ctx : type a.
   match typ with
   | Uint8 ->
       fun _runtime buf off v ->
-        Bytes.set_uint8 buf off v;
+        Types.set_uint8 buf off v;
         off + 1
   | Uint16 Little ->
       fun _runtime buf off v ->
-        Bytes.set_uint16_le buf off v;
+        Types.set_uint16_le buf off v;
         off + 2
   | Uint16 Big ->
       fun _runtime buf off v ->
-        Bytes.set_uint16_be buf off v;
+        Types.set_uint16_be buf off v;
         off + 2
   | Uint32 Little ->
       fun _runtime buf off v ->
@@ -169,20 +169,11 @@ and build_field_encoder_ctx : type a.
       fun _runtime buf off v ->
         Bytes.set_int64_be buf off v;
         off + 8
-  | Int8 -> fun _runtime -> setter_off 1 Bytes.set_int8
-  | Int16 Little -> fun _runtime -> setter_off 2 Bytes.set_int16_le
-  | Int16 Big -> fun _runtime -> setter_off 2 Bytes.set_int16_be
-  (* Keep the conversion and primitive call visible together. Passing the
-     setter through [setter_off_int32] boxes the temporary [int32] on every
-     staged write when Flambda is disabled. *)
-  | Int32 Little ->
-      fun _runtime buf off v ->
-        Bytes.set_int32_le buf off (Int32.of_int v);
-        off + 4
-  | Int32 Big ->
-      fun _runtime buf off v ->
-        Bytes.set_int32_be buf off (Int32.of_int v);
-        off + 4
+  | Int8 -> fun _runtime -> setter_off 1 Types.set_int8
+  | Int16 Little -> fun _runtime -> setter_off 2 Types.set_int16_le
+  | Int16 Big -> fun _runtime -> setter_off 2 Types.set_int16_be
+  | Int32 Little -> fun _runtime -> setter_off 4 Types.set_int32_le
+  | Int32 Big -> fun _runtime -> setter_off 4 Types.set_int32_be
   | Int64 Little -> fun _runtime -> setter_off 8 Bytes.set_int64_le
   | Int64 Big -> fun _runtime -> setter_off 8 Bytes.set_int64_be
   | Float32 Little -> fun _runtime -> float32_field_encoder Bytes.set_int32_le
@@ -425,29 +416,21 @@ let rec build_immediate_encoder : type a.
   | Uint8 ->
       Some
         (fun buf off v ->
-          Bytes.set_uint8 buf off v;
+          Types.set_uint8 buf off v;
           off + 1)
-  | Uint16 Little -> Some (setter_off 2 Bytes.set_uint16_le)
-  | Uint16 Big -> Some (setter_off 2 Bytes.set_uint16_be)
+  | Uint16 Little -> Some (setter_off 2 Types.set_uint16_le)
+  | Uint16 Big -> Some (setter_off 2 Types.set_uint16_be)
   | Uint32 Little -> Some (setter_off 4 UInt32.set_le)
   | Uint32 Big -> Some (setter_off 4 UInt32.set_be)
   | Uint63 Little -> Some (setter_off 8 UInt63.set_le)
   | Uint63 Big -> Some (setter_off 8 UInt63.set_be)
   | Uint64 Little -> Some (setter_off 8 Bytes.set_int64_le)
   | Uint64 Big -> Some (setter_off 8 Bytes.set_int64_be)
-  | Int8 -> Some (setter_off 1 Bytes.set_int8)
-  | Int16 Little -> Some (setter_off 2 Bytes.set_int16_le)
-  | Int16 Big -> Some (setter_off 2 Bytes.set_int16_be)
-  | Int32 Little ->
-      Some
-        (fun buf off v ->
-          Bytes.set_int32_le buf off (Int32.of_int v);
-          off + 4)
-  | Int32 Big ->
-      Some
-        (fun buf off v ->
-          Bytes.set_int32_be buf off (Int32.of_int v);
-          off + 4)
+  | Int8 -> Some (setter_off 1 Types.set_int8)
+  | Int16 Little -> Some (setter_off 2 Types.set_int16_le)
+  | Int16 Big -> Some (setter_off 2 Types.set_int16_be)
+  | Int32 Little -> Some (setter_off 4 Types.set_int32_le)
+  | Int32 Big -> Some (setter_off 4 Types.set_int32_be)
   | Int64 Little -> Some (setter_off 8 Bytes.set_int64_le)
   | Int64 Big -> Some (setter_off 8 Bytes.set_int64_be)
   | Float32 Little -> Some (float32_field_encoder Bytes.set_int32_le)
@@ -1258,39 +1241,39 @@ let build_bf_writer base byte_off shift width =
   match base with
   | U8 ->
       fun buf off value ->
-        Types.check_bits_encode ~width value;
+        Types.check_unsigned_encode ~bits:width value;
         let cur = Bytes.get_uint8 buf (off + byte_off) in
         Bytes.set_uint8 buf (off + byte_off)
           (cur lor ((value land mask) lsl shift))
   | U16 Little ->
       fun buf off value ->
-        Types.check_bits_encode ~width value;
+        Types.check_unsigned_encode ~bits:width value;
         let cur = Bytes.get_uint16_le buf (off + byte_off) in
         Bytes.set_uint16_le buf (off + byte_off)
           (cur lor ((value land mask) lsl shift))
   | U16 Big ->
       fun buf off value ->
-        Types.check_bits_encode ~width value;
+        Types.check_unsigned_encode ~bits:width value;
         let cur = Bytes.get_uint16_be buf (off + byte_off) in
         Bytes.set_uint16_be buf (off + byte_off)
           (cur lor ((value land mask) lsl shift))
   | U32 Little when not Bitfield.int_holds_u32 ->
       fun buf off value ->
-        Types.check_bits_encode ~width value;
+        Types.check_unsigned_encode ~bits:width value;
         Bitfield.u32_field_or_le buf (off + byte_off) shift (value land mask)
   | U32 Big when not Bitfield.int_holds_u32 ->
       fun buf off value ->
-        Types.check_bits_encode ~width value;
+        Types.check_unsigned_encode ~bits:width value;
         Bitfield.u32_field_or_be buf (off + byte_off) shift (value land mask)
   | U32 Little ->
       fun buf off value ->
-        Types.check_bits_encode ~width value;
+        Types.check_unsigned_encode ~bits:width value;
         let cur = Bitfield.u32_le buf (off + byte_off) in
         Bitfield.set_u32_le buf (off + byte_off)
           (cur lor ((value land mask) lsl shift))
   | U32 Big ->
       fun buf off value ->
-        Types.check_bits_encode ~width value;
+        Types.check_unsigned_encode ~bits:width value;
         let cur = Bitfield.u32_be buf (off + byte_off) in
         Bitfield.set_u32_be buf (off + byte_off)
           (cur lor ((value land mask) lsl shift))
@@ -1304,41 +1287,41 @@ let build_bf_accessor_writer base byte_off shift width =
   match base with
   | U8 ->
       fun buf off value ->
-        Types.check_bits_encode ~width value;
+        Types.check_unsigned_encode ~bits:width value;
         let cur = Bytes.get_uint8 buf (off + byte_off) in
         Bytes.set_uint8 buf (off + byte_off)
           (cur land clear_mask lor ((value land mask) lsl shift))
   | U16 Little ->
       fun buf off value ->
-        Types.check_bits_encode ~width value;
+        Types.check_unsigned_encode ~bits:width value;
         let cur = Bytes.get_uint16_le buf (off + byte_off) in
         Bytes.set_uint16_le buf (off + byte_off)
           (cur land clear_mask lor ((value land mask) lsl shift))
   | U16 Big ->
       fun buf off value ->
-        Types.check_bits_encode ~width value;
+        Types.check_unsigned_encode ~bits:width value;
         let cur = Bytes.get_uint16_be buf (off + byte_off) in
         Bytes.set_uint16_be buf (off + byte_off)
           (cur land clear_mask lor ((value land mask) lsl shift))
   | U32 Little when not Bitfield.int_holds_u32 ->
       fun buf off value ->
-        Types.check_bits_encode ~width value;
+        Types.check_unsigned_encode ~bits:width value;
         Bitfield.u32_field_set_le buf (off + byte_off) shift mask
           (value land mask)
   | U32 Big when not Bitfield.int_holds_u32 ->
       fun buf off value ->
-        Types.check_bits_encode ~width value;
+        Types.check_unsigned_encode ~bits:width value;
         Bitfield.u32_field_set_be buf (off + byte_off) shift mask
           (value land mask)
   | U32 Little ->
       fun buf off value ->
-        Types.check_bits_encode ~width value;
+        Types.check_unsigned_encode ~bits:width value;
         let cur = Bitfield.u32_le buf (off + byte_off) in
         Bitfield.set_u32_le buf (off + byte_off)
           (cur land clear_mask lor ((value land mask) lsl shift))
   | U32 Big ->
       fun buf off value ->
-        Types.check_bits_encode ~width value;
+        Types.check_unsigned_encode ~bits:width value;
         let cur = Bitfield.u32_be buf (off + byte_off) in
         Bitfield.set_u32_be buf (off + byte_off)
           (cur land clear_mask lor ((value land mask) lsl shift))
@@ -1614,20 +1597,20 @@ and read_case_body : type a k.
 let rec write_elem : type a. a typ -> runtime -> bytes -> int -> a -> unit =
  fun typ runtime buf off v ->
   match typ with
-  | Uint8 -> Bytes.set_uint8 buf off v
-  | Uint16 Little -> Bytes.set_uint16_le buf off v
-  | Uint16 Big -> Bytes.set_uint16_be buf off v
+  | Uint8 -> Types.set_uint8 buf off v
+  | Uint16 Little -> Types.set_uint16_le buf off v
+  | Uint16 Big -> Types.set_uint16_be buf off v
   | Uint32 Little -> UInt32.set_le buf off v
   | Uint32 Big -> UInt32.set_be buf off v
   | Uint63 Little -> UInt63.set_le buf off v
   | Uint63 Big -> UInt63.set_be buf off v
   | Uint64 Little -> Bytes.set_int64_le buf off v
   | Uint64 Big -> Bytes.set_int64_be buf off v
-  | Int8 -> Bytes.set_int8 buf off v
-  | Int16 Little -> Bytes.set_int16_le buf off v
-  | Int16 Big -> Bytes.set_int16_be buf off v
-  | Int32 Little -> Bytes.set_int32_le buf off (Int32.of_int v)
-  | Int32 Big -> Bytes.set_int32_be buf off (Int32.of_int v)
+  | Int8 -> Types.set_int8 buf off v
+  | Int16 Little -> Types.set_int16_le buf off v
+  | Int16 Big -> Types.set_int16_be buf off v
+  | Int32 Little -> Types.set_int32_le buf off v
+  | Int32 Big -> Types.set_int32_be buf off v
   | Int64 Little -> Bytes.set_int64_le buf off v
   | Int64 Big -> Bytes.set_int64_be buf off v
   | Float32 Little -> Bytes.set_int32_le buf off (Int32.bits_of_float v)

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -84,9 +84,7 @@ let bits_field_encoder ~width ~base ~bit_order buf off v =
   let total = Bitfield.total_bits base in
   let shift = Bitfield.shift ~bit_order ~total ~bits_used:0 ~width in
   let mask = (1 lsl width) - 1 in
-  if v land lnot mask <> 0 then
-    Fmt.invalid_arg "Codec.encode: value 0x%X exceeds %d-bit field width" v
-      width;
+  Types.check_bits_encode ~width v;
   (match base with
   | U32 Little when not Bitfield.int_holds_u32 ->
       Bitfield.u32_field_word_le buf off shift v
@@ -1255,89 +1253,92 @@ let build_bf_reader base byte_off shift width =
   | U32 Big ->
       fun buf off -> (Bitfield.u32_be buf (off + byte_off) lsr shift) land mask
 
-let err_bf_overflow width value =
-  Fmt.invalid_arg "Codec.encode: value 0x%X exceeds %d-bit field width" value
-    width
-
-let[@inline] check_bf_overflow width value =
-  if value lsr width <> 0 then err_bf_overflow width value
-
 let build_bf_writer base byte_off shift width =
   let mask = (1 lsl width) - 1 in
   match base with
   | U8 ->
       fun buf off value ->
-        check_bf_overflow width value;
+        Types.check_bits_encode ~width value;
         let cur = Bytes.get_uint8 buf (off + byte_off) in
         Bytes.set_uint8 buf (off + byte_off)
           (cur lor ((value land mask) lsl shift))
   | U16 Little ->
       fun buf off value ->
-        check_bf_overflow width value;
+        Types.check_bits_encode ~width value;
         let cur = Bytes.get_uint16_le buf (off + byte_off) in
         Bytes.set_uint16_le buf (off + byte_off)
           (cur lor ((value land mask) lsl shift))
   | U16 Big ->
       fun buf off value ->
-        check_bf_overflow width value;
+        Types.check_bits_encode ~width value;
         let cur = Bytes.get_uint16_be buf (off + byte_off) in
         Bytes.set_uint16_be buf (off + byte_off)
           (cur lor ((value land mask) lsl shift))
   | U32 Little when not Bitfield.int_holds_u32 ->
       fun buf off value ->
-        check_bf_overflow width value;
+        Types.check_bits_encode ~width value;
         Bitfield.u32_field_or_le buf (off + byte_off) shift (value land mask)
   | U32 Big when not Bitfield.int_holds_u32 ->
       fun buf off value ->
-        check_bf_overflow width value;
+        Types.check_bits_encode ~width value;
         Bitfield.u32_field_or_be buf (off + byte_off) shift (value land mask)
   | U32 Little ->
       fun buf off value ->
-        check_bf_overflow width value;
+        Types.check_bits_encode ~width value;
         let cur = Bitfield.u32_le buf (off + byte_off) in
         Bitfield.set_u32_le buf (off + byte_off)
           (cur lor ((value land mask) lsl shift))
   | U32 Big ->
       fun buf off value ->
-        check_bf_overflow width value;
+        Types.check_bits_encode ~width value;
         let cur = Bitfield.u32_be buf (off + byte_off) in
         Bitfield.set_u32_be buf (off + byte_off)
           (cur lor ((value land mask) lsl shift))
 
+(* The [Codec.set] writer. It range-checks like {!build_bf_writer}: masking here
+   is the one silent truncation no later check can catch, because the masked
+   result is a legal field value that [Codec.get] and [validate] both accept. *)
 let build_bf_accessor_writer base byte_off shift width =
   let mask = (1 lsl width) - 1 in
   let clear_mask = lnot (mask lsl shift) in
   match base with
   | U8 ->
       fun buf off value ->
+        Types.check_bits_encode ~width value;
         let cur = Bytes.get_uint8 buf (off + byte_off) in
         Bytes.set_uint8 buf (off + byte_off)
           (cur land clear_mask lor ((value land mask) lsl shift))
   | U16 Little ->
       fun buf off value ->
+        Types.check_bits_encode ~width value;
         let cur = Bytes.get_uint16_le buf (off + byte_off) in
         Bytes.set_uint16_le buf (off + byte_off)
           (cur land clear_mask lor ((value land mask) lsl shift))
   | U16 Big ->
       fun buf off value ->
+        Types.check_bits_encode ~width value;
         let cur = Bytes.get_uint16_be buf (off + byte_off) in
         Bytes.set_uint16_be buf (off + byte_off)
           (cur land clear_mask lor ((value land mask) lsl shift))
   | U32 Little when not Bitfield.int_holds_u32 ->
       fun buf off value ->
+        Types.check_bits_encode ~width value;
         Bitfield.u32_field_set_le buf (off + byte_off) shift mask
           (value land mask)
   | U32 Big when not Bitfield.int_holds_u32 ->
       fun buf off value ->
+        Types.check_bits_encode ~width value;
         Bitfield.u32_field_set_be buf (off + byte_off) shift mask
           (value land mask)
   | U32 Little ->
       fun buf off value ->
+        Types.check_bits_encode ~width value;
         let cur = Bitfield.u32_le buf (off + byte_off) in
         Bitfield.set_u32_le buf (off + byte_off)
           (cur land clear_mask lor ((value land mask) lsl shift))
   | U32 Big ->
       fun buf off value ->
+        Types.check_bits_encode ~width value;
         let cur = Bitfield.u32_be buf (off + byte_off) in
         Bitfield.set_u32_be buf (off + byte_off)
           (cur land clear_mask lor ((value land mask) lsl shift))

--- a/lib/codec.mli
+++ b/lib/codec.mli
@@ -160,10 +160,11 @@ val set : 'r t -> ('a, 'r) field -> (bytes -> int -> 'a -> unit) Staged.t
 
     Raises [Invalid_argument], leaving the buffer untouched, on a value the
     field cannot represent: a byte string whose length differs from the declared
-    size, an integer with bits above a [bits ~width] field or bytes above a
-    [uint ~size] one, or a byte a [byte_array_where] refinement rejects. Each of
-    those would otherwise put different bytes on the wire than the caller asked
-    for, and a masked integer is indistinguishable from a value meant that way.
+    size, an integer outside the range of its width (fixed or [bits ~width] or
+    [uint ~size] alike), or a byte a [byte_array_where] refinement rejects. Each
+    of those would otherwise put different bytes on the wire than the caller
+    asked for, and a masked integer is indistinguishable from a value meant that
+    way.
 
     Does not check what the surrounding record permits -- record-level [~where]
     clauses, other fields' [~constraint_] checks, [enum] membership -- and does

--- a/lib/codec.mli
+++ b/lib/codec.mli
@@ -9,9 +9,10 @@
       allocates the record value.
 
     - {!get} / {!set} provide zero-copy field access. {!get} fires the field's
-      [~action] (if any), so output parameters are updated. It does {b not}
-      check record-level [~where] clauses or other fields' [~constraint_]
-      checks. Fields without actions have zero overhead.
+      [~action] (if any), so output parameters are updated. Neither checks
+      record-level [~where] clauses or other fields' [~constraint_] checks;
+      {!set} does refuse a value its own field cannot represent. Fields without
+      actions have zero overhead.
 
     - {!validate} checks all field [~constraint_] checks and [~where] clauses
       without constructing a record and without firing actions. Use it before a
@@ -155,9 +156,19 @@ val get :
     other fields' constraints -- call {!validate} first on untrusted input. *)
 
 val set : 'r t -> ('a, 'r) field -> (bytes -> int -> 'a -> unit) Staged.t
-(** Staged zero-copy field setter. Does not check constraints or fire actions --
-    call {!validate} after a batch of writes to verify constraints still hold.
-*)
+(** Staged zero-copy field setter.
+
+    Raises [Invalid_argument], leaving the buffer untouched, on a value the
+    field cannot represent: a byte string whose length differs from the declared
+    size, an integer with bits above a [bits ~width] field or bytes above a
+    [uint ~size] one, or a byte a [byte_array_where] refinement rejects. Each of
+    those would otherwise put different bytes on the wire than the caller asked
+    for, and a masked integer is indistinguishable from a value meant that way.
+
+    Does not check what the surrounding record permits -- record-level [~where]
+    clauses, other fields' [~constraint_] checks, [enum] membership -- and does
+    not fire actions. Call {!validate} after a batch of writes to verify those
+    still hold. *)
 
 val zeroterm_nul_pos : bytes -> first:int -> limit:int -> int
 (** [zeroterm_nul_pos buf ~first ~limit] is the index of the first NUL byte in

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -1827,29 +1827,74 @@ let check_zeroterm_region ~region ~len =
       "Wire.encode: zeroterm string needs %d bytes but region is %d" (len + 1)
       region
 
-(* A [bits ~width] field owns exactly [width] bits. Masking a wider value is the
-   one truncation nothing downstream can catch: the masked result is itself a
-   legal field value, so decode, [validate] and the EverParse validator all
-   accept it and the number the caller meant is gone without trace. *)
-let check_bits_encode ~width v =
-  if v lsr width <> 0 then
-    Fmt.invalid_arg "Wire.encode: value 0x%X exceeds %d-bit field width" v width
+(* A field of [bits] bits owns exactly those bits, whether it was declared as a
+   fixed-width scalar or as a [bits ~width] slice of one: both are carried in an
+   OCaml [int], which holds far more than the field does. Masking a wider value
+   is the one truncation nothing downstream can catch, because the masked result
+   is itself a legal field value that decode, [validate] and the EverParse
+   validator all accept, and the number the caller meant is gone without trace.
+   So each width accepts exactly what its decoder produces -- [0, 2^bits - 1]
+   unsigned, [-2^(bits-1), 2^(bits-1) - 1] signed -- and encode stays inverse to
+   decode.
 
-(* A [uint ~size] field owns exactly [size] bytes. Dropping the high bytes of a
-   wider value leaves a legal [size]-byte number on the wire, so the same
-   argument as [check_bits_encode] applies. Eight bytes and up hold every
-   [UInt63.t], so only the narrower widths need the test. *)
-let check_uint_var_encode ~size v =
-  if size < 8 then begin
-    let bits = 8 * max size 0 in
-    let limit = Optint.Int63.shift_left Optint.Int63.one bits in
-    if
-      Optint.Int63.compare v Optint.Int63.zero < 0
-      || Optint.Int63.compare v limit >= 0
-    then
-      Fmt.invalid_arg "Wire.encode: value 0x%Lx exceeds %d-byte uint field"
-        (Optint.Int63.to_int64 v) size
+   Where the native [int] is no wider than the field (a 32-bit field under
+   js_of_ocaml, anything from 31 bits up under wasm_of_ocaml) no [int] is out of
+   range, so the guard narrows to what is still checkable there rather than
+   rejecting a value the target can represent.
+
+   The wider carriers guard themselves, next to the representation that decides
+   what fits: {!UInt32.check_encode} and {!UInt63.check_encode}. [uint64] and
+   [int64] have no guard, because an [int64] is exactly the eight bytes written
+   and no value of it is out of range. *)
+let check_unsigned_encode ~bits v =
+  let out_of_range = if bits >= Sys.int_size then v < 0 else v lsr bits <> 0 in
+  if out_of_range then
+    Fmt.invalid_arg
+      "Wire.encode: value %d does not fit an unsigned %d-bit field" v bits
+
+let check_signed_encode ~bits v =
+  if bits < Sys.int_size then begin
+    let limit = 1 lsl (bits - 1) in
+    if v < -limit || v >= limit then
+      Fmt.invalid_arg "Wire.encode: value %d does not fit a signed %d-bit field"
+        v bits
   end
+
+(* The range-checking counterparts of [Bytes.set_*]: every wire encode path
+   writes a fixed-width scalar through one of these, because the [Bytes]
+   primitives mask instead ([Bytes.set_uint8 b 0 0x1FF] writes 0xFF). *)
+
+let set_uint8 buf off v =
+  check_unsigned_encode ~bits:8 v;
+  Bytes.set_uint8 buf off v
+
+let set_uint16_le buf off v =
+  check_unsigned_encode ~bits:16 v;
+  Bytes.set_uint16_le buf off v
+
+let set_uint16_be buf off v =
+  check_unsigned_encode ~bits:16 v;
+  Bytes.set_uint16_be buf off v
+
+let set_int8 buf off v =
+  check_signed_encode ~bits:8 v;
+  Bytes.set_int8 buf off v
+
+let set_int16_le buf off v =
+  check_signed_encode ~bits:16 v;
+  Bytes.set_int16_le buf off v
+
+let set_int16_be buf off v =
+  check_signed_encode ~bits:16 v;
+  Bytes.set_int16_be buf off v
+
+let set_int32_le buf off v =
+  check_signed_encode ~bits:32 v;
+  Bytes.set_int32_le buf off (Int32.of_int v)
+
+let set_int32_be buf off v =
+  check_signed_encode ~bits:32 v;
+  Bytes.set_int32_be buf off (Int32.of_int v)
 
 (* 3D's [var x = a; p] requires [a] to be an atomic action (extern call,
    field_ptr, ...), not an arbitrary expression. Wire's [Action.var name e]

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -1827,6 +1827,30 @@ let check_zeroterm_region ~region ~len =
       "Wire.encode: zeroterm string needs %d bytes but region is %d" (len + 1)
       region
 
+(* A [bits ~width] field owns exactly [width] bits. Masking a wider value is the
+   one truncation nothing downstream can catch: the masked result is itself a
+   legal field value, so decode, [validate] and the EverParse validator all
+   accept it and the number the caller meant is gone without trace. *)
+let check_bits_encode ~width v =
+  if v lsr width <> 0 then
+    Fmt.invalid_arg "Wire.encode: value 0x%X exceeds %d-bit field width" v width
+
+(* A [uint ~size] field owns exactly [size] bytes. Dropping the high bytes of a
+   wider value leaves a legal [size]-byte number on the wire, so the same
+   argument as [check_bits_encode] applies. Eight bytes and up hold every
+   [UInt63.t], so only the narrower widths need the test. *)
+let check_uint_var_encode ~size v =
+  if size < 8 then begin
+    let bits = 8 * max size 0 in
+    let limit = Optint.Int63.shift_left Optint.Int63.one bits in
+    if
+      Optint.Int63.compare v Optint.Int63.zero < 0
+      || Optint.Int63.compare v limit >= 0
+    then
+      Fmt.invalid_arg "Wire.encode: value 0x%Lx exceeds %d-byte uint field"
+        (Optint.Int63.to_int64 v) size
+  end
+
 (* 3D's [var x = a; p] requires [a] to be an atomic action (extern call,
    field_ptr, ...), not an arbitrary expression. Wire's [Action.var name e]
    binds a name to a pure expression, so we lower it by substituting

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -148,6 +148,18 @@ val check_zeroterm_region : region:int -> len:int -> unit
     terminator inside a [region]-byte span. Internal helper shared by every
     encoder path. *)
 
+val check_bits_encode : width:int -> int -> unit
+(** Check an integer fits a [bits ~width] field before encoding it. A value with
+    bits above [width] raises [Invalid_argument]: masking it would put a
+    different, equally legal, number on the wire, which no later check can tell
+    from the one the caller meant. Internal helper shared by every encoder path.
+*)
+
+val check_uint_var_encode : size:int -> UInt63.t -> unit
+(** Check a value fits a [uint ~size] field before encoding it. A value needing
+    more than [size] bytes raises [Invalid_argument], for the same reason as
+    {!check_bits_encode}. Internal helper shared by every encoder path. *)
+
 (** {1 Param handles} *)
 
 type param_input

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -148,17 +148,52 @@ val check_zeroterm_region : region:int -> len:int -> unit
     terminator inside a [region]-byte span. Internal helper shared by every
     encoder path. *)
 
-val check_bits_encode : width:int -> int -> unit
-(** Check an integer fits a [bits ~width] field before encoding it. A value with
-    bits above [width] raises [Invalid_argument]: masking it would put a
-    different, equally legal, number on the wire, which no later check can tell
-    from the one the caller meant. Internal helper shared by every encoder path.
-*)
+val check_unsigned_encode : bits:int -> int -> unit
+(** Check an integer fits an unsigned [bits]-wide field before encoding it. The
+    accepted range is [[0, 2^bits - 1]], exactly what the decoder produces, so
+    encode stays inverse to decode; anything else raises [Invalid_argument],
+    because masking it would put a different, equally legal, number on the wire
+    that no later check can tell from the one the caller meant. Shared by
+    {!val-uint8}, {!val-uint16} and [bits ~width], one rule at three widths.
+    Where the native [int] is no wider than the field the guard narrows to what
+    is still checkable, so it never rejects a value the target can represent. *)
 
-val check_uint_var_encode : size:int -> UInt63.t -> unit
-(** Check a value fits a [uint ~size] field before encoding it. A value needing
-    more than [size] bytes raises [Invalid_argument], for the same reason as
-    {!check_bits_encode}. Internal helper shared by every encoder path. *)
+val check_signed_encode : bits:int -> int -> unit
+(** Check an integer fits a signed [bits]-wide field before encoding it. The
+    accepted range is [[-2^(bits-1), 2^(bits-1) - 1]]: the decoder produces
+    exactly that, so [200] into an {!val-int8} is refused rather than
+    round-tripping back as [-56]. Same narrow-target narrowing as
+    {!check_unsigned_encode}. *)
+
+(** {2 Checked scalar writers}
+
+    The range-checking counterparts of [Bytes.set_*]. Every wire encode path
+    writes a fixed-width scalar through one of these, because the [Bytes]
+    primitives mask silently. *)
+
+val set_uint8 : bytes -> int -> int -> unit
+(** [set_uint8 buf off v] writes [v] as one unsigned byte. *)
+
+val set_uint16_le : bytes -> int -> int -> unit
+(** [set_uint16_le buf off v] writes [v] as two unsigned little-endian bytes. *)
+
+val set_uint16_be : bytes -> int -> int -> unit
+(** [set_uint16_be buf off v] writes [v] as two unsigned big-endian bytes. *)
+
+val set_int8 : bytes -> int -> int -> unit
+(** [set_int8 buf off v] writes [v] as one signed byte. *)
+
+val set_int16_le : bytes -> int -> int -> unit
+(** [set_int16_le buf off v] writes [v] as two signed little-endian bytes. *)
+
+val set_int16_be : bytes -> int -> int -> unit
+(** [set_int16_be buf off v] writes [v] as two signed big-endian bytes. *)
+
+val set_int32_le : bytes -> int -> int -> unit
+(** [set_int32_le buf off v] writes [v] as four signed little-endian bytes. *)
+
+val set_int32_be : bytes -> int -> int -> unit
+(** [set_int32_be buf off v] writes [v] as four signed big-endian bytes. *)
 
 (** {1 Param handles} *)
 

--- a/lib/uInt32.ml
+++ b/lib/uInt32.ml
@@ -11,6 +11,22 @@ let pp = Optint.pp
 
 let mask16 = Optint.of_int 0xFFFF
 
+(* Computed at run time: an 0xFFFF_FFFF int literal lands in the bytecode as
+   an out-of-range constant on a narrow-int target (wasm_of_ocaml warns). *)
+let mask32 = Int64.to_int 0xFFFF_FFFFL
+let field_mask = Optint.of_int mask32
+
+(* A uint32 field owns exactly 32 bits. Where the native int is wide, [Optint.t]
+   is that int and holds numbers the field cannot; masking one leaves a legal
+   32-bit value on the wire that no decoder, [validate] or generated C validator
+   can tell from the number the caller meant. Where [Optint.t] falls back to a
+   boxed [int32] the carrier is exactly the field, [field_mask] is all-ones, and
+   the guard never fires: every representable value is a legal uint32 there. *)
+let check_encode v =
+  if not (Optint.equal (Optint.logand v field_mask) v) then
+    Fmt.invalid_arg
+      "Wire.encode: value %a does not fit an unsigned 32-bit field" Optint.pp v
+
 let le buf off =
   let lo = Bytes.get_uint16_le buf off in
   let hi = Bytes.get_uint16_le buf (off + 2) in
@@ -23,19 +39,24 @@ let be buf off =
 
 let low16 v = Optint.to_int (Optint.logand v mask16)
 
+(* Every encoder path -- typ-level, compiled field, [Codec.set] -- writes a
+   uint32 through here, so the width check belongs here too. *)
 let set_le buf off v =
+  check_encode v;
   Bytes.set_uint16_le buf off (low16 v);
   Bytes.set_uint16_le buf (off + 2) (low16 (Optint.shift_right_logical v 16))
 
 let set_be buf off v =
+  check_encode v;
   Bytes.set_uint16_be buf off (low16 (Optint.shift_right_logical v 16));
   Bytes.set_uint16_be buf (off + 2) (low16 v)
 
 let to_int = Optint.to_int
-
-(* Computed at run time: an 0xFFFF_FFFF int literal lands in the bytecode as
-   an out-of-range constant on a narrow-int target (wasm_of_ocaml warns). *)
-let mask32 = Int64.to_int 0xFFFF_FFFFL
 let of_int v = Optint.of_int (v land mask32)
 let to_int32 = Optint.to_int32
-let of_int32 = Optint.of_int32
+
+(* [Optint.of_int32] keeps the signed view, so where [Optint.t] is a wide native
+   int a word with bit 31 set arrives as a negative number: not what [le] and
+   [be] decode those same bytes to, and not a value a uint32 field may hold.
+   Masking back to the field brings it to the one canonical representation. *)
+let of_int32 n = Optint.logand (Optint.of_int32 n) field_mask

--- a/lib/uInt32.mli
+++ b/lib/uInt32.mli
@@ -16,12 +16,18 @@ val le : bytes -> int -> t
 val be : bytes -> int -> t
 (** [be buf off] reads a big-endian value from [buf] at offset [off]. *)
 
+val check_encode : t -> unit
+(** [check_encode v] raises [Invalid_argument] when [v] is not an unsigned
+    32-bit value. Only reachable where the native [int] is wider than the field,
+    which is the only place a {!type-t} can hold a number 32 bits cannot. *)
+
 val set_le : bytes -> int -> t -> unit
 (** [set_le buf off v] writes [v] as little-endian into [buf] at offset [off].
-*)
+    Raises [Invalid_argument] on a value {!check_encode} rejects. *)
 
 val set_be : bytes -> int -> t -> unit
-(** [set_be buf off v] writes [v] as big-endian into [buf] at offset [off]. *)
+(** [set_be buf off v] writes [v] as big-endian into [buf] at offset [off].
+    Raises [Invalid_argument] on a value {!check_encode} rejects. *)
 
 val mask32 : int
 (** The low-32-bit mask, [0xFFFF_FFFF] where the native [int] is wide and the
@@ -41,4 +47,7 @@ val to_int32 : t -> int32
     platform). *)
 
 val of_int32 : int32 -> t
-(** [of_int32 n] is the [int32] bit pattern as a 32-bit value. *)
+(** [of_int32 n] is the [int32] bit pattern as a 32-bit value: the same value
+    {!le} and {!be} decode those four bytes to, on every platform. Prefer it to
+    [Optint.of_int32], which keeps the signed view and so yields a negative
+    number for a word with bit 31 set where [Optint.t] is a wide native int. *)

--- a/lib/uInt63.ml
+++ b/lib/uInt63.ml
@@ -37,13 +37,31 @@ let be buf off =
 
 let chunk v shift = I.to_int (I.logand (I.shift_right_logical v shift) mask16)
 
+(* A [size]-byte unsigned field owns exactly that many bytes, and the carrier is
+   a signed 63-bit integer. A negative value, or one wider than the field, loses
+   its high bits to [chunk] and reaches the wire as a legal smaller number that
+   no decoder, [validate] or generated C validator can tell from the one the
+   caller meant, so writing refuses instead. Eight bytes hold every non-negative
+   [t], so at that width only the sign can be wrong. *)
+let check_encode ~size v =
+  let too_wide =
+    size < 8 && I.compare v (I.shift_left I.one (8 * max size 0)) >= 0
+  in
+  if I.compare v I.zero < 0 || too_wide then
+    Fmt.invalid_arg
+      "Wire.encode: value %a does not fit an unsigned %d-byte field" I.pp v size
+
+(* Every encoder path -- typ-level, compiled field, [Codec.set] -- writes a
+   uint63 through here, so the width check belongs here too. *)
 let set_le buf off v =
+  check_encode ~size:8 v;
   Bytes.set_uint16_le buf off (chunk v 0);
   Bytes.set_uint16_le buf (off + 2) (chunk v 16);
   Bytes.set_uint16_le buf (off + 4) (chunk v 32);
   Bytes.set_uint16_le buf (off + 6) (chunk v 48)
 
 let set_be buf off v =
+  check_encode ~size:8 v;
   Bytes.set_uint16_be buf off (chunk v 48);
   Bytes.set_uint16_be buf (off + 2) (chunk v 32);
   Bytes.set_uint16_be buf (off + 4) (chunk v 16);

--- a/lib/uInt63.mli
+++ b/lib/uInt63.mli
@@ -15,12 +15,20 @@ val le : bytes -> int -> t
 val be : bytes -> int -> t
 (** [be buf off] reads a big-endian value from [buf] at offset [off]. *)
 
+val check_encode : size:int -> t -> unit
+(** [check_encode ~size v] raises [Invalid_argument] when [v] is negative or
+    needs more than [size] bytes. Truncating it would leave a legal [size]-byte
+    number on the wire that nothing downstream can tell from the one the caller
+    meant. Shared by every [size]-byte unsigned field: the eight-byte {!set_le}
+    and {!set_be} below, and the narrower [uint ~size]. *)
+
 val set_le : bytes -> int -> t -> unit
 (** [set_le buf off v] writes [v] as little-endian into [buf] at offset [off].
-*)
+    Raises [Invalid_argument] on a value {!check_encode} rejects. *)
 
 val set_be : bytes -> int -> t -> unit
-(** [set_be buf off v] writes [v] as big-endian into [buf] at offset [off]. *)
+(** [set_be buf off v] writes [v] as big-endian into [buf] at offset [off].
+    Raises [Invalid_argument] on a value {!check_encode} rejects. *)
 
 val to_int : t -> int
 (** [to_int t] is the value as a native [int]. Exact on a 64-bit host. *)

--- a/lib/uint_var.ml
+++ b/lib/uint_var.ml
@@ -50,7 +50,7 @@ let byte_at v i =
 (* Every encoder path -- typ-level, compiled field, [Codec.set] -- writes a
    [uint ~size] through here, so the width check belongs here too. *)
 let write endian buf off size v =
-  Types.check_uint_var_encode ~size v;
+  UInt63.check_encode ~size v;
   let v = Optint.Int63.to_int64 v in
   match (endian : Types.endian) with
   | Big ->

--- a/lib/uint_var.ml
+++ b/lib/uint_var.ml
@@ -47,7 +47,10 @@ let read endian buf off size =
 let byte_at v i =
   Int64.to_int (Int64.logand (Int64.shift_right_logical v (8 * i)) 0xFFL)
 
+(* Every encoder path -- typ-level, compiled field, [Codec.set] -- writes a
+   [uint ~size] through here, so the width check belongs here too. *)
 let write endian buf off size v =
+  Types.check_uint_var_encode ~size v;
   let v = Optint.Int63.to_int64 v in
   match (endian : Types.endian) with
   | Big ->

--- a/lib/uint_var.mli
+++ b/lib/uint_var.mli
@@ -7,4 +7,7 @@ val read : Types.endian -> bytes -> int -> int -> UInt63.t
 (** [read endian buf off size] reads [size] bytes as an unsigned value. *)
 
 val write : Types.endian -> bytes -> int -> int -> UInt63.t -> unit
-(** [write endian buf off size v] writes [v] as [size] bytes. *)
+(** [write endian buf off size v] writes [v] as [size] bytes. Raises
+    [Invalid_argument] when [v] needs more than [size] bytes: truncating it
+    would leave a legal [size]-byte number on the wire that nothing downstream
+    can tell from the one the caller meant. *)

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -682,20 +682,36 @@ let check_byte_field_size size ~actual =
 let rec encode_into : type a. a typ -> a -> encoder -> unit =
  fun typ v enc ->
   match typ with
-  | Uint8 -> write_byte enc v
-  | Uint16 Little -> write_uint16_le enc v
-  | Uint16 Big -> write_uint16_be enc v
+  | Uint8 ->
+      Types.check_unsigned_encode ~bits:8 v;
+      write_byte enc v
+  | Uint16 Little ->
+      Types.check_unsigned_encode ~bits:16 v;
+      write_uint16_le enc v
+  | Uint16 Big ->
+      Types.check_unsigned_encode ~bits:16 v;
+      write_uint16_be enc v
   | Uint32 Little -> write_uint32_le enc v
   | Uint32 Big -> write_uint32_be enc v
   | Uint63 Little -> write_uint63_le enc v
   | Uint63 Big -> write_uint63_be enc v
   | Uint64 Little -> write_int64_le enc v
   | Uint64 Big -> write_int64_be enc v
-  | Int8 -> write_int8 enc v
-  | Int16 Little -> write_int16_le enc v
-  | Int16 Big -> write_int16_be enc v
-  | Int32 Little -> write_int32_le enc (Int32.of_int v)
-  | Int32 Big -> write_int32_be enc (Int32.of_int v)
+  | Int8 ->
+      Types.check_signed_encode ~bits:8 v;
+      write_int8 enc v
+  | Int16 Little ->
+      Types.check_signed_encode ~bits:16 v;
+      write_int16_le enc v
+  | Int16 Big ->
+      Types.check_signed_encode ~bits:16 v;
+      write_int16_be enc v
+  | Int32 Little ->
+      Types.check_signed_encode ~bits:32 v;
+      write_int32_le enc (Int32.of_int v)
+  | Int32 Big ->
+      Types.check_signed_encode ~bits:32 v;
+      write_int32_be enc (Int32.of_int v)
   | Int64 Little -> write_int64_le enc v
   | Int64 Big -> write_int64_be enc v
   | Float32 Little -> write_int32_le enc (Int32.bits_of_float v)
@@ -708,7 +724,7 @@ let rec encode_into : type a. a typ -> a -> encoder -> unit =
       Uint_var.write endian enc.o enc.o_next n v;
       enc.o_next <- enc.o_next + n
   | Bits { width; base; bit_order } -> (
-      Types.check_bits_encode ~width v;
+      Types.check_unsigned_encode ~bits:width v;
       let mask = (1 lsl width) - 1 in
       let total = Bitfield.total_bits base in
       let shift = Bitfield.shift ~bit_order ~total ~bits_used:0 ~width in
@@ -821,7 +837,7 @@ let to_writer typ v writer =
 (* Helpers extracted from [encode_direct] to keep the dispatch readable. *)
 
 let encode_bits buf off v width base bit_order =
-  Types.check_bits_encode ~width v;
+  Types.check_unsigned_encode ~bits:width v;
   let mask = (1 lsl width) - 1 in
   let total = Bitfield.total_bits base in
   let shift = Bitfield.shift ~bit_order ~total ~bits_used:0 ~width in
@@ -864,13 +880,13 @@ let rec encode_direct : type a. a typ -> bytes -> int -> a -> int =
  fun typ buf off v ->
   match typ with
   | Uint8 ->
-      Bytes.set_uint8 buf off v;
+      Types.set_uint8 buf off v;
       off + 1
   | Uint16 Little ->
-      Bytes.set_uint16_le buf off v;
+      Types.set_uint16_le buf off v;
       off + 2
   | Uint16 Big ->
-      Bytes.set_uint16_be buf off v;
+      Types.set_uint16_be buf off v;
       off + 2
   | Uint32 Little ->
       UInt32.set_le buf off v;

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -708,6 +708,7 @@ let rec encode_into : type a. a typ -> a -> encoder -> unit =
       Uint_var.write endian enc.o enc.o_next n v;
       enc.o_next <- enc.o_next + n
   | Bits { width; base; bit_order } -> (
+      Types.check_bits_encode ~width v;
       let mask = (1 lsl width) - 1 in
       let total = Bitfield.total_bits base in
       let shift = Bitfield.shift ~bit_order ~total ~bits_used:0 ~width in
@@ -820,6 +821,7 @@ let to_writer typ v writer =
 (* Helpers extracted from [encode_direct] to keep the dispatch readable. *)
 
 let encode_bits buf off v width base bit_order =
+  Types.check_bits_encode ~width v;
   let mask = (1 lsl width) - 1 in
   let total = Bitfield.total_bits base in
   let shift = Bitfield.shift ~bit_order ~total ~bits_used:0 ~width in

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -523,27 +523,46 @@ end
 
     In ordinary use, one starts from primitive integer or byte descriptions and
     combines them with {!bits}, {!array}, {!byte_slice}, {!where}, {!enum}, and
-    related combinators. *)
+    related combinators.
+
+    Every fixed-width integer accepts exactly the range its decoder produces:
+    [0] to [2^n - 1] for an unsigned width, [-2^(n-1)] to [2^(n-1) - 1] for a
+    signed one. Encoding anything else raises [Invalid_argument] rather than
+    dropping the bits that do not fit, on every entry point ({!to_string},
+    {!Codec.encode} and {!Codec.set} alike). OCaml carries the narrow widths in
+    a plain [int], which holds far more than the field does, so [uint8] given
+    [0x1FF] would otherwise put an [0xFF] on the wire that reads back as a
+    perfectly legal [255], with nothing left to say the caller meant something
+    else. *)
 
 val uint8 : int typ
-(** Unsigned 8-bit integer. *)
+(** Unsigned 8-bit integer. Encodes [0] to [255]. *)
 
 val uint16 : int typ
-(** Unsigned 16-bit little-endian integer. *)
+(** Unsigned 16-bit little-endian integer. Encodes [0] to [65535]. *)
 
 val uint16be : int typ
-(** Unsigned 16-bit big-endian integer. *)
+(** Unsigned 16-bit big-endian integer. Encodes [0] to [65535]. *)
 
 val uint32 : Optint.t typ
 (** Unsigned 32-bit little-endian integer. Decodes to an [Optint.t] so a value
-    with bit 31 set survives on a narrow-int target (js/wasm). *)
+    with bit 31 set survives on a narrow-int target (js/wasm).
+
+    On a 64-bit host that [Optint.t] is a native [int] wide enough to hold more
+    than 32 bits, so encoding checks the range and refuses a negative value
+    rather than reading it as its two's complement. Build a word with bit 31 set
+    from its bit pattern with [Wire.Private.UInt32.of_int32], not with
+    [Optint.of_int32], which keeps the signed view. *)
 
 val uint32be : Optint.t typ
 (** Unsigned 32-bit big-endian integer. Decodes to an [Optint.t]. *)
 
 val uint63 : Optint.Int63.t typ
 (** Unsigned 63-bit little-endian integer carried on 8 bytes. Decodes to an
-    [Optint.Int63.t]. *)
+    [Optint.Int63.t], whose range starts at zero, so encoding refuses a negative
+    value. The eight wire bytes hold more than the carrier does: the decoder
+    keeps the low bits, so the widest value that round-trips is
+    [Optint.Int63.max_int]. *)
 
 val uint63be : Optint.Int63.t typ
 (** Unsigned 63-bit big-endian integer carried on 8 bytes. Decodes to an
@@ -551,31 +570,36 @@ val uint63be : Optint.Int63.t typ
 
 val uint64 : int64 typ
 (** [uint64] is an unsigned 64-bit little-endian integer represented as an OCaml
-    64-bit integer. *)
+    64-bit integer. The representation is exactly the eight bytes written, so
+    every [int64] encodes and none is out of range. *)
 
 val uint64be : int64 typ
 (** [uint64be] is an unsigned 64-bit big-endian integer represented as an OCaml
     64-bit integer. *)
 
 val int8 : int typ
-(** Signed 8-bit two's-complement integer. *)
+(** Signed 8-bit two's-complement integer. Encodes [-128] to [127]: [200] is not
+    an [int8], even though its low byte is a legal one, and would come back from
+    the decoder as [-56]. *)
 
 val int16 : int typ
-(** Signed 16-bit little-endian integer. *)
+(** Signed 16-bit little-endian integer. Encodes [-32768] to [32767]. *)
 
 val int16be : int typ
-(** Signed 16-bit big-endian integer. *)
+(** Signed 16-bit big-endian integer. Encodes [-32768] to [32767]. *)
 
 val int32 : int typ
 (** [int32] is a signed 32-bit little-endian integer, returned as an OCaml
-    integer (64-bit hosts only: on a 32-bit host, the top bit may not fit). *)
+    integer (64-bit hosts only: on a 32-bit host, the top bit may not fit).
+    Encodes [-2^31] to [2^31 - 1]. *)
 
 val int32be : int typ
 (** [int32be] is a signed 32-bit big-endian integer, returned as an OCaml
     integer. *)
 
 val int64 : int64 typ
-(** Signed 64-bit little-endian integer. *)
+(** Signed 64-bit little-endian integer. Like {!uint64}, the representation is
+    exactly the eight bytes written, so no value is out of range. *)
 
 val int64be : int64 typ
 (** Signed 64-bit big-endian integer. *)

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -611,7 +611,10 @@ val uint : ?endian:endian -> int expr -> Optint.Int63.t typ
     order (default {!Big}). The size may be a dynamic expression for
     parameter-driven widths. Decodes to an [Optint.Int63.t]: a 7-byte value
     needs 56 bits, which does not fit an int on a narrow-int target (js/wasm).
-*)
+
+    Encoding a value that needs more than [size] bytes raises [Invalid_argument]
+    rather than dropping its high bytes: the truncated result is itself a legal
+    [size]-byte number, so nothing downstream could tell the two apart. *)
 
 val bits : ?bit_order:bit_order -> width:int -> bitfield -> int typ
 (** [bits ~width base] declares a bitfield of [width] bits inside [base].
@@ -619,7 +622,10 @@ val bits : ?bit_order:bit_order -> width:int -> bitfield -> int typ
     [~bit_order] selects which end of the base word the first declared bitfield
     occupies. It defaults to {!Msb_first}, which makes the DSL match how
     protocol specifications draw their bit diagrams. Pass [~bit_order:Lsb_first]
-    when mirroring MSVC-style C bit-fields. *)
+    when mirroring MSVC-style C bit-fields.
+
+    Encoding a value with bits above [width] raises [Invalid_argument] rather
+    than masking it, for the same reason as {!uint}. *)
 
 val map : decode:('w -> 'a) -> encode:('a -> 'w) -> 'w typ -> 'a typ
 (** [map ~decode ~encode t] views a wire value through conversion functions. *)

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -2348,7 +2348,7 @@ let test_encode_exact_uint_width () =
           let typ = uint ~endian (int n) in
           let codec, _ = uint_width_codec ~endian n in
           let label = Fmt.str "uint(%d,%s) <- 0x%X" n ename over in
-          let sub = Fmt.str "exceeds %d-byte uint field" n in
+          let sub = Fmt.str "does not fit an unsigned %d-byte field" n in
           let value = Wire.Private.UInt63.of_int over in
           expect_exact_width_error (label ^ " to_string") ~sub (fun () ->
               Wire.to_string typ value);
@@ -2378,7 +2378,7 @@ let test_set_exact_uint_width () =
           let buf = Bytes.make 8 '\x00' in
           let label = Fmt.str "set uint(%d,%s) <- 0x%X" n ename over in
           expect_exact_width_error label
-            ~sub:(Fmt.str "exceeds %d-byte uint field" n) (fun () ->
+            ~sub:(Fmt.str "does not fit an unsigned %d-byte field" n) (fun () ->
               set buf 0 (Wire.Private.UInt63.of_int over);
               Bytes.sub_string buf 0 n);
           Alcotest.(check string)
@@ -2430,7 +2430,7 @@ let test_encode_exact_bits_width () =
       let codec, _ = bits_width_codec ~bit_order ~width base in
       let over = 1 lsl width in
       let label = Fmt.str "bits(%d,%s,%s) <- 0x%X" width bname oname over in
-      let sub = Fmt.str "exceeds %d-bit field width" width in
+      let sub = Fmt.str "does not fit an unsigned %d-bit field" width in
       expect_exact_width_error (label ^ " to_bytes") ~sub (fun () ->
           Bytes.to_string (Wire.to_bytes typ over));
       expect_exact_width_error (label ^ " Codec.encode") ~sub (fun () ->
@@ -2458,7 +2458,7 @@ let test_set_exact_bits_width () =
       let buf = Bytes.make size '\x00' in
       let label = Fmt.str "set bits(%d,%s,%s) <- 0x%X" width bname oname over in
       expect_exact_width_error label
-        ~sub:(Fmt.str "exceeds %d-bit field width" width) (fun () ->
+        ~sub:(Fmt.str "does not fit an unsigned %d-bit field" width) (fun () ->
           set buf 0 over;
           Bytes.to_string buf);
       Alcotest.(check string)
@@ -2491,17 +2491,162 @@ let test_map_inherits_exact_width () =
   let codec = Codec.v "MapBits3" Fun.id Codec.[ cf ] in
   let set = Staged.unstage (Codec.set codec cf) in
   expect_exact_width_error "map(bits(3,U8)) to_string"
-    ~sub:"exceeds 3-bit field width" (fun () -> Wire.to_string typ 0xFF);
+    ~sub:"does not fit an unsigned 3-bit field" (fun () ->
+      Wire.to_string typ 0xFF);
   expect_exact_width_error "map(bits(3,U8)) Codec.encode"
-    ~sub:"exceeds 3-bit field width" (fun () ->
+    ~sub:"does not fit an unsigned 3-bit field" (fun () ->
       let buf = Bytes.make 1 '\x00' in
       Codec.encode codec 0xFF buf 0;
       Bytes.to_string buf);
   expect_exact_width_error "map(bits(3,U8)) Codec.set"
-    ~sub:"exceeds 3-bit field width" (fun () ->
+    ~sub:"does not fit an unsigned 3-bit field" (fun () ->
       let buf = Bytes.make 1 '\x00' in
       set buf 0 0xFF;
       Bytes.to_string buf)
+
+(* The fixed-width scalars are the same rule at a fixed width. OCaml carries the
+   narrow ones in a plain [int], which holds far more than the field does, so
+   nothing but a runtime check stands between a caller's 0x1FF and an 0xFF on
+   the wire that reads back as a perfectly legal 255. The signed ones accept
+   exactly what their decoder produces, [-2^(n-1) .. 2^(n-1) - 1]: 200 into an
+   [int8] is refused rather than round-tripped back as -56. *)
+let scalar_range_codec name typ =
+  let cf = Codec.(Field.v "v" typ $ Fun.id) in
+  (Codec.v name Fun.id Codec.[ cf ], cf)
+
+(* Sweep one scalar typ. Every [outside] value must be refused by all three
+   entry points and leave the buffer untouched; every [inside] one must write
+   the same bytes through both encoders and read back through [Codec.get]. *)
+let check_scalar_range ~name ~typ ~sub ~equal ~pp ~inside ~outside =
+  let codec, cf = scalar_range_codec name typ in
+  let size = Codec.wire_size codec in
+  let set = Staged.unstage (Codec.set codec cf) in
+  let get = Staged.unstage (Codec.get codec cf) in
+  List.iter
+    (fun v ->
+      let label = Fmt.str "%s <- %a" name pp v in
+      expect_exact_width_error (label ^ " to_string") ~sub (fun () ->
+          Wire.to_string typ v);
+      expect_exact_width_error (label ^ " Codec.encode") ~sub (fun () ->
+          let buf = Bytes.make size '\x00' in
+          Codec.encode codec v buf 0;
+          Bytes.to_string buf);
+      let buf = Bytes.make size '\x00' in
+      expect_exact_width_error (label ^ " Codec.set") ~sub (fun () ->
+          set buf 0 v;
+          Bytes.to_string buf);
+      Alcotest.(check string)
+        (label ^ ": rejected set left the buffer alone")
+        (String.make size '\x00') (Bytes.to_string buf))
+    outside;
+  List.iter
+    (fun v ->
+      let label = Fmt.str "%s <- %a" name pp v in
+      let buf = Bytes.make size '\x00' in
+      Codec.encode codec v buf 0;
+      Alcotest.(check string)
+        (label ^ ": widest legal value agrees across entry points")
+        (Wire.to_string typ v) (Bytes.to_string buf);
+      Bytes.fill buf 0 size '\x00';
+      set buf 0 v;
+      Alcotest.(check bool)
+        (label ^ ": widest legal value reads back")
+        true
+        (equal (get buf 0) v))
+    inside
+
+let test_encode_exact_unsigned_scalar () =
+  List.iter
+    (fun (name, bits, typ) ->
+      let widest = (1 lsl bits) - 1 in
+      check_scalar_range ~name ~typ
+        ~sub:(Fmt.str "does not fit an unsigned %d-bit field" bits)
+        ~equal:Int.equal ~pp:Fmt.int ~inside:[ 0; widest ]
+        ~outside:[ widest + 1; -1 ])
+    [ ("uint8", 8, uint8); ("uint16", 16, uint16); ("uint16be", 16, uint16be) ]
+
+let test_encode_exact_signed_scalar () =
+  List.iter
+    (fun (name, bits, typ) ->
+      if width_is_testable bits then
+        let limit = 1 lsl (bits - 1) in
+        check_scalar_range ~name ~typ
+          ~sub:(Fmt.str "does not fit a signed %d-bit field" bits)
+          ~equal:Int.equal ~pp:Fmt.int
+          ~inside:[ -limit; limit - 1 ]
+          ~outside:[ limit; -limit - 1 ])
+    [
+      ("int8", 8, int8);
+      ("int16", 16, int16);
+      ("int16be", 16, int16be);
+      ("int32", 32, int32);
+      ("int32be", 32, int32be);
+    ]
+
+(* [uint32] rides an [Optint.t], which is a plain [int] where that is wide
+   enough to hold more than 32 bits and a boxed [int32] where it is not. Only
+   the first can carry an out-of-range value, so the case exists only there. *)
+let test_encode_exact_uint32 () =
+  if width_is_testable 32 then
+    let mask = Wire.Private.UInt32.mask32 in
+    List.iter
+      (fun (name, typ) ->
+        check_scalar_range ~name ~typ
+          ~sub:"does not fit an unsigned 32-bit field" ~equal:Optint.equal
+          ~pp:Optint.pp
+          ~inside:[ Optint.zero; Optint.of_int mask ]
+          ~outside:[ Optint.of_int (mask + 1); Optint.of_int (-1) ])
+      [ ("uint32", uint32); ("uint32be", uint32be) ]
+
+(* [uint63] fills its carrier, so the only unrepresentable value left is a
+   negative one, and that one is unrepresentable on every target. *)
+let test_encode_exact_uint63 () =
+  List.iter
+    (fun (name, typ) ->
+      check_scalar_range ~name ~typ ~sub:"does not fit an unsigned 8-byte field"
+        ~equal:Optint.Int63.equal ~pp:Optint.Int63.pp
+        ~inside:[ Optint.Int63.zero; Optint.Int63.max_int ]
+        ~outside:[ Optint.Int63.of_int (-1); Optint.Int63.min_int ])
+    [ ("uint63", uint63); ("uint63be", uint63be) ]
+
+(* [array] and [repeat] elements are written by an encoder of their own, so a
+   value no element can hold has to be refused on that path too. *)
+let test_element_exact_width () =
+  let acf = Codec.(Field.v "vs" (array ~len:(int 3) uint8) $ Fun.id) in
+  let acodec = Codec.v "ArrayU8" Fun.id Codec.[ acf ] in
+  expect_exact_width_error "array(3,uint8) <- [0; 0x1FF; 0]"
+    ~sub:"does not fit an unsigned 8-bit field" (fun () ->
+      let buf = Bytes.make 3 '\x00' in
+      Codec.encode acodec [ 0; 0x1FF; 0 ] buf 0;
+      Bytes.to_string buf);
+  let rcf = Codec.(Field.repeat "vs" ~size:(int 3) uint8 $ Fun.id) in
+  let rcodec = Codec.v "RepeatU8" Fun.id Codec.[ rcf ] in
+  expect_exact_width_error "repeat(3,uint8) <- [0; 0x1FF; 0]"
+    ~sub:"does not fit an unsigned 8-bit field" (fun () ->
+      let buf = Bytes.make 3 '\x00' in
+      Codec.encode rcodec [ 0; 0x1FF; 0 ] buf 0;
+      Bytes.to_string buf)
+
+(* The other end of the rule: an [int64] is exactly the eight bytes written, so
+   no value of it is out of range and none may be refused. A guard here would be
+   dead code that only ever rejected a legal frame. *)
+let test_encode_int64_carrier_has_no_range () =
+  List.iter
+    (fun (name, typ) ->
+      List.iter
+        (fun v ->
+          let s = Wire.to_string typ v in
+          Alcotest.(check int) (name ^ ": eight bytes") 8 (String.length s);
+          Alcotest.(check int64)
+            (Fmt.str "%s <- %Ld round-trips" name v)
+            v (Wire.of_string_exn typ s))
+        Int64.[ min_int; -1L; zero; max_int ])
+    [
+      ("uint64", uint64);
+      ("uint64be", uint64be);
+      ("int64", int64);
+      ("int64be", int64be);
+    ]
 
 (* A reference-free constant size expression normalises to the literal form at
    construction, so every [Int n] fast path and range guard in the library sees
@@ -3912,7 +4057,9 @@ let test_raw_with_offset () =
   let codec = Codec.v "RawOff" (fun v -> v) [ cf_v ] in
   let buf = Bytes.create 20 in
   Bytes.fill buf 0 20 '\x00';
-  (Staged.unstage (Codec.set codec cf_v)) buf 10 (Optint.of_int32 0xDEADBEEFl);
+  (Staged.unstage (Codec.set codec cf_v))
+    buf 10
+    (Wire.Private.UInt32.of_int32 0xDEADBEEFl);
   Alcotest.(check int32)
     "get at offset 10" 0xDEADBEEFl
     (Optint.to_int32 ((Staged.unstage (Codec.get codec cf_v)) buf 10))
@@ -5785,7 +5932,7 @@ let test_tm_like_roundtrip () =
           ({ id = 0x0B; data = 0x000B } : packet);
           ({ id = 0x0C; data = 0x000C } : packet);
         ];
-      ocf = Some (Optint.of_int32 0xDEADBEEFl);
+      ocf = Some (Wire.Private.UInt32.of_int32 0xDEADBEEFl);
       fecf = Some 0xCAFE;
     }
   in
@@ -7504,6 +7651,16 @@ let suite =
         test_set_bits_no_silent_truncation;
       Alcotest.test_case "exact width: map reaches the inner typ" `Quick
         test_map_inherits_exact_width;
+      Alcotest.test_case "exact width: unsigned scalars" `Quick
+        test_encode_exact_unsigned_scalar;
+      Alcotest.test_case "exact width: signed scalars" `Quick
+        test_encode_exact_signed_scalar;
+      Alcotest.test_case "exact width: uint32" `Quick test_encode_exact_uint32;
+      Alcotest.test_case "exact width: uint63" `Quick test_encode_exact_uint63;
+      Alcotest.test_case "exact width: int64 carrier has no range" `Quick
+        test_encode_int64_carrier_has_no_range;
+      Alcotest.test_case "exact width: array and repeat elements" `Quick
+        test_element_exact_width;
       Alcotest.test_case "exact byte field: literal size" `Quick
         test_exact_byte_field_literal_size;
       Alcotest.test_case "exact byte field: expression size" `Quick

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -2302,6 +2302,207 @@ let test_set_exact_fixed_byte_array () =
     ~after:"XY\xff\xee\xee" ~oversized:"ABCD" ~exact:"XY"
     (Staged.unstage (Codec.set codec cf))
 
+(* A width-refined leaf -- [bits ~width], [uint ~size] -- is exact for a harsher
+   reason than a fixed-size byte field. A masked value is still a legal value at
+   that width, so decode, [validate] and the EverParse validator all accept it:
+   the number the caller meant is gone with nothing left to detect it. Every
+   entry point that can write one has to refuse instead. *)
+let expect_exact_width_error label ~sub f =
+  match f () with
+  | wrote ->
+      Alcotest.failf "%s: expected an exact-width error, wrote %S" label wrote
+  | exception Invalid_argument msg ->
+      Alcotest.(check bool)
+        (label ^ ": names the value and the width")
+        true (contains ~sub msg)
+
+let uint_width_codec ~endian n =
+  let cf = Codec.(Field.v "v" (uint ~endian (int n)) $ Fun.id) in
+  (Codec.v (Fmt.str "ExactUint%d" n) Fun.id Codec.[ cf ], cf)
+
+(* A hostile value needs one bit more than the field it overflows, so a width is
+   only testable where the host [int] holds that extra bit. [Sys.int_size] is 31
+   under wasm_of_ocaml, which drops the widest cases there. *)
+let width_is_testable bits = bits + 1 <= Sys.int_size - 1
+
+(* Each case is a declared size, the widest value it holds and a value it does
+   not: one byte holds 0xFF, and 0x1FF is the reported truncation. *)
+let uint_width_cases =
+  List.filter_map
+    (fun n ->
+      if width_is_testable (8 * n) then
+        let widest = (1 lsl (8 * n)) - 1 in
+        Some (n, widest, widest lor (widest + 1))
+      else None)
+    [ 1; 2; 3; 5; 7 ]
+
+let uint_endians = [ (Big, "be"); (Little, "le") ]
+
+(* 0x1FF through a 1-byte [uint] used to come out as 0xFF on both encode entry
+   points, and decode back as 255. *)
+let test_encode_exact_uint_width () =
+  List.iter
+    (fun (n, max_v, over) ->
+      List.iter
+        (fun (endian, ename) ->
+          let typ = uint ~endian (int n) in
+          let codec, _ = uint_width_codec ~endian n in
+          let label = Fmt.str "uint(%d,%s) <- 0x%X" n ename over in
+          let sub = Fmt.str "exceeds %d-byte uint field" n in
+          let value = Wire.Private.UInt63.of_int over in
+          expect_exact_width_error (label ^ " to_string") ~sub (fun () ->
+              Wire.to_string typ value);
+          expect_exact_width_error (label ^ " Codec.encode") ~sub (fun () ->
+              let buf = Bytes.make 8 '\x00' in
+              Codec.encode codec value buf 0;
+              Bytes.sub_string buf 0 n);
+          (* The widest value the field does hold still encodes, identically
+             through both entry points. *)
+          let widest = Wire.Private.UInt63.of_int max_v in
+          let buf = Bytes.make 8 '\x00' in
+          Codec.encode codec widest buf 0;
+          Alcotest.(check string)
+            (label ^ ": widest legal value agrees across entry points")
+            (Wire.to_string typ widest)
+            (Bytes.sub_string buf 0 n))
+        uint_endians)
+    uint_width_cases
+
+let test_set_exact_uint_width () =
+  List.iter
+    (fun (n, max_v, over) ->
+      List.iter
+        (fun (endian, ename) ->
+          let codec, cf = uint_width_codec ~endian n in
+          let set = Staged.unstage (Codec.set codec cf) in
+          let buf = Bytes.make 8 '\x00' in
+          let label = Fmt.str "set uint(%d,%s) <- 0x%X" n ename over in
+          expect_exact_width_error label
+            ~sub:(Fmt.str "exceeds %d-byte uint field" n) (fun () ->
+              set buf 0 (Wire.Private.UInt63.of_int over);
+              Bytes.sub_string buf 0 n);
+          Alcotest.(check string)
+            (label ^ ": rejected set left the buffer alone")
+            (String.make 8 '\x00') (Bytes.to_string buf);
+          let widest = Wire.Private.UInt63.of_int max_v in
+          set buf 0 widest;
+          Alcotest.(check string)
+            (label ^ ": widest legal value writes")
+            (String.make n '\xff') (Bytes.sub_string buf 0 n))
+        uint_endians)
+    uint_width_cases
+
+let bits_width_bases =
+  [
+    (U8, "U8", 8);
+    (U16, "U16", 16);
+    (U16be, "U16be", 16);
+    (U32, "U32", 32);
+    (U32be, "U32be", 32);
+  ]
+
+let bits_orders = [ (Msb_first, "Msb"); (Lsb_first, "Lsb") ]
+
+let bits_width_codec ~bit_order ~width base =
+  let cf = Codec.(Field.v "v" (bits ~bit_order ~width base) $ Fun.id) in
+  (Codec.v "ExactBits" Fun.id Codec.[ cf ], cf)
+
+let iter_bits_widths f =
+  List.iter
+    (fun (base, bname, total) ->
+      List.iter
+        (fun width ->
+          if width_is_testable width then
+            List.iter
+              (fun (bit_order, oname) ->
+                f ~base ~bname ~width ~bit_order ~oname)
+              bits_orders)
+        [ 1; 3; total ])
+    bits_width_bases
+
+(* [Wire.to_bytes (bits ~width:3 U8) 0x8] used to write 00 where [Codec.encode]
+   of the same value raised: the two encode entry points disagreed on a value
+   neither can represent. Swept over every base, bit order and boundary width so
+   they cannot drift apart again. *)
+let test_encode_exact_bits_width () =
+  iter_bits_widths (fun ~base ~bname ~width ~bit_order ~oname ->
+      let typ = bits ~bit_order ~width base in
+      let codec, _ = bits_width_codec ~bit_order ~width base in
+      let over = 1 lsl width in
+      let label = Fmt.str "bits(%d,%s,%s) <- 0x%X" width bname oname over in
+      let sub = Fmt.str "exceeds %d-bit field width" width in
+      expect_exact_width_error (label ^ " to_bytes") ~sub (fun () ->
+          Bytes.to_string (Wire.to_bytes typ over));
+      expect_exact_width_error (label ^ " Codec.encode") ~sub (fun () ->
+          let buf = Bytes.make 4 '\x00' in
+          Codec.encode codec over buf 0;
+          Bytes.to_string buf);
+      let widest = over - 1 in
+      let buf = Bytes.make (Codec.wire_size codec) '\x00' in
+      Codec.encode codec widest buf 0;
+      Alcotest.(check string)
+        (label ^ ": widest legal value agrees across entry points")
+        (Bytes.to_string (Wire.to_bytes typ widest))
+        (Bytes.to_string buf))
+
+(* The worst of the family: [Codec.set] wrote 0xFF into a 3-bit field as 7,
+   which [Codec.get] reads back and [validate] accepts, so no later check can
+   recover that the caller meant 255. *)
+let test_set_exact_bits_width () =
+  iter_bits_widths (fun ~base ~bname ~width ~bit_order ~oname ->
+      let codec, cf = bits_width_codec ~bit_order ~width base in
+      let size = Codec.wire_size codec in
+      let set = Staged.unstage (Codec.set codec cf) in
+      let get = Staged.unstage (Codec.get codec cf) in
+      let over = 1 lsl width in
+      let buf = Bytes.make size '\x00' in
+      let label = Fmt.str "set bits(%d,%s,%s) <- 0x%X" width bname oname over in
+      expect_exact_width_error label
+        ~sub:(Fmt.str "exceeds %d-bit field width" width) (fun () ->
+          set buf 0 over;
+          Bytes.to_string buf);
+      Alcotest.(check string)
+        (label ^ ": rejected set left the buffer alone")
+        (String.make size '\x00') (Bytes.to_string buf);
+      let widest = over - 1 in
+      set buf 0 widest;
+      Alcotest.(check int)
+        (label ^ ": widest legal value reads back")
+        widest (get buf 0))
+
+(* The concrete case from the bug report, pinned on its own: 0xFF into a 3-bit
+   field left a buffer of 0xE0 that read back as 7 and passed [validate]. *)
+let test_set_bits_no_silent_truncation () =
+  let cf = Codec.(Field.v "v" (bits ~width:3 U8) $ Fun.id) in
+  let codec = Codec.v "SetBits3" Fun.id Codec.[ cf ] in
+  let set = Staged.unstage (Codec.set codec cf) in
+  let buf = Bytes.make 1 '\x00' in
+  (match set buf 0 0xFF with
+  | () ->
+      Alcotest.failf "set bits(3,U8) <- 0xFF wrote %02x" (Bytes.get_uint8 buf 0)
+  | exception Invalid_argument _ -> ());
+  Alcotest.(check int) "buffer untouched" 0x00 (Bytes.get_uint8 buf 0)
+
+(* [map] adds no encode path of its own: it hands the mapped value to the inner
+   typ, so the width checks have to reach through it. *)
+let test_map_inherits_exact_width () =
+  let typ = map ~decode:Fun.id ~encode:Fun.id (bits ~width:3 U8) in
+  let cf = Codec.(Field.v "v" typ $ Fun.id) in
+  let codec = Codec.v "MapBits3" Fun.id Codec.[ cf ] in
+  let set = Staged.unstage (Codec.set codec cf) in
+  expect_exact_width_error "map(bits(3,U8)) to_string"
+    ~sub:"exceeds 3-bit field width" (fun () -> Wire.to_string typ 0xFF);
+  expect_exact_width_error "map(bits(3,U8)) Codec.encode"
+    ~sub:"exceeds 3-bit field width" (fun () ->
+      let buf = Bytes.make 1 '\x00' in
+      Codec.encode codec 0xFF buf 0;
+      Bytes.to_string buf);
+  expect_exact_width_error "map(bits(3,U8)) Codec.set"
+    ~sub:"exceeds 3-bit field width" (fun () ->
+      let buf = Bytes.make 1 '\x00' in
+      set buf 0 0xFF;
+      Bytes.to_string buf)
+
 (* A reference-free constant size expression normalises to the literal form at
    construction, so every [Int n] fast path and range guard in the library sees
    it. Sizes that must stay symbolic, and arithmetic the fold cannot do
@@ -7291,6 +7492,18 @@ let suite =
         test_packed_mapped_bf_size;
       Alcotest.test_case "fixed byte regions: size_of_value" `Quick
         test_fixed_byte_region_size_of_value;
+      Alcotest.test_case "exact width: uint encode" `Quick
+        test_encode_exact_uint_width;
+      Alcotest.test_case "exact width: uint set" `Quick
+        test_set_exact_uint_width;
+      Alcotest.test_case "exact width: bits encode" `Quick
+        test_encode_exact_bits_width;
+      Alcotest.test_case "exact width: bits set" `Quick
+        test_set_exact_bits_width;
+      Alcotest.test_case "exact width: set bits(3,U8) <- 0xFF" `Quick
+        test_set_bits_no_silent_truncation;
+      Alcotest.test_case "exact width: map reaches the inner typ" `Quick
+        test_map_inherits_exact_width;
       Alcotest.test_case "exact byte field: literal size" `Quick
         test_exact_byte_field_literal_size;
       Alcotest.test_case "exact byte field: expression size" `Quick

--- a/test/test_wire.ml
+++ b/test/test_wire.ml
@@ -1090,7 +1090,7 @@ let test_stream_uint16_chunk3 () =
   | Error e -> Alcotest.failf "uint16be chunk=3: %a" pp_parse_error e
 
 let test_stream_uint32_chunk1 () =
-  let encoded = to_string uint32 (Optint.of_int32 0xDEADBEEFl) in
+  let encoded = to_string uint32 (Wire.Private.UInt32.of_int32 0xDEADBEEFl) in
   match parse_chunked ~chunk_size:1 uint32 encoded with
   | Ok v ->
       Alcotest.(check int32) "uint32 chunk=1" 0xDEADBEEFl (Optint.to_int32 v)
@@ -1197,7 +1197,9 @@ let test_stream_bitfield_chunk1 () =
 (* Encode roundtrip through chunked writer *)
 let test_stream_encode_chunk1 () =
   let v = 0xDEADBEEFl in
-  let encoded = encode_chunked ~chunk_size:1 uint32be (Optint.of_int32 v) in
+  let encoded =
+    encode_chunked ~chunk_size:1 uint32be (Wire.Private.UInt32.of_int32 v)
+  in
   match of_string uint32be encoded with
   | Ok decoded ->
       Alcotest.(check int32) "encode chunk=1" v (Optint.to_int32 decoded)


### PR DESCRIPTION
Writing an integer a fixed-width field cannot hold truncated silently on every encode path: `uint8` given `0x1FF` put `ff` on the wire, which reads back as a legal `255`. Each width now raises `Invalid_argument` unless the value is one its own decoder produces, which is breaking for callers relying on the mask.