### PR TITLE
fuzz: gate the diff fuzzer's alias on the profile alone

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,9 +90,10 @@ jobs:
   # One AFL job per fuzzer: fuzz/ fuzzes the [wire] library (round-trip and
   # validation) and fuzz/3d/ fuzzes [wire_3d] (the EverParse / 3D projection),
   # mirroring the lib/ layout. The [afl] profile (dune-workspace) instruments
-  # native code with AFL coverage, and each dir's [fuzz] alias seeds its corpus
-  # and runs afl-fuzz for a fixed wall-clock budget. The job then fails if
-  # afl-fuzz found any crashing input in either fuzzer.
+  # native code with AFL coverage, and a dir's [fuzz] alias seeds its corpus and
+  # runs afl-fuzz for a fixed wall-clock budget. The job names those two aliases
+  # non-recursively, as fuzz/diff/ belongs to fuzz-afl-diff below. The job then
+  # fails if afl-fuzz found any crashing input in either fuzzer.
   fuzz-afl:
     runs-on: ubuntu-latest
     steps:
@@ -111,7 +112,7 @@ jobs:
         run: |
           sudo sh -c 'echo core > /proc/sys/kernel/core_pattern'
           export AFL_SKIP_CPUFREQ=1 AFL_NO_AFFINITY=1
-          opam exec -- dune build --profile afl @fuzz/fuzz
+          opam exec -- dune build --profile afl @@fuzz/fuzz @@fuzz/3d/fuzz
 
       - name: Fail on crashes
         run: |

--- a/fuzz/diff/dune
+++ b/fuzz/diff/dune
@@ -1,7 +1,10 @@
 ; Differential AFL fuzzer: OCaml wire codec vs EverParse C validator, driven by
 ; the registry. The EverParse C validators and FFI stubs are generated, so the
 ; fuzzer only builds when EverParse is available (BUILD_EVERPARSE=1, 3d.exe in
-; PATH). The generator (test/diff/gen_diff.ml) is pure OCaml and always builds.
+; PATH), which the generation rule and the executable below enforce; the [fuzz]
+; alias gates on the profile alone, so naming it without EverParse fails rather
+; than doing nothing. The generator (test/diff/gen_diff.ml) is pure OCaml and
+; always builds.
 
 (rule
  (enabled_if
@@ -55,9 +58,7 @@
 (rule
  (alias fuzz)
  (enabled_if
-  (and
-   (= %{env:BUILD_EVERPARSE=} "1")
-   (= %{profile} afl)))
+  (= %{profile} afl))
  (deps fuzz.exe ../afl.dict)
  (action
   (progn


### PR DESCRIPTION
The fuzz alias in fuzz/diff/ also required BUILD_EVERPARSE=1, a half of the gate that existed only to stop the recursive @fuzz/fuzz build from descending into a directory whose executable cannot be built without EverParse; the fuzz-afl job now names its two aliases non-recursively, so the rule gates on the profile alone and naming it without EverParse fails instead of quietly doing nothing.
