### PR TITLE
everparse: add equal_field_action_form

### DIFF
--- a/lib/everparse.ml
+++ b/lib/everparse.ml
@@ -616,6 +616,11 @@ let extern_fn_names s =
 
 type field_action_form = No_action | On_act | On_success
 
+let equal_field_action_form a b =
+  match (a, b) with
+  | No_action, No_action | On_act, On_act | On_success, On_success -> true
+  | (No_action | On_act | On_success), _ -> false
+
 let field_action_forms (st : Types.struct_) =
   List.map
     (fun (Types.Field f) ->

--- a/lib/everparse.mli
+++ b/lib/everparse.mli
@@ -125,6 +125,9 @@ val entrypoint_struct : t -> struct_ option
 
 type field_action_form = No_action | On_act | On_success
 
+val equal_field_action_form : field_action_form -> field_action_form -> bool
+(** Structural equality on field action forms. *)
+
 val field_action_forms :
   struct_ -> (string option * bool * field_action_form) list
 (** [field_action_forms st] enumerates the fields of [st] in declaration order.

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -1316,6 +1316,9 @@ module Everparse : sig
 
   type field_action_form = No_action | On_act | On_success
 
+  val equal_field_action_form : field_action_form -> field_action_form -> bool
+  (** Structural equality on field action forms. *)
+
   val field_action_forms :
     struct_ -> (string option * bool * field_action_form) list
   (** [field_action_forms st] enumerates fields as [(name, is_bitfield, form)]

--- a/test/stubs/test_wire_stubs.ml
+++ b/test/stubs/test_wire_stubs.ml
@@ -577,7 +577,7 @@ let check_action_forms codec =
       let expected =
         expected_action_form ~named:(Option.is_some name) ~is_bitfield
       in
-      if form <> expected then
+      if not (Wire.Everparse.equal_field_action_form form expected) then
         Alcotest.failf "%s field %s: expected %s, got %s" schema.name
           (Option.value name ~default:"<anon>")
           (pp_action_form expected) (pp_action_form form))


### PR DESCRIPTION
The stubs test compared two Wire.Everparse.field_action_form values with polymorphic (<>), which merlint flags as E106; the type now carries its own equal_field_action_form, exported through Wire.Everparse next to field_action_forms, and the test calls that.
