### PR TITLE
codec: scan a span where it lies instead of copying it to check it

### DIFF
--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -42,9 +42,32 @@ let const_span_reader ~field_off n read =
    path that yields the span runs it, so [Codec.decode] and [Codec.validate]
    reject the same bytes as [Wire.of_string] and as the EverParse validator
    built from the same schema. *)
-let refined_span_reader ~elt_var ~cond buf ~first ~len =
+let refined_span_check ~elt_var ~cond buf ~first ~len =
   let bad = Eval.bad_byte ~elt_var ~cond buf ~first ~len in
-  if bad >= 0 then raise_constraint ~at:(first + bad) ~which:Per_byte ();
+  if bad >= 0 then raise_constraint ~at:(first + bad) ~which:Per_byte ()
+
+let refined_span_reader ~elt_var ~cond buf ~first ~len =
+  refined_span_check ~elt_var ~cond buf ~first ~len;
+  Bytes.sub_string buf first len
+
+(* Index of the first byte of [buf.[first .. first + len - 1]] that is not NUL,
+   or [-1] when the span is all zeros. Scans the buffer where it lies, so the
+   check costs nothing beyond the walk it has to do anyway. *)
+let all_zeros_bad_byte buf ~first ~len =
+  let limit = first + len in
+  let rec go i =
+    if i >= limit then -1
+    else if Bytes.get_uint8 buf i <> 0 then i
+    else go (i + 1)
+  in
+  go first
+
+let all_zeros_check buf ~first ~len =
+  let bad = all_zeros_bad_byte buf ~first ~len in
+  if bad >= 0 then raise_non_zero_padding ~at:bad
+
+let all_zeros_reader buf ~first ~len =
+  all_zeros_check buf ~first ~len;
   Bytes.sub_string buf first len
 
 (* A refinement decode enforces has to gate encode too, or the encoder emits
@@ -652,9 +675,12 @@ let rec build_populate : type a.
       fun _slots _runtime _buf _base -> ()
   | _ ->
       (* No int slot to populate, but the reader performs a real decode-side
-         check (all-zeros span, NUL terminator, refined span, embedded codec /
-         array element constraints), so run it for effect: [Codec.validate] then
-         rejects exactly what [decode] does. The value is discarded. *)
+         check (an embedded codec, an array or repeat element's constraints), so
+         run it for effect: [Codec.validate] then rejects exactly what [decode]
+         does. The value is discarded. Span types whose reader scans the payload
+         do not reach here: [span_populate] gives them the scan without the
+         copy, since what a validator drops on the floor must not be sized by
+         the sender. *)
       fun _slots runtime buf base -> ignore (reader runtime buf base)
 
 (* Bitfield extraction descriptor: word reader + packed shift/mask.
@@ -2335,13 +2361,7 @@ let var_bytes_reader : type a.
       let first = base + fo in
       let nul = zeroterm_nul_pos buf ~first ~limit:(first + sz) in
       Bytes.sub_string buf first (nul - first)
-  | All_zeros ->
-      let s = Bytes.sub_string buf (base + fo) sz in
-      String.iteri
-        (fun i c ->
-          if c <> '\000' then raise_non_zero_padding ~at:(base + fo + i))
-        s;
-      s
+  | All_zeros -> all_zeros_reader buf ~first:(base + fo) ~len:sz
   | Casetype _ -> read_elem typ runtime buf (base + fo)
   | Single_elem { elem; at_most; _ } ->
       let first = base + fo in
@@ -2350,6 +2370,53 @@ let var_bytes_reader : type a.
         raise_eof ~at:(first + min consumed sz) ~expected:sz ~got:consumed;
       read_elem elem runtime buf first
   | _ -> assert false
+
+(* The scan a span type's reader performs, without the string it hands back.
+   [Codec.validate] returns unit, so running the reader for its checks alone
+   turns over a copy of the span and drops it: allocation that scales with a
+   length the sender chose, on the path a server runs once per packet.
+   [None] for the spans whose reader only re-slices the buffer and has nothing
+   to scan. *)
+let span_check : type a. a typ -> (bytes -> first:int -> len:int -> unit) option
+    = function
+  | Byte_array_where { elt_var; cond; _ } ->
+      Some
+        (fun buf ~first ~len ->
+          check_span_bounds buf ~first ~sz:len;
+          refined_span_check ~elt_var ~cond buf ~first ~len)
+  | All_zeros ->
+      Some
+        (fun buf ~first ~len ->
+          check_span_bounds buf ~first ~sz:len;
+          all_zeros_check buf ~first ~len)
+  | Zeroterm_at_most _ ->
+      Some
+        (fun buf ~first ~len ->
+          check_span_bounds buf ~first ~sz:len;
+          ignore (zeroterm_nul_pos buf ~first ~limit:(first + len) : int))
+  | Zeroterm ->
+      (* The terminator search is the size computation, so [len] could not have
+         been reached without it. Only the span itself is left to check. *)
+      Some (fun buf ~first ~len -> check_span_bounds buf ~first ~sz:len)
+  | _ -> None
+
+(* Populate for a span field: the reader's checks, none of its copying, and no
+   slot to fill (a span has no int slot). [None] leaves the field to the
+   generic [build_populate]. *)
+let span_populate : type a.
+    a typ ->
+    off_fn:(runtime -> bytes -> int -> int) ->
+    size_fn:(runtime -> bytes -> int -> int) ->
+    (slots -> runtime -> bytes -> int -> unit) option =
+ fun typ ~off_fn ~size_fn ->
+  match span_check typ with
+  | None -> None
+  | Some check ->
+      Some
+        (fun _slots runtime buf base ->
+          check buf
+            ~first:(base + off_fn runtime buf base)
+            ~len:(size_fn runtime buf base))
 
 (* Kept at top level: as local closures they would be heap-allocated on
    every call (two allocations per variable-bytes field on each encode). *)
@@ -2518,7 +2585,11 @@ let compile_var_bytes : type a r.
         in
         (raw_reader, raw_writer, int_reader)
   in
-  let populate = build_populate typ ctx.n_fields raw_reader in
+  let populate =
+    match span_populate typ ~off_fn ~size_fn with
+    | Some p -> p
+    | None -> build_populate typ ctx.n_fields raw_reader
+  in
   {
     raw_reader;
     raw_writer;
@@ -2565,7 +2636,19 @@ let compile_scalar_or_var : type a r.
       let int_reader runtime buf base =
         int_of_typ_value typ (raw_reader runtime buf base)
       in
-      let populate = build_populate typ ctx.n_fields raw_reader in
+      let populate =
+        (* A negative literal width never reaches a scan: the reader refuses it
+           on sight ([const_span_reader]) and allocates nothing doing so, and
+           validate has to refuse it the same way decode does. *)
+        match
+          if fsize < 0 then None
+          else
+            span_populate typ ~off_fn:field_off_fn
+              ~size_fn:(fun _runtime _buf _base -> fsize)
+        with
+        | Some p -> p
+        | None -> build_populate typ ctx.n_fields raw_reader
+      in
       {
         raw_reader;
         raw_writer;

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -7681,6 +7681,39 @@ let test_truncated_still_reports_eof () =
     (Codec.decode two_span_codec (Bytes.of_string "\010X") 0);
   expect_eof "of_string two-span" (of_string (codec two_span_codec) "\010X")
 
+(* [Codec.validate] scans a refined span where it lies rather than copying it,
+   so the scan has to refuse everything the reader refuses. A literal width
+   below zero is refused before any scan, and by the reader, so both entry
+   points have to name the same fault: a validate that reported end-of-input
+   here while decode reported the negative width would be a validator that
+   rejects for a different reason than the decoder it stands in for. *)
+let test_negative_span_width_agrees () =
+  let c =
+    Codec.v "NegWidth" Fun.id
+      Codec.
+        [
+          Field.v "d"
+            (byte_array_where ~size:(int (-1)) ~per_byte:printable_byte)
+          $ Fun.id;
+        ]
+  in
+  let buf = Bytes.make 8 'a' in
+  let kind f =
+    match f () with
+    | () -> Alcotest.failf "accepted a span of width -1"
+    | exception Wire.Parse_error e -> Fmt.str "%a" pp_error_kind e.kind
+  in
+  let validated = kind (fun () -> Codec.validate c buf 0) in
+  let decoded =
+    kind (fun () ->
+        match Codec.decode c buf 0 with
+        | Ok _ -> ()
+        | Error e -> raise (Wire.Parse_error e))
+  in
+  Alcotest.(check string)
+    "validate rejects a negative span width for decode's reason" decoded
+    validated
+
 let test_negative_span_is_parse_error () =
   let neg_codec =
     Codec.v "NegSpan" Fun.id
@@ -8452,6 +8485,8 @@ let suite =
         test_negative_span_is_parse_error;
       Alcotest.test_case "diag: eof counts do not move with the base" `Quick
         test_eof_counts_are_base_invariant;
+      Alcotest.test_case "diag: negative span width agrees with decode" `Quick
+        test_negative_span_width_agrees;
       (* accessor and container contracts *)
       Alcotest.test_case "set: a refused sub-codec value writes nothing" `Quick
         test_set_refusal_leaves_buffer_untouched;

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -7609,6 +7609,118 @@ let test_set_no_allocation () =
   check_no_per_call_allocation "set int32be" (fun () -> set_i32 buf 0 70_000);
   check_no_per_call_allocation "set map" (fun () -> set_priority buf 0 High)
 
+(* {2 Resource bounds}
+
+   Allocation is the deterministic half of cost: the same work turns over the
+   same number of words on any machine, where wall-clock does not. The two
+   tests below are not performance targets. They assert a shape -- how much
+   memory a read path churns must not be a function of a length the sender
+   picked -- on the entry points [codec.mli] tells a caller to run per packet
+   on untrusted input.
+
+   [Gc.minor_words] cannot measure it: it does not count blocks over
+   [Max_young_wosize] (256 words), so a version written with it silently
+   measures nothing once the payload passes 2 KiB. *)
+let words_per_call ~iters f =
+  ignore (Sys.opaque_identity (f ()));
+  Gc.full_major ();
+  let before = Gc.allocated_bytes () in
+  for _ = 1 to iters do
+    ignore (Sys.opaque_identity (f ()))
+  done;
+  let after = Gc.allocated_bytes () in
+  int_of_float (Float.round ((after -. before) /. float_of_int iters /. 8.))
+
+(* Length-parameterised span codecs, each with a buffer it accepts. All five
+   hand the caller one string of about [n] bytes, so they are comparable to
+   each other and to the payload; [byte_array] and [all_bytes] are the
+   unrefined twins of the three that check something as they go. *)
+let span_family name typ =
+  Codec.v name Fun.id Codec.[ Field.v "d" typ $ Fun.id ]
+
+let span_families =
+  [
+    ( "byte_array",
+      (fun n -> span_family "SpanArray" (byte_array ~size:(int n))),
+      fun n -> Bytes.make n 'a' );
+    ( "byte_array_where",
+      (fun n ->
+        span_family "SpanWhere"
+          (byte_array_where ~size:(int n) ~per_byte:printable_byte)),
+      fun n -> Bytes.make n 'a' );
+    ( "zeroterm_at_most",
+      (fun n -> span_family "SpanZeroterm" (zeroterm_at_most ~size:(int n))),
+      fun n ->
+        let b = Bytes.make n 'a' in
+        Bytes.set b (n - 1) '\000';
+        b );
+    ( "all_bytes",
+      (fun _ -> span_family "SpanAll" all_bytes),
+      fun n -> Bytes.make n 'a' );
+    ( "all_zeros",
+      (fun _ -> span_family "SpanZeros" all_zeros),
+      fun n -> Bytes.make n '\000' );
+  ]
+
+let report_span_failures what failures =
+  if failures <> [] then
+    Alcotest.failf "%s: %s" what (String.concat "; " (List.rev failures))
+
+(* [Codec.validate] returns unit, so everything it allocates it drops on the
+   floor. What it turns over must therefore not depend on how long the sender
+   made the frame. The two runs compared differ in nothing but a number the
+   sender chose, which is what makes the growth between them attributable. A
+   validator that copies the span it is scanning gives an attacker a heap
+   multiplier on a path a server runs once per packet. *)
+let test_validate_allocation_is_bounded () =
+  skip_unless_gc_counters ();
+  let small = 512 and large = 4096 in
+  let failures =
+    List.fold_left
+      (fun acc (name, mk, mkbuf) ->
+        let words n =
+          let c = mk n and buf = mkbuf n in
+          words_per_call ~iters:2000 (fun () -> Codec.validate c buf 0)
+        in
+        let at_small = words small and at_large = words large in
+        if at_large - at_small > 32 then
+          Fmt.str
+            "%s grows %d words between a %d-byte and a %d-byte frame (%d then \
+             %d)"
+            name (at_large - at_small) small large at_small at_large
+          :: acc
+        else acc)
+      [] span_families
+  in
+  report_span_failures "validate allocation scales with the frame length"
+    failures
+
+(* [Codec.decode] hands the span back, so one copy of it is the price of the
+   answer. A second copy is work the caller never sees and the sender sizes.
+   The bound is against the payload the returned value carries, not against
+   another run of the same decoder: a decoder measured against itself would
+   agree with any amount of copying. *)
+let test_decode_allocates_one_copy () =
+  skip_unless_gc_counters ();
+  let n = 4096 in
+  let payload = n / 8 in
+  let failures =
+    List.fold_left
+      (fun acc (name, mk, mkbuf) ->
+        let c = mk n and buf = mkbuf n in
+        let words =
+          words_per_call ~iters:2000 (fun () -> Codec.decode c buf 0)
+        in
+        if words > payload + 32 then
+          Fmt.str "%s allocates %d words for a %d-word payload" name words
+            payload
+          :: acc
+        else acc)
+      [] span_families
+  in
+  report_span_failures "decode allocates more than the value it returns"
+    failures
+
 (* Decode diagnostics: end of input is reported only for a read that actually
    ran off the end of the buffer. A misuse in a size expression keeps its own
    error, and a byte span the data sizes below zero stays inside the result
@@ -8476,6 +8588,10 @@ let suite =
         test_get_no_allocation;
       Alcotest.test_case "set: immediate fields allocate nothing" `Quick
         test_set_no_allocation;
+      Alcotest.test_case "validate: allocation does not scale with the frame"
+        `Quick test_validate_allocation_is_bounded;
+      Alcotest.test_case "decode: allocates at most one copy of the span" `Quick
+        test_decode_allocates_one_copy;
       (* decode diagnostics *)
       Alcotest.test_case "diag: field_pos in a size expression reports itself"
         `Quick test_size_misuse_reports_itself;


### PR DESCRIPTION
Codec.validate built and dropped a copy of every refined, zero-terminated or all-zero span it checked, so what it allocated scaled with a length the sender chose; the scans now run over the buffer in place, and the bound that catches it, that neither validate nor decode allocates in proportion to a length the sender picked, lands here instead of four PRs ahead of the fix.
