### PR TITLE
build: replace deprecated Bytes.Slice.drop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,9 +74,17 @@ jobs:
           ocaml-compiler: '5.4'
           dune-version: '3.21'
 
-      - run: opam repository add tangled git+https://tangled.org/gazagnaire.org/opam-overlay.git --rank=-1
       - run: opam install . --deps-only --with-test
-      - run: opam install merlint
+      - run: opam repository add tangled git+https://tangled.org/gazagnaire.org/opam-overlay.git --rank=-1
+
+      # merlint pins bytesrw to a commit older than the 0.4.0 wire needs and
+      # calls no bytesrw API itself, so the pin must not move the one the
+      # project just resolved.
+      - run: opam install merlint --ignore-constraints-on bytesrw
+
+      # merlint --build runs this itself but reports only the exit code, so
+      # run it here first to get the compiler error on its own line.
+      - run: opam exec -- dune build @check
       - run: opam exec -- merlint --build
 
   # One AFL job per fuzzer: fuzz/ fuzzes the [wire] library (round-trip and

--- a/dune-project
+++ b/dune-project
@@ -23,7 +23,7 @@
    emit .3d files for verified C parser generation via EverParse.")
  (depends
   (ocaml (>= 5.2))
-  (bytesrw (>= 0.1))
+  (bytesrw (>= 0.4.0))
   (fmt (>= 0.9))
   (optint (>= 0.3))
   (memtrace :with-test)

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -486,10 +486,8 @@ let read_exact reader (n : int) =
         let need = n - off in
         let take = Int.min need slice_len in
         Bytes.blit (Slice.bytes slice) (Slice.first slice) buf off take;
-        (if slice_len > take then
-           match Slice.drop take slice with
-           | None -> assert false
-           | Some rest -> Reader.push_back reader rest);
+        if slice_len > take then
+          Reader.push_back reader (Slice.drop_first_or_eod take slice);
         loop (off + take)
   in
   loop 0

--- a/wire.opam
+++ b/wire.opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/parsimoni-labs/ocaml-wire/issues"
 depends: [
   "dune" {>= "3.21"}
   "ocaml" {>= "5.2"}
-  "bytesrw" {>= "0.1"}
+  "bytesrw" {>= "0.4.0"}
   "fmt" {>= "0.9"}
   "optint" {>= "0.3"}
   "memtrace" {with-test}


### PR DESCRIPTION
bytesrw 0.4.0 deprecates Bytes.Slice.drop, which fails the build under -warn-error +a; read_exact now uses the total drop_first_or_eod and the opam lower bound moves to 0.4.0. The lint lane resolved bytesrw from the tangled overlay, which pins a commit older than 0.4.0 and so stopped compiling lib/wire.ml, so it now installs merlint without that constraint and runs dune build @check on its own line.
