### PR TITLE
codec: check a bitfield accessor's word is in the buffer

### DIFF
--- a/lib/bitfield.ml
+++ b/lib/bitfield.ml
@@ -12,6 +12,17 @@ let equal a b =
   | U32 e1, U32 e2 -> Types.equal_endian e1 e2
   | _ -> false
 
+(* The word helpers below reach their bytes with [Bytes.unsafe_get] and write a
+   u32 as two halves, so a caller whose offset is not already known to be in
+   the buffer checks the whole span with this first: the decoders have checked
+   the frame's extent before they read a word, but [Codec.get], [Codec.set] and
+   [Codec.load_word] take their offset from the application. Raises what
+   [Bytes.get_uint8] raises, so a bitfield accessor refuses a short buffer the
+   same way whatever its base. *)
+let[@inline always] check_word buf off n =
+  if off < 0 || off > Bytes.length buf - n then
+    invalid_arg "index out of bounds"
+
 (* Fast word reads -- avoid Bytes.get_int32_be which goes through Int32
    boxing/unboxing and byte-by-byte assembly on ARM64. *)
 let[@inline always] u16_le buf off =

--- a/lib/bitfield.mli
+++ b/lib/bitfield.mli
@@ -10,20 +10,27 @@ val total_bits : Types.bitfield_base -> int
 val equal : Types.bitfield_base -> Types.bitfield_base -> bool
 (** Check if two bitfield bases are the same type and endianness. *)
 
+val check_word : bytes -> int -> int -> unit
+(** [check_word buf off n] raises [Invalid_argument] unless the [n] bytes at
+    [off] are inside [buf]. The word readers and writers below reach their bytes
+    unchecked, so a caller whose offset came from outside the library -- the
+    field accessors, whose offset is the application's -- checks the span with
+    this before it reads a byte it does not own or writes half a word. *)
+
 val read_word : Types.bitfield_base -> bytes -> int -> int
-(** Read the base word from bytes at offset. *)
+(** Read the base word from bytes at offset. Unchecked: see {!check_word}. *)
 
 val u16_le : bytes -> int -> int
-(** Inline little-endian 16-bit word read. *)
+(** Inline little-endian 16-bit word read. Unchecked: see {!check_word}. *)
 
 val u16_be : bytes -> int -> int
-(** Inline big-endian 16-bit word read. *)
+(** Inline big-endian 16-bit word read. Unchecked: see {!check_word}. *)
 
 val u32_le : bytes -> int -> int
-(** Inline little-endian 32-bit word read. *)
+(** Inline little-endian 32-bit word read. Unchecked: see {!check_word}. *)
 
 val u32_be : bytes -> int -> int
-(** Inline big-endian 32-bit word read. *)
+(** Inline big-endian 32-bit word read. Unchecked: see {!check_word}. *)
 
 val set_u32_le : bytes -> int -> int -> unit
 (** Inline little-endian 32-bit word write of a native-[int] bitfield word. *)

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -1317,7 +1317,10 @@ let equal_bit_order (a : Types.bit_order) (b : Types.bit_order) =
   | Msb_first, Lsb_first | Lsb_first, Msb_first -> false
 
 (* Build-time dispatch: pattern match on base happens once at codec
-   construction, not on every read/write call. *)
+   construction, not on every read/write call. The word reads are unchecked
+   past the [U8]/[U16] primitives' own bounds check, so the caller has to know
+   the word is in the buffer: the decoders have checked their frame's extent,
+   and the field accessors go through {!build_bf_accessor_reader}. *)
 let build_bf_reader base byte_off shift width =
   let mask = (1 lsl width) - 1 in
   match base with
@@ -1337,6 +1340,18 @@ let build_bf_reader base byte_off shift width =
       fun buf off -> (Bitfield.u32_le buf (off + byte_off) lsr shift) land mask
   | U32 Big ->
       fun buf off -> (Bitfield.u32_be buf (off + byte_off) lsr shift) land mask
+
+(* A field accessor's offset is the application's, so its base word has still
+   to be shown to be in the buffer. A u32 word is assembled from unchecked byte
+   reads, so [Codec.get] on a frame shorter than the word used to answer with
+   whatever followed it: the same bytes read one value where the frame lay and
+   another once it moved along the buffer, and neither was in the frame. *)
+let build_bf_accessor_reader base byte_off shift width =
+  let read = build_bf_reader base byte_off shift width in
+  let word = bf_base_byte_size base in
+  fun buf off ->
+    Bitfield.check_word buf (off + byte_off) word;
+    read buf off
 
 let build_bf_writer base byte_off shift width =
   let mask = (1 lsl width) - 1 in
@@ -1382,8 +1397,11 @@ let build_bf_writer base byte_off shift width =
 
 (* The [Codec.set] writer. It range-checks like {!build_bf_writer}: masking here
    is the one silent truncation no later check can catch, because the masked
-   result is a legal field value that [Codec.get] and [validate] both accept. *)
-let build_bf_accessor_writer base byte_off shift width =
+   result is a legal field value that [Codec.get] and [validate] both accept.
+   [set] promises the buffer is untouched when it raises, so the word's span is
+   checked before any of it is written: a u32 goes down as two halves, and a
+   short buffer used to take the first before the second raised. *)
+let build_bf_accessor_writer_raw base byte_off shift width =
   let mask = (1 lsl width) - 1 in
   let clear_mask = lnot (mask lsl shift) in
   match base with
@@ -1427,6 +1445,13 @@ let build_bf_accessor_writer base byte_off shift width =
         let cur = Bitfield.u32_be buf (off + byte_off) in
         Bitfield.set_u32_be buf (off + byte_off)
           (cur land clear_mask lor ((value land mask) lsl shift))
+
+let build_bf_accessor_writer base byte_off shift width =
+  let write = build_bf_accessor_writer_raw base byte_off shift width in
+  let word = bf_base_byte_size base in
+  fun buf off value ->
+    Bitfield.check_word buf (off + byte_off) word;
+    write buf off value
 
 let build_bf_clear base byte_off =
  fun buf off -> bf_write_base base buf (off + byte_off) 0
@@ -4275,7 +4300,7 @@ let rec build_staged_reader : type a.
  fun typ access ->
   match (typ, access) with
   | Bits _, Bitfield { base; byte_off; shift; width } ->
-      let read = build_bf_reader base byte_off shift width in
+      let read = build_bf_accessor_reader base byte_off shift width in
       fun _runtime buf base -> read buf base
   | _, Fixed off ->
       let read = build_field_reader_ctx typ off in
@@ -4451,7 +4476,7 @@ let rec build_immediate_staged_reader : type a.
  fun typ access ->
   match (typ, access) with
   | Bits _, Bitfield { base; byte_off; shift; width } ->
-      Some (build_bf_reader base byte_off shift width)
+      Some (build_bf_accessor_reader base byte_off shift width)
   | _, Fixed off -> build_immediate_reader typ off
   | Where { inner; _ }, _ -> build_immediate_staged_reader inner access
   | Enum { base; cases; closed; _ }, _ -> (
@@ -4624,7 +4649,7 @@ let bitfield (type r) (codec : r t) (f : (int, r) field) : bitfield =
          is a direct read of the right width with [byte_off] baked in.
          Avoids the partial-application + runtime [match] that
          [Bitfield.read_word base] would create. *)
-      let word_reader =
+      let read_word =
         match base with
         | U8 ->
             fun buf off -> Optint.of_int (Bytes.get_uint8 buf (off + byte_off))
@@ -4642,6 +4667,12 @@ let bitfield (type r) (codec : r t) (f : (int, r) field) : bitfield =
               Optint.of_int (Bitfield.u32_be buf (off + byte_off))
             else fun buf off ->
               Optint.of_int32 (Bytes.get_int32_be buf (off + byte_off))
+      in
+      (* Same caller-supplied offset as {!get}, so the same span check. *)
+      let word = bf_base_byte_size base in
+      let word_reader buf off =
+        Bitfield.check_word buf (off + byte_off) word;
+        read_word buf off
       in
       let mask = (1 lsl width) - 1 in
       { word_reader; bf_shift = shift; bf_mask = Optint.of_int mask }

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -7868,6 +7868,91 @@ let test_set_refusal_leaves_buffer_untouched () =
   Alcotest.(check string)
     "an accepted set still writes" "\x2a" (Bytes.to_string buf)
 
+(* A bitfield accessor takes its offset from the caller, so it has to check
+   that its base word is in the buffer. The U32 word helpers reached the bytes
+   unchecked, so [Codec.get] on a frame shorter than the word answered with
+   whatever followed the buffer -- the same bytes read one value at base 0 and
+   another once the frame moved along the buffer, and neither was in the frame
+   -- while [Codec.set] laid down the low half of the word before the high half
+   raised. Walked over every base and every offset that puts part of the word
+   past the end: only the U32 bases were unchecked, and the half-written word
+   only shows on a field the low half carries. *)
+let bounds_bitpack base bit_order (w_a, w_b, w_c) =
+  let f_a = Field.v "a" (bits ~bit_order ~width:w_a base) in
+  let f_b = Field.v "b" (bits ~bit_order ~width:w_b base) in
+  let f_c = Field.v "c" (bits ~bit_order ~width:w_c base) in
+  let proj_a (a, _, _) = a and proj_b (_, b, _) = b and proj_c (_, _, c) = c in
+  let codec =
+    Codec.v "BfBounds"
+      (fun a b c -> (a, b, c))
+      Codec.[ f_a $ proj_a; f_b $ proj_b; f_c $ proj_c ]
+  in
+  ( codec,
+    [
+      ("a", Codec.( $ ) f_a proj_a);
+      ("b", Codec.( $ ) f_b proj_b);
+      ("c", Codec.( $ ) f_c proj_c);
+    ] )
+
+let bitpack_bases =
+  [
+    ("U16", U16, Msb_first, (3, 2, 11));
+    ("U16be", U16be, Lsb_first, (3, 2, 11));
+    ("U32", U32, Msb_first, (6, 10, 16));
+    ("U32be", U32be, Lsb_first, (6, 10, 16));
+  ]
+
+(* Every (base, field) pair with the word size the base needs. *)
+let iter_bitpacks f =
+  List.iter
+    (fun (name, base, bit_order, widths) ->
+      let codec, fields = bounds_bitpack base bit_order widths in
+      let word = Codec.wire_size codec in
+      List.iter (fun (fname, field) -> f name word fname field codec) fields)
+    bitpack_bases
+
+let test_get_bitfield_word_past_buffer_raises () =
+  iter_bitpacks (fun name word fname field codec ->
+      let get = Staged.unstage (Codec.get codec field) in
+      let load =
+        Staged.unstage (Codec.load_word (Codec.bitfield codec field))
+      in
+      let expect_refusal reader len off =
+        match reader (Bytes.make len '\xff') off with
+        | v ->
+            Alcotest.failf
+              "%s field %s: read %d at offset %d of a %d-byte buffer" name fname
+              v off len
+        | exception Invalid_argument _ -> ()
+      in
+      List.iter
+        (fun reader ->
+          (* No room for the word at all, and room for it but not where the
+             frame starts. *)
+          for len = 0 to word - 1 do
+            expect_refusal reader len 0
+          done;
+          for off = 1 to word do
+            expect_refusal reader word off
+          done)
+        [ get; (fun buf off -> Optint.to_int (load buf off)) ])
+
+let test_set_bitfield_word_past_buffer_writes_nothing () =
+  iter_bitpacks (fun name word fname field codec ->
+      let set = Staged.unstage (Codec.set codec field) in
+      for len = 0 to word - 1 do
+        let buf = Bytes.make len '\x00' in
+        (match set buf 0 1 with
+        | () ->
+            Alcotest.failf
+              "%s field %s: Codec.set wrote a word into a %d-byte buffer" name
+              fname len
+        | exception Invalid_argument _ -> ());
+        Alcotest.(check string)
+          (Fmt.str "%s field %s: %d-byte buffer untouched" name fname len)
+          (String.make len '\x00') (Bytes.to_string buf)
+      done)
+
 (* [Codec.get] had no reader for a statically gated optional and fell through
    to a bare [Failure], on fields [Codec.decode] reads without trouble. Check
    both flavours and both gates against what decode returns. *)
@@ -8606,6 +8691,10 @@ let suite =
       (* accessor and container contracts *)
       Alcotest.test_case "set: a refused sub-codec value writes nothing" `Quick
         test_set_refusal_leaves_buffer_untouched;
+      Alcotest.test_case "get: a bitfield word past the buffer raises" `Quick
+        test_get_bitfield_word_past_buffer_raises;
+      Alcotest.test_case "set: a bitfield word past the buffer writes nothing"
+        `Quick test_set_bitfield_word_past_buffer_writes_nothing;
       Alcotest.test_case "get: statically gated optionals agree with decode"
         `Quick test_get_static_optional_agrees_with_decode;
       Alcotest.test_case


### PR DESCRIPTION
A u32 bitfield accessor assembled its base word from unchecked byte reads, so Codec.get on a short frame returned bytes from past the buffer and Codec.set half-wrote the word before raising; both now check the word's span first.
