### PR TITLE
codec: refuse to size a casetype value no case encodes

### DIFF
--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -155,7 +155,7 @@ let rec build_casetype_encoder_ctx : type a k.
   let tag_enc = build_field_encoder_ctx tag in
   fun runtime ->
     let rec find buf off v = function
-      | [] -> invalid_arg "Wire.casetype: encoding a value no case matches"
+      | [] -> Types.raise_no_matching_case ()
       | Case_branch { cb_inner; cb_project; _ } :: rest -> (
           (* [cb_project] yields the tag to write (its fixed index for an explicit
            case, or the value-carried tag for the default) and the body. *)

--- a/lib/codec.mli
+++ b/lib/codec.mli
@@ -62,7 +62,10 @@ val size_of_value : 'r t -> 'r -> int
     buffer-driven {!wire_size_at} cannot distinguish "value's tail" from
     "remaining buffer space". Fixed-size byte arrays and slices contribute their
     declared region size, which {!encode} requires the value to match exactly.
-*)
+
+    Raises [Invalid_argument] for a value {!encode} would refuse, such as a
+    casetype value no case projects: there is no size to report for bytes that
+    cannot be written. *)
 
 val is_fixed : 'r t -> bool
 (** [is_fixed c] is [true] iff the codec [c] has a fixed wire size. *)

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -1829,6 +1829,13 @@ and pp_packed_expr ppf (Pack_expr e) = pp_expr ppf e
    [Invalid_argument]: an unencodable value is a caller error, not malformed
    input. *)
 
+(* A casetype value no branch projects has no encoding at all, so it has no size
+   either. One raiser for the size path and both encode paths, so a caller
+   sizing a buffer for such a value is told the same thing, in the same words,
+   as one trying to write it. *)
+let raise_no_matching_case () =
+  invalid_arg "Wire.casetype: encoding a value no case matches"
+
 (* Membership in a closed [enum]: the single rule both halves use, so decode and
    encode agree on which values a closed enum admits. An open enum names known
    codes without restricting the set, so it has no encode guard at all. *)
@@ -3243,10 +3250,12 @@ let rec size_of_typ_value : type a. a typ -> a -> int =
          [project] accepts [v], then size its inner from the projected body.
          Without this the value-driven size dropped the whole casetype to 0,
          so [Codec.size_of_value] under-allocated and [encode] ran off the
-         buffer. *)
+         buffer. A value no branch projects has no size for the same reason it
+         has no bytes, and says so rather than answering with the tag width a
+         caller would then allocate for. *)
       let tag_size = Option.value ~default:0 (inner_wire_size tag) in
       let rec find = function
-        | [] -> tag_size
+        | [] -> raise_no_matching_case ()
         | Case_branch { cb_inner; cb_project; _ } :: rest -> (
             match cb_project v with
             | Some (_tag, body) -> tag_size + size_of_typ_value cb_inner body

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -123,6 +123,11 @@ val check_nested_size : at_most:bool -> expected:int -> actual:int -> unit
 (** Check an inner value against an exact or at-most nested region. Internal
     helper shared by sizing and encoders. *)
 
+val raise_no_matching_case : unit -> 'a
+(** Raise [Invalid_argument] for a casetype value no case projects. Such a value
+    has no encoding, so it has no size either: the size path and both encode
+    paths raise through here so all three say the same thing. *)
+
 val enum_values : (string * int) list -> int list
 (** The value set of an enum's named cases. *)
 
@@ -1043,7 +1048,8 @@ val size_of_typ_value : 'a typ -> 'a -> int
     computed from the value rather than from a buffer. Falls back to [0] for
     typs whose size depends on an out-of-band parameter or sibling field --
     those only appear inside a codec, where {!Codec.size_of_value} sums per-
-    field projections instead. *)
+    field projections instead. Raises [Invalid_argument] for a casetype value no
+    case projects, which encoding refuses for the same reason. *)
 
 val c_type_of : 'a typ -> string
 (** [c_type_of typ] returns the C type name (e.g., ["uint8_t"], ["uint32_t"]).

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -818,7 +818,7 @@ and encode_casetype : type a k.
     k typ -> (a, k) case_branch list -> a -> encoder -> unit =
  fun tag cases v enc ->
   let rec find_case = function
-    | [] -> invalid_arg "Wire.casetype: encoding a value no case matches"
+    | [] -> Types.raise_no_matching_case ()
     | Case_branch { cb_inner; cb_project; _ } :: rest -> (
         match cb_project v with
         | Some (t, body) ->

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -1067,7 +1067,9 @@ module Codec : sig
   val size_of_value : 'r t -> 'r -> int
   (** [size_of_value c v] returns the number of bytes that [encode c v] will
       write for value [v]. For fixed-size codecs, this is the same as
-      {!wire_size}; for dynamic-size codecs, the result depends on [v]. *)
+      {!wire_size}; for dynamic-size codecs, the result depends on [v]. Raises
+      [Invalid_argument] for a value {!encode} would refuse, such as a casetype
+      value no case projects. *)
 
   val is_fixed : 'r t -> bool
   (** Returns true iff the codec has a statically known size. *)

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -3884,6 +3884,39 @@ let test_undecodable_description_is_invalid_argument () =
                  ]) );
     ]
 
+(* [Codec.size_of_value] answers how many bytes [Codec.encode] will write, and a
+   caller sizes its buffer from that answer. For a casetype value no case
+   projects there are no such bytes: encode refuses it. Answering with the tag
+   width instead sent the caller off to allocate for a write that cannot happen
+   and meet the refusal one line later, so the two must refuse the same value in
+   the same words. *)
+let invalid_argument_message f =
+  match f () with () -> None | exception Invalid_argument m -> Some m
+
+let test_size_of_value_refuses_unmatched_case () =
+  let buf = Bytes.make 8 '\000' in
+  let sized =
+    invalid_argument_message (fun () ->
+        ignore (Codec.size_of_value misuse_casetype_codec (Other 5) : int))
+  in
+  (match sized with
+  | None ->
+      Alcotest.fail
+        "Codec.size_of_value answered with a size for a value no case projects"
+  | Some _ -> ());
+  let encoded =
+    invalid_argument_message (fun () ->
+        Codec.encode misuse_casetype_codec (Other 5) buf 0)
+  in
+  Alcotest.(check (option string))
+    "size_of_value refuses in encode's own words" encoded sized;
+  (* The control: a value a case does project still sizes what encode writes. *)
+  let n = Codec.size_of_value misuse_casetype_codec (B 9) in
+  Codec.encode misuse_casetype_codec (B 9) buf 0;
+  Alcotest.(check int) "a projected value sizes its tag and its body" 2 n;
+  Alcotest.(check string)
+    "and encode wrote exactly those bytes" "\002\009" (Bytes.sub_string buf 0 n)
+
 let test_get_field_notin_codec () =
   (* get with a field that was never added to this codec raises Not_found
      at staging time *)
@@ -9032,6 +9065,9 @@ let suite =
       Alcotest.test_case
         "misuse: an undecodable description raises Invalid_argument" `Quick
         test_undecodable_description_is_invalid_argument;
+      Alcotest.test_case
+        "size_of_value: a casetype value no case projects raises" `Quick
+        test_size_of_value_refuses_unmatched_case;
       Alcotest.test_case "get: a bitfield word past the buffer raises" `Quick
         test_get_bitfield_word_past_buffer_raises;
       Alcotest.test_case "set: a bitfield word past the buffer writes nothing"


### PR DESCRIPTION
Codec.size_of_value reported the tag width for a casetype value no case projects, sending a caller to allocate a buffer for a write that Codec.encode then refuses; the size path now raises the same Invalid_argument as encode, through one raiser all three paths share.
