### PR TITLE
codec: walk a repeat of wide scalars without boxing them

### DIFF
--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -2301,13 +2301,16 @@ let repeat_raw_reader : type elt seq.
 
 (* An element whose reader's only product is the value it hands back. A
    fixed-width byte span re-slices or copies bytes the budget prologue has
-   already bounded to the buffer, and a NUL-terminated one's terminator search
-   has run in [size_of_elem] before the reader is called, so on the check walk
-   there is nothing left for the reader to do. Every other element's reader does
-   something [Codec.validate] needs (an enum's membership, a sub-codec's
-   constraints, a casetype's tag dispatch), so it runs. *)
+   already bounded to the buffer, a NUL-terminated one's terminator search has
+   run in [size_of_elem] before the reader is called, and a 64-bit or
+   floating-point scalar is one unchecked read of a word inside the same
+   bounded budget, so on the check walk there is nothing left for the reader to
+   do. Every other element's reader does something [Codec.validate] needs (an
+   enum's membership, a sub-codec's constraints, a casetype's tag dispatch), so
+   it runs. *)
 let elem_reader_is_value_only : type a. a typ -> bool = function
   | Byte_array { size = Int _ } | Byte_slice { size = Int _ } | Zeroterm -> true
+  | Uint64 _ | Int64 _ | Float32 _ | Float64 _ -> true
   | _ -> false
 
 (* The element read the check walk runs. Skipping a value-only reader keeps the

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -7865,9 +7865,10 @@ let test_validate_allocation_is_bounded () =
    length field: the sender picks how many times the element loop runs.
    [Codec.validate] wants those elements checked and does not want the
    sequence, so building one and dropping it handed an attacker a heap
-   multiplier per packet. The byte spans are here for the same reason one step
-   in: their reader's only product is the value, so on a walk that keeps nothing
-   they have nothing to do. What an element's reader has to do to check it (a
+   multiplier per packet. The byte spans and the 64-bit and floating-point
+   scalars are here for the same reason one step in: their reader's only product
+   is the value, boxed for the wide scalars and copied for the spans, so on a
+   walk that keeps nothing they have nothing to do. What an element's reader has to do to check it (a
    sub-codec's constraints, a casetype's tag dispatch) is a separate question,
    so those stay out. *)
 let f_repeat_len = Field.v "len" uint16be
@@ -7928,6 +7929,10 @@ let test_repeat_validate_allocation_is_bounded () =
         repeat_budget_case "int8" int8;
         repeat_budget_case "int16be" int16be;
         repeat_budget_case "uint63be" uint63be;
+        repeat_budget_case "uint64be" uint64be;
+        repeat_budget_case "int64be" int64be;
+        repeat_budget_case "float32be" float32be;
+        repeat_budget_case "float64be" float64be;
         repeat_budget_case "byte_array" (byte_array ~size:(int 4));
         repeat_budget_case "byte_slice" (byte_slice ~size:(int 4));
         repeat_budget_case ~buf:repeat_zeroterm_buf "zeroterm" zeroterm;


### PR DESCRIPTION
A uint64, int64, float32 or float64 repeat element boxed the word its reader returned and the check walk dropped it, two to three words an element on a count the byte budget names; those four widths now join the byte spans in the walk's value-only list, since none of them checks anything.
