### PR TITLE
wire.3d: seed differential corpora across both verdicts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ### Added
 
+- Add `Wire.Everparse.Raw.field_seeds`, exposing constrained whole-byte integer
+  values so generated corpora can construct inputs that uniform bytes would
+  never reach (#314, @samoht)
+
 - Add `Wire.equal_error_kind`, structural equality on error kinds ignoring
   location (#299, @samoht)
 
@@ -26,6 +30,10 @@
   (#263, @samoht)
 
 ### Changed
+
+- Seed `Wire_3d.generate_corpus` from accepted inputs and constraint boundaries,
+  and refuse one-sided corpora, which cannot distinguish a validator from a
+  constant answer (#314, @samoht)
 
 - **Breaking:** `Codec.encode` and `Wire.to_string` raise `Invalid_argument` on
   a value their own decoder rejects, rather than writing bytes that fail to read

--- a/lib/3d/wire_3d.ml
+++ b/lib/3d/wire_3d.ml
@@ -1156,19 +1156,23 @@ let hex_of_bytes b =
   Format.pp_print_flush ppf ();
   Buffer.contents buf
 
-(* The accept/reject decision the validator must reproduce: the OCaml codec
-   decodes (structure plus constraints), validates (constraints and
-   where-clauses), and the record spans the whole buffer -- the hardened
-   [<Base>CheckWire<Codec>] wrapper rejects trailing bytes (see [harden_wrapper]),
-   so the oracle must too. *)
-let codec_accepts ?env c buf =
+(* The accept/reject decision the validator must reproduce, and -- on rejection
+   -- what the codec objected to, which makes an input repairable. The record
+   must span the whole buffer because the hardened [Check] wrapper rejects
+   trailing bytes. [`Resize n] means that the parsed record occupies [n] bytes. *)
+let codec_verdict ?env c buf =
   match Wire.Codec.decode ?env c buf 0 with
+  | Error e -> `Reject e
   | Ok _ -> (
-      try
+      match
         Wire.Codec.validate ?env c buf 0;
-        Wire.Codec.wire_size_at c buf 0 = Bytes.length buf
-      with Wire.Parse_error _ -> false)
-  | Error _ -> false
+        Wire.Codec.wire_size_at c buf 0
+      with
+      | n -> if n = Bytes.length buf then `Accept else `Resize n
+      | exception Wire.Parse_error e -> `Reject e)
+
+let codec_accepts ?env c buf =
+  match codec_verdict ?env c buf with `Accept -> true | _ -> false
 
 (* A small param value, biased around the codec's footprint so a parameter that
    bounds a field size (e.g. a max length) straddles the accept/reject boundary
@@ -1193,41 +1197,239 @@ let fuzz_length rng center =
   | 4 -> center + 1
   | _ -> center
 
-let generate_corpus ?(count = 256) ppf codecs =
-  let rng = Random.State.make [| 0x5eed51 |] in
-  List.iter
-    (fun (Pack c) ->
-      let s = project ~mode:`Standalone c in
-      let name = s.name in
-      let pnames =
-        match s.source with Some st -> Raw.input_param_names st | None -> []
+(* [agree.c] reads a line into a fixed 64 KiB buffer. *)
+let max_corpus_input = 65536
+
+let random_bytes rng n =
+  Bytes.init n (fun _ -> Char.chr (Random.State.int rng 256))
+
+(* Keep bytes already repaired when the codec supplies the record's true size. *)
+let resize rng buf n =
+  let out = random_bytes rng n in
+  Bytes.blit buf 0 out 0 (min n (Bytes.length buf));
+  out
+
+(* Write the low [width] bytes of [v] without native-int shifts: field seeds may
+   describe an eight-byte slot even on wasm_of_ocaml or js_of_ocaml. Negative
+   signed values naturally produce their two's-complement wire bytes. *)
+let write_slot buf off (slot : Raw.int_slot) v =
+  let width = slot.width in
+  if off >= 0 && off + width <= Bytes.length buf then
+    for i = 0 to width - 1 do
+      let shift =
+        8
+        * match slot.endian with Wire.Big -> width - 1 - i | Wire.Little -> i
       in
-      let center = Wire.Codec.min_wire_size c in
-      for _ = 1 to count do
-        let len = fuzz_length rng center in
-        let b = Bytes.init len (fun _ -> Char.chr (Random.State.int rng 256)) in
-        let pvals = List.map (fun _ -> fuzz_param_value rng center) pnames in
-        (* Seed the validator env with the same param values the C wrapper will
-           be given, so the two agree on what they validated against. *)
-        let env =
-          match pnames with
-          | [] -> None
-          | _ ->
-              Some
-                (List.fold_left2
-                   (fun e n v -> Wire.Param.bind_by_name n v e)
-                   (Wire.Codec.env c) pnames pvals)
+      let byte = Int64.(to_int (logand (shift_right_logical v shift) 0xffL)) in
+      Bytes.set buf (off + i) (Char.chr byte)
+    done
+
+let seed_for seeds (e : Wire.parse_error) =
+  match List.rev e.field with
+  | leaf :: _ ->
+      List.find_opt
+        (fun (seed : Raw.field_seed) -> String.equal seed.field leaf)
+        seeds
+  | [] -> None
+
+(* An EOF can be repaired by growing the input. Other failures can be repaired
+   when the failing field's declaration names candidate values. *)
+let repair_for ~seeds ~len (e : Wire.parse_error) =
+  match e.kind with
+  | Wire.Unexpected_eof { expected; got } when expected > got ->
+      `Grow (len + expected - got)
+  | _ -> (
+      match seed_for seeds e with
+      | Some seed -> `Place (e.at, seed)
+      | None -> `Stuck)
+
+(* Construct one accepting input by repeatedly asking the codec how to repair
+   the earliest failure. The field offsets come from parse errors rather than a
+   static layout, so the same loop works after variable-width prefixes. *)
+let seed_input ?env rng ~seeds ~center c =
+  let fuel = ref ((2 * List.length seeds) + 6) in
+  let buf = ref (random_bytes rng (max 1 center)) in
+  let placed = ref [] in
+  let out = ref None in
+  let grow n =
+    if n >= 0 && n <> Bytes.length !buf && n <= max_corpus_input then
+      buf := resize rng !buf n
+    else fuel := 0
+  in
+  let place off (seed : Raw.field_seed) =
+    let values = Array.of_list seed.values in
+    write_slot !buf off seed.slot
+      values.(Random.State.int rng (Array.length values));
+    if not (List.mem_assoc off !placed) then placed := (off, seed) :: !placed
+  in
+  while !out = None && !fuel > 0 do
+    decr fuel;
+    match codec_verdict ?env c !buf with
+    | `Accept -> out := Some !buf
+    | `Resize n -> grow n
+    | `Reject e -> (
+        match repair_for ~seeds ~len:(Bytes.length !buf) e with
+        | `Grow n -> grow n
+        | `Place (off, seed) -> place off seed
+        | `Stuck -> fuel := 0)
+  done;
+  match !out with Some b -> Some (b, List.rev !placed) | None -> None
+
+let neighbours v =
+  let before = if Int64.equal v Int64.min_int then [] else [ Int64.pred v ] in
+  let after = if Int64.equal v Int64.max_int then [] else [ Int64.succ v ] in
+  before @ (v :: after)
+
+(* Put each named value, and its immediate neighbours, directly into every
+   constrained field settled while constructing the seed. These cases expose a
+   stale validator whose boundary differs by one without relying on chance. *)
+let boundary_inputs seed placed =
+  List.concat_map
+    (fun (off, (field_seed : Raw.field_seed)) ->
+      field_seed.values |> List.concat_map neighbours
+      |> List.sort_uniq Int64.compare
+      |> List.map (fun value ->
+          let b = Bytes.copy seed in
+          write_slot b off field_seed.slot value;
+          b))
+    placed
+
+(* Mutants cross field constraints and the checked wrapper's whole-buffer
+   boundary while retaining most of a known-accepted record. *)
+let mutate rng seed =
+  let len = Bytes.length seed in
+  if len = 0 then seed
+  else
+    match Random.State.int rng 8 with
+    | 0 -> Bytes.sub seed 0 (len - 1)
+    | 1 when len < max_corpus_input ->
+        let b = Bytes.create (len + 1) in
+        Bytes.blit seed 0 b 0 len;
+        Bytes.set b len (Char.chr (Random.State.int rng 256));
+        b
+    | kind ->
+        let b = Bytes.copy seed in
+        let offset = Random.State.int rng len in
+        let value = Char.code (Bytes.get b offset) in
+        let value' =
+          if kind land 1 = 0 then value lxor (1 lsl Random.State.int rng 8)
+          else Random.State.int rng 256
         in
-        let pfield =
-          match pvals with
-          | [] -> "-"
-          | _ -> String.concat "," (List.map string_of_int pvals)
-        in
-        let hex = if len = 0 then "-" else hex_of_bytes b in
-        Fmt.pf ppf "%s %s %s %d@\n" name pfield hex
-          (if codec_accepts ?env c b then 1 else 0)
-      done)
-    codecs;
+        Bytes.set b offset (Char.chr (value' land 0xff));
+        b
+
+(* Try a bounded number of fresh byte/parameter combinations for each desired
+   accepting seed. An unsolved constraint is reported by the vacuity check
+   rather than spinning. *)
+let corpus_seeds ?env_of rng ~seeds ~center ~draw_params ~want c =
+  let env_of = match env_of with Some f -> f | None -> fun _ -> None in
+  let found = ref [] and attempts = ref (4 * want) in
+  while List.length !found < want && !attempts > 0 do
+    decr attempts;
+    let pvals = draw_params () in
+    match seed_input ?env:(env_of pvals) rng ~seeds ~center c with
+    | Some (b, placed) -> found := (pvals, b, placed) :: !found
+    | None -> ()
+  done;
+  Array.of_list !found
+
+let vacuous_corpus name ~accepts ~rejects =
+  Fmt.failwith
+    "corpus for %s is vacuous: %d accepted, %d rejected. A differential over \
+     it cannot tell the validator from one that answers the same way to every \
+     input.@\n\
+     %s"
+    name accepts rejects
+    (if accepts = 0 then
+       "Nothing reached the accepting side of the codec's constraints. \
+        Wire.Everparse.Raw.field_seeds names values only for equality, \
+        inequality, ordering and closed-enum constraints on whole-byte integer \
+        fields; any other constraint needs a hand-written corpus."
+     else "Every input was accepted; the corpus needs a rejected one.")
+
+(* Seeds, boundary cases, seed mutants, then uniform bytes for breadth. Keep the
+   boundary cases ahead of random mutants and preserve exactly [count] lines. *)
+let emit_streams ~count ~emit ~rng ~center ~draw_params seeded =
+  let emitted = ref 0 in
+  Array.iter
+    (fun (pvals, b, _) ->
+      if !emitted < count then begin
+        emit (pvals, b);
+        incr emitted
+      end)
+    seeded;
+  Array.iter
+    (fun (pvals, b, placed) ->
+      List.iter
+        (fun boundary ->
+          if !emitted < count then begin
+            emit (pvals, boundary);
+            incr emitted
+          end)
+        (boundary_inputs b placed))
+    seeded;
+  let mutant_count =
+    if Array.length seeded = 0 then 0
+    else min (count / 2) (max 0 (count - !emitted))
+  in
+  for _ = 1 to mutant_count do
+    let pvals, b, _ = seeded.(Random.State.int rng (Array.length seeded)) in
+    emit (pvals, mutate rng b);
+    incr emitted
+  done;
+  for _ = 1 to max 0 (count - !emitted) do
+    let len = min max_corpus_input (fuzz_length rng center) in
+    emit (draw_params (), random_bytes rng len)
+  done
+
+let corpus_of_codec ~count ppf (Pack c) =
+  let rng = Random.State.make [| 0x5eed51 |] in
+  let schema = project ~mode:`Standalone c in
+  let name = schema.name in
+  let pnames =
+    match schema.source with
+    | Some source -> Raw.input_param_names source
+    | None -> []
+  in
+  let seeds =
+    match schema.source with
+    | Some source -> Raw.field_seeds source
+    | None -> []
+  in
+  let center = Wire.Codec.min_wire_size c in
+  let draw_params () = List.map (fun _ -> fuzz_param_value rng center) pnames in
+  let env_of pvals =
+    match pnames with
+    | [] -> None
+    | _ ->
+        Some
+          (List.fold_left2
+             (fun env name value -> Wire.Param.bind_by_name name value env)
+             (Wire.Codec.env c) pnames pvals)
+  in
+  let accepts = ref 0 and rejects = ref 0 in
+  let emit (pvals, b) =
+    let pfield =
+      match pvals with
+      | [] -> "-"
+      | _ -> String.concat "," (List.map string_of_int pvals)
+    in
+    let hex = if Bytes.length b = 0 then "-" else hex_of_bytes b in
+    let accepted = codec_accepts ?env:(env_of pvals) c b in
+    if accepted then incr accepts else incr rejects;
+    Fmt.pf ppf "%s %s %s %d@\n" name pfield hex (if accepted then 1 else 0)
+  in
+  emit_streams ~count ~emit ~rng ~center ~draw_params
+    (corpus_seeds ~env_of rng ~seeds ~center ~draw_params
+       ~want:(max 1 (count / 8))
+       c);
+  if !accepts = 0 || !rejects = 0 then
+    vacuous_corpus name ~accepts:!accepts ~rejects:!rejects
+
+let generate_corpus ?(count = 256) ppf codecs =
+  if count < 2 then
+    Fmt.invalid_arg "Wire_3d.generate_corpus: count must be at least 2";
+  List.iter (corpus_of_codec ~count ppf) codecs;
   Format.pp_print_flush ppf ()
 
 let emit_agree_preamble ppf base ~has_params =

--- a/lib/3d/wire_3d.mli
+++ b/lib/3d/wire_3d.mli
@@ -255,15 +255,30 @@ val archive_link_steps :
     logic. *)
 
 val generate_corpus : ?count:int -> Format.formatter -> packed list -> unit
-(** [generate_corpus ?count ppf codecs] prints, for each codec, [count] fuzzed
-    inputs as [<codec> <hex> <verdict>] lines, where [verdict] is [1] when the
+(** [generate_corpus ?count ppf codecs] prints, for each codec, [count] inputs
+    as [<codec> <params> <hex> <verdict>] lines, where [verdict] is [1] when the
     OCaml codec accepts the bytes (decodes, validates, and the record spans the
     whole input -- matching the hardened [Check] wrapper's whole-buffer
-    contract) and [0] otherwise, and [<hex>] is [-] for the empty input. Lengths
-    are biased around each codec's minimum size so the corpus straddles the
-    accept/reject boundary. This is the oracle half of the doc pipeline's
-    differential self-check; {!main}'s [corpus] subcommand calls it on stdout.
-*)
+    contract) and [0] otherwise, [<params>] is the comma-separated input
+    parameter values ([-] when the codec takes none), and [<hex>] is [-] for the
+    empty input. [count] must be at least two. This is the oracle half of the
+    doc pipeline's differential self-check; {!main}'s [corpus] subcommand calls
+    it on stdout.
+
+    The inputs come from four streams: accepting seeds, built by writing the
+    values each constrained field's own declaration names (see
+    {!Wire.Everparse.Raw.field_seeds}) at the offsets the codec's parse errors
+    report; boundary inputs, each seed with one constrained field set to each of
+    those values and its immediate neighbours; mutants of the seeds; and
+    uniformly drawn bytes at lengths biased around the codec's minimum size.
+
+    Uniform bytes alone are vacuous for a codec that pins a field:
+    [magic == 0x53504F53] leaves one accepting value in [2^32], so every input
+    is a reject and the differential holds equally for a validator that rejects
+    everything. [generate_corpus] therefore raises [Failure] rather than emit a
+    corpus with nothing on one side of the accept/reject boundary, naming the
+    codec and tally. A constraint {!Wire.Everparse.Raw.field_seeds} cannot
+    describe needs a hand-written corpus. *)
 
 val generate_agree :
   ?name:string -> outdir:string -> package:string -> packed list -> unit

--- a/lib/everparse.ml
+++ b/lib/everparse.ml
@@ -771,6 +771,16 @@ module Raw = struct
     | Unit
 
   let field_kinds = Types.field_kinds
+
+  type int_slot = Types.int_slot = { width : int; endian : Types.endian }
+
+  type field_seed = Types.field_seed = {
+    field : string;
+    slot : int_slot;
+    values : int64 list;
+  }
+
+  let field_seeds = Types.field_seeds
   let struct_params (s : Types.struct_) = s.params
 
   let input_param_names (s : Types.struct_) =

--- a/lib/everparse.mli
+++ b/lib/everparse.mli
@@ -245,6 +245,28 @@ module Raw : sig
   val field_kinds : struct_ -> (string * ocaml_kind) list
   (** Field names with their OCaml kind. *)
 
+  type int_slot = Types.int_slot = { width : int; endian : Types.endian }
+  (** Byte width and order of a whole-byte integer field on the wire. *)
+
+  type field_seed = Types.field_seed = {
+    field : string;
+    slot : int_slot;
+    values : int64 list;
+  }
+  (** A field whose own declaration singles out particular wire values. *)
+
+  val field_seeds : struct_ -> field_seed list
+  (** [field_seeds s] is, for each named whole-byte integer field of [s] whose
+      declaration singles out values, the byte slot it occupies and those
+      values: the constant an equality or inequality refinement names, the
+      values either side of an ordering refinement's boundary, and the members
+      of a closed enumeration. Bitfields are omitted because their base word is
+      shared, so a byte offset alone cannot seed one.
+
+      The list over-approximates: it names candidates worth trying, not values
+      the description is guaranteed to admit, so a consumer must run each
+      through the codec to learn the verdict. *)
+
   val struct_params : struct_ -> Types.param list
   (** Formal parameters of a struct. *)
 

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -3337,3 +3337,111 @@ let ml_type_of : type a. a typ -> string = function
   | Int64 _ -> "int64"
   | Float32 _ | Float64 _ -> "float"
   | _ -> "int"
+
+(* -- Seed values: what a field's own declaration says its wire bytes may be.
+
+   A differential test over uniformly drawn bytes is only as good as the odds
+   of drawing something the parser accepts. A field pinned to a constant --
+   [magic == 0x53504F53] -- leaves one accepting value in 2^32, so the whole
+   corpus is rejects and both implementations agree on garbage. The values are
+   already in the description, so expose them rather than making every corpus
+   generator interpret refinements independently. -- *)
+
+type int_slot = { width : int; endian : endian }
+type field_seed = { field : string; slot : int_slot; values : int64 list }
+
+(* Look through decorations that do not change the wire encoding. Bitfields are
+   omitted deliberately: their base word is shared with neighbouring fields,
+   so a byte offset alone is not enough to seed one correctly. *)
+let rec int_slot_of_typ : type a. a typ -> int_slot option = function
+  | Uint8 | Int8 -> Some { width = 1; endian = Big }
+  | Uint16 e | Int16 e -> Some { width = 2; endian = e }
+  | Uint32 e | Int32 e -> Some { width = 4; endian = e }
+  | Uint63 e | Uint64 e | Int64 e -> Some { width = 8; endian = e }
+  | Uint_var { size = Int width; endian } -> Some { width; endian }
+  | Enum { base; _ } -> int_slot_of_typ base
+  | Where { inner; _ } -> int_slot_of_typ inner
+  | Map { inner; _ } -> int_slot_of_typ inner
+  | Optional { inner; _ } -> int_slot_of_typ inner
+  | Optional_or { inner; _ } -> int_slot_of_typ inner
+  | _ -> None
+
+let neighbours k =
+  let before = if Int64.equal k Int64.min_int then [] else [ Int64.pred k ] in
+  let after = if Int64.equal k Int64.max_int then [] else [ Int64.succ k ] in
+  before @ (k :: after)
+
+(* An equality names the value itself; an ordering names the values either side
+   of its boundary. Conjunction and disjunction both contribute their operands'
+   values. This is intentionally an over-approximation: consumers must ask the
+   codec for the verdict, so an inadmissible candidate costs one retry rather
+   than producing a wrong oracle. *)
+let constraint_values name (e : bool expr) =
+  let is_self : type a. a expr -> bool = function
+    | Ref (_, n) -> String.equal n name
+    | _ -> false
+  in
+  let literal : type a. a expr -> int64 option = function
+    | Int k -> Some (Int64.of_int k)
+    | Int64 k -> Some k
+    | _ -> None
+  in
+  let against : type a. a expr -> a expr -> int64 option =
+   fun x y ->
+    if is_self x then literal y else if is_self y then literal x else None
+  in
+  let rec go : bool expr -> int64 list = function
+    | And (a, b) | Or (a, b) -> go a @ go b
+    | Not a -> go a
+    | Eq (a, b) -> ( match against a b with Some k -> [ k ] | None -> [])
+    | Ne (a, b) -> ( match against a b with Some k -> [ k ] | None -> [])
+    | Lt (a, b) -> (
+        match against a b with Some k -> neighbours k | None -> [])
+    | Le (a, b) -> (
+        match against a b with Some k -> neighbours k | None -> [])
+    | Gt (a, b) -> (
+        match against a b with Some k -> neighbours k | None -> [])
+    | Ge (a, b) -> (
+        match against a b with Some k -> neighbours k | None -> [])
+    | _ -> []
+  in
+  go e
+
+(* A closed enumeration lists every value the field may take. *)
+let rec enum_seed_values : type a. a typ -> int64 list = function
+  | Enum { cases; closed = true; _ } ->
+      List.map (fun (_, value) -> Int64.of_int value) cases
+  | Where { inner; _ } -> enum_seed_values inner
+  | Map { inner; _ } -> enum_seed_values inner
+  | Optional { inner; _ } -> enum_seed_values inner
+  | Optional_or { inner; _ } -> enum_seed_values inner
+  | _ -> []
+
+let rec typ_constraints : type a. string -> a typ -> int64 list =
+ fun name -> function
+  | Where { cond; inner } ->
+      constraint_values name cond @ typ_constraints name inner
+  | Map { inner; _ } -> typ_constraints name inner
+  | Optional { inner; _ } -> typ_constraints name inner
+  | Optional_or { inner; _ } -> typ_constraints name inner
+  | _ -> []
+
+let field_seeds s =
+  let of_field (Field f) =
+    match (f.field_name, int_slot_of_typ f.field_typ) with
+    | Some name, Some slot ->
+        let from_field =
+          match f.constraint_ with
+          | Some constraint_ -> constraint_values name constraint_
+          | None -> []
+        in
+        let values =
+          from_field
+          @ typ_constraints name f.field_typ
+          @ enum_seed_values f.field_typ
+          |> List.sort_uniq Int64.compare
+        in
+        if values = [] then None else Some { field = name; slot; values }
+    | _ -> None
+  in
+  List.filter_map of_field s.fields

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -1066,3 +1066,25 @@ val ml_type_of : 'a typ -> string
 (** [ml_type_of typ] returns the OCaml type name for FFI stub generation:
     ["int"] for integer types that fit in OCaml integers, ["int64"] for uint64.
 *)
+
+(** {1 Seed values} *)
+
+type int_slot = { width : int; endian : endian }
+(** Byte width and order of a whole-byte integer field on the wire. *)
+
+type field_seed = { field : string; slot : int_slot; values : int64 list }
+(** A field whose own declaration singles out particular wire values. *)
+
+val field_seeds : struct_ -> field_seed list
+(** [field_seeds s] is, for each named whole-byte integer field of [s] whose
+    declaration singles out values, the byte slot it occupies and those values:
+    the constant an equality or inequality refinement names, the values either
+    side of an ordering refinement's boundary, and the members of a closed
+    enumeration. Fields with no such value, and fields that are not whole-byte
+    integers (bitfields in particular, whose base word is shared), are omitted.
+
+    The list over-approximates: it names candidates worth trying, not values the
+    description is guaranteed to admit, so a consumer must run each through the
+    codec to learn the verdict. It exists so a generated corpus can reach the
+    accepting side of a constraint that drawing bytes never would -- a magic
+    number leaves one accepting value in [2^32]. *)

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -1434,6 +1434,24 @@ module Everparse : sig
     val field_kinds : struct_ -> (string * ocaml_kind) list
     (** Named field names with their OCaml type kind. *)
 
+    type int_slot = { width : int; endian : endian }
+    (** Byte width and order of a whole-byte integer field on the wire. *)
+
+    type field_seed = { field : string; slot : int_slot; values : int64 list }
+    (** A field whose own declaration singles out particular wire values. *)
+
+    val field_seeds : struct_ -> field_seed list
+    (** [field_seeds s] is, for each named whole-byte integer field of [s] whose
+        declaration singles out values, the byte slot it occupies and those
+        values: the constant an equality or inequality refinement names, the
+        values either side of an ordering refinement's boundary, and the members
+        of a closed enumeration. Bitfields are omitted because their base word
+        is shared, so a byte offset alone cannot seed one.
+
+        The list over-approximates: it names candidates worth trying, not values
+        the description is guaranteed to admit, so a consumer must run each
+        through the codec to learn the verdict. *)
+
     val struct_project :
       struct_ -> name:string -> keep:Field.packed list -> struct_
     (** [struct_project s ~name ~keep] returns a copy of [s] renamed to [name]

--- a/test/3d/test_wire_3d.ml
+++ b/test/3d/test_wire_3d.ml
@@ -562,6 +562,75 @@ let test_doc_differential_no_params () =
   differential_ok ~name:"plainspec" ~package:"plain-doc" ~corpus:(`Fuzz 100)
     [ Wire_3d.pack diff_enum_codec; Wire_3d.pack diff_range_codec ]
 
+(* A uniform byte draw cannot reach this accepting side: one 32-bit value out
+   of 2^32 satisfies the magic constraint. The generated corpus must construct
+   accepted records and retain rejected neighbours. This test is pure OCaml and
+   therefore runs without 3d.exe. *)
+let corpus_magic_codec =
+  let open Wire in
+  let magic =
+    Field.v "magic" uint32be ~self_constraint:(fun self ->
+        Expr.(self = int 0x53504F53))
+  in
+  let ver = Field.v "ver" uint8 in
+  Codec.v "Super"
+    (fun m v -> (m, v))
+    [ Codec.( $ ) magic fst; Codec.( $ ) ver snd ]
+
+let corpus_verdicts ?(count = 256) codecs =
+  let buf = Buffer.create 4096 in
+  let ppf = Fmt.with_buffer buf in
+  Wire_3d.generate_corpus ~count ppf codecs;
+  Format.pp_print_flush ppf ();
+  Buffer.contents buf |> String.split_on_char '\n'
+  |> List.filter_map (fun line ->
+      match String.rindex_opt line ' ' with
+      | Some i -> Some (String.sub line (i + 1) (String.length line - i - 1))
+      | None -> None)
+  |> List.fold_left
+       (fun (accepted, rejected) -> function
+         | "1" -> (accepted + 1, rejected)
+         | "0" -> (accepted, rejected + 1)
+         | _ -> (accepted, rejected))
+       (0, 0)
+
+let test_corpus_straddles_a_constraint () =
+  let accepted, rejected =
+    corpus_verdicts [ Wire_3d.pack corpus_magic_codec ]
+  in
+  Alcotest.(check bool)
+    (Fmt.str "corpus reaches the accepting side (%d accepted)" accepted)
+    true (accepted > 0);
+  Alcotest.(check bool)
+    (Fmt.str "corpus keeps rejected inputs (%d rejected)" rejected)
+    true (rejected > 0);
+  Alcotest.(check int) "every line carries a verdict" 256 (accepted + rejected)
+
+(* A whole-record where-clause has no failing field offset to repair. Refuse a
+   one-sided corpus instead of allowing an always-rejecting validator to pass. *)
+let corpus_unseedable_codec =
+  let open Wire in
+  let tag = Field.v "tag" uint32be in
+  Codec.v "Opaque"
+    ~where:Expr.(Field.ref tag = int 0x53504F53)
+    Fun.id
+    [ Codec.( $ ) tag Fun.id ]
+
+let test_corpus_refuses_when_vacuous () =
+  match corpus_verdicts ~count:64 [ Wire_3d.pack corpus_unseedable_codec ] with
+  | accepted, rejected ->
+      Alcotest.failf
+        "generate_corpus returned a vacuous corpus (%d accepted, %d rejected) \
+         instead of refusing"
+        accepted rejected
+  | exception Failure msg ->
+      Alcotest.(check bool)
+        "the refusal names the codec" true
+        (Re.execp (Re.compile (Re.str "Opaque")) msg);
+      Alcotest.(check bool)
+        "the refusal reports the tally" true
+        (Re.execp (Re.compile (Re.str "0 accepted")) msg)
+
 let test_doc_differential_nested_regions () =
   needs_3d_exe ();
   differential_ok ~name:"nestedspec" ~package:"nested-doc"
@@ -1637,6 +1706,10 @@ let suite =
         test_generate_dune_standalone_name_override;
       Alcotest.test_case "generate_dune_standalone context policy" `Quick
         test_generate_dune_standalone_context_policy;
+      Alcotest.test_case "corpus straddles a constraint" `Quick
+        test_corpus_straddles_a_constraint;
+      Alcotest.test_case "corpus refuses when vacuous" `Quick
+        test_corpus_refuses_when_vacuous;
       Alcotest.test_case "generate_standalone (needs 3d.exe)" `Quick
         test_generate_standalone;
       Alcotest.test_case "archive hides raw validators (needs 3d.exe)" `Quick


### PR DESCRIPTION
Uniform byte draws could certify an always-rejecting validator when pinned fields made every sample invalid. Derive accepted seeds and refuse one-sided corpora so the differential exercises both verdicts.