### PR TITLE
codec: check an enum's membership without building its case list

### DIFF
--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -291,12 +291,12 @@ let build_field_encoder typ =
 (* An [enum] decodes through its base integer type; validate that the value is
    one of the named cases, raising [Invalid_enum] otherwise, so the decoder
    rejects exactly the inputs the EverParse-generated validator (and the
-   [parse_direct] path) does, instead of accepting any base value. [valid] is
-   computed once so the returned check allocates nothing per decode. *)
-let enum_checker cases =
-  let valid = List.map snd cases in
-  fun ~at v ->
-    if List.mem v valid then v else raise_invalid_enum ~at ~value:v ~valid
+   [parse_direct] path) does, instead of accepting any base value. The scan
+   reads the cases where they lie, so an accepted value costs nothing however
+   many cases the enum names. *)
+let enum_checker cases ~at v =
+  Types.check_enum_decode ~at ~cases v;
+  v
 
 (* An open enum ([closed = false]) accepts any base value: the names only
    document known members, so decode does not reject the rest. *)
@@ -1655,7 +1655,11 @@ let rec read_elem : type a. a typ -> runtime -> bytes -> int -> a =
         (read_elem inner runtime buf off)
   | Where { inner; _ } -> read_elem inner runtime buf off
   | Enum { base; cases; closed; _ } ->
-      enum_check cases closed ~at:off (read_elem base runtime buf off)
+      (* Applied whole rather than through [enum_check]: an element's check runs
+         per element, and staging one here would allocate the closure per
+         element too, on a count the sender picks through the byte budget. *)
+      let v = read_elem base runtime buf off in
+      if closed then enum_checker cases ~at:off v else v
   | Casetype { tag; cases; _ } ->
       let tag_val = read_elem tag runtime buf off in
       read_case_body ~at:off ~tag cases tag_val runtime buf

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -1833,7 +1833,23 @@ and pp_packed_expr ppf (Pack_expr e) = pp_expr ppf e
    encode agree on which values a closed enum admits. An open enum names known
    codes without restricting the set, so it has no encode guard at all. *)
 let enum_values cases = List.map snd cases
-let enum_member valid v = List.exists (Int.equal v) valid
+
+let rec enum_member valid (v : int) =
+  match valid with [] -> false | x :: rest -> x = v || enum_member rest v
+
+(* Decode-side membership scans the case list itself. The [valid] list an
+   [Invalid_enum] carries is built on the failure path only: the scan runs once
+   per decoded value, and a repeat's element count is the sender's choice
+   through its byte budget, so building a list to succeed hands the sender a
+   heap multiplier per element. *)
+let rec enum_case_member cases (v : int) =
+  match cases with
+  | [] -> false
+  | (_, x) :: rest -> x = v || enum_case_member rest v
+
+let check_enum_decode ~at ~cases v =
+  if not (enum_case_member cases v) then
+    raise_invalid_enum ~at ~value:v ~valid:(enum_values cases)
 
 let check_enum_encode ~name ~valid v =
   if not (enum_member valid v) then

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -131,6 +131,12 @@ val enum_member : int list -> int -> bool
     membership rule decode and encode share, so the two halves agree on what a
     closed enum admits. *)
 
+val check_enum_decode : at:int -> cases:(string * int) list -> int -> unit
+(** Check a decoded value against a closed enum's named cases. An unlisted value
+    raises {!constructor-Invalid_enum} carrying the case set. Scans the cases in
+    place, so a value that is a member costs no allocation however many cases
+    there are. *)
+
 val check_enum_encode : name:string -> valid:int list -> int -> unit
 (** Check a value against a closed enum's case set before encoding it. An
     unlisted value raises [Invalid_argument]: decode rejects it, so emitting it

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -181,10 +181,7 @@ let parse_codec_typ codec_decode fixed_size size_of buf off len =
    accepts any value. [Codec.decode] gates on [closed] the same way, so the two
    decode paths agree on an unlisted code. *)
 let check_enum_membership ~at ~closed cases v =
-  if closed then begin
-    let valid = List.map snd cases in
-    if not (List.mem v valid) then raise_invalid_enum ~at ~value:v ~valid
-  end
+  if closed then Types.check_enum_decode ~at ~cases v
 
 (* [Codec.validator_of_struct] compiles a struct into a validator whose scratch
    is domain-local, and a domain-local scratch is backed by a [Domain.DLS] key

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -7922,6 +7922,48 @@ let test_repeat_validate_allocation_is_bounded () =
   report_span_failures "validate allocation scales with a repeat's budget"
     failures
 
+(* A closed [enum] checks membership once per decoded element, and both sides of
+   that cost are the sender's: the element count comes from the byte budget, and
+   a protocol enum names as many codes as it likes. Validating a repeat of them
+   must turn over the same words whatever the budget and whatever the case
+   count, or naming 128 codes multiplies the heap a packet churns by the number
+   of elements it carries. *)
+let enum_of_case_count n =
+  enum "Codes" (List.init n (fun i -> (Fmt.str "C%d" i, i))) uint8
+
+let enum_budget_words ~cases ~budget =
+  let c = repeat_budget_codec (enum_of_case_count cases) in
+  let buf = repeat_budget_buf budget in
+  words_per_call ~iters:500 (fun () -> Codec.validate c buf 0)
+
+let test_enum_element_validate_allocation_is_bounded () =
+  skip_unless_gc_counters ();
+  let small = 512 and large = 4096 in
+  let failures =
+    List.fold_left
+      (fun acc cases ->
+        let at_small = enum_budget_words ~cases ~budget:small in
+        let at_large = enum_budget_words ~cases ~budget:large in
+        if at_large <> at_small then
+          Fmt.str
+            "a %d-case enum grows %d words between a %d-byte and a %d-byte \
+             budget (%d then %d)"
+            cases (at_large - at_small) small large at_small at_large
+          :: acc
+        else acc)
+      [] [ 2; 128 ]
+  in
+  let few = enum_budget_words ~cases:2 ~budget:large in
+  let many = enum_budget_words ~cases:128 ~budget:large in
+  let failures =
+    if many <> few then
+      Fmt.str "a 128-case enum costs %d words where a 2-case one costs %d" many
+        few
+      :: failures
+    else failures
+  in
+  report_span_failures "validate allocation scales with a closed enum" failures
+
 (* [Codec.decode] hands the span back, so one copy of it is the price of the
    answer. A second copy is work the caller never sees and the sender sizes.
    The bound is against the payload the returned value carries, not against
@@ -8905,6 +8947,9 @@ let suite =
       Alcotest.test_case
         "validate: allocation does not scale with a repeat's budget" `Quick
         test_repeat_validate_allocation_is_bounded;
+      Alcotest.test_case
+        "validate: allocation does not scale with an enum's cases" `Quick
+        test_enum_element_validate_allocation_is_bounded;
       Alcotest.test_case "decode: allocates at most one copy of the span" `Quick
         test_decode_allocates_one_copy;
       (* decode diagnostics *)


### PR DESCRIPTION
A closed enum built its list of valid values on every element read, costing 389 words an element for 128 cases on a count the sender picks through the byte budget; the scan now reads the cases in place and builds the list only for the error.
