### PR TITLE
codec: raise the documented exception for a description that cannot be read

### DIFF
--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -155,7 +155,7 @@ let rec build_casetype_encoder_ctx : type a k.
   let tag_enc = build_field_encoder_ctx tag in
   fun runtime ->
     let rec find buf off v = function
-      | [] -> failwith "build_field_encoder: casetype: no matching case"
+      | [] -> invalid_arg "Wire.casetype: encoding a value no case matches"
       | Case_branch { cb_inner; cb_project; _ } :: rest -> (
           (* [cb_project] yields the tag to write (its fixed index for an explicit
            case, or the value-carried tag for the default) and the body. *)
@@ -1460,7 +1460,9 @@ let build_idx readers =
   let rev_readers = List.rev readers in
   fun name ->
     let rec find i = function
-      | [] -> failwith ("unbound field: " ^ name)
+      | [] ->
+          Fmt.invalid_arg
+            "Codec: unbound field ref %S in a field constraint or action" name
       | (n, _) :: _ when n = name -> i
       | _ :: rest -> find (i + 1) rest
     in
@@ -1684,7 +1686,9 @@ let rec read_elem : type a. a typ -> runtime -> bytes -> int -> a =
      decode each element at its stride. *)
   | Array { len = Int n; elem; seq = Seq_map s } -> (
       match field_wire_size elem with
-      | None -> failwith "read_elem: variable-size array element"
+      | None ->
+          Fmt.invalid_arg "Wire.array: element %s has no stride to read at"
+            (field_shape elem)
       | Some esz ->
           let acc = Stdlib.ref s.empty in
           for i = 0 to n - 1 do
@@ -1694,7 +1698,8 @@ let rec read_elem : type a. a typ -> runtime -> bytes -> int -> a =
   (* A nested region as an element: decode its inner at the region start; the
      enclosing region size (padding) is accounted for by the caller. *)
   | Single_elem { elem; _ } -> read_elem elem runtime buf off
-  | _ -> failwith "read_elem: unsupported element type in repeat"
+  | _ ->
+      Fmt.invalid_arg "Wire.repeat: no element reader for %s" (field_shape typ)
 
 (* Dispatch a casetype's matched case body. A top-level recursion rather than a
    [let rec find] inside [read_elem]: the inner form would allocate a fresh
@@ -1767,7 +1772,8 @@ let rec write_elem : type a. a typ -> runtime -> bytes -> int -> a -> unit =
       ignore (build_field_encoder typ buf off v : int)
   | Byte_slice { size = Int _ } ->
       ignore (build_field_encoder typ buf off v : int)
-  | _ -> failwith "write_elem: unsupported element type in repeat"
+  | _ ->
+      Fmt.invalid_arg "Wire.repeat: no element writer for %s" (field_shape typ)
 
 (* Compute the wire size of one element at a buffer position. Used by Repeat
    for variable-size elements. *)
@@ -1798,7 +1804,9 @@ let rec elem_size_of : type a. a typ -> runtime -> bytes -> int -> int =
   | _ -> (
       match field_wire_size typ with
       | Some n -> n
-      | None -> failwith "elem_size_of: cannot determine element size")
+      | None ->
+          Fmt.invalid_arg "Wire.repeat: element %s has no determinable size"
+            (field_shape typ))
 
 (* Wire size of a casetype's matched case body. Top-level for the same reason
    as [read_case_body]: a per-call [let rec find] would allocate a closure on
@@ -3441,7 +3449,7 @@ let build_decode : type full r.
 
 let lookup_reader_idx rev_readers name =
   let rec find i = function
-    | [] -> failwith ("unbound field: " ^ name)
+    | [] -> Fmt.invalid_arg "Codec: unbound field ref %S in a where clause" name
     | (n, _) :: _ when n = name -> i
     | _ :: rest -> find (i + 1) rest
   in

--- a/lib/eval.ml
+++ b/lib/eval.ml
@@ -21,9 +21,14 @@ let bind name value ctx = { name; value } :: ctx
 
 let rec lookup name = function
   | [] ->
-      failwith
-        ("Eval.expr: unbound field " ^ name
-       ^ " (cross-field references are only valid inside a struct)")
+      (* A description referencing another field, evaluated where there is no
+         record to read it from, cannot be decoded whatever the input: the
+         entry points document that as [Invalid_argument], and the [Param_ref]
+         arm below already raises it. *)
+      Fmt.invalid_arg
+        "Eval.expr: unbound field %s (cross-field references are only valid \
+         inside a struct)"
+        name
   | b :: tl -> if String.equal b.name name then b.value else lookup name tl
 
 (* Convert a typed value to [int]. Returns [None] for types that don't
@@ -126,9 +131,10 @@ let rec expr : type a. ctx -> a expr -> a =
   | Bool b -> b
   | Ref (I, name) -> lookup name ctx
   | Ref (I64, name) ->
-      failwith
-        ("Eval.expr: unbound int64 field " ^ name
-       ^ " (cross-field references are only valid inside a struct)")
+      Fmt.invalid_arg
+        "Eval.expr: unbound int64 field %s (cross-field references are only \
+         valid inside a struct)"
+        name
   | Param_ref p ->
       Fmt.invalid_arg
         "Eval.expr: parameter %S requires a codec evaluation context" p.name

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -346,9 +346,10 @@ let rec parse_direct : type a. a typ -> bytes -> int -> int -> a * int =
   | Repeat { size; elem; seq } ->
       let budget = Eval.expr Eval.empty size in
       parse_repeat_loop ~elem ~seq buf off len ~budget
-  | Type_ref _ -> failwith "type_ref requires a type registry"
-  | Qualified_ref _ -> failwith "qualified_ref requires a type registry"
-  | Apply _ -> failwith "apply requires a type registry"
+  | Type_ref _ -> invalid_arg "Wire.type_ref: decoding needs a type registry"
+  | Qualified_ref _ ->
+      invalid_arg "Wire.qualified_ref: decoding needs a type registry"
+  | Apply _ -> invalid_arg "Wire.apply: decoding needs a type registry"
 
 and parse_where : type a. a typ -> bool expr -> bytes -> int -> int -> a * int =
  fun inner cond buf off len ->
@@ -810,16 +811,17 @@ let rec encode_into : type a. a typ -> a -> encoder -> unit =
         v
       |> List.iter (fun (elem_v, _) -> encode_into elem elem_v enc)
   | Casetype { tag; cases; _ } -> encode_casetype tag cases v enc
-  | Struct _ -> failwith "struct encoding: use Codec.encode"
-  | Type_ref _ -> failwith "type_ref requires a type registry"
-  | Qualified_ref _ -> failwith "qualified_ref requires a type registry"
-  | Apply _ -> failwith "apply requires a type registry"
+  | Struct _ -> invalid_arg "Wire.struct_: encoding a struct goes through Codec"
+  | Type_ref _ -> invalid_arg "Wire.type_ref: encoding needs a type registry"
+  | Qualified_ref _ ->
+      invalid_arg "Wire.qualified_ref: encoding needs a type registry"
+  | Apply _ -> invalid_arg "Wire.apply: encoding needs a type registry"
 
 and encode_casetype : type a k.
     k typ -> (a, k) case_branch list -> a -> encoder -> unit =
  fun tag cases v enc ->
   let rec find_case = function
-    | [] -> failwith "casetype encoding: no matching case"
+    | [] -> invalid_arg "Wire.casetype: encoding a value no case matches"
     | Case_branch { cb_inner; cb_project; _ } :: rest -> (
         match cb_project v with
         | Some (t, body) ->
@@ -911,7 +913,8 @@ let rec encode_direct : type a. a typ -> bytes -> int -> a -> int =
   | Uint_var { size = Int n; endian } ->
       Uint_var.write endian buf off n v;
       off + n
-  | Uint_var _ -> failwith "encode_direct: Uint_var with dynamic size"
+  | Uint_var _ ->
+      invalid_arg "Wire.uint: encoding a field-dependent size needs Codec"
   | Bits { width; base; bit_order } ->
       encode_bits buf off v width base bit_order
   | Unit -> off

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -3788,6 +3788,102 @@ let test_encode_shared_bitfield () =
 
 (* -- API misuse / safety tests -- *)
 
+(* A description that cannot be decoded or encoded whatever the input is a
+   programmer error, and [wire.mli] says so: it "raises [Invalid_argument], the
+   same way encoding does". Eighteen sites raised [Failure] instead, thirteen of
+   them reachable from a public entry point, which no documented caller has any
+   reason to catch and which a [Codec.encode] caller cannot tell apart from a
+   bug in the library. The evidence that the code was wrong rather than the doc
+   is next door: an unbound field ref in a size expression already raised
+   [Invalid_argument] while the same ref in a where clause raised [Failure].
+   Every reachable site gets a case, so one that regresses names itself. *)
+
+type misuse_v = A of int | B of int | Other of int
+
+let misuse_casetype =
+  casetype "MisuseCT" uint8
+    [
+      case ~index:1 uint8
+        ~inject:(fun x -> A x)
+        ~project:(function A x -> Some x | _ -> None);
+      case ~index:2 uint8
+        ~inject:(fun x -> B x)
+        ~project:(function B x -> Some x | _ -> None);
+    ]
+
+let misuse_casetype_codec =
+  Codec.v "MisuseCTRec" Fun.id Codec.[ Field.v "u" misuse_casetype $ Fun.id ]
+
+let f_absent = Field.v "absent" uint8
+let f_absent64 = Field.v "absent64" uint64be
+
+let test_undecodable_description_is_invalid_argument () =
+  let expect (name, f) =
+    match f () with
+    | () -> Alcotest.failf "%s: raised nothing" name
+    | exception Invalid_argument _ -> ()
+    | exception Failure m ->
+        Alcotest.failf "%s: raised Failure %S, which the contract forbids" name
+          m
+  in
+  List.iter expect
+    [
+      (* Direct decode and encode of a form with no reader or writer. *)
+      ("of_string type_ref", fun () -> ignore (of_string (type_ref "T") "abcd"));
+      ( "of_string qualified_ref",
+        fun () -> ignore (of_string (qualified_ref "M" "T") "abcd") );
+      ( "of_string apply",
+        fun () -> ignore (of_string (apply uint8 [ int 1 ]) "abcd") );
+      ("to_string type_ref", fun () -> ignore (to_string (type_ref "T") 0));
+      ( "to_string qualified_ref",
+        fun () -> ignore (to_string (qualified_ref "M" "T") 0) );
+      ("to_string apply", fun () -> ignore (to_string (apply uint8 [ int 1 ]) 0));
+      ( "to_string struct_typ",
+        fun () ->
+          ignore
+            (to_string (struct_typ (struct_ "MisuseS" [ field "a" uint8 ])) ())
+      );
+      (* A cross-field reference evaluated where there is no record. *)
+      ( "of_string size ref outside a struct",
+        fun () ->
+          ignore (of_string (byte_array ~size:(Field.ref f_absent)) "\003abc")
+      );
+      ( "to_string size ref outside a struct",
+        fun () ->
+          ignore (to_string (byte_array ~size:(Field.ref f_absent)) "abc") );
+      ( "of_string int64 ref outside a struct",
+        fun () ->
+          ignore
+            (of_string
+               (where Expr.(Field.int64 f_absent64 = int64 0L) uint8)
+               "\003") );
+      (* A casetype value no case projects. *)
+      ( "to_string casetype no case matches",
+        fun () -> ignore (to_string misuse_casetype (Other 5)) );
+      ( "Codec.encode casetype no case matches",
+        fun () ->
+          Codec.encode misuse_casetype_codec (Other 5) (Bytes.make 8 '\000') 0
+      );
+      (* A codec sealed against a field it never got. *)
+      ( "Codec.v where ref to a field not in the codec",
+        fun () ->
+          ignore
+            (Codec.v "MisuseWhere"
+               ~where:Expr.(Field.ref f_absent = int 0)
+               Fun.id
+               Codec.[ Field.v "a" uint8 $ Fun.id ]) );
+      ( "Codec.v constraint ref to a field not in the codec",
+        fun () ->
+          ignore
+            (Codec.v "MisuseConstraint" Fun.id
+               Codec.
+                 [
+                   Field.v "a" uint8
+                     ~constraint_:Expr.(Field.ref f_absent = int 0)
+                   $ Fun.id;
+                 ]) );
+    ]
+
 let test_get_field_notin_codec () =
   (* get with a field that was never added to this codec raises Not_found
      at staging time *)
@@ -8825,6 +8921,9 @@ let suite =
       (* accessor and container contracts *)
       Alcotest.test_case "set: a refused sub-codec value writes nothing" `Quick
         test_set_refusal_leaves_buffer_untouched;
+      Alcotest.test_case
+        "misuse: an undecodable description raises Invalid_argument" `Quick
+        test_undecodable_description_is_invalid_argument;
       Alcotest.test_case "get: a bitfield word past the buffer raises" `Quick
         test_get_bitfield_word_past_buffer_raises;
       Alcotest.test_case "set: a bitfield word past the buffer writes nothing"

--- a/test/test_eval.ml
+++ b/test/test_eval.ml
@@ -84,9 +84,11 @@ let test_expr_const () =
     "lt" true
     (Eval.expr ctx (Types.Lt (Types.Int 1, Types.Int 2)))
 
+(* A cross-field reference with no record to read it from is a programmer
+   error, which the entry points document as [Invalid_argument]. *)
 let test_expr_ref_fails () =
   Alcotest.check_raises "Ref at top level should fail"
-    (Failure
+    (Invalid_argument
        "Eval.expr: unbound field x (cross-field references are only valid \
         inside a struct)") (fun () ->
       ignore (Eval.expr Eval.empty (Types.ref "x")))


### PR DESCRIPTION
Eighteen places raised Failure for a description no decoder or encoder can handle, thirteen of them reachable from a public entry point, where wire.mli documents Invalid_argument; they all raise it now, naming the combinator and the fault.
