### PR TITLE
codec: scan a gated span where it lies too

### DIFF
--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -2689,6 +2689,22 @@ let compile_scalar_or_var : type a r.
       }
   | None -> compile_var_bytes ctx fld
 
+(* The scan a fixed-width span inner needs in place of its reader. A gate lays
+   out its inner itself rather than going through the plain field path, so
+   without this a validator put back the copy {!span_populate} took out and grew
+   with a length the sender chose. [None] for an inner with nothing to scan; the
+   caller keeps its reader-driven populate then. *)
+let inner_span_scan ctx inner fsize =
+  if fsize < 0 then None
+  else
+    span_populate inner ~off_fn:(off_fn_of ctx)
+      ~size_fn:(fun _runtime _buf _base -> fsize)
+
+(* An absent field is not there to be checked, so its populate runs only when
+   the gate says the bytes are. *)
+let gated_populate gate populate arr runtime buf base =
+  if gate runtime buf base then populate arr runtime buf base
+
 (* An [optional] field whose value disagrees with its presence predicate cannot
    be encoded: reject it rather than write a record decode cannot read back. *)
 let optional_presence_mismatch : type a. bool -> a =
@@ -2801,7 +2817,11 @@ and compile_optional : type a r.
   match (present, inner_size) with
   | Bool true, Some fsize ->
       let inner_reader, inner_writer = inner_codec_accessors inner ctx in
-      let inner_populate = build_populate inner nfields inner_reader in
+      let inner_populate =
+        match inner_span_scan ctx inner fsize with
+        | Some scan -> scan
+        | None -> build_populate inner nfields inner_reader
+      in
       let get = fld.get in
       optional_compiled ctx
         ~raw_reader:(fun runtime buf base ->
@@ -2822,7 +2842,11 @@ and compile_optional : type a r.
       let present_fn = compile_bool_expr ctx.field_readers present in
       let readable = present_in_bounds ctx present_fn fsize in
       let inner_reader, inner_writer = inner_codec_accessors inner ctx in
-      let inner_populate = build_populate inner nfields inner_reader in
+      let inner_populate =
+        match inner_span_scan ctx inner fsize with
+        | Some scan -> scan
+        | None -> build_populate inner nfields inner_reader
+      in
       let get = fld.get in
       optional_compiled ctx
         ~raw_reader:(fun runtime buf base ->
@@ -2835,8 +2859,7 @@ and compile_optional : type a r.
           | present, _ -> optional_presence_mismatch present)
         ~size_delta:0
         ~next_off:(dynamic_optional_next_off ctx present_fn fsize)
-        ~populate:(fun arr runtime buf base ->
-          if readable runtime buf base then inner_populate arr runtime buf base)
+        ~populate:(gated_populate readable inner_populate)
         ()
   | _ -> compile_optional_variable ctx fld present inner
 
@@ -2884,8 +2907,7 @@ and compile_optional_variable : type a r.
            if present_fn runtime buf base then
              next_off_pos cf.next_off runtime buf base
            else next_off_pos ctx.next_off runtime buf base))
-    ~populate:(fun arr runtime buf base ->
-      if present_fn runtime buf base then cf.populate arr runtime buf base)
+    ~populate:(gated_populate present_fn cf.populate)
     ()
 
 and compile_optional_or : type a r.
@@ -2901,7 +2923,11 @@ and compile_optional_or : type a r.
   | Bool true, Some fsize ->
       let inner_reader, inner_writer = inner_codec_accessors inner ctx in
       let get = fld.get in
-      let populate = build_populate fld.typ ctx.n_fields inner_reader in
+      let populate =
+        match inner_span_scan ctx inner fsize with
+        | Some scan -> scan
+        | None -> build_populate fld.typ ctx.n_fields inner_reader
+      in
       optional_compiled ctx ~raw_reader:inner_reader
         ~int_reader:(fun runtime buf base ->
           int_of_typ_value inner (inner_reader runtime buf base))
@@ -2925,7 +2951,13 @@ and compile_optional_or : type a r.
         if readable runtime buf base then inner_reader runtime buf base
         else default
       in
-      let populate = build_populate fld.typ ctx.n_fields raw_reader in
+      let populate =
+        match inner_span_scan ctx inner fsize with
+        (* The reader the generic populate would run answers [default] for an
+           absent gate, so a scan standing in for it takes the same gate. *)
+        | Some scan -> gated_populate readable scan
+        | None -> build_populate fld.typ ctx.n_fields raw_reader
+      in
       (* Encode is value-driven: the user always has a value, so always
          write [fsize] bytes. The gate is the decode-side oracle that
          chooses between the decoded inner and [default]. Round-trips

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -7631,36 +7631,101 @@ let words_per_call ~iters f =
   let after = Gc.allocated_bytes () in
   int_of_float (Float.round ((after -. before) /. float_of_int iters /. 8.))
 
-(* Length-parameterised span codecs, each with a buffer it accepts. All five
+(* Length-parameterised span types, each with a payload it accepts. All five
    hand the caller one string of about [n] bytes, so they are comparable to
    each other and to the payload; [byte_array] and [all_bytes] are the
    unrefined twins of the three that check something as they go. *)
+(* The two a presence gate can hold: [optional] and [optional_or] refuse an
+   inner that is neither byte-sized nor self-delimiting, since 3D has no way to
+   bound one inside a gate, which rules out the terminator search and both
+   greedy spans. *)
+let gateable_span_typs =
+  [
+    ( "byte_array",
+      (fun n -> byte_array ~size:(int n)),
+      fun n -> Bytes.make n 'a' );
+    ( "byte_array_where",
+      (fun n -> byte_array_where ~size:(int n) ~per_byte:printable_byte),
+      fun n -> Bytes.make n 'a' );
+  ]
+
+let span_typs =
+  gateable_span_typs
+  @ [
+      ( "zeroterm_at_most",
+        (fun n -> zeroterm_at_most ~size:(int n)),
+        fun n ->
+          let b = Bytes.make n 'a' in
+          Bytes.set b (n - 1) '\000';
+          b );
+      ("all_bytes", (fun _ -> all_bytes), fun n -> Bytes.make n 'a');
+      ("all_zeros", (fun _ -> all_zeros), fun n -> Bytes.make n '\000');
+    ]
+
 let span_family name typ =
   Codec.v name Fun.id Codec.[ Field.v "d" typ $ Fun.id ]
 
 let span_families =
-  [
-    ( "byte_array",
-      (fun n -> span_family "SpanArray" (byte_array ~size:(int n))),
-      fun n -> Bytes.make n 'a' );
-    ( "byte_array_where",
-      (fun n ->
-        span_family "SpanWhere"
-          (byte_array_where ~size:(int n) ~per_byte:printable_byte)),
-      fun n -> Bytes.make n 'a' );
-    ( "zeroterm_at_most",
-      (fun n -> span_family "SpanZeroterm" (zeroterm_at_most ~size:(int n))),
-      fun n ->
-        let b = Bytes.make n 'a' in
-        Bytes.set b (n - 1) '\000';
-        b );
-    ( "all_bytes",
-      (fun _ -> span_family "SpanAll" all_bytes),
-      fun n -> Bytes.make n 'a' );
-    ( "all_zeros",
-      (fun _ -> span_family "SpanZeros" all_zeros),
-      fun n -> Bytes.make n '\000' );
-  ]
+  List.map
+    (fun (name, typ, payload) ->
+      (name, (fun n -> span_family ("Span" ^ name) (typ n)), payload))
+    span_typs
+
+(* The same spans behind a presence gate. [optional] and [optional_or] lay out
+   their inner themselves instead of going through the plain field path, and
+   each has a branch for a gate the schema fixes and one for a gate the frame
+   carries, so a scan wired into one of the four says nothing about the other
+   three. A leading gate byte puts the span at offset 1. *)
+let f_span_gate = Field.v "gate" uint8
+let gate_is_set = Expr.(Field.ref f_span_gate = int 1)
+
+let gated_payload payload n =
+  let src = payload n in
+  let b = Bytes.make (Bytes.length src + 1) '\001' in
+  Bytes.blit src 0 b 1 (Bytes.length src);
+  b
+
+let optional_family name ~present typ =
+  Codec.v name
+    (fun _ d -> d)
+    Codec.
+      [ (f_span_gate $ fun _ -> 1); Field.optional "d" ~present typ $ Fun.id ]
+
+let optional_or_family name ~present typ =
+  Codec.v name
+    (fun _ d -> d)
+    Codec.
+      [
+        (f_span_gate $ fun _ -> 1);
+        Field.optional_or "d" ~present ~default:"" typ $ Fun.id;
+      ]
+
+(* A [name, validate this size] pair, so gates whose codecs have different
+   record types measure through one fold. *)
+let validate_case name mk payload n =
+  let c = mk n and buf = gated_payload payload n in
+  (name, fun () -> Codec.validate c buf 0)
+
+let gated_span_cases n =
+  List.concat_map
+    (fun (name, typ, payload) ->
+      [
+        validate_case ("optional(true)/" ^ name)
+          (fun n -> optional_family "OptT" ~present:Expr.true_ (typ n))
+          payload n;
+        validate_case ("optional(gate)/" ^ name)
+          (fun n -> optional_family "OptG" ~present:gate_is_set (typ n))
+          payload n;
+        validate_case
+          ("optional_or(true)/" ^ name)
+          (fun n -> optional_or_family "OptOrT" ~present:Expr.true_ (typ n))
+          payload n;
+        validate_case
+          ("optional_or(gate)/" ^ name)
+          (fun n -> optional_or_family "OptOrG" ~present:gate_is_set (typ n))
+          payload n;
+      ])
+    gateable_span_typs
 
 let report_span_failures what failures =
   if failures <> [] then
@@ -7675,14 +7740,19 @@ let report_span_failures what failures =
 let test_validate_allocation_is_bounded () =
   skip_unless_gc_counters ();
   let small = 512 and large = 4096 in
+  let cases n =
+    List.map
+      (fun (name, mk, mkbuf) ->
+        let c = mk n and buf = mkbuf n in
+        (name, fun () -> Codec.validate c buf 0))
+      span_families
+    @ gated_span_cases n
+  in
   let failures =
-    List.fold_left
-      (fun acc (name, mk, mkbuf) ->
-        let words n =
-          let c = mk n and buf = mkbuf n in
-          words_per_call ~iters:2000 (fun () -> Codec.validate c buf 0)
-        in
-        let at_small = words small and at_large = words large in
+    List.fold_left2
+      (fun acc (name, at_small) (_, at_large) ->
+        let at_small = words_per_call ~iters:2000 at_small in
+        let at_large = words_per_call ~iters:2000 at_large in
         if at_large - at_small > 32 then
           Fmt.str
             "%s grows %d words between a %d-byte and a %d-byte frame (%d then \
@@ -7690,7 +7760,7 @@ let test_validate_allocation_is_bounded () =
             name (at_large - at_small) small large at_small at_large
           :: acc
         else acc)
-      [] span_families
+      [] (cases small) (cases large)
   in
   report_span_failures "validate allocation scales with the frame length"
     failures


### PR DESCRIPTION
The fixed-width branches of optional and optional_or ran their inner's reader to validate it, so a refined span behind a gate copied the payload once per validate (448 words between a 512-byte and a 4096-byte frame); they now reach the same scan the unwrapped span does.
