### PR TITLE
codec: fix three public API contract violations

### DIFF
--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -105,6 +105,15 @@ let uint_var_field_encoder endian n buf off v =
   Uint_var.write endian buf off n v;
   off + n
 
+(* Name the field type for an "unsupported shape" refusal. [Types.pp_typ]
+   renders 3D syntax and asserts on a field decoration, which is the one shape
+   that actually reaches those refusals, so say what it is in prose instead. *)
+let field_shape : type a. a typ -> string = function
+  | Optional _ -> "an optional field behind a runtime gate"
+  | Optional_or _ -> "an optional_or field behind a runtime gate"
+  | Repeat _ -> "a repeat field"
+  | t -> Fmt.str "%a" pp_typ t
+
 let rec build_casetype_encoder_ctx : type a k.
     k typ ->
     (a, k) case_branch list ->
@@ -230,10 +239,21 @@ and build_field_encoder_ctx : type a.
   | Single_elem { size = Int n; elem; at_most } ->
       let enc = build_field_encoder_ctx elem in
       fun runtime -> single_elem_region ~at_most n elem (enc runtime)
-  | _ ->
-      (* Fallback for complex types - not specialized *)
-      fun _runtime _buf _off _v ->
-        failwith "build_field_encoder: unsupported type"
+  (* Mirror of the reader's statically gated optionals, so [Codec.set] can
+     write the field [Codec.get] can read. Presence is fixed at construction:
+     present writes the inner in place, absent writes nothing. An [optional]
+     handed [None] while its gate says present writes nothing either, which is
+     what the record encoder does with the same value. *)
+  | Optional { present = Bool true; inner } -> (
+      let enc = build_field_encoder_ctx inner in
+      let width = Option.value ~default:0 (field_wire_size inner) in
+      fun runtime buf off v ->
+        match v with Some iv -> enc runtime buf off iv | None -> off + width)
+  | Optional { present = Bool false; _ } -> fun _runtime _buf off _v -> off
+  | Optional_or { present = Bool true; inner; _ } ->
+      build_field_encoder_ctx inner
+  | Optional_or { present = Bool false; _ } -> fun _runtime _buf off _v -> off
+  | _ -> Fmt.invalid_arg "Codec.encode: no writer for %s" (field_shape typ)
 
 let build_field_encoder typ =
   let encode = build_field_encoder_ctx typ in
@@ -262,6 +282,14 @@ let enum_encode_check ~name ~cases ~closed =
   else
     let valid = Types.enum_values cases in
     fun v -> Types.check_enum_encode ~name ~valid v
+
+(* No reader exists for this shape. [Codec.get] is the only caller that can
+   reach it, since every field the record decoder reads has a case in the table
+   below, and [get] documents [Invalid_argument]. Refuse while the accessor is
+   being staged rather than let a [Failure] escape from inside it on every
+   read. *)
+let no_field_reader : type a b. a typ -> b =
+ fun typ -> Fmt.invalid_arg "Codec.get: no reader for %s" (field_shape typ)
 
 (** Build a direct field reader that reads at a fixed offset. No tuples, no refs
     \- just pure value read. Caller must ensure the buffer is large enough. *)
@@ -349,11 +377,22 @@ let rec build_field_reader_ctx : type a.
               acc := s.add !acc v
             done;
             s.finish !acc
-      | None ->
-          fun _runtime _buf _base ->
-            failwith "build_field_reader: unsupported type")
-  | _ ->
-      fun _runtime _buf _base -> failwith "build_field_reader: unsupported type"
+      | None -> no_field_reader typ)
+  (* A statically gated optional is transparent: present is the inner at the
+     same offset, absent is no bytes at all and the value is fixed. That is
+     what [compile_optional] / [compile_optional_or] read on the decode path,
+     so an accessor over the same field agrees with {!decode}. A runtime gate
+     is not readable here: deciding presence means evaluating an expression
+     over sibling fields, which only the compiled record plan holds. *)
+  | Optional { present = Bool true; inner } ->
+      let read = build_field_reader_ctx inner field_off in
+      fun runtime buf base -> Some (read runtime buf base)
+  | Optional { present = Bool false; _ } -> fun _runtime _buf _base -> None
+  | Optional_or { present = Bool true; inner; _ } ->
+      build_field_reader_ctx inner field_off
+  | Optional_or { present = Bool false; default; _ } ->
+      fun _runtime _buf _base -> default
+  | _ -> no_field_reader typ
 
 (* [eval_ctx] is necessary for parameter-dependent layouts, but routing every
    fixed scalar access through it costs an extra argument and a match per read.

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -3379,35 +3379,6 @@ let validate_with_bounds wire_size_info min_size param_slots param_base
   check_decode_bounds wire_size_info min_size runtime buf off;
   validate_checks ?env_slots buf off
 
-(* Whether a field consumes the rest of the buffer: a greedy leaf ([all_bytes] /
-   [all_zeros]), an embedded sub-codec whose own last field does, or a casetype
-   any of whose case bodies does (if that case is selected its greedy tail has no
-   boundary). A greedy tail has no boundary once another field follows it, so
-   each of these is just as unbounded as a bare greedy field. *)
-let rec field_consumes_rest : type a. a Types.typ -> bool =
- fun t ->
-  is_greedy t
-  ||
-  match t with
-  | Types.Codec { codec_struct; _ } -> (
-      match List.rev codec_struct.fields with
-      | Types.Field f :: _ -> field_consumes_rest f.field_typ
-      | [] -> false)
-  | Types.Casetype { cases; _ } ->
-      List.exists
-        (fun (Types.Case_branch { cb_inner; _ }) ->
-          field_consumes_rest cb_inner)
-        cases
-  | Types.Map { inner; _ } -> field_consumes_rest inner
-  | Types.Where { inner; _ } -> field_consumes_rest inner
-  | Types.Enum { base; _ } -> field_consumes_rest base
-  | Types.Optional { present = Types.Bool false; _ }
-  | Types.Optional_or { present = Types.Bool false; _ } ->
-      false
-  | Types.Optional { inner; _ } -> field_consumes_rest inner
-  | Types.Optional_or { inner; _ } -> field_consumes_rest inner
-  | _ -> false
-
 (* A greedy field consumes the rest of the buffer, so it is only meaningful as
    the last field: an earlier one starves every field after it (and 3D's
    [:consume-all] must be last too). This also covers an embedded sub-codec
@@ -3418,7 +3389,7 @@ let reject_greedy_not_last name fields =
   let rec check = function
     | [] | [ _ ] -> ()
     | Types.Field f :: rest ->
-        if field_consumes_rest f.field_typ then
+        if Types.ends_greedy f.field_typ then
           Fmt.invalid_arg
             "Codec.v %s: a field that consumes the rest of the buffer \
              (all_bytes / all_zeros, or a sub-codec ending in one) must be the \

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -4181,6 +4181,47 @@ let rec build_staged_reader : type a.
   | _, Variable _ | _, Variable_dynamic _ ->
       invalid_arg "Codec.get: unsupported variable-size field type"
 
+(* Every leaf encoder checks the value before it writes a byte, so it puts
+   down the whole field or nothing. A composite one writes part by part: a
+   sub-codec validates the record it has just laid down, a casetype writes its
+   tag ahead of its body, an array walks its elements one at a time. Any of
+   those can raise with bytes already in the buffer. *)
+let rec encoder_writes_before_checking : type a. a typ -> bool = function
+  | Codec _ | Casetype _ | Array _ | Repeat _ -> true
+  | Single_elem { elem; _ } -> encoder_writes_before_checking elem
+  | Map { inner; _ } -> encoder_writes_before_checking inner
+  | Where { inner; _ } -> encoder_writes_before_checking inner
+  | Enum { base; _ } -> encoder_writes_before_checking base
+  | Optional { inner; _ } -> encoder_writes_before_checking inner
+  | Optional_or { inner; _ } -> encoder_writes_before_checking inner
+  | Apply { typ; _ } -> encoder_writes_before_checking typ
+  | _ -> false
+
+(* [Codec.set] promises the buffer is untouched when it raises, so a writer
+   that can raise mid-field keeps a copy of the bytes it is about to replace
+   and puts them back. The width is the value-driven size the record encoder
+   budgets the same field with, clipped to what the buffer holds so a short
+   buffer still fails through the encoder's own message. *)
+let field_writer : type a. a typ -> Types.eval_ctx -> bytes -> int -> a -> unit
+    =
+ fun typ ->
+  let encode = build_field_encoder_ctx typ in
+  if not (encoder_writes_before_checking typ) then fun runtime buf off value ->
+    ignore (encode runtime buf off value : int)
+  else fun runtime buf off value ->
+    let room = Bytes.length buf - off in
+    let saved =
+      if off >= 0 && room > 0 then
+        Bytes.sub buf off (min (Types.size_of_typ_value typ value) room)
+      else Bytes.empty
+    in
+    match encode runtime buf off value with
+    | _ -> ()
+    | exception e ->
+        let n = Bytes.length saved in
+        if n > 0 then Bytes.blit saved 0 buf off n;
+        raise e
+
 (* Build a staged writer from field type and access info. *)
 let rec build_staged_writer : type a.
     a typ -> field_access -> runtime -> bytes -> int -> a -> unit =
@@ -4190,16 +4231,13 @@ let rec build_staged_writer : type a.
       let write = build_bf_accessor_writer base byte_off shift width in
       fun _runtime buf base value -> write buf base value
   | _, Fixed off ->
-      let encode = build_field_encoder_ctx typ in
-      fun runtime buf base value ->
-        let _ = encode runtime buf (base + off) value in
-        ()
+      let encode = field_writer typ in
+      fun runtime buf base value -> encode runtime buf (base + off) value
   | _, Dynamic fn ->
-      let encode = build_field_encoder_ctx typ in
+      let encode = field_writer typ in
       fun runtime buf base value ->
         let off = fn runtime buf base in
-        let _ = encode runtime buf (base + off) value in
-        ()
+        encode runtime buf (base + off) value
   (* A field whose size is only known at run time still owns exactly that many
      bytes: writing the value's length instead would overwrite the fields that
      follow. Check before blitting, with the same error [Codec.encode] gives. *)

--- a/lib/codec.mli
+++ b/lib/codec.mli
@@ -132,7 +132,12 @@ val encode : ?env:Param.env -> 'r t -> 'r -> bytes -> int -> unit
     non-zero byte, a [byte_array_where] byte failing its refinement, or a
     [where] clause or field [~constraint_] that does not hold for the values
     given. Encode never emits bytes its own decoder refuses. Field [~action]s
-    are not run by encode. *)
+    are not run by encode.
+
+    Encode is not all-or-nothing: it writes the record field by field and checks
+    the result, so after any of those raises the bytes from [off] on hold a
+    partial record and must be treated as scrap. Only the single-field {!set}
+    rolls its write back. *)
 
 val to_struct : 'r t -> Types.struct_
 (** Project to a {!Types.struct_} declaration. *)
@@ -161,10 +166,12 @@ val set : 'r t -> ('a, 'r) field -> (bytes -> int -> 'a -> unit) Staged.t
     Raises [Invalid_argument], leaving the buffer untouched, on a value the
     field cannot represent: a byte string whose length differs from the declared
     size, an integer outside the range of its width (fixed or [bits ~width] or
-    [uint ~size] alike), or a byte a [byte_array_where] refinement rejects. Each
+    [uint ~size] alike), a byte a [byte_array_where] refinement rejects, or a
+    sub-codec value its own [where] clause or field [~constraint_] rejects. Each
     of those would otherwise put different bytes on the wire than the caller
     asked for, and a masked integer is indistinguishable from a value meant that
-    way.
+    way. The buffer is restored even for a compound field the writer had to
+    part-write before the failure showed up.
 
     Does not check what the surrounding record permits -- record-level [~where]
     clauses, other fields' [~constraint_] checks, [enum] membership -- and does

--- a/lib/field.ml
+++ b/lib/field.ml
@@ -69,11 +69,10 @@ let optional_or name ?constraint_ ?self_constraint ?self_int64 ?action ~present
 
 (* A sub-codec ending in a greedy field ([all_bytes] / [all_zeros]) reads "the
    rest of the buffer" as its tail, so it cannot be iterated as a repeat element
-   (the first element would consume everything). *)
-let codec_ends_greedy (s : Types.struct_) =
-  match List.rev s.fields with
-  | Types.Field f :: _ -> Types.is_greedy f.field_typ
-  | [] -> false
+   (the first element would consume everything). A tail counts at any depth: a
+   sub-codec that ends with a sub-codec that ends greedy is just as unbounded
+   as one holding the greedy field itself. *)
+let codec_ends_greedy = Types.struct_ends_greedy
 
 (* Types decodable as a casetype case body inside a repeat: exactly the set
    [Codec.read_elem] handles. Unlike a bare repeat element, a lone [bits] field
@@ -140,7 +139,10 @@ let reject_unprojectable_repeat ~combinator typ =
     Fmt.invalid_arg
       "Wire.%s: element type does not project to 3D as a repeat element -- the \
        byte-budget loop only supports fixed-width scalars, byte spans of at \
-       least one byte, NUL-terminated strings, sub-codecs, and casetypes."
+       least one byte, NUL-terminated strings, and self-bounded sub-codecs and \
+       casetypes. A sub-codec is not self-bounded when its tail is an \
+       all_bytes / all_zeros field, its own or one it embeds: the first \
+       element would take the whole budget."
       combinator
 
 let repeat name ?constraint_ ?self_constraint ?self_int64 ?action ~size typ =

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -774,6 +774,37 @@ let reject_greedy_case_body t =
       "Wire.casetype: a case body cannot be a bare all_bytes / all_zeros \
        greedy field; it has no determinate type. Wrap it in a sub-codec."
 
+(* Whether a decoder for [t] runs to the end of the buffer: a greedy leaf, a
+   sub-codec whose own last field does, a casetype with such a case body (if
+   that case is selected its greedy tail has no boundary), or a gated optional
+   wrapping one. Each is as unbounded as a bare greedy field, so it is only
+   meaningful as the last thing in the buffer: nothing after it, and nothing
+   that iterates it. *)
+let rec ends_greedy : type a. a typ -> bool =
+ fun t ->
+  is_greedy t
+  ||
+  match t with
+  | Codec { codec_struct; _ } -> struct_ends_greedy codec_struct
+  | Casetype { cases; _ } ->
+      List.exists
+        (fun (Case_branch { cb_inner; _ }) -> ends_greedy cb_inner)
+        cases
+  | Map { inner; _ } -> ends_greedy inner
+  | Where { inner; _ } -> ends_greedy inner
+  | Enum { base; _ } -> ends_greedy base
+  | Optional { present = Bool false; _ }
+  | Optional_or { present = Bool false; _ } ->
+      false
+  | Optional { inner; _ } -> ends_greedy inner
+  | Optional_or { inner; _ } -> ends_greedy inner
+  | _ -> false
+
+and struct_ends_greedy (s : struct_) =
+  match List.rev s.fields with
+  | Field f :: _ -> ends_greedy f.field_typ
+  | [] -> false
+
 let array ~len elem =
   reject_decoration ~combinator:"array" elem;
   reject_bitfield_element ~combinator:"array" elem;

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -998,6 +998,15 @@ val is_greedy : 'a typ -> bool
     transparent wrappers). Such a field is only valid as the last field of a
     struct or codec. *)
 
+val ends_greedy : 'a typ -> bool
+(** Like {!is_greedy} but through composition: a sub-codec or casetype case
+    whose own tail is greedy reads to the end of the buffer just the same. Such
+    a type can only be the last thing in the buffer, so nothing may follow it
+    and no container may iterate it. *)
+
+val struct_ends_greedy : struct_ -> bool
+(** [struct_ends_greedy s] is {!ends_greedy} of [s]'s last field. *)
+
 val nz : 'a typ -> bool
 (** Whether the type's parser always consumes a positive minimum number of bytes
     (EverParse's [nz] parser-kind index). [false] for a byte span, a

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -7769,6 +7769,62 @@ let test_get_dynamic_optional_refuses_cleanly () =
     "Codec.get refuses a runtime-gated optional with Invalid_argument" true
     (raises_invalid (fun () -> Codec.get c cf_pay))
 
+(* A [repeat] element whose decoder runs to the end of the buffer cannot be
+   iterated: the first element takes the whole budget, so anything the encoder
+   writes past it is bytes the decoder (and the EverParse validator built from
+   the same schema) refuses. The greedy tail counts whether it is the element's
+   own last field or sits at the end of a sub-codec the element ends with. *)
+let test_repeat_rejects_nested_greedy_element () =
+  let pad =
+    Codec.v "PadTail"
+      (fun n tail -> (n, tail))
+      Codec.[ Field.v "n" uint8 $ fst; Field.v "tail" all_zeros $ snd ]
+  in
+  let greedy_elem =
+    Codec.v "GreedyElem"
+      (fun a b -> (a, b))
+      Codec.[ Field.v "f0" uint8 $ fst; Field.v "f1" (codec pad) $ snd ]
+  in
+  Alcotest.(check bool)
+    "repeat over a codec whose own tail is greedy rejected" true
+    (raises_invalid (fun () -> Field.repeat "items" ~size:(int 12) (codec pad)));
+  Alcotest.(check bool)
+    "repeat over a codec ending in a greedy sub-codec rejected" true
+    (raises_invalid (fun () ->
+         Field.repeat "items" ~size:(int 12) (codec greedy_elem)))
+
+(* The control for the rejection above: give the same element a bounded tail
+   and it is self-delimiting again, so the repeat builds and more than one
+   element survives the round trip. *)
+let test_repeat_bounded_element_roundtrips () =
+  let bounded =
+    Codec.v "PadFixed"
+      (fun n tail -> (n, tail))
+      Codec.
+        [
+          Field.v "n" uint8 $ fst;
+          Field.v "tail" (byte_array ~size:(int 2)) $ snd;
+        ]
+  in
+  let elem =
+    Codec.v "BoundedElem"
+      (fun a b -> (a, b))
+      Codec.[ Field.v "f0" uint8 $ fst; Field.v "f1" (codec bounded) $ snd ]
+  in
+  let f_total = Field.v "total" uint8 in
+  let f_items = Field.repeat "items" ~size:(Field.ref f_total) (codec elem) in
+  let outer =
+    Codec.v "BoundedRep"
+      (fun _ xs -> xs)
+      Codec.
+        [ (f_total $ fun xs -> 4 * List.length xs); (f_items $ fun xs -> xs) ]
+  in
+  let xs = [ (1, (2, "\000\000")); (3, (4, "\000\000")) ] in
+  let buf = Bytes.create (Codec.size_of_value outer xs) in
+  Codec.encode outer xs buf 0;
+  let ys = decode_ok (Codec.decode outer buf 0) in
+  Alcotest.(check bool) "two bounded elements round-trip" true (ys = xs)
+
 (* -- Suite -- *)
 
 let suite =
@@ -8391,4 +8447,8 @@ let suite =
       Alcotest.test_case
         "get: runtime-gated optional refused with Invalid_argument" `Quick
         test_get_dynamic_optional_refuses_cleanly;
+      Alcotest.test_case "repeat: element ending in a greedy sub-codec rejected"
+        `Quick test_repeat_rejects_nested_greedy_element;
+      Alcotest.test_case "repeat: bounded element round-trips" `Quick
+        test_repeat_bounded_element_roundtrips;
     ] )

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -7688,6 +7688,30 @@ let test_negative_span_is_parse_error () =
   expect "of_bytes typ"
     (of_bytes (byte_array ~size:(int (-1))) (Bytes.of_string "abc"))
 
+(* -- Accessor and container contracts -- *)
+
+(* [Codec.set] documents [Invalid_argument] "leaving the buffer untouched". A
+   sub-codec field writes the whole sub-record and validates it afterwards, so
+   the refusal used to arrive with the rejected byte already on the wire. *)
+let test_set_refusal_leaves_buffer_untouched () =
+  let inner_f =
+    Field.v "v" uint8 ~self_constraint:(fun r ->
+        Expr.(r >= int 10 && r <= int 100))
+  in
+  let inner = Codec.v "SetRollbackInner" Fun.id Codec.[ inner_f $ Fun.id ] in
+  let outer_f = Codec.(Field.v "v" (codec inner) $ Fun.id) in
+  let outer = Codec.v "SetRollbackOuter" Fun.id Codec.[ outer_f ] in
+  let set = Staged.unstage (Codec.set outer outer_f) in
+  let buf = Bytes.make 1 '\xee' in
+  (match set buf 0 200 with
+  | () -> Alcotest.fail "Codec.set accepted a value the sub-codec refuses"
+  | exception Invalid_argument _ -> ());
+  Alcotest.(check string)
+    "buffer untouched after a refused set" "\xee" (Bytes.to_string buf);
+  set buf 0 42;
+  Alcotest.(check string)
+    "an accepted set still writes" "\x2a" (Bytes.to_string buf)
+
 (* -- Suite -- *)
 
 let suite =
@@ -8302,4 +8326,7 @@ let suite =
         test_truncated_still_reports_eof;
       Alcotest.test_case "diag: negative span is a parse error" `Quick
         test_negative_span_is_parse_error;
+      (* accessor and container contracts *)
+      Alcotest.test_case "set: a refused sub-codec value writes nothing" `Quick
+        test_set_refusal_leaves_buffer_untouched;
     ] )

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -7712,6 +7712,63 @@ let test_set_refusal_leaves_buffer_untouched () =
   Alcotest.(check string)
     "an accepted set still writes" "\x2a" (Bytes.to_string buf)
 
+(* [Codec.get] had no reader for a statically gated optional and fell through
+   to a bare [Failure], on fields [Codec.decode] reads without trouble. Check
+   both flavours and both gates against what decode returns. *)
+let test_get_static_optional_agrees_with_decode () =
+  let f_len = Field.optional_or "Len" ~present:Expr.true_ ~default:0 uint8 in
+  let f_on = Field.optional "On" ~present:Expr.true_ uint8 in
+  let f_off = Field.optional "Off" ~present:Expr.false_ uint8 in
+  let f_or_off =
+    Field.optional_or "OrOff" ~present:Expr.false_ ~default:7 uint8
+  in
+  let f_data = Field.v "Data" (byte_array ~size:(Field.ref f_len)) in
+  let cf_len = Codec.(f_len $ fun (l, _, _, _, _) -> l) in
+  let cf_on = Codec.(f_on $ fun (_, o, _, _, _) -> o) in
+  let cf_off = Codec.(f_off $ fun (_, _, o, _, _) -> o) in
+  let cf_or_off = Codec.(f_or_off $ fun (_, _, _, o, _) -> o) in
+  let cf_data = Codec.(f_data $ fun (_, _, _, _, d) -> d) in
+  let c =
+    Codec.v "StaticGates"
+      (fun len on off or_off data -> (len, on, off, or_off, data))
+      [ cf_len; cf_on; cf_off; cf_or_off; cf_data ]
+  in
+  let buf = Bytes.of_string "\003\009abc" in
+  let len, on, off, or_off, _ = decode_ok (Codec.decode c buf 0) in
+  let read f = Staged.unstage (Codec.get c f) buf 0 in
+  Alcotest.(check int) "optional_or, gate on" len (read cf_len);
+  Alcotest.(check (option int)) "optional, gate on" on (read cf_on);
+  Alcotest.(check (option int)) "optional, gate off" off (read cf_off);
+  Alcotest.(check int)
+    "optional_or, gate off is the default" or_off (read cf_or_off);
+  Alcotest.(check string) "span sized by the optional_or" "abc" (read cf_data);
+  (* And the matching setter, so a field [get] can read is one [set] can
+     write. The absent gates own no bytes, so writing them moves nothing. *)
+  Staged.unstage (Codec.set c cf_on) buf 0 (Some 5);
+  Staged.unstage (Codec.set c cf_off) buf 0 None;
+  Staged.unstage (Codec.set c cf_or_off) buf 0 7;
+  Alcotest.(check (option int)) "set then get, gate on" (Some 5) (read cf_on);
+  Alcotest.(check string)
+    "the absent gates wrote no bytes" "\003\005abc" (Bytes.to_string buf)
+
+(* A runtime gate is decided by an expression over sibling fields, which only
+   the compiled record plan evaluates. The accessor cannot read it, and has to
+   say so with the exception the interface documents. *)
+let test_get_dynamic_optional_refuses_cleanly () =
+  let f_gate = Field.v "gate" uint8 in
+  let f_pay =
+    Field.optional "pay" ~present:Expr.(Field.ref f_gate <> int 0) uint16be
+  in
+  let cf_pay = Codec.(f_pay $ snd) in
+  let c =
+    Codec.v "DynGate"
+      (fun gate pay -> (gate, pay))
+      [ Codec.(f_gate $ fst); cf_pay ]
+  in
+  Alcotest.(check bool)
+    "Codec.get refuses a runtime-gated optional with Invalid_argument" true
+    (raises_invalid (fun () -> Codec.get c cf_pay))
+
 (* -- Suite -- *)
 
 let suite =
@@ -8329,4 +8386,9 @@ let suite =
       (* accessor and container contracts *)
       Alcotest.test_case "set: a refused sub-codec value writes nothing" `Quick
         test_set_refusal_leaves_buffer_untouched;
+      Alcotest.test_case "get: statically gated optionals agree with decode"
+        `Quick test_get_static_optional_agrees_with_decode;
+      Alcotest.test_case
+        "get: runtime-gated optional refused with Invalid_argument" `Quick
+        test_get_dynamic_optional_refuses_cleanly;
     ] )


### PR DESCRIPTION
Three public API contract violations the fuzz harness turned up, one commit each with a regression test that fails on the parent: Codec.set now rolls back a write it refuses, the staged accessors read and write statically gated optional fields instead of raising a bare Failure, and Field.repeat refuses an element whose greedy tail hides inside a sub-codec.