### PR TITLE
codec: count bytes, not buffer positions, in an end-of-input error

### DIFF
--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -12,6 +12,12 @@ let blit_slice_exact n buf off src =
   Bytes.blit (Slice.bytes src) (Slice.first src) buf off n;
   off + n
 
+(* Bytes of [buf] a read starting at [off] can have, which is what
+   {!Types.Unexpected_eof}'s [got] counts. A start before the buffer or past
+   its end has none of them; the count is never negative. *)
+let[@inline] bytes_from buf off =
+  if off < 0 || off > Bytes.length buf then 0 else Bytes.length buf - off
+
 (* A read of [width] bytes at [at] that must stay inside [buf]. Reads whose
    position was itself computed from the buffer can land past the end on
    truncated input; reporting the span here keeps the failure a precise
@@ -19,7 +25,7 @@ let blit_slice_exact n buf off src =
    caller cannot tell apart from a misuse or from a user [map] callback. *)
 let[@inline] check_read_bounds buf ~at ~width =
   if at < 0 || at + width > Bytes.length buf then
-    raise_eof ~at ~expected:width ~got:(max 0 (Bytes.length buf - at))
+    raise_eof ~at ~expected:width ~got:(bytes_from buf at)
 
 (* Reader for a byte span of constant width. A negative width comes from a size
    expression that underflows or names a negative literal, so it is data rather
@@ -2159,7 +2165,7 @@ let repeat_raw_fixed : type elt seq.
      buffer before reading so an oversized length fails cleanly instead of
      crashing [read_elem] with an out-of-range [Bytes.sub]. *)
   if budget < 0 || start + budget > Bytes.length buf then
-    raise_eof ~at:start ~expected:(start + budget) ~got:(Bytes.length buf);
+    raise_eof ~at:start ~expected:budget ~got:(bytes_from buf start);
   let remainder = if esz > 0 then budget mod esz else budget in
   if remainder <> 0 then
     raise_eof ~at:(start + budget - remainder) ~expected:esz ~got:remainder;
@@ -2185,7 +2191,7 @@ let repeat_raw_variable : type elt seq.
   let start = base + off_fn runtime buf base in
   (* Bound the untrusted budget to the buffer (see [repeat_raw_fixed]). *)
   if budget < 0 || start + budget > Bytes.length buf then
-    raise_eof ~at:start ~expected:(start + budget) ~got:(Bytes.length buf);
+    raise_eof ~at:start ~expected:budget ~got:(bytes_from buf start);
   let rec loop acc pos remaining =
     if remaining <= 0 then seq.finish acc
     else
@@ -2290,7 +2296,7 @@ let compile_repeat : type elt seq r.
    as end-of-input instead. *)
 let[@inline] check_span_bounds buf ~first ~sz =
   if sz < 0 || first < 0 || first + sz > Bytes.length buf then
-    raise_eof ~at:first ~expected:(first + sz) ~got:(Bytes.length buf)
+    raise_eof ~at:first ~expected:sz ~got:(bytes_from buf first)
 
 (* Absolute index of the first NUL at or after [first], searching up to (but
    not including) [limit]. Raises [Parse_error] when the region ends before a
@@ -2315,7 +2321,7 @@ let var_bytes_reader : type a.
          [make_or_eod] with a raw [Invalid_argument] that escapes the decode
          result. Fail cleanly instead. *)
       if sz < 0 || first < 0 then
-        raise_eof ~at:first ~expected:(first + sz) ~got:(Bytes.length buf)
+        raise_eof ~at:first ~expected:sz ~got:(bytes_from buf first)
   | _ -> check_span_bounds buf ~first ~sz);
   match typ with
   | Byte_slice _ -> Slice.make_or_eod buf ~first:(base + fo) ~length:sz
@@ -3386,7 +3392,7 @@ let fill_param_slots tbl param_base handles =
    before a zero-copy [get] reads its fields. *)
 let check_decode_bounds wire_size_info min_size runtime buf off =
   if off + min_size > Bytes.length buf then
-    raise_eof ~at:off ~expected:min_size ~got:(Bytes.length buf - off);
+    raise_eof ~at:off ~expected:min_size ~got:(bytes_from buf off);
   match wire_size_info with
   | Fixed _ -> ()
   | Variable { compute; _ } ->
@@ -3396,9 +3402,9 @@ let check_decode_bounds wire_size_info min_size runtime buf off =
          raise is a real error and propagates. *)
       let end_off = compute runtime buf off in
       if end_off < off + min_size then
-        raise_eof ~at:off ~expected:min_size ~got:(Bytes.length buf - off);
+        raise_eof ~at:off ~expected:min_size ~got:(bytes_from buf off);
       if end_off > Bytes.length buf then
-        raise_eof ~at:off ~expected:(end_off - off) ~got:(Bytes.length buf - off)
+        raise_eof ~at:off ~expected:(end_off - off) ~got:(bytes_from buf off)
 
 let build_checked_decode raw_decode wire_size_info min_size =
  fun runtime buf off ->

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -33,9 +33,12 @@ val eval_set_param : eval_ctx -> string -> int -> unit
 (** Which predicate a {!Constraint_failed} came from. *)
 type predicate = Where | Field | Action | Per_byte
 
-(** Parse failure categories. For {!constructor-Constraint_failed}, [value] is
-    the offending field's value for a single-field self-constraint and [None]
-    for a cross-field or where predicate. *)
+(** Parse failure categories. {!constructor-Unexpected_eof} counts bytes, not
+    buffer positions: [expected] is how many the value needed and [got] how many
+    were left where it starts, so both are the same whatever offset the frame is
+    read at. For {!constructor-Constraint_failed}, [value] is the offending
+    field's value for a single-field self-constraint and [None] for a
+    cross-field or where predicate. *)
 type error_kind =
   | Unexpected_eof of { expected : int; got : int }
   | Invalid_enum of { value : int; valid : int list }

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -134,8 +134,12 @@ end
 module Reader = Bytesrw.Bytes.Reader
 module Slice = Bytesrw.Bytes.Slice
 
-let[@inline] check_eof len need =
-  if need > len then raise_eof ~at:len ~expected:need ~got:len
+(* [n] bytes starting at [off] must fit inside the region ending at [limit].
+   {!Types.Unexpected_eof} counts bytes, not positions: the value needed [n] of
+   them and the region had only [limit - off] left. *)
+let[@inline] check_eof limit ~off ~n =
+  if off + n > limit then
+    raise_eof ~at:limit ~expected:n ~got:(max 0 (limit - off))
 
 (* A span of [n] bytes starting at [off]. [n] comes from a size expression, so
    an underflowing subtraction or a negative literal reaches here as data: a
@@ -143,7 +147,7 @@ let[@inline] check_eof len need =
    [Invalid_argument] that escapes [of_string]'s result. *)
 let[@inline] check_span len ~off ~n =
   if n < 0 then raise_out_of_range ~at:off (Int64.of_int n);
-  check_eof len (off + n)
+  check_eof len ~off ~n
 
 (* The single decoder kernel. Bytes-based, returns [(value, end_off)].
    All types handled here -- no fallback. Expressions are evaluated in
@@ -227,7 +231,7 @@ let parse_struct_typ s buf off len =
   ((), off + sz)
 
 let parse_fixed size get buf off len =
-  check_eof len (off + size);
+  check_eof len ~off ~n:size;
   (get buf off, off + size)
 
 let int32_le buf off = Int32.to_int (Bytes.get_int32_le buf off)
@@ -266,7 +270,7 @@ let rec parse_direct : type a. a typ -> bytes -> int -> int -> a * int =
       (Uint_var.read endian buf off n, off + n)
   | Bits { width; base; bit_order } ->
       let sz = Bitfield.byte_size base in
-      check_eof len (off + sz);
+      check_eof len ~off ~n:sz;
       let total = Bitfield.total_bits base in
       let shift = Bitfield.shift ~bit_order ~total ~bits_used:0 ~width in
       let mask = (1 lsl width) - 1 in
@@ -398,8 +402,8 @@ and parse_repeat_loop : type elt seq.
     seq * int =
  fun ~elem ~seq:(Seq_map s) buf off len ~budget ->
   let start = off in
-  if budget < 0 then raise_eof ~at:off ~expected:0 ~got:budget;
-  check_eof len (start + budget);
+  if budget < 0 then raise_eof ~at:off ~expected:budget ~got:(max 0 (len - off));
+  check_eof len ~off:start ~n:budget;
   let region_end = start + budget in
   let rec loop acc off' =
     if off' = region_end then (s.finish acc, off')

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -859,9 +859,12 @@ val size : 'a typ -> int option
 (** Which predicate a {!Constraint_failed} came from. *)
 type predicate = Where | Field | Action | Per_byte
 
-(** Parse failure categories. For {!constructor-Constraint_failed}, [value] is
-    the offending field's value for a single-field self-constraint and [None]
-    for a cross-field or where predicate. *)
+(** Parse failure categories. {!constructor-Unexpected_eof} counts bytes, not
+    buffer positions: [expected] is how many the value needed and [got] how many
+    were left where it starts, so both are the same whatever offset the frame is
+    read at. For {!constructor-Constraint_failed}, [value] is the offending
+    field's value for a single-field self-constraint and [None] for a
+    cross-field or where predicate. *)
 type error_kind =
   | Unexpected_eof of { expected : int; got : int }
   | Invalid_enum of { value : int; valid : int list }

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -1152,9 +1152,9 @@ let validate_uint_var_codec =
 
 let test_validate_uint_var_past_end () =
   let buf = Bytes.of_string "\x07\x00\x00" in
-  (* The span check reports the offset the buffer would have had to reach (8)
-     against the length it has (3), the way a truncated byte span does. *)
-  check_located_eof "validate" ~at:1 ~expected:8 ~got:3
+  (* The span check reports the 7 bytes the field asked for against the 2 the
+     buffer still had at offset 1, the way a truncated byte span does. *)
+  check_located_eof "validate" ~at:1 ~expected:7 ~got:2
     (validating "validate" (fun () ->
          Codec.validate validate_uint_var_codec buf 0))
 
@@ -1229,6 +1229,17 @@ let test_validate_repeat_partial_element () =
   in
   accepts "repeat" repeat_budget_codec;
   accepts "repeat_seq" repeat_seq_budget_codec
+
+(* The same truncation read at a nonzero base. [expected] and [got] are byte
+   counts, so they say the same thing wherever the frame sits; only [at] moves.
+   Reporting buffer positions instead made both of them grow with the base, and
+   made [got] equal [expected] on a failure that says the input ran out. *)
+let test_eof_counts_are_base_invariant () =
+  let pad = 8 in
+  let buf = Bytes.of_string (String.make pad '\xee' ^ "\x07\x00\x00") in
+  check_located_eof "validate at base 8" ~at:(pad + 1) ~expected:7 ~got:2
+    (validating "validate at base 8" (fun () ->
+         Codec.validate validate_uint_var_codec buf pad))
 
 (* A byte_slice whose resolved size goes negative (here a [Sub] on an untrusted
    length field) must fail cleanly: [make_or_eod] would otherwise raise a raw
@@ -8439,6 +8450,8 @@ let suite =
         test_truncated_still_reports_eof;
       Alcotest.test_case "diag: negative span is a parse error" `Quick
         test_negative_span_is_parse_error;
+      Alcotest.test_case "diag: eof counts do not move with the base" `Quick
+        test_eof_counts_are_base_invariant;
       (* accessor and container contracts *)
       Alcotest.test_case "set: a refused sub-codec value writes nothing" `Quick
         test_set_refusal_leaves_buffer_untouched;


### PR DESCRIPTION
Unexpected_eof carried absolute buffer positions in `expected` and `got`, so the numbers grew with the offset a frame was read at and an end-of-input error could report `expected = got`; they are byte counts now, as the doc always said.