### PR TITLE
codec: bound-check the three remaining validate-path reads

### DIFF
--- a/fuzz/gen/fuzz_gen.ml
+++ b/fuzz/gen/fuzz_gen.ml
@@ -2149,6 +2149,64 @@ let optional_or_dynamic =
          Bytes.set_uint16_be buf 1 0xCAFE;
          ((0, 0xCAFE), buf)))
 
+(* Dynamic-gate optional at a *runtime* offset. [optional_dynamic] keeps its
+   gate and payload adjacent at static offsets, where the payload can never
+   land past the end of the buffer. Here a length-prefixed span sits between
+   them, so the payload's offset comes from the [len] byte, and the greedy
+   tail lets the record's span resolve to the whole buffer -- the record-level
+   bounds check passes and the optional's own read is the first thing that can
+   leave the buffer. That is the shape whose read has no [field_wire_size] to
+   bound-check it. *)
+let optional_dyn_after_span =
+  let f_gate = Wire.Field.v "gate" Wire.uint8 in
+  let f_len = Wire.Field.v "len" Wire.uint8 in
+  let codec =
+    Wire.Codec.v "_opt_dyn_span"
+      (fun gate _len span payload tail -> (gate, span, payload, tail))
+      Wire.Codec.
+        [
+          (f_gate $ fun (g, _, _, _) -> g);
+          (f_len $ fun (_, span, _, _) -> String.length span);
+          ( Wire.Field.v "span" (Wire.byte_array ~size:(Wire.Field.ref f_len))
+          $ fun (_, span, _, _) -> span );
+          ( Wire.Field.optional "payload" ~present:(gate_present f_gate)
+              Wire.uint16be
+          $ fun (_, _, payload, _) -> payload );
+          (Wire.Field.v "tail" Wire.all_zeros $ fun (_, _, _, tail) -> tail);
+        ]
+  in
+  let positive =
+    Alcobar.map
+      Alcobar.
+        [
+          Alcobar.bool;
+          Alcobar.uint16;
+          Alcobar.range ~min:0 8;
+          Alcobar.range ~min:0 4;
+        ]
+      (fun present v span_len tail_len ->
+        let value =
+          ( (if present then 1 else 0),
+            String.make span_len 'x',
+            (if present then Some v else None),
+            String.make tail_len '\x00' )
+        in
+        let sz = Wire.Codec.size_of_value codec value in
+        let buf = Bytes.create sz in
+        Wire.Codec.encode codec value buf 0;
+        (value, buf))
+  in
+  {
+    codec;
+    typ = Wire.codec codec;
+    positive;
+    random = bytes_any;
+    adversarial = bytes_any;
+    equal = ( = );
+    env = None;
+    adversarial_value = None;
+  }
+
 (* {1 Casetype} *)
 
 type 'a case =
@@ -2623,6 +2681,7 @@ let var_leaves : any list =
        value-driven (optional_or) payload. *)
     Any { g = optional_dynamic; size = None; label = "optdyn" };
     Any { g = optional_or_dynamic; size = None; label = "optordyn" };
+    Any { g = optional_dyn_after_span; size = None; label = "optdynspan" };
     Any { g = if_then_else; size = None; label = "ite" };
   ]
 
@@ -3666,6 +3725,7 @@ let wrapper_gens =
     ("optional_or(false)", Pack (optional_or ~present:false ~default:42 uint8));
     ("optional_dynamic", Pack optional_dynamic);
     ("optional_or_dynamic", Pack optional_or_dynamic);
+    ("optional_dyn_after_span", Pack optional_dyn_after_span);
     ("nested(0,empty)", Pack (nested 0 empty));
     ("nested(2,uint16be)", Pack (nested 2 uint16be));
     ("nested(4,byte_array4)", Pack (nested 4 (byte_array 4)));

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -2041,6 +2041,21 @@ let next_off_pos : next_off -> runtime -> bytes -> int -> int = function
   | Static n -> fun _runtime _buf base -> base + n
   | Dynamic f -> f
 
+(* [present_fn] plus the bounds check the field's read needs when the gate is
+   set. [read_guard] cannot install that check: it takes the extent from
+   [field_wire_size], which is [None] for a conditional optional precisely
+   because an absent one occupies nothing. A present one occupies exactly
+   [fsize] bytes, so gate the extent check on the same condition as the read:
+   an optional pushed past the end by an overlong predecessor then reports
+   end-of-input at its own span instead of crashing. *)
+let present_in_bounds ctx present_fn fsize =
+  let pos = next_off_pos ctx.next_off in
+  fun runtime buf base ->
+    let present = present_fn runtime buf base in
+    if present then
+      check_read_bounds buf ~at:(pos runtime buf base) ~width:fsize;
+    present
+
 let optional_compiled : type a r.
     layout_ctx ->
     ?int_reader:(runtime -> bytes -> int -> int) ->
@@ -2209,6 +2224,15 @@ let compile_repeat : type elt seq r.
     populate = no_populate;
   }
 
+(* The span [first, first + sz) must lie inside [buf]. Both ends derive from
+   length fields, i.e. untrusted input: a span sized past the buffer, or a
+   negative size from an overrun offset, would crash the read with a raw
+   [Invalid_argument] that escapes the decode result. Report the missing bytes
+   as end-of-input instead. *)
+let[@inline] check_span_bounds buf ~first ~sz =
+  if sz < 0 || first < 0 || first + sz > Bytes.length buf then
+    raise_eof ~at:first ~expected:(first + sz) ~got:(Bytes.length buf)
+
 (* Absolute index of the first NUL at or after [first], searching up to (but
    not including) [limit]. Raises [Parse_error] when the region ends before a
    terminator is found -- a truncated / unterminated zero-terminated string. *)
@@ -2224,10 +2248,6 @@ let var_bytes_reader : type a.
   let fo = off_fn runtime buf base in
   let sz = size_fn runtime buf base in
   let first = base + fo in
-  (* [fo] and [sz] derive from length fields, i.e. untrusted input. A field
-     sized past the buffer (or a negative size from an overrun offset) would
-     crash [Bytes.sub]; fail cleanly instead. [Byte_slice] is handled by
-     [make_or_eod]. *)
   (match typ with
   | Byte_slice _ ->
       (* A byte_slice reading at or past the end yields an eod slice (an oversize
@@ -2237,9 +2257,7 @@ let var_bytes_reader : type a.
          result. Fail cleanly instead. *)
       if sz < 0 || first < 0 then
         raise_eof ~at:first ~expected:(first + sz) ~got:(Bytes.length buf)
-  | _ ->
-      if sz < 0 || first < 0 || first + sz > Bytes.length buf then
-        raise_eof ~at:first ~expected:(first + sz) ~got:(Bytes.length buf));
+  | _ -> check_span_bounds buf ~first ~sz);
   match typ with
   | Byte_slice _ -> Slice.make_or_eod buf ~first:(base + fo) ~length:sz
   | Byte_array _ -> Bytes.sub_string buf (base + fo) sz
@@ -2410,7 +2428,12 @@ let compile_var_bytes : type a r.
          fun runtime buf base ->
           let fo = off_fn runtime buf base in
           let sz = size_fn runtime buf base in
-          Uint_var.read endian buf (base + fo) sz
+          let first = base + fo in
+          (* This branch bypasses [var_bytes_reader]; run the same span check it
+             would have run, so a [uint] sized past the end reports truncation
+             the way a [byte_array] does instead of crashing. *)
+          check_span_bounds buf ~first ~sz;
+          Uint_var.read endian buf first sz
         in
         let raw_writer : r -> runtime -> bytes -> int -> int -> int =
          fun v runtime buf base write_off ->
@@ -2613,13 +2636,13 @@ and compile_optional : type a r.
         ~size_delta:0 ~next_off:ctx.next_off ~populate:no_populate ()
   | _, Some fsize ->
       let present_fn = compile_bool_expr ctx.field_readers present in
+      let readable = present_in_bounds ctx present_fn fsize in
       let inner_reader, inner_writer = inner_codec_accessors inner ctx in
       let inner_populate = build_populate inner nfields inner_reader in
       let get = fld.get in
       optional_compiled ctx
         ~raw_reader:(fun runtime buf base ->
-          if present_fn runtime buf base then
-            Some (inner_reader runtime buf base)
+          if readable runtime buf base then Some (inner_reader runtime buf base)
           else None)
         ~raw_writer:(fun v runtime buf base write_off ->
           match (present_fn runtime buf base, get v) with
@@ -2629,8 +2652,7 @@ and compile_optional : type a r.
         ~size_delta:0
         ~next_off:(dynamic_optional_next_off ctx present_fn fsize)
         ~populate:(fun arr runtime buf base ->
-          if present_fn runtime buf base then
-            inner_populate arr runtime buf base)
+          if readable runtime buf base then inner_populate arr runtime buf base)
         ()
   | _ -> compile_optional_variable ctx fld present inner
 
@@ -2712,10 +2734,11 @@ and compile_optional_or : type a r.
         ~size_delta:0 ~next_off:ctx.next_off ~populate:no_populate ()
   | _, Some fsize ->
       let present_fn = compile_bool_expr ctx.field_readers present in
+      let readable = present_in_bounds ctx present_fn fsize in
       let inner_reader, inner_writer = inner_codec_accessors inner ctx in
       let get = fld.get in
       let raw_reader runtime buf base =
-        if present_fn runtime buf base then inner_reader runtime buf base
+        if readable runtime buf base then inner_reader runtime buf base
         else default
       in
       let populate = build_populate fld.typ ctx.n_fields raw_reader in
@@ -2859,9 +2882,11 @@ let wrap_field_errors ~validates ~check ~act name raw_reader full check_only =
    reports truncation as end-of-input at the span that was missing.
 
    Only accesses with a known extent get a guard. A variable-width field reads
-   through [var_bytes_reader], which bounds-checks itself, and a field whose
-   footprint differs from its wire size (an optional, a bitfield continuation)
-   is left alone: it may legitimately occupy no bytes. *)
+   through a span check of its own ([var_bytes_reader], or [check_span_bounds]
+   directly for a [uint] of computed width). A conditional optional has no
+   extent here -- [field_wire_size] is [None] for it, since an absent one
+   occupies nothing -- so it carries its own presence-gated check instead, in
+   [present_in_bounds]. *)
 let read_guard : type a r.
     (a, r) compiled_field -> a typ -> (runtime -> bytes -> int -> unit) option =
  fun cf typ ->
@@ -3777,21 +3802,8 @@ let build_field_checks acc ~populate ~validator_off ~name ~action ~constraint_ =
   in
   let check = Option.map (compile_bool_arr cc) constraint_ in
   let act = compile_action cc action in
-  let raise_check_failed arr base =
-    raise_field_constraint ~field_idx:acc.n_fields ~at:base arr
-  in
-  let full arr runtime buf base =
-    populate arr runtime buf base;
-    (match check with
-    | Some f when not (f arr) -> raise_check_failed arr base
-    | _ -> ());
-    Option.iter (fun f -> f arr) act
-  in
-  let check_only arr runtime buf base =
-    populate arr runtime buf base;
-    match check with
-    | Some f when not (f arr) -> raise_check_failed arr base
-    | _ -> ()
+  let check_only, full =
+    field_validators ~field_idx:acc.n_fields ~populate ~check ~act
   in
   (full, check_only, List.length action_vanames)
 
@@ -3844,7 +3856,8 @@ and apply_field_to_validator_acc acc (Types.Field f) =
       let layout = layout_ctx_of_validator_acc acc in
       let cf = compile_field layout codec_field in
       let full, check_only, n_extra_vars =
-        build_field_checks acc ~populate:cf.populate
+        build_field_checks acc
+          ~populate:(guarded_populate cf f.field_typ)
           ~validator_off:cf.validator_off ~name ~action:f.action
           ~constraint_:f.constraint_
       in

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -1005,6 +1005,160 @@ let test_validate_overrun_field_offset () =
   | exception Invalid_argument m ->
       Alcotest.failf "decode crashed instead of failing cleanly: %s" m
 
+(* Assert a *located* end-of-input: the failure kind, the extent the field was
+   missing, and the offset it was missing it at. Checking only the exception
+   class would also pass for a blanket [Invalid_argument -> Parse_error]
+   wrapper around validate, which reports a garbage location; the offset is
+   what shows a real per-field guard ran, at the field that overran. *)
+let check_located_eof name ~at ~expected ~got = function
+  | Ok () ->
+      Alcotest.failf "%s: accepted a record whose field runs off the end" name
+  | Error (e : parse_error) -> (
+      Alcotest.(check int) (name ^ ": offset of the failing field") at e.at;
+      match e.kind with
+      | Unexpected_eof { expected = ex; got = g } ->
+          Alcotest.(check int) (name ^ ": bytes the field needed") expected ex;
+          Alcotest.(check int) (name ^ ": bytes the buffer had there") got g
+      | k -> Alcotest.failf "%s: expected an eof, got %a" name pp_error_kind k)
+
+(* Run a validate-style call and shape its outcome for [check_located_eof]. A
+   raw [Invalid_argument] is the crash under test, so it fails here rather than
+   being folded into a parse error. *)
+let validating name f =
+  match f () with
+  | () -> Ok ()
+  | exception Wire.Parse_error e -> Error e
+  | exception Invalid_argument m ->
+      Alcotest.failf "%s: crashed instead of failing cleanly: %s" name m
+
+(* [Codec.validate_struct] runs the same populate-driven field pass as
+   [Codec.validate] and needs the same per-field bounds check. [Data] is sized
+   by [Len], so a [Len] of 200 in a 5-byte buffer puts [V] at offset 201: the
+   first byte read off the end. The trailing greedy [Z] keeps the struct's span
+   resolvable, so nothing rejects the record before [V]'s read. *)
+let validate_struct_overrun () =
+  let module T = Wire.Private.Types in
+  T.struct_ "Overrun"
+    [
+      T.field "Len" uint8;
+      T.field "Data" (byte_array ~size:(T.ref "Len"));
+      T.field "V" uint16be;
+      T.field "Z" all_zeros;
+    ]
+
+let validate_struct_overrun_input = "\xc8\x00\x00\x00\x00"
+
+let test_validate_struct_field_past_end () =
+  let module T = Wire.Private.Types in
+  let s = validate_struct_overrun () in
+  let v = Codec.validator_of_struct s in
+  let buf = Bytes.of_string validate_struct_overrun_input in
+  (* [V] wants 2 bytes at 201; the 5-byte buffer has none of them. *)
+  check_located_eof "validate_struct" ~at:201 ~expected:2 ~got:0
+    (validating "validate_struct" (fun () -> Codec.validate_struct v buf 0));
+  check_located_eof "of_string" ~at:201 ~expected:2 ~got:0
+    (validating "of_string" (fun () ->
+         match of_string (T.struct_typ s) validate_struct_overrun_input with
+         | Ok () -> ()
+         | Error e -> raise (Wire.Parse_error e)))
+
+(* Unlike [Codec.validate], [Codec.validate_struct] has no whole-record bounds
+   check in front of the field pass, so even a statically placed field can be
+   read off the end: [B] sits at offset 1 in a 1-byte buffer. The constraint is
+   what makes the validator populate [B] at all. *)
+let validate_struct_short () =
+  let module T = Wire.Private.Types in
+  T.struct_ "Short"
+    [
+      T.field "A" uint8;
+      T.field "B" uint16be ~constraint_:Expr.(T.ref "B" < int 1000);
+    ]
+
+let test_validate_struct_fixed_field_past_end () =
+  let v = Codec.validator_of_struct (validate_struct_short ()) in
+  (* [B] wants 2 bytes at 1; the 1-byte buffer has none of them. *)
+  check_located_eof "validate_struct" ~at:1 ~expected:2 ~got:0
+    (validating "validate_struct" (fun () ->
+         Codec.validate_struct v (Bytes.of_string "\x01") 0))
+
+(* An optional whose presence is a runtime expression has no wire size of its
+   own: an absent one occupies nothing. A present one occupies exactly the
+   inner's width, so its read needs the bounds check every other field's gets.
+   [data] is sized by [len], so a [len] of 200 in a 5-byte buffer puts [opt] at
+   offset 202, and [flag = 1] says it is there. The greedy [z] keeps the
+   record's span resolvable so the read is reached. *)
+let validate_optional_codec =
+  let f_flag = Field.v "flag" uint8 in
+  let f_len = Field.v "len" uint8 in
+  Codec.v "OptOverrun"
+    (fun flag len data opt z -> (flag, len, data, opt, z))
+    Codec.
+      [
+        (f_flag $ fun (flag, _, _, _, _) -> flag);
+        (f_len $ fun (_, len, _, _, _) -> len);
+        ( Field.v "data" (byte_array ~size:(Field.ref f_len))
+        $ fun (_, _, data, _, _) -> data );
+        ( Field.optional "opt" ~present:Expr.(Field.ref f_flag = int 1) uint16be
+        $ fun (_, _, _, opt, _) -> opt );
+        (Field.v "z" all_zeros $ fun (_, _, _, _, z) -> z);
+      ]
+
+let test_validate_present_optional_past_end () =
+  let buf = Bytes.of_string "\x01\xc8\x00\x00\x00" in
+  (* [opt] wants 2 bytes at 202; the 5-byte buffer has none of them. *)
+  check_located_eof "validate" ~at:202 ~expected:2 ~got:0
+    (validating "validate" (fun () ->
+         Codec.validate validate_optional_codec buf 0))
+
+(* [optional_or] gates its read on the same kind of runtime expression and has
+   the same hole. Same shape and same bytes as [validate_optional_codec]. *)
+let validate_optional_or_codec =
+  let f_flag = Field.v "flag" uint8 in
+  let f_len = Field.v "len" uint8 in
+  Codec.v "OptOrOverrun"
+    (fun flag len data opt z -> (flag, len, data, opt, z))
+    Codec.
+      [
+        (f_flag $ fun (flag, _, _, _, _) -> flag);
+        (f_len $ fun (_, len, _, _, _) -> len);
+        ( Field.v "data" (byte_array ~size:(Field.ref f_len))
+        $ fun (_, _, data, _, _) -> data );
+        ( Field.optional_or "opt"
+            ~present:Expr.(Field.ref f_flag = int 1)
+            ~default:0 uint16be
+        $ fun (_, _, _, opt, _) -> opt );
+        (Field.v "z" all_zeros $ fun (_, _, _, _, z) -> z);
+      ]
+
+let test_validate_present_optional_or_past_end () =
+  let buf = Bytes.of_string "\x01\xc8\x00\x00\x00" in
+  check_located_eof "validate" ~at:202 ~expected:2 ~got:0
+    (validating "validate" (fun () ->
+         Codec.validate validate_optional_or_codec buf 0))
+
+(* A [uint] of runtime width reads its bytes directly instead of through the
+   span reader every other variable-width field uses, so it needs that
+   reader's span check of its own. [len] is 7, so [v] claims bytes 1..8 of a
+   3-byte buffer. *)
+let validate_uint_var_codec =
+  let f_len = Field.v "len" uint8 in
+  Codec.v "UintOverrun"
+    (fun len v z -> (len, v, z))
+    Codec.
+      [
+        (f_len $ fun (len, _, _) -> len);
+        (Field.v "v" (uint (Field.int f_len)) $ fun (_, v, _) -> v);
+        (Field.v "z" all_zeros $ fun (_, _, z) -> z);
+      ]
+
+let test_validate_uint_var_past_end () =
+  let buf = Bytes.of_string "\x07\x00\x00" in
+  (* The span check reports the offset the buffer would have had to reach (8)
+     against the length it has (3), the way a truncated byte span does. *)
+  check_located_eof "validate" ~at:1 ~expected:8 ~got:3
+    (validating "validate" (fun () ->
+         Codec.validate validate_uint_var_codec buf 0))
+
 (* A byte_slice whose resolved size goes negative (here a [Sub] on an untrusted
    length field) must fail cleanly: [make_or_eod] would otherwise raise a raw
    [Invalid_argument] that escapes the decode result. A large variable field
@@ -7211,6 +7365,16 @@ let suite =
         test_byte_slice_negative_size;
       Alcotest.test_case "validate: field past end fails cleanly" `Quick
         test_validate_overrun_field_offset;
+      Alcotest.test_case "validate_struct: field past end fails cleanly" `Quick
+        test_validate_struct_field_past_end;
+      Alcotest.test_case "validate_struct: fixed field past a short buffer"
+        `Quick test_validate_struct_fixed_field_past_end;
+      Alcotest.test_case "validate: present optional past end fails cleanly"
+        `Quick test_validate_present_optional_past_end;
+      Alcotest.test_case "validate: present optional_or past end fails cleanly"
+        `Quick test_validate_present_optional_or_past_end;
+      Alcotest.test_case "validate: runtime-width uint past end fails cleanly"
+        `Quick test_validate_uint_var_past_end;
       Alcotest.test_case "repeat/array reject bitfield element" `Quick
         test_repeat_array_reject_bitfield;
       Alcotest.test_case "array/repeat reject zero-width element" `Quick


### PR DESCRIPTION
PR #271 wired its bounds guard into one of the four places `Codec.validate` reaches a field's bytes, so a struct field after an overlong span, a conditional `optional` or `optional_or`, and a `uint` of runtime width all still raised `Invalid_argument` where a parse error was due. Each now reports a located end-of-input, and the fuzz composer gains a shape that can generate the case at all.