### PR TITLE
codec: make validate run sub-codec field checks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -87,6 +87,10 @@
 
 ### Fixed
 
+- Fix `Codec.validate` skipping a sub-codec field's constraints, `where`,
+  closed-enum membership, `per_byte` refinements and actions, which now reject
+  the same bytes as decoding and generated EverParse validators (#311, @samoht)
+
 - Fix `Codec.{get,set}` on a bitfield whose base word is not entirely inside the
   buffer. A `u32` word is assembled from unchecked byte reads, so a short frame
   read at an application-chosen offset answered with the bytes that followed it,

--- a/fuzz/fuzz_wire.ml
+++ b/fuzz/fuzz_wire.ml
@@ -22,6 +22,14 @@ let nested_tests () =
   @ nested_cases "nested(d3)" 3
   @ nested_cases "nested(d4)" 4
 
+(* [Codec.validate] and [Codec.decode] must agree on which bytes are valid. A
+   check that reaches one and not the other leaves a caller reading fields it
+   never validated, and the differential lane cannot see it: its OCaml side is
+   [Codec.decode_exn], so it never runs the gate. *)
+let validate_agrees_tests () =
+  validate_agrees_cases "validate_agrees(d2)" 2
+  @ validate_agrees_cases "validate_agrees(d3)" 3
+
 let entry_point_tests () = entry_point_cases "entry"
 let api_tests () = api_cases "api"
 
@@ -31,8 +39,8 @@ let suite =
     ( "wire",
       registry_tests ()
       @ reject_cases "action_abort" action_abort
-      @ sized_cases "sized" @ nested_tests () @ entry_point_tests ()
-      @ api_tests ()
+      @ sized_cases "sized" @ nested_tests () @ validate_agrees_tests ()
+      @ entry_point_tests () @ api_tests ()
       @ semantic_invariant_cases "semantic"
       @ construction_guard_cases "construction"
       @ invariant_cases "invariants" )

--- a/fuzz/gen/fuzz_gen.ml
+++ b/fuzz/gen/fuzz_gen.ml
@@ -3438,28 +3438,59 @@ let check_encode_safety label ?env g value =
           Alcobar.failf
             "%s encode safety: encode wrote bytes that crash the decoder" label)
 
-let decode_accepts ?env g bs =
-  try
-    match Wire.Codec.decode ?env g.codec bs 0 with
-    | Ok _ -> `Accept
-    | Error _ -> `Reject
-  with Invalid_argument _ -> `Crash
+(* One entry point's answer on one buffer: the value it built, the parse error
+   it reported, or [Invalid_argument], which no entry point is allowed to raise
+   ([check_decode_safety] / [check_validate_safety] own that). *)
+type 'a verdict = Accepted of 'a | Rejected of Wire.parse_error | Crashed
 
-let validate_accepts ?env g bs =
-  match validate_one ?env g bs with
-  | `Ok -> `Accept
-  | `Reject -> `Reject
-  | `Crash -> `Crash
+let decode_at ?env g bs off =
+  match Wire.Codec.decode ?env g.codec bs off with
+  | Ok v -> Accepted v
+  | Error e -> Rejected e
+  | exception Invalid_argument _ -> Crashed
 
+let validate_at ?env g bs off =
+  match Wire.Codec.validate ?env g.codec bs off with
+  | () -> Accepted ()
+  | exception Wire.Parse_error e -> Rejected e
+  | exception Invalid_argument _ -> Crashed
+
+(* Two rejections of the same buffer, blamed on the same field, must give the
+   same reason. Blamed on different fields they need not: a buffer can break
+   several fields at once, and the two paths do not reach them in the same order
+   (decode fills a record, so its field readers run in the compiler's argument
+   order; validate walks the compiled field list in declaration order). Which of
+   several genuine faults gets reported is not a property worth pinning; that a
+   fault the other path found is a fault this one found too, is. *)
+let same_rejection (a : Wire.parse_error) (b : Wire.parse_error) =
+  List.compare String.compare a.Wire.field b.Wire.field <> 0
+  || Wire.equal_error_kind a.Wire.kind b.Wire.kind
+
+(* [Codec.validate] is the gate [codec.mli] tells a caller to run on untrusted
+   input before reading fields zero-copy, so it must raise on exactly the bytes
+   [Codec.decode] returns [Error] on, and for the same reason. Two entry points
+   of one library that disagree about which bytes are valid are a parser
+   differential inside it: what the caller validated is not what it goes on to
+   read. Only the reason is compared, not the offset -- validate reaches a
+   failing field through its own populate and may locate the same rejection at a
+   different byte. *)
 let check_decode_validate_agree label kind ?env g bs =
-  match (decode_accepts ?env g bs, validate_accepts ?env g bs) with
-  | `Crash, _ -> Alcobar.failf "%s %s crashed decoder" label kind
-  | _, `Crash -> Alcobar.failf "%s %s crashed validator" label kind
-  | `Accept, `Accept | `Reject, `Reject -> ()
-  | `Accept, `Reject ->
-      Alcobar.failf "%s %s decode accepted but validate rejected" label kind
-  | `Reject, `Accept ->
-      Alcobar.failf "%s %s validate accepted but decode rejected" label kind
+  match (decode_at ?env g bs 0, validate_at ?env g bs 0) with
+  | Crashed, _ -> Alcobar.failf "%s %s crashed decoder" label kind
+  | _, Crashed -> Alcobar.failf "%s %s crashed validator" label kind
+  | Accepted _, Accepted () -> ()
+  | Rejected d, Rejected v ->
+      if not (same_rejection d v) then
+        Alcobar.failf
+          "%s %s: decode and validate rejected for different reasons (decode: \
+           %a, validate: %a)"
+          label kind Wire.pp_parse_error d Wire.pp_parse_error v
+  | Accepted _, Rejected v ->
+      Alcobar.failf "%s %s: decode accepted but validate rejected (%a)" label
+        kind Wire.pp_parse_error v
+  | Rejected d, Accepted () ->
+      Alcobar.failf "%s %s: validate accepted what decode rejects (%a)" label
+        kind Wire.pp_parse_error d
 
 (* One sample of the hostile-value stream, or [None] for a shape with no
    refinement to violate. Kept as an [option] stream so every gen presents the
@@ -3789,7 +3820,9 @@ let check_fields label a g (value, bs) other hostile =
    from the fuzzer's byte generators rather than from any encoder, so neither
    side is reading back something it wrote. *)
 let check_field_reads label kind ?env a g bs =
-  let validated = validate_accepts ?env g bs = `Accept in
+  let validated =
+    match validate_at ?env g bs 0 with Accepted () -> true | _ -> false
+  in
   let decoded =
     match Wire.Codec.decode ?env g.codec bs 0 with
     | Ok record -> Some record
@@ -3844,20 +3877,6 @@ let noise_gen =
     Alcobar.[ Alcobar.bytes ]
     (fun s ->
       bytes_of_string (if String.length s > 8 then String.sub s 0 8 else s))
-
-type 'a verdict = Accepted of 'a | Rejected of Wire.parse_error | Crashed
-
-let decode_at ?env g bs off =
-  match Wire.Codec.decode ?env g.codec bs off with
-  | Ok v -> Accepted v
-  | Error e -> Rejected e
-  | exception Invalid_argument _ -> Crashed
-
-let validate_at ?env g bs off =
-  match Wire.Codec.validate ?env g.codec bs off with
-  | () -> Accepted ()
-  | exception Wire.Parse_error e -> Rejected e
-  | exception Invalid_argument _ -> Crashed
 
 let size_at g bs off =
   match Wire.Codec.wire_size_at g.codec bs off with
@@ -4397,6 +4416,20 @@ let check_nested_bytes label kind noise (NB (g, comp, bs, mk)) =
   check_frame_extent label kind ?env g noise bs;
   check_read_purity label kind ?env a g bs
 
+(* An arbitrary nested codec paired with one buffer to read it at: the
+   adversarial stream sits on the codec's own boundaries, the random one is
+   arbitrary bytes. *)
+let nested_bytes_gen depth ~adversarial =
+  Alcobar.dynamic_bind (gen_any depth) (fun (Any a) ->
+      let stream = if adversarial then a.g.adversarial else bytes_any in
+      match a.g.env with
+      | None ->
+          Alcobar.map Alcobar.[ stream ] (fun bs -> NB (a.g, a.label, bs, None))
+      | Some s ->
+          Alcobar.map
+            Alcobar.[ stream; s.fuzz ]
+            (fun bs mk -> NB (a.g, a.label, bs, Some mk)))
+
 let nested_cases label depth =
   let positive =
     Alcobar.dynamic_bind (gen_any depth) (fun (Any a) ->
@@ -4404,19 +4437,7 @@ let nested_cases label depth =
           Alcobar.[ a.g.positive; a.g.positive ]
           (fun pos (other, _) -> NS (a.g, a.label, pos, other)))
   in
-  let with_bytes adversarial =
-    Alcobar.dynamic_bind (gen_any depth) (fun (Any a) ->
-        let stream = if adversarial then a.g.adversarial else bytes_any in
-        match a.g.env with
-        | None ->
-            Alcobar.map
-              Alcobar.[ stream ]
-              (fun bs -> NB (a.g, a.label, bs, None))
-        | Some s ->
-            Alcobar.map
-              Alcobar.[ stream; s.fuzz ]
-              (fun bs mk -> NB (a.g, a.label, bs, Some mk)))
-  in
+  let with_bytes adversarial = nested_bytes_gen depth ~adversarial in
   [
     Alcobar.test_case (label ^ " all")
       Alcobar.[ positive; with_bytes false; with_bytes true; noise_gen ]
@@ -4424,6 +4445,30 @@ let nested_cases label depth =
         check_nested_positive label noise positive;
         check_nested_bytes label "random" noise random;
         check_nested_bytes label "adversarial" noise adversarial);
+  ]
+
+(* The agreement property on generated compositions rather than curated ones.
+   A check a combinator carries is enforced at every use site or at none, and a
+   use site only exists once the combinator is nested inside something else, so
+   the shapes that can drift are exactly the ones no curated list enumerates:
+   the registry gens are each their own top-level codec, where decode and
+   validate share the same compiled field list and cannot disagree. *)
+let validate_agrees_cases label depth =
+  let check kind (NB (g, comp, bs, mk)) =
+    let env = Option.map (fun f -> f (Wire.Codec.env g.codec)) mk in
+    check_decode_validate_agree (Fmt.str "%s [%s]" label comp) kind ?env g bs
+  in
+  [
+    Alcobar.test_case
+      (label ^ " validate agrees with decode")
+      Alcobar.
+        [
+          nested_bytes_gen depth ~adversarial:false;
+          nested_bytes_gen depth ~adversarial:true;
+        ]
+      (fun random adversarial ->
+        check "random" random;
+        check "adversarial" adversarial);
   ]
 
 (* Round-trip through {!Wire.of_string} / {!Wire.to_string}: the typ-level

--- a/fuzz/gen/fuzz_gen.mli
+++ b/fuzz/gen/fuzz_gen.mli
@@ -83,6 +83,15 @@ val nested_cases : string -> int -> Alcobar.test_case list
     list enumerates, surfacing offset / [size_of_value] drift that only shows up
     when combinators nest. *)
 
+val validate_agrees_cases : string -> int -> Alcobar.test_case list
+(** [validate_agrees_cases label depth] asserts {!Wire.Codec.validate} raises
+    exactly when {!Wire.Codec.decode} returns [Error], with the same
+    [error_kind], over an arbitrary nested codec per sample (cf.
+    {!nested_cases}). The gate a caller runs on untrusted input and the decoder
+    it is standing in for must not disagree about which bytes are valid, and a
+    check that reaches one path but not the other shows up here rather than in
+    the generated C. *)
+
 val reject_cases : string -> 'a t -> Alcobar.test_case list
 (** [reject_cases label g] is a batched Alcobar case asserting that decode
     rejects every input on [g.random] and [g.adversarial]. Use for codecs that

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -1249,6 +1249,12 @@ type 'r t = {
   wire_size : wire_size_info;
   struct_fields : Types.field list;
   validate : ?env_slots:int array -> bytes -> int -> unit;
+  validate_ctx : runtime -> bytes -> int -> unit;
+      (* [validate] for a codec embedded in another: the same bounds check and
+         the same field pass, with parameters resolved by name against the
+         caller's context rather than a [Param.env]. This is what a use site of
+         the codec runs, so a sub-codec's checks are enforced wherever it
+         appears. *)
   validate_arr : slots -> runtime -> bytes -> int -> unit;
   populate : slots -> runtime -> bytes -> int -> unit;
   n_array_slots : int;
@@ -1928,6 +1934,17 @@ let null_int_reader : runtime -> bytes -> int -> int =
 let no_populate : slots -> runtime -> bytes -> int -> unit =
  fun _arr _runtime _buf _base -> ()
 
+(* A sub-codec field's check pass: run the sub-codec's own validator where the
+   field sits. This is the whole of what the generated C emits for a sub-struct
+   field, a call to the nested struct's validator, and it is what makes
+   [Codec.validate] reject at a use site everything the sub-codec's [decode]
+   rejects. No int slot is filled: a record-typed field has no scalar value an
+   enclosing expression could reference. *)
+let sub_codec_populate ~codec_validate ~off_fn :
+    slots -> runtime -> bytes -> int -> unit =
+ fun _arr runtime buf base ->
+  codec_validate runtime buf (base + off_fn runtime buf base)
+
 (* Reader+writer pair for a Codec-or-scalar inner type placed at the current
    frame offset. Extracted so [compile_optional] and [compile_optional_or]
    share it. *)
@@ -2066,11 +2083,13 @@ let compile_codec_variable : type a r.
     layout_ctx ->
     get:(r -> a) ->
     codec_decode:(runtime -> bytes -> int -> a) ->
+    codec_validate:(runtime -> bytes -> int -> unit) ->
     codec_encode:(a -> runtime -> bytes -> int -> int) ->
     codec_size_of:(runtime -> bytes -> int -> int) ->
     nested_readers:field_reader list ->
     (a, r) compiled_field =
- fun ctx ~get ~codec_decode ~codec_encode ~codec_size_of ~nested_readers ->
+ fun ctx ~get ~codec_decode ~codec_validate ~codec_encode ~codec_size_of
+     ~nested_readers ->
   let off_fn, (field_access : field_access), validator_off =
     match ctx.next_off with
     | Static n ->
@@ -2107,20 +2126,21 @@ let compile_codec_variable : type a r.
     int_reader = null_int_reader;
     nested_readers;
     validator_off;
-    populate = no_populate;
+    populate = sub_codec_populate ~codec_validate ~off_fn;
   }
 
 let compile_codec : type a r.
     layout_ctx ->
     (a, r) field ->
     codec_decode:(runtime -> bytes -> int -> a) ->
+    codec_validate:(runtime -> bytes -> int -> unit) ->
     codec_encode:(a -> runtime -> bytes -> int -> int) ->
     codec_fixed_size:int option ->
     codec_size_of:(runtime -> bytes -> int -> int) ->
     codec_field_readers:field_reader list ->
     (a, r) compiled_field =
- fun ctx fld ~codec_decode ~codec_encode ~codec_fixed_size ~codec_size_of
-     ~codec_field_readers ->
+ fun ctx fld ~codec_decode ~codec_validate ~codec_encode ~codec_fixed_size
+     ~codec_size_of ~codec_field_readers ->
   let nested_readers = build_nested_readers ctx codec_field_readers in
   let get = fld.get in
   match codec_fixed_size with
@@ -2140,11 +2160,11 @@ let compile_codec : type a r.
         int_reader = null_int_reader;
         nested_readers;
         validator_off = validator_off_of ctx;
-        populate = no_populate;
+        populate = sub_codec_populate ~codec_validate ~off_fn:(off_fn_of ctx);
       }
   | None ->
-      compile_codec_variable ctx ~get ~codec_decode ~codec_encode ~codec_size_of
-        ~nested_readers
+      compile_codec_variable ctx ~get ~codec_decode ~codec_validate
+        ~codec_encode ~codec_size_of ~nested_readers
 
 (* Variable-size sub-codec: dispatch on whether we sit at a static or a
    dynamic running offset. Mirrors [compile_var_bytes] -- both flavours
@@ -2299,28 +2319,59 @@ let repeat_raw_reader : type elt seq.
   | Some esz -> repeat_raw_fixed seq ~read esz ~off_fn ~size_fn
   | None -> repeat_raw_variable seq ~read ~size_of_elem ~off_fn ~size_fn
 
-(* An element whose reader's only product is the value it hands back. A
-   fixed-width byte span re-slices or copies bytes the budget prologue has
-   already bounded to the buffer, a NUL-terminated one's terminator search has
-   run in [size_of_elem] before the reader is called, and a 64-bit or
-   floating-point scalar is one unchecked read of a word inside the same
-   bounded budget, so on the check walk there is nothing left for the reader to
-   do. Every other element's reader does something [Codec.validate] needs (an
-   enum's membership, a sub-codec's constraints, a casetype's tag dispatch), so
-   it runs. *)
-let elem_reader_is_value_only : type a. a typ -> bool = function
-  | Byte_array { size = Int _ } | Byte_slice { size = Int _ } | Zeroterm -> true
-  | Uint64 _ | Int64 _ | Float32 _ | Float64 _ -> true
-  | _ -> false
+(* How the check walk gets at an element's checks without keeping the value.
 
-(* The element read the check walk runs. Skipping a value-only reader keeps the
-   span out of the heap: the element count comes from the byte budget, which
-   comes from a length field, so a copy per element is a multiplier the sender
-   sizes on the path a server runs once per packet. *)
+   [By_reading] is the derived answer: run the element's own reader and drop
+   what it built. It cannot disagree with decode, because it is decode, so it is
+   the default for anything not deliberately classified otherwise.
+
+   [Value_only] says the reader's only product is the value it hands back, so on
+   the check walk there is nothing left for it to do: a fixed-width byte span
+   re-slices or copies bytes the budget prologue has already bounded to the
+   buffer, a NUL-terminated one's terminator search has run in [size_of_elem]
+   before the reader is called, and a 64-bit or floating-point scalar is one
+   unchecked read of a word inside the same bounded budget.
+
+   [By] says the element type carries its own validator, which a sub-codec does.
+
+   The last two are departures from derivation, and each is a claim about a
+   reader that [Codec.validate] agreeing with [Codec.decode] is what keeps
+   honest. *)
+type 'a elem_strategy =
+  | By_reading
+  | Value_only
+  | By of (runtime -> bytes -> int -> unit)
+
+(* Every constructor is listed and there is deliberately no [| _ -> ...]: a typ
+   added later must not pick a strategy by falling through, since picking
+   [Value_only] for a reader that checks something is how [Codec.validate] comes
+   to accept what [Codec.decode] rejects. Adding one stops the build until
+   somebody chooses. *)
+let elem_strategy : type a. a typ -> a elem_strategy = function
+  | Codec { codec_validate; _ } -> By codec_validate
+  | Byte_array { size = Int _ } | Byte_slice { size = Int _ } | Zeroterm ->
+      Value_only
+  | Uint64 _ | Int64 _ | Float32 _ | Float64 _ -> Value_only
+  | Uint8 | Uint16 _ | Uint32 _ | Uint63 _ | Int8 | Int16 _ | Int32 _
+  | Uint_var _ | Bits _ | Unit | All_bytes | All_zeros | Zeroterm_at_most _
+  | Where _ | Array _ | Byte_array _ | Byte_array_where _ | Byte_slice _
+  | Single_elem _ | Enum _ | Casetype _ | Struct _ | Type_ref _
+  | Qualified_ref _ | Map _ | Apply _ | Optional _ | Optional_or _ | Repeat _ ->
+      By_reading
+
+(* The element check the walk runs. Skipping a value-only reader keeps the span
+   out of the heap, and letting a sub-codec check itself keeps the record out of
+   it: the element count comes from the byte budget, which comes from a length
+   field, so anything built per element is a multiplier the sender sizes on the
+   path a server runs once per packet. This is the C's element loop, which calls
+   the element validator and keeps one position. *)
 let elem_check : type a. a typ -> runtime -> bytes -> int -> unit =
  fun typ ->
-  if elem_reader_is_value_only typ then fun _runtime _buf _off -> ()
-  else fun runtime buf off -> ignore (read_elem typ runtime buf off : a)
+  match elem_strategy typ with
+  | Value_only -> fun _runtime _buf _off -> ()
+  | By check -> check
+  | By_reading ->
+      fun runtime buf off -> ignore (read_elem typ runtime buf off : a)
 
 (* Write a repeat's elements at their own strides. Kept out of
    [compile_repeat] so the writer is staged once, with the sequence, the element
@@ -2828,14 +2879,15 @@ let rec compile_field : type a r.
   | Codec
       {
         codec_decode;
+        codec_validate;
         codec_encode;
         codec_fixed_size;
         codec_size_of;
         codec_field_readers;
         _;
       } ->
-      compile_codec ctx fld ~codec_decode ~codec_encode ~codec_fixed_size
-        ~codec_size_of ~codec_field_readers
+      compile_codec ctx fld ~codec_decode ~codec_validate ~codec_encode
+        ~codec_fixed_size ~codec_size_of ~codec_field_readers
   | Optional { present; inner } -> compile_optional ctx fld present inner
   | Optional_or { present; inner; default } ->
       compile_optional_or ctx fld present inner default
@@ -3867,6 +3919,25 @@ let has_encode_checks struct_fields where =
          Option.fold ~none:false ~some:is_real_cond f.constraint_)
        struct_fields
 
+(* Bind the codec's formals from the caller's context, and write the mutable
+   ones back after the pass. Written as loops taking everything as arguments
+   rather than as [List.iteri] over a closure: this runs once per sub-codec per
+   element of an enclosing repeat, where the element count is the sender's to
+   choose, and a closure capturing the slots and the context is two heap blocks
+   a validator has no business turning over. *)
+let rec seed_params arr runtime param_base i = function
+  | [] -> ()
+  | Param.Pack p :: rest ->
+      arr.ints.(param_base + i) <- Types.eval_param runtime p.Types.name;
+      seed_params arr runtime param_base (i + 1) rest
+
+let rec writeback_params arr runtime param_base i = function
+  | [] -> ()
+  | Param.Pack p :: rest ->
+      if p.Types.mutable_ then
+        Types.eval_set_param runtime p.Types.name arr.ints.(param_base + i);
+      writeback_params arr runtime param_base (i + 1) rest
+
 (* Replay the decode-side check pass over the record encode just assembled, so a
    cond that reads sibling fields is enforced on both halves. Field actions are
    deliberately excluded: [populate] runs the check-only validators, so encoding
@@ -3875,14 +3946,23 @@ let encode_checker ~scratch ~n_total ~param_base ~param_handles ~populate
     ~compiled_where runtime buf off =
   let arr = scratch () in
   clear_slots arr n_total;
-  List.iteri
-    (fun i (Param.Pack p) ->
-      arr.ints.(param_base + i) <- Types.eval_param runtime p.Types.name)
-    param_handles;
+  seed_params arr runtime param_base 0 param_handles;
   populate arr runtime buf off;
   match compiled_where with
   | Some f when not (f arr) -> raise_constraint ~at:off ~which:Where ()
   | _ -> ()
+
+(* The check pass over one codec's fields at [off], with its parameters bound
+   from the caller's context. Taken apart from [validate_runtime] so [seal] can
+   build the same pass into the sub-codec entry point a use site calls, and the
+   two cannot drift. *)
+let validate_runtime_of ~scratch ~n_total ~param_base ~param_handles
+    ~validate_arr runtime buf off =
+  let arr = scratch () in
+  clear_slots arr n_total;
+  seed_params arr runtime param_base 0 param_handles;
+  validate_arr arr runtime buf off;
+  writeback_params arr runtime param_base 0 param_handles
 
 let build_record_encoder name writers size_of_value ~check =
   let n = Array.length writers in
@@ -3962,6 +4042,11 @@ let seal : type r. (r, r) record -> r t =
     validate =
       validate_with_bounds wire_size_info min_size r.param_slots param_base
         validate_checks;
+    validate_ctx =
+      (fun runtime buf off ->
+        check_decode_bounds wire_size_info min_size runtime buf off;
+        validate_runtime_of ~scratch ~n_total ~param_base ~param_handles
+          ~validate_arr runtime buf off);
     validate_arr;
     populate;
     n_array_slots = n_total;
@@ -4303,18 +4388,9 @@ let embed_encode_ctx (t : 'r t) v runtime buf off = t.encode v runtime buf off
 let embed_encode (t : 'r t) v buf off = embed_encode_ctx t v no_runtime buf off
 
 let validate_runtime t runtime buf off =
-  let arr = t.decode_scratch () in
-  clear_slots arr t.n_array_slots;
-  List.iteri
-    (fun i (Param.Pack p) ->
-      arr.ints.(t.param_base + i) <- Types.eval_param runtime p.Types.name)
-    t.param_handles;
-  t.validate_arr arr runtime buf off;
-  List.iteri
-    (fun i (Param.Pack p) ->
-      if p.Types.mutable_ then
-        Types.eval_set_param runtime p.name arr.ints.(t.param_base + i))
-    t.param_handles
+  validate_runtime_of ~scratch:t.decode_scratch ~n_total:t.n_array_slots
+    ~param_base:t.param_base ~param_handles:t.param_handles
+    ~validate_arr:t.validate_arr runtime buf off
 
 let embed_decode_ctx (t : 'r t) runtime buf off =
   let v = t.decode runtime buf off in
@@ -4322,6 +4398,10 @@ let embed_decode_ctx (t : 'r t) runtime buf off =
   v
 
 let embed_decode (t : 'r t) buf off = embed_decode_ctx t no_runtime buf off
+
+(* [embed_decode_ctx] with the record construction dropped: the same bounds
+   check and the same field pass, and nothing built. *)
+let embed_validate_ctx (t : 'r t) = t.validate_ctx
 
 let wire_size_info_ctx (t : _ t) =
   match t.wire_size with

--- a/lib/codec.mli
+++ b/lib/codec.mli
@@ -209,6 +209,14 @@ val embed_decode : 'r t -> bytes -> int -> 'r
 val embed_decode_ctx : 'r t -> Types.eval_ctx -> bytes -> int -> 'r
 (** Context-threaded embedded decode. Internal use. *)
 
+val embed_validate_ctx : 'r t -> Types.eval_ctx -> bytes -> int -> unit
+(** [embed_validate_ctx c ctx buf off] runs everything {!embed_decode_ctx}
+    checks and builds nothing: the bounds check, the field constraints, the
+    [where] clauses, the enum and span refinements and the field actions of the
+    sub-codec at [off]. This is what an embedded codec's use site runs,
+    mirroring the call to the nested struct's validator the generated C makes.
+    Internal use. *)
+
 val wire_size_info : 'r t -> [ `Fixed of int | `Variable of bytes -> int -> int ]
 (** Wire size information for embedding. *)
 

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -241,6 +241,12 @@ and _ typ =
   | Codec : {
       codec_name : string;
       codec_decode : eval_ctx -> bytes -> int -> 'r;
+      codec_validate : eval_ctx -> bytes -> int -> unit;
+          (* Everything [codec_decode] checks, none of what it builds. The
+             OCaml counterpart of the call to a nested struct's validator that
+             EverParse generates for a sub-struct field: a use site runs the
+             sub-codec's constraints, [where], enum membership, span refinements
+             and actions without materialising the record. *)
       codec_encode : 'r -> eval_ctx -> bytes -> int -> int;
           (* Returns the offset after the bytes the encoder wrote. *)
       codec_fixed_size : int option;

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -353,6 +353,10 @@ and _ typ =
   | Codec : {
       codec_name : string;
       codec_decode : eval_ctx -> bytes -> int -> 'r;
+      codec_validate : eval_ctx -> bytes -> int -> unit;
+          (** Everything [codec_decode] checks, none of what it builds. Run at
+              every use site of the sub-codec, as the generated C runs the
+              nested struct's validator. *)
       codec_encode : 'r -> eval_ctx -> bytes -> int -> int;
       codec_fixed_size : int option;
       codec_size_of : eval_ctx -> bytes -> int -> int;

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -67,6 +67,7 @@ let is_nan (f : float Field.t) : bool Types.expr =
 
 let codec (c : 'r Codec.t) : 'r typ =
   let codec_decode = Codec.embed_decode_ctx c in
+  let codec_validate = Codec.embed_validate_ctx c in
   let codec_encode = Codec.embed_encode_ctx c in
   let codec_field_readers = Codec.field_readers_ctx c in
   let codec_struct = Codec.to_struct c in
@@ -77,6 +78,7 @@ let codec (c : 'r Codec.t) : 'r typ =
         {
           codec_name = Codec.name c;
           codec_decode;
+          codec_validate;
           codec_encode;
           codec_fixed_size = Some n;
           codec_size_of = (fun _ctx _buf _off -> n);
@@ -89,6 +91,7 @@ let codec (c : 'r Codec.t) : 'r typ =
         {
           codec_name = Codec.name c;
           codec_decode;
+          codec_validate;
           codec_encode;
           codec_fixed_size = None;
           codec_size_of = size_of;

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -383,6 +383,111 @@ let test_validate_matches_decode_rejections () =
   in
   rejects "array element constraint" arr_c "\x01\x63"
 
+(* [Codec.validate] is the gate [codec.mli] tells a caller to run on untrusted
+   input before reading fields zero-copy, so a sub-codec used as a field has to
+   be checked where it sits. EverParse compiles that field to a call to the
+   nested struct's validator, which enforces everything the struct declares, so
+   a use site that skipped those checks would accept bytes the verified C
+   rejects. Each case puts the sub-codec behind a header byte, so a use site
+   that validated at the wrong offset fails too. *)
+type sub_codec_case =
+  | Sub_codec_case : string * 'a Codec.t * string -> sub_codec_case
+
+let sub_codec_check_cases =
+  let outer name inner =
+    Codec.v name
+      (fun h s -> (h, s))
+      Codec.[ Field.v "h" uint8 $ fst; Field.v "s" (codec inner) $ snd ]
+  in
+  let constraint_inner =
+    Codec.v "SubConstraint" Fun.id
+      Codec.
+        [
+          Field.v "v" uint8 ~self_constraint:(fun v -> Expr.(v >= int 10))
+          $ Fun.id;
+        ]
+  in
+  let where_inner =
+    let f_a = Field.v "a" uint8 and f_b = Field.v "b" uint8 in
+    Codec.v "SubWhere"
+      ~where:Expr.(Field.ref f_a < Field.ref f_b)
+      (fun a b -> (a, b))
+      Codec.[ f_a $ fst; f_b $ snd ]
+  in
+  let enum_inner =
+    Codec.v "SubEnum" Fun.id
+      Codec.[ Field.v "e" (enum "Code" [ ("A", 1); ("B", 2) ] uint8) $ Fun.id ]
+  in
+  let action_inner =
+    let f_x = Field.v "x" uint8 in
+    let f_y =
+      Field.v "y" uint8
+        ~action:
+          (Action.on_success
+             [ Action.return_bool Expr.(Field.ref f_x < int 128) ])
+    in
+    Codec.v "SubAction" (fun x y -> (x, y)) Codec.[ f_x $ fst; f_y $ snd ]
+  in
+  let per_byte_inner =
+    Codec.v "SubPerByte" Fun.id
+      Codec.
+        [
+          Field.v "s"
+            (byte_array_where ~size:(int 2) ~per_byte:(fun b ->
+                 Expr.(b >= int 0x41)))
+          $ Fun.id;
+        ]
+  in
+  let variable_inner =
+    let f_len =
+      Field.v "len" uint8 ~self_constraint:(fun v -> Expr.(v <= int 2))
+    in
+    let f_data = Field.v "data" (byte_array ~size:(Field.ref f_len)) in
+    Codec.v "SubVariable"
+      (fun len data -> (len, data))
+      Codec.[ f_len $ fst; f_data $ snd ]
+  in
+  let codec_in_codec =
+    Codec.v "SubOfSub" Fun.id
+      Codec.[ Field.v "i" (codec constraint_inner) $ Fun.id ]
+  in
+  [
+    Sub_codec_case
+      ("field constraint", outer "OuterConstraint" constraint_inner, "\000\001");
+    Sub_codec_case
+      ("codec where", outer "OuterWhere" where_inner, "\000\002\001");
+    Sub_codec_case ("enum membership", outer "OuterEnum" enum_inner, "\000\009");
+    Sub_codec_case
+      ("field action", outer "OuterAction" action_inner, "\000\200\000");
+    Sub_codec_case
+      ("per-byte span", outer "OuterPerByte" per_byte_inner, "\000\000\000");
+    Sub_codec_case
+      ( "variable inner",
+        outer "OuterVariable" variable_inner,
+        "\000\009aaaaaaaaa" );
+    Sub_codec_case
+      ("codec in codec", outer "OuterOfSub" codec_in_codec, "\000\001");
+  ]
+
+let test_validate_runs_sub_codec_checks () =
+  List.iter
+    (fun (Sub_codec_case (what, c, bytes)) ->
+      let buf = Bytes.of_string bytes in
+      let decoded =
+        match Codec.decode c buf 0 with
+        | Ok _ -> Alcotest.failf "%s: decode accepted a bad sub-codec" what
+        | Error e -> e
+      in
+      match Codec.validate c buf 0 with
+      | () ->
+          Alcotest.failf "%s: validate accepted what decode rejects (%a)" what
+            pp_parse_error decoded
+      | exception Parse_error e ->
+          if not (equal_error_kind e.kind decoded.kind) then
+            Alcotest.failf "%s: validate rejected for another reason (%a vs %a)"
+              what pp_parse_error e pp_parse_error decoded)
+    sub_codec_check_cases
+
 (* The allocation tests read [Gc.minor_words], which only counts under the
    native and bytecode runtimes; under wasm_of_ocaml or js_of_ocaml the
    counters stay at zero and the assertions would pass vacuously. *)
@@ -7901,9 +8006,13 @@ let test_validate_allocation_is_bounded () =
    multiplier per packet. The byte spans and the 64-bit and floating-point
    scalars are here for the same reason one step in: their reader's only product
    is the value, boxed for the wide scalars and copied for the spans, so on a
-   walk that keeps nothing they have nothing to do. What an element's reader has to do to check it (a
-   sub-codec's constraints, a casetype's tag dispatch) is a separate question,
-   so those stay out. *)
+   walk that keeps nothing they have nothing to do. A sub-codec element is here
+   because it carries its own validator: the C loop EverParse generates calls
+   that validator and keeps one position, so validating a repeat of them must
+   keep no more, where building a record per element would hand the sender the
+   multiplier again. What an element's reader has to do to check it (a
+   casetype's tag dispatch, a [map]'s conversion) is a separate question, so
+   those stay out. *)
 let f_repeat_len = Field.v "len" uint16be
 
 let repeat_budget_codec elem =
@@ -7939,6 +8048,20 @@ let repeat_budget_case ?(buf = repeat_budget_buf) name elem =
       let buf = buf n in
       fun () -> Codec.validate c buf 0 )
 
+(* Four bytes wide, so a 512- and a 4096-byte budget both divide into whole
+   elements, and constrained, so the element has something to check. *)
+let repeat_elem_codec =
+  Codec.v "RepeatElem"
+    (fun a b c d -> (a, b, c, d))
+    Codec.
+      [
+        ( Field.v "a" uint8 ~self_constraint:(fun r -> Expr.(r <> int 0))
+        $ fun (a, _, _, _) -> a );
+        (Field.v "b" uint8 $ fun (_, b, _, _) -> b);
+        (Field.v "c" uint8 $ fun (_, _, c, _) -> c);
+        (Field.v "d" uint8 $ fun (_, _, _, d) -> d);
+      ]
+
 let test_repeat_validate_allocation_is_bounded () =
   skip_unless_gc_counters ();
   let small = 512 and large = 4096 in
@@ -7969,6 +8092,7 @@ let test_repeat_validate_allocation_is_bounded () =
         repeat_budget_case "byte_array" (byte_array ~size:(int 4));
         repeat_budget_case "byte_slice" (byte_slice ~size:(int 4));
         repeat_budget_case ~buf:repeat_zeroterm_buf "zeroterm" zeroterm;
+        repeat_budget_case "codec" (codec repeat_elem_codec);
       ]
   in
   report_span_failures "validate allocation scales with a repeat's budget"
@@ -8477,6 +8601,8 @@ let suite =
         test_validate_check_free_no_alloc;
       Alcotest.test_case "validate: matches decode rejections" `Quick
         test_validate_matches_decode_rejections;
+      Alcotest.test_case "validate: runs a sub-codec's checks" `Quick
+        test_validate_runs_sub_codec_checks;
       Alcotest.test_case "decode: enforces typ-level where" `Quick
         test_decode_enforces_typ_where;
       Alcotest.test_case "validate: enforces typ-level where" `Quick


### PR DESCRIPTION
`Codec.validate` skipped constraints carried by a codec used as a field, so callers could accept bytes that decoding and EverParse reject. The sub-codec validation pass now runs at every use site without materialising nested records.