### PR TITLE
fuzz: move the differential generator out of the fuzz tree

### DIFF
--- a/fuzz/diff/dune
+++ b/fuzz/diff/dune
@@ -1,7 +1,7 @@
 ; Differential AFL fuzzer: OCaml wire codec vs EverParse C validator, driven by
 ; the registry. The EverParse C validators and FFI stubs are generated, so the
 ; fuzzer only builds when EverParse is available (BUILD_EVERPARSE=1, 3d.exe in
-; PATH). The generator (gen/) is pure OCaml and always builds.
+; PATH). The generator (test/diff/gen_diff.ml) is pure OCaml and always builds.
 
 (rule
  (enabled_if
@@ -18,9 +18,9 @@
   stubs.ml
   diff_index.ml
   libdiffcodecs.a)
- (deps gen/gen_diff.exe)
+ (deps ../../test/diff/gen_diff.exe)
  (action
-  (run %{dep:gen/gen_diff.exe} schemas)))
+  (run %{dep:../../test/diff/gen_diff.exe} schemas)))
 
 (executable
  (name fuzz)

--- a/fuzz/diff/gen/dune
+++ b/fuzz/diff/gen/dune
@@ -1,9 +1,3 @@
 (library
  (name diff_codecs)
- (modules diff_codecs)
  (libraries fmt wire fuzz_gen))
-
-(executable
- (name gen_diff)
- (modules gen_diff)
- (libraries diff_codecs fuzz_gen wire wire.3d wire.stubs unix fmt))

--- a/test/diff/dune
+++ b/test/diff/dune
@@ -61,6 +61,14 @@
  (action
   (run ./gen_c.exe schemas 100)))
 
+; Generate the differential fuzzer's EverParse C and FFI stubs
+; Run by the code generation rule in fuzz/diff/
+
+(executable
+ (name gen_diff)
+ (modules gen_diff)
+ (libraries diff_codecs fuzz_gen wire wire.3d wire.stubs unix fmt))
+
 ; Differential test: compile C stubs (includes EverParse generated C)
 ; NOTE: Only builds with BUILD_EVERPARSE=1 after running @gen_c first
 

--- a/test/diff/gen_diff.ml
+++ b/test/diff/gen_diff.ml
@@ -8,7 +8,8 @@
     predicate must stay in agreement. Emits the EverParse C into [<argv1>/]
     (default [schemas/]) and [wire_ffi.c] + [stubs.ml] + [diff_index.ml] (a
     [covered] array pairing each codec's label with a [bytes -> bool] accept
-    check) into the current directory. Run by the [gen] dune rule.
+    check) into the current directory. Run by the code generation rule in
+    [fuzz/diff/].
 
     EverParse spends ~9s verifying each module, so the codecs are generated in a
     bounded fork pool, each run in a private directory (EverParse's shared

--- a/test/stubs/test_wire_stubs.mli
+++ b/test/stubs/test_wire_stubs.mli
@@ -1,3 +1,5 @@
+(** Tests for the [wire_stubs] module. *)
+
 val suite : string * unit Alcotest.test_case list
 (** [suite] is the Alcotest suite for Wire_stubs compile and EverParse
     end-to-end tests. *)


### PR DESCRIPTION
merlint applies its fuzz-layout rules to every directory under fuzz/, and gen_diff is a code generator rather than a fuzzer, so it now sits in test/diff/ next to gen_c and gen_schemas while the diff_codecs library stays put. The test/stubs mli also gains the module doc comment merlint asks for; E724 on fuzz/diff/dune is left alone because its enabled_if gate is needed to keep the AFL alias buildable without EverParse.

