### PR TITLE
codec: give a parameter-free validate the constant context

### DIFF
--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -3482,16 +3482,23 @@ let seed_param_slots arr n_total = function
       let n = Array.length slots in
       Array.blit slots 0 arr.ints (n_total - n) n
 
+(* A codec with no parameters gets the constant context: with an empty slot
+   table the two lookups below can only answer 0 and drop the write, which is
+   what an unbound context already does, and an unbound context is an immediate
+   rather than two closures, a record and a block. The saving is per
+   [Codec.validate] call, and a validate is what a server runs per packet. *)
 let validation_runtime param_slots arr =
-  Types.eval_ctx
-    ~set_param:(fun name value ->
-      match Hashtbl.find_opt param_slots name with
-      | Some idx -> arr.ints.(idx) <- value
-      | None -> ())
-    (fun name ->
-      match Hashtbl.find_opt param_slots name with
-      | Some idx -> arr.ints.(idx)
-      | None -> 0)
+  if Hashtbl.length param_slots = 0 then no_runtime
+  else
+    Types.eval_ctx
+      ~set_param:(fun name value ->
+        match Hashtbl.find_opt param_slots name with
+        | Some idx -> arr.ints.(idx) <- value
+        | None -> ())
+      (fun name ->
+        match Hashtbl.find_opt param_slots name with
+        | Some idx -> arr.ints.(idx)
+        | None -> 0)
 
 let build_validators validators_rev checkers_rev compiled_where struct_fields
     param_slots n_total =

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -7964,6 +7964,47 @@ let test_enum_element_validate_allocation_is_bounded () =
   in
   report_span_failures "validate allocation scales with a closed enum" failures
 
+(* A check-free codec skips the validator pass, so it never builds an
+   evaluation context. One with a constraint or a where clause does run the
+   pass, and a parameter-free codec has nothing to put in the context it used to
+   build on the way in. [Codec.validate] is the entry point a server runs per
+   packet, so what it costs must not depend on whether the codec checks
+   anything. *)
+let checked_no_param_codecs =
+  let f_a = Field.v "a" uint8 in
+  let f_bounded =
+    Field.v "b" ~self_constraint:(fun self -> Expr.(self < int 200)) uint8
+  in
+  [
+    ( "field constraint",
+      Codec.v "Constrained"
+        (fun a b -> (a, b))
+        Codec.[ (f_a $ fun (a, _) -> a); (f_bounded $ fun (_, b) -> b) ] );
+    ( "where clause",
+      Codec.v "Whered"
+        ~where:Expr.(Field.ref f_a < int 200)
+        (fun a b -> (a, b))
+        Codec.[ (f_a $ fun (a, _) -> a); (Field.v "b" uint8 $ fun (_, b) -> b) ]
+    );
+  ]
+
+let test_validate_checked_no_param_no_alloc () =
+  skip_unless_gc_counters ();
+  let buf = Bytes.make 8 '\001' in
+  let failures =
+    List.fold_left
+      (fun acc (name, c) ->
+        let words =
+          words_per_call ~iters:5000 (fun () -> Codec.validate c buf 0)
+        in
+        if words <> 0 then
+          Fmt.str "a codec with a %s costs %d words a validate" name words
+          :: acc
+        else acc)
+      [] checked_no_param_codecs
+  in
+  report_span_failures "a parameter-free validate allocates" failures
+
 (* [Codec.decode] hands the span back, so one copy of it is the price of the
    answer. A second copy is work the caller never sees and the sender sizes.
    The bound is against the payload the returned value carries, not against
@@ -8950,6 +8991,9 @@ let suite =
       Alcotest.test_case
         "validate: allocation does not scale with an enum's cases" `Quick
         test_enum_element_validate_allocation_is_bounded;
+      Alcotest.test_case
+        "validate: a checked param-free codec allocates nothing" `Quick
+        test_validate_checked_no_param_no_alloc;
       Alcotest.test_case "decode: allocates at most one copy of the span" `Quick
         test_decode_allocates_one_copy;
       (* decode diagnostics *)


### PR DESCRIPTION
Codec.validate built an evaluation context per call, 18 words of closures and blocks, even for a codec with no parameters to put in it; those now get the constant unbound context, so a validate that checks a constraint or a where clause allocates nothing.
