### PR TITLE
wire: add equal_error_kind

### DIFF
--- a/fuzz/gen/fuzz_gen.ml
+++ b/fuzz/gen/fuzz_gen.ml
@@ -3888,7 +3888,7 @@ let check_shifted label what ~k ~same base0 basek =
         Alcobar.failf "%s: %s at base %d read a different value than at base 0"
           label what k
   | Rejected a, Rejected b ->
-      if a.Wire.kind <> b.Wire.kind then
+      if not (Wire.equal_error_kind a.Wire.kind b.Wire.kind) then
         Alcobar.failf
           "%s: %s rejected for a different reason at base %d (%a at base 0, %a \
            at base %d)"
@@ -4120,7 +4120,10 @@ let check_repeated label what ~same first second =
           "%s: %s answered differently once another frame had been read" label
           what
   | Rejected a, Rejected b ->
-      if a.Wire.kind <> b.Wire.kind || a.Wire.at <> b.Wire.at then
+      if
+        (not (Wire.equal_error_kind a.Wire.kind b.Wire.kind))
+        || a.Wire.at <> b.Wire.at
+      then
         Alcobar.failf
           "%s: %s reported a different failure once another frame had been \
            read (%a, then %a)"

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -3148,6 +3148,8 @@ let compare_error_kind a b =
       0
   | _ -> Int.compare (kind_rank a) (kind_rank b)
 
+let equal_error_kind a b = compare_error_kind a b = 0
+
 let compare_parse_error a b =
   let c = compare_error_kind a.kind b.kind in
   if c <> 0 then c

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -1009,6 +1009,9 @@ val pp_error_kind : Format.formatter -> error_kind -> unit
 val equal_parse_error : parse_error -> parse_error -> bool
 (** Structural equality on parse errors. *)
 
+val equal_error_kind : error_kind -> error_kind -> bool
+(** Structural equality on parse error kinds, ignoring location. *)
+
 val compare_parse_error : parse_error -> parse_error -> int
 (** Total order on parse errors. *)
 

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -893,6 +893,9 @@ val pp_error_kind : Format.formatter -> error_kind -> unit
 val equal_parse_error : parse_error -> parse_error -> bool
 (** Structural equality on parse errors. *)
 
+val equal_error_kind : error_kind -> error_kind -> bool
+(** Structural equality on error kinds, ignoring location. *)
+
 val compare_parse_error : parse_error -> parse_error -> int
 (** Total order on parse errors. *)
 


### PR DESCRIPTION
The fuzz metamorphic checks compared error_kind values with polymorphic (<>), which merlint rejects; equal_error_kind reuses the existing compare_error_kind so there is one definition of kind equality.
