### PR TITLE
types: retire uint63 and uint63be

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,16 @@
   and refuse one-sided corpora, which cannot distinguish a validator from a
   constant answer (#314, @samoht)
 
+- **Breaking:** Remove `uint63` and `uint63be`. An 8-byte field spans more
+  values than their `Optint.Int63.t` carrier holds, and decoding masked the
+  difference away instead of failing: eight `0xff` bytes arrived as
+  `0x3fff_ffff_ffff_ffff` and were written back out as those bytes, with no
+  error on either path, while the generated C validator passed the same frame
+  through untouched. Use `uint64` / `uint64be` instead, whose `int64` carrier is
+  exactly the eight bytes on the wire, and convert an existing value with
+  `Optint.Int63.to_int64`. `Wire.uint ~size` is unaffected: its carrier is exact
+  for the one to seven bytes it accepts (#316, @samoht)
+
 - **Breaking:** `Codec.encode` and `Wire.to_string` raise `Invalid_argument` on
   a value their own decoder rejects, rather than writing bytes that fail to read
   back: an unlisted value in a closed `enum`, a non-zero byte in an `all_zeros`
@@ -64,10 +74,10 @@
 - Require `bytesrw` >= 0.4.0, for `Bytes.Slice.drop_first_or_eod`
   (#297, @samoht)
 
-- `Wire.uint` decodes to `Optint.Int63.t` rather than a native `int`, like
-  `uint63` before it: a 7-byte value needs 56 bits, which does not fit an int on
-  a narrow-int target and used to truncate there. Read the value with
-  `Optint.Int63.to_int` / `to_int64` (#232, @samoht)
+- `Wire.uint` decodes to `Optint.Int63.t` rather than a native `int`: a 7-byte
+  value needs 56 bits, which does not fit an int on a narrow-int target and used
+  to truncate there. Read the value with `Optint.Int63.to_int` / `to_int64`
+  (#232, @samoht)
 
 - Spell `Wire.uint`'s result type as `Optint.Int63.t` rather than the `UInt63.t`
   alias, reachable only through the unstable `Wire.Private`. Same type, same

--- a/fuzz/gen/fuzz_gen.ml
+++ b/fuzz/gen/fuzz_gen.ml
@@ -192,14 +192,6 @@ let above_uint32 =
     Alcobar.[ Alcobar.int ]
     (fun n -> Optint.of_int (n land mask lor (mask + 1)))
 
-(* [uint63] fills its carrier, so the only unrepresentable value left is a
-   negative one: [chunk] would drop its sign bit and leave a legal positive
-   number on the wire. *)
-let below_zero_uint63 =
-  Alcobar.map
-    Alcobar.[ Alcobar.int ]
-    (fun n -> Optint.Int63.of_int (-(n land max_int) - 1))
-
 (* A byte string of one of the lengths around [n], for a byte span whose
    declared size is [n]: only the exact length may encode. *)
 let byte_lengths_around n =
@@ -273,22 +265,12 @@ let scalar_optint ~hostile typ size value_gen boundaries =
   in
   { g with adversarial_value = Some hostile }
 
-let scalar_optint63 ~hostile typ size value_gen boundaries =
-  let g =
-    leaf ~equal:Optint.Int63.equal ~typ ~value_gen ~random:(bytes_fixed size)
-      ~adversarial:(Alcobar.choose (List.map Alcobar.const boundaries))
-  in
-  { g with adversarial_value = Some hostile }
-
 let u8_boundaries = [ 0; 1; 0x7F; 0x80; 0xFE; 0xFF ]
 let u16_boundaries = [ 0; 1; 0x7F; 0x80; 0x7FFF; 0x8000; 0xFFFE; 0xFFFF ]
 
 let u32_boundaries =
   List.map Optint.of_int
     [ 0; 1; 0xFFFF; 0x7FFF_FFFF; 0x8000_0000; 0xFFFF_FFFE; 0xFFFF_FFFF ]
-
-let u63_boundaries =
-  List.map Optint.Int63.of_int [ 0; 1; 0xFFFF_FFFF; max_int - 1; max_int ]
 
 let u64_boundaries_i64 =
   Int64.[ zero; one; of_int 0xFFFF_FFFF; max_int; min_int; -1L; sub max_int 1L ]
@@ -318,24 +300,11 @@ let masked_u32 =
     Alcobar.[ Alcobar.int ]
     (fun n -> Optint.of_int (n land 0xFFFF_FFFF))
 
-let masked_u63 =
-  Alcobar.map
-    Alcobar.[ Alcobar.int ]
-    (fun n -> Optint.Int63.of_int (n land max_int))
-
 let uint32 =
   scalar_optint ~hostile:above_uint32 Wire.uint32 4 masked_u32 u32_boundaries
 
 let uint32be =
   scalar_optint ~hostile:above_uint32 Wire.uint32be 4 masked_u32 u32_boundaries
-
-let uint63 =
-  scalar_optint63 ~hostile:below_zero_uint63 Wire.uint63 8 masked_u63
-    u63_boundaries
-
-let uint63be =
-  scalar_optint63 ~hostile:below_zero_uint63 Wire.uint63be 8 masked_u63
-    u63_boundaries
 
 let uint64 = scalar_int64 Wire.uint64 8 Alcobar.int64 u64_boundaries_i64
 let uint64be = scalar_int64 Wire.uint64be 8 Alcobar.int64 u64_boundaries_i64
@@ -4644,8 +4613,6 @@ let unsigned_scalar_gens =
     ("uint32be", Pack uint32be);
     ("uint32(endian_edges)", Pack uint32_endian_edges);
     ("uint32be(endian_edges)", Pack uint32be_endian_edges);
-    ("uint63", Pack uint63);
-    ("uint63be", Pack uint63be);
     ("uint64", Pack uint64);
     ("uint64be", Pack uint64be);
     ("uint64(endian_edges)", Pack uint64_endian_edges);
@@ -5151,8 +5118,6 @@ let expected_registry_labels =
     "uint32be";
     "uint32(endian_edges)";
     "uint32be(endian_edges)";
-    "uint63";
-    "uint63be";
     "uint64";
     "uint64be";
     "uint64(endian_edges)";

--- a/fuzz/gen/fuzz_gen.mli
+++ b/fuzz/gen/fuzz_gen.mli
@@ -256,12 +256,6 @@ val uint32 : Optint.t t
 val uint32be : Optint.t t
 (** [uint32be] generates for {!Wire.uint32be}. *)
 
-val uint63 : Optint.Int63.t t
-(** [uint63] generates for {!Wire.uint63}. *)
-
-val uint63be : Optint.Int63.t t
-(** [uint63be] generates for {!Wire.uint63be}. *)
-
 val uint64 : int64 t
 (** [uint64] generates for {!Wire.uint64}. *)
 

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -191,14 +191,6 @@ and build_field_encoder_ctx : type a.
       fun _runtime buf off v ->
         UInt32.set_be buf off v;
         off + 4
-  | Uint63 Little ->
-      fun _runtime buf off v ->
-        UInt63.set_le buf off v;
-        off + 8
-  | Uint63 Big ->
-      fun _runtime buf off v ->
-        UInt63.set_be buf off v;
-        off + 8
   | Uint64 Little ->
       fun _runtime buf off v ->
         Bytes.set_int64_le buf off v;
@@ -333,8 +325,6 @@ let rec build_field_reader_ctx : type a.
       fun _runtime buf base -> Bytes.get_uint16_be buf (base + field_off)
   | Uint32 Little -> fun _runtime buf base -> UInt32.le buf (base + field_off)
   | Uint32 Big -> fun _runtime buf base -> UInt32.be buf (base + field_off)
-  | Uint63 Little -> fun _runtime buf base -> UInt63.le buf (base + field_off)
-  | Uint63 Big -> fun _runtime buf base -> UInt63.be buf (base + field_off)
   | Uint64 Little ->
       fun _runtime buf base -> Bytes.get_int64_le buf (base + field_off)
   | Uint64 Big ->
@@ -439,8 +429,6 @@ let rec build_immediate_reader : type a.
   | Uint16 Big -> Some (fun buf base -> Bytes.get_uint16_be buf (at base))
   | Uint32 Little -> Some (fun buf base -> UInt32.le buf (at base))
   | Uint32 Big -> Some (fun buf base -> UInt32.be buf (at base))
-  | Uint63 Little -> Some (fun buf base -> UInt63.le buf (at base))
-  | Uint63 Big -> Some (fun buf base -> UInt63.be buf (at base))
   | Uint64 Little -> Some (fun buf base -> Bytes.get_int64_le buf (at base))
   | Uint64 Big -> Some (fun buf base -> Bytes.get_int64_be buf (at base))
   | Int8 -> Some (fun buf base -> Bytes.get_int8 buf (at base))
@@ -494,8 +482,6 @@ let rec build_immediate_encoder : type a.
   | Uint16 Big -> Some (setter_off 2 Types.set_uint16_be)
   | Uint32 Little -> Some (setter_off 4 UInt32.set_le)
   | Uint32 Big -> Some (setter_off 4 UInt32.set_be)
-  | Uint63 Little -> Some (setter_off 8 UInt63.set_le)
-  | Uint63 Big -> Some (setter_off 8 UInt63.set_be)
   | Uint64 Little -> Some (setter_off 8 Bytes.set_int64_le)
   | Uint64 Big -> Some (setter_off 8 Bytes.set_int64_be)
   | Int8 -> Some (setter_off 1 Types.set_int8)
@@ -580,7 +566,7 @@ let populate_uint32 idx reader =
     Option.iter (set_int_slot slots idx)
       (Int32.unsigned_to_int (UInt32.to_int32 (reader runtime buf base)))
 
-let populate_uint63 idx reader =
+let populate_uint_var idx reader =
   if Sys.int_size >= 63 then fun slots runtime buf base ->
     set_int_slot slots idx (UInt63.to_int (reader runtime buf base))
   else fun slots runtime buf base ->
@@ -620,9 +606,8 @@ let rec build_populate : type a.
   | Int16 _ -> populate_int idx reader
   | Int32 _ -> populate_int idx reader
   | Bits _ -> populate_int idx reader
-  | Uint_var _ -> populate_uint63 idx reader
+  | Uint_var _ -> populate_uint_var idx reader
   | Uint32 _ -> populate_uint32 idx reader
-  | Uint63 _ -> populate_uint63 idx reader
   (* [Uint64] / [Int64] populate both slots: the full value in [int64s] for
      full-width [Field.int64] refs, and the truncated value in [ints] so legacy
      int-kind [Field.ref] / [Field.int] constraints keep their pre-int64
@@ -1596,9 +1581,9 @@ let rec iter_param_refs_typ : type a. (Param.packed -> unit) -> a typ -> unit =
      structural form. *)
   | Codec { codec_struct; _ } ->
       iter_param_refs_fields f codec_struct.fields codec_struct.where
-  | Uint8 | Uint16 _ | Uint32 _ | Uint63 _ | Uint64 _ | Int8 | Int16 _ | Int32 _
-  | Int64 _ | Float32 _ | Float64 _ | Bits _ | Unit | All_bytes | All_zeros
-  | Zeroterm | Struct _ | Type_ref _ | Qualified_ref _ ->
+  | Uint8 | Uint16 _ | Uint32 _ | Uint64 _ | Int8 | Int16 _ | Int32 _ | Int64 _
+  | Float32 _ | Float64 _ | Bits _ | Unit | All_bytes | All_zeros | Zeroterm
+  | Struct _ | Type_ref _ | Qualified_ref _ ->
       ()
 
 and iter_param_refs_fields f fields where =
@@ -1629,7 +1614,7 @@ let tag_byte_size : type a. a typ -> int =
   | Uint8 | Int8 -> 1
   | Uint16 _ | Int16 _ -> 2
   | Uint32 _ | Int32 _ -> 4
-  | Uint63 _ | Uint64 _ | Int64 _ -> 8
+  | Uint64 _ | Int64 _ -> 8
   | _ -> ( match field_wire_size typ with Some n -> n | None -> assert false)
 
 (* Read one element of a typ at a given buffer position. Used by Repeat. *)
@@ -1641,8 +1626,6 @@ let rec read_elem : type a. a typ -> runtime -> bytes -> int -> a =
   | Uint16 Big -> Bytes.get_uint16_be buf off
   | Uint32 Little -> UInt32.le buf off
   | Uint32 Big -> UInt32.be buf off
-  | Uint63 Little -> UInt63.le buf off
-  | Uint63 Big -> UInt63.be buf off
   | Uint64 Little -> Bytes.get_int64_le buf off
   | Uint64 Big -> Bytes.get_int64_be buf off
   | Int8 -> Bytes.get_int8 buf off
@@ -1748,8 +1731,6 @@ let rec write_elem : type a. a typ -> runtime -> bytes -> int -> a -> unit =
   | Uint16 Big -> Types.set_uint16_be buf off v
   | Uint32 Little -> UInt32.set_le buf off v
   | Uint32 Big -> UInt32.set_be buf off v
-  | Uint63 Little -> UInt63.set_le buf off v
-  | Uint63 Big -> UInt63.set_be buf off v
   | Uint64 Little -> Bytes.set_int64_le buf off v
   | Uint64 Big -> Bytes.set_int64_be buf off v
   | Int8 -> Types.set_int8 buf off v
@@ -2352,11 +2333,11 @@ let elem_strategy : type a. a typ -> a elem_strategy = function
   | Byte_array { size = Int _ } | Byte_slice { size = Int _ } | Zeroterm ->
       Value_only
   | Uint64 _ | Int64 _ | Float32 _ | Float64 _ -> Value_only
-  | Uint8 | Uint16 _ | Uint32 _ | Uint63 _ | Int8 | Int16 _ | Int32 _
-  | Uint_var _ | Bits _ | Unit | All_bytes | All_zeros | Zeroterm_at_most _
-  | Where _ | Array _ | Byte_array _ | Byte_array_where _ | Byte_slice _
-  | Single_elem _ | Enum _ | Casetype _ | Struct _ | Type_ref _
-  | Qualified_ref _ | Map _ | Apply _ | Optional _ | Optional_or _ | Repeat _ ->
+  | Uint8 | Uint16 _ | Uint32 _ | Int8 | Int16 _ | Int32 _ | Uint_var _ | Bits _
+  | Unit | All_bytes | All_zeros | Zeroterm_at_most _ | Where _ | Array _
+  | Byte_array _ | Byte_array_where _ | Byte_slice _ | Single_elem _ | Enum _
+  | Casetype _ | Struct _ | Type_ref _ | Qualified_ref _ | Map _ | Apply _
+  | Optional _ | Optional_or _ | Repeat _ ->
       By_reading
 
 (* The element check the walk runs. Skipping a value-only reader keeps the span
@@ -3176,10 +3157,10 @@ let compile_field_check cc fld =
    A field's own [constraint_] / [action] / a [where] clause are accounted for
    separately, so this is only about the type's intrinsic read-time validation. *)
 let rec field_reader_validates : type a. a Types.typ -> bool = function
-  | Types.Uint8 | Types.Uint16 _ | Types.Uint32 _ | Types.Uint63 _
-  | Types.Uint64 _ | Types.Int8 | Types.Int16 _ | Types.Int32 _ | Types.Int64 _
-  | Types.Float32 _ | Types.Float64 _ | Types.Uint_var _ | Types.Bits _
-  | Types.Byte_array _ | Types.Byte_slice _ | Types.All_bytes | Types.Unit ->
+  | Types.Uint8 | Types.Uint16 _ | Types.Uint32 _ | Types.Uint64 _ | Types.Int8
+  | Types.Int16 _ | Types.Int32 _ | Types.Int64 _ | Types.Float32 _
+  | Types.Float64 _ | Types.Uint_var _ | Types.Bits _ | Types.Byte_array _
+  | Types.Byte_slice _ | Types.All_bytes | Types.Unit ->
       false
   | Types.Enum { closed; _ } -> closed
   | Types.Map { inner; index_bound; _ } ->

--- a/lib/eval.ml
+++ b/lib/eval.ml
@@ -39,11 +39,10 @@ let rec int_of : type a. a typ -> a -> int option =
   | Uint8 -> Some v
   | Uint16 _ -> Some v
   | Uint_var _ -> Int64.unsigned_to_int (Optint.Int63.to_int64 v)
-  (* On a narrow-int platform a u32/u63 value may not fit either; the
-     unsigned conversions return [None] exactly then and are identity-exact
-     on a 64-bit host. *)
+  (* On a narrow-int platform a u32 value may not fit either; the unsigned
+     conversion returns [None] exactly then and is identity-exact on a 64-bit
+     host. *)
   | Uint32 _ -> Int32.unsigned_to_int (UInt32.to_int32 v)
-  | Uint63 _ -> Int64.unsigned_to_int (Optint.Int63.to_int64 v)
   | Uint64 _ -> Int64.unsigned_to_int v
   | Int8 -> Some v
   | Int16 _ -> Some v
@@ -96,12 +95,6 @@ let rec int_of_exn : type a. a typ -> a -> int =
         | None ->
             int_overflow
               (Int64.logand (Int64.of_int32 (UInt32.to_int32 v)) 0xFFFF_FFFFL))
-  | Uint63 _ -> (
-      if Sys.int_size >= 63 then UInt63.to_int v
-      else
-        match Int64.unsigned_to_int (Optint.Int63.to_int64 v) with
-        | Some n -> n
-        | None -> int_overflow (Optint.Int63.to_int64 v))
   | Uint64 _ -> (
       match Int64.unsigned_to_int v with Some n -> n | None -> int_overflow v)
   | Int8 -> v

--- a/lib/everparse.ml
+++ b/lib/everparse.ml
@@ -69,8 +69,6 @@ let rec type_suffix : type a. a Types.typ -> string = function
   | Types.Uint16 Types.Big -> "U16BE"
   | Types.Uint32 Types.Little -> "U32"
   | Types.Uint32 Types.Big -> "U32BE"
-  | Types.Uint63 Types.Little -> "U63"
-  | Types.Uint63 Types.Big -> "U63BE"
   | Types.Uint64 Types.Little -> "U64"
   | Types.Uint64 Types.Big -> "U64BE"
   (* Signed integers and floats project to the same-width [UINT*] (the

--- a/lib/field.ml
+++ b/lib/field.ml
@@ -83,8 +83,8 @@ let rec is_repeat_case_body : type a. a Types.typ -> bool =
  fun typ ->
   let open Types in
   match typ with
-  | Uint8 | Uint16 _ | Uint32 _ | Uint63 _ | Uint64 _ | Int8 | Int16 _ | Int32 _
-  | Int64 _ | Float32 _ | Float64 _ | Unit | Zeroterm | Bits _ ->
+  | Uint8 | Uint16 _ | Uint32 _ | Uint64 _ | Int8 | Int16 _ | Int32 _ | Int64 _
+  | Float32 _ | Float64 _ | Unit | Zeroterm | Bits _ ->
       true
   | Uint_var { size = Int _; _ } -> true
   | Byte_array { size = Int _ } | Byte_slice { size = Int _ } -> true
@@ -115,8 +115,8 @@ let rec is_repeat_element : type a. a Types.typ -> bool =
  fun typ ->
   let open Types in
   match typ with
-  | Uint8 | Uint16 _ | Uint32 _ | Uint63 _ | Uint64 _ | Int8 | Int16 _ | Int32 _
-  | Int64 _ | Float32 _ | Float64 _ | Uint_var _ | Zeroterm ->
+  | Uint8 | Uint16 _ | Uint32 _ | Uint64 _ | Int8 | Int16 _ | Int32 _ | Int64 _
+  | Float32 _ | Float64 _ | Uint_var _ | Zeroterm ->
       true
   (* [Unit] is 0-width: a byte-budget list of it carries no bytes and projects to
      a zero-size element EverParse refuses to extract, like the [array] case. A

--- a/lib/param.ml
+++ b/lib/param.ml
@@ -26,7 +26,6 @@ let rec int_cvt : type a. a Types.typ -> a int_cvt =
   | Uint16 _ -> id
   | Uint_var _ -> { fwd = optint_to_int UInt63.to_int; bwd = UInt63.of_int }
   | Uint32 _ -> { fwd = optint_to_int UInt32.to_int; bwd = UInt32.of_int }
-  | Uint63 _ -> { fwd = optint_to_int UInt63.to_int; bwd = UInt63.of_int }
   | Uint64 _ ->
       {
         fwd =
@@ -58,8 +57,8 @@ let of_int typ v = (int_cvt typ).bwd v
 
 let rec is_int_representable : type a. a Types.typ -> bool = function
   | Types.Uint8 | Types.Uint16 _ | Types.Uint_var _ | Types.Uint32 _
-  | Types.Uint63 _ | Types.Uint64 _ | Types.Int8 | Types.Int16 _ | Types.Int32 _
-  | Types.Int64 _ | Types.Bits _ ->
+  | Types.Uint64 _ | Types.Int8 | Types.Int16 _ | Types.Int32 _ | Types.Int64 _
+  | Types.Bits _ ->
       true
   | Types.Enum { base; _ } -> is_int_representable base
   | Types.Map { inner; _ } -> is_int_representable inner

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -169,7 +169,6 @@ and _ typ =
   | Uint8 : int typ
   | Uint16 : endian -> int typ
   | Uint32 : endian -> UInt32.t typ
-  | Uint63 : endian -> UInt63.t typ
   | Uint64 : endian -> int64 typ (* boxed, for full 64-bit *)
   | Int8 : int typ
   | Int16 : endian -> int typ
@@ -468,8 +467,6 @@ let uint16 = Uint16 Little
 let uint16be = Uint16 Big
 let uint32 = Uint32 Little
 let uint32be = Uint32 Big
-let uint63 = Uint63 Little
-let uint63be = Uint63 Big
 let uint64 = Uint64 Little
 let uint64be = Uint64 Big
 let int8 = Int8
@@ -643,7 +640,7 @@ let check_nested_size ~at_most ~expected ~actual =
    fixed [wire_size]. Reject everything else at the smart constructor
    so the error fires at the user's call site. *)
 let rec has_wire_size_expr : type a. a typ -> bool = function
-  | Uint8 | Uint16 _ | Uint32 _ | Uint63 _ | Uint64 _ -> true
+  | Uint8 | Uint16 _ | Uint32 _ | Uint64 _ -> true
   | Int8 | Int16 _ | Int32 _ | Int64 _ -> true
   | Float32 _ | Float64 _ -> true
   | Bits _ -> true
@@ -671,7 +668,7 @@ let rec has_wire_size_expr : type a. a typ -> bool = function
    This is what makes a named composite usable as an element: a [T_nlist] over a
    non-[nz] element fails EverParse extraction. *)
 let rec nz : type a. a typ -> bool = function
-  | Uint8 | Uint16 _ | Uint32 _ | Uint63 _ | Uint64 _ -> true
+  | Uint8 | Uint16 _ | Uint32 _ | Uint64 _ -> true
   | Int8 | Int16 _ | Int32 _ | Int64 _ -> true
   | Float32 _ | Float64 _ -> true
   | Bits _ -> true
@@ -710,7 +707,7 @@ and struct_nz (s : struct_) =
    stricter than [has_wire_size_expr], which admits sized-but-undecodable
    elements for the [optional] byte-size suffix. *)
 let rec is_array_element : type a. a typ -> bool = function
-  | Uint8 | Uint16 _ | Uint32 _ | Uint63 _ | Uint64 _ -> true
+  | Uint8 | Uint16 _ | Uint32 _ | Uint64 _ -> true
   | Int8 | Int16 _ | Int32 _ | Int64 _ -> true
   | Float32 _ | Float64 _ -> true
   (* [Unit] is 0-width: an array of it carries no bytes and projects to a
@@ -946,7 +943,7 @@ let default inner ~inject ~project =
    projected as its base scalar with a membership refinement (closed) or bare
    base (open) instead, the same shape used outside the doc projection. *)
 let enum_base_is_be : type a. a typ -> bool = function
-  | Uint16 Big | Uint32 Big | Uint63 Big | Uint64 Big -> true
+  | Uint16 Big | Uint32 Big | Uint64 Big -> true
   | Int16 Big | Int32 Big | Int64 Big -> true
   | Uint_var { endian = Big; _ } -> true
   | _ -> false
@@ -1052,7 +1049,7 @@ let struct_project s ~name ~keep =
 type ocaml_kind = Int | Int64 | Float32 | Float64 | Bool | String | Unit
 
 let rec ocaml_kind_of : type a. a typ -> ocaml_kind = function
-  | Uint8 | Uint16 _ | Uint32 _ | Uint63 _ | Uint_var _ -> Int
+  | Uint8 | Uint16 _ | Uint32 _ | Uint_var _ -> Int
   | Uint64 _ -> Int64
   | Int8 | Int16 _ | Int32 _ -> Int
   | Int64 _ -> Int64
@@ -1286,8 +1283,8 @@ let list_elem_pp : type a.
    shaped scalars plus enums. String/byte tags use the two-step shape
    (split into adjacent fields, dispatch in caller code) instead. *)
 let is_int_dispatch_typ : type a. a typ -> bool = function
-  | Uint8 | Uint16 _ | Uint32 _ | Uint63 _ | Uint_var _ | Int8 | Int16 _
-  | Int32 _ | Bits _ | Enum _ ->
+  | Uint8 | Uint16 _ | Uint32 _ | Uint_var _ | Int8 | Int16 _ | Int32 _ | Bits _
+  | Enum _ ->
       true
   | _ -> false
 
@@ -1302,7 +1299,7 @@ let uint32_case_index k =
         "Wire.casetype: case index %Ld does not fit this platform's native int"
         index
 
-let uint63_case_index k =
+let uint_var_case_index k =
   match UInt63.to_int k with
   | index -> index
   | exception (Failure _ | Invalid_argument _) ->
@@ -1320,8 +1317,7 @@ let case_index_to_expr : type k. k typ -> k -> packed_expr =
   | Uint8 -> Pack_expr (Int k)
   | Uint16 _ -> Pack_expr (Int k)
   | Uint32 _ -> Pack_expr (Int (uint32_case_index k))
-  | Uint63 _ -> Pack_expr (Int (uint63_case_index k))
-  | Uint_var _ -> Pack_expr (Int (uint63_case_index k))
+  | Uint_var _ -> Pack_expr (Int (uint_var_case_index k))
   | Int8 -> Pack_expr (Int k)
   | Int16 _ -> Pack_expr (Int k)
   | Int32 _ -> Pack_expr (Int k)
@@ -1398,8 +1394,6 @@ let rec wrap_tag : type a. a typ -> string = function
   | Uint16 Big -> "u16b"
   | Uint32 Little -> "u32l"
   | Uint32 Big -> "u32b"
-  | Uint63 Little -> "u63l"
-  | Uint63 Big -> "u63b"
   | Uint64 Little -> "u64l"
   | Uint64 Big -> "u64b"
   | Int8 -> "i8"
@@ -1438,8 +1432,8 @@ let rec wrap_tag : type a. a typ -> string = function
 let some fmt = Fmt.kstr (fun s -> Some s) fmt
 
 let rec single_elem_struct : type a. a typ -> string option = function
-  | Uint8 | Uint16 _ | Uint32 _ | Uint63 _ | Uint64 _ | Int8 | Int16 _ | Int32 _
-  | Int64 _ | Float32 _ | Float64 _ | Codec _ | Casetype _ ->
+  | Uint8 | Uint16 _ | Uint32 _ | Uint64 _ | Int8 | Int16 _ | Int32 _ | Int64 _
+  | Float32 _ | Float64 _ | Codec _ | Casetype _ ->
       None
   | Map { inner; _ } -> single_elem_struct inner
   | Where { inner; _ } -> single_elem_struct inner
@@ -1759,10 +1753,6 @@ and pp_typ : type a. a typ Fmt.t =
   | Uint8 -> Fmt.string ppf "UINT8"
   | Uint16 e -> Fmt.pf ppf "UINT16%a" pp_endian e
   | Uint32 e -> Fmt.pf ppf "UINT32%a" pp_endian e
-  (* 3D has no 63-bit type. Project to the 8-byte UINT64: both decoders then
-     accept every 8-byte input (the OCaml reader keeps the low 63 bits), so the
-     C validator never accepts more than the OCaml one. *)
-  | Uint63 e -> Fmt.pf ppf "UINT64%a" pp_endian e
   | Uint64 e -> Fmt.pf ppf "UINT64%a" pp_endian e
   (* 3D has no native signed types: project to the same-width UINT*. The
      two's-complement reinterpretation lives in the OCaml decoder. *)
@@ -2056,7 +2046,7 @@ let rec inner_wire_size : type a. a typ -> int option = function
   | Uint8 | Int8 -> Some 1
   | Uint16 _ | Int16 _ -> Some 2
   | Uint32 _ | Int32 _ | Float32 _ -> Some 4
-  | Uint63 _ | Uint64 _ | Int64 _ | Float64 _ -> Some 8
+  | Uint64 _ | Int64 _ | Float64 _ -> Some 8
   | Bits { base = U8; _ } -> Some 1
   | Bits { base = U16 _; _ } -> Some 2
   | Bits { base = U32 _; _ } -> Some 4
@@ -2155,7 +2145,6 @@ let rec bit_width_of : type a. a typ -> int option = function
   | Uint8 | Int8 -> Some 8
   | Uint16 _ | Int16 _ -> Some 16
   | Uint32 _ | Int32 _ -> Some 32
-  | Uint63 _ -> Some 63
   | Uint64 _ | Int64 _ -> Some 64
   | Map { inner; _ } -> bit_width_of inner
   | Where { inner; _ } -> bit_width_of inner
@@ -3182,7 +3171,6 @@ let rec size_of_typ_value : type a. a typ -> a -> int =
   | Uint8 -> 1
   | Uint16 _ -> 2
   | Uint32 _ -> 4
-  | Uint63 _ -> 8
   | Uint64 _ -> 8
   | Int8 -> 1
   | Int16 _ -> 2
@@ -3278,7 +3266,6 @@ let rec field_wire_size : type a. a typ -> int option = function
   | Uint8 -> Some 1
   | Uint16 _ -> Some 2
   | Uint32 _ -> Some 4
-  | Uint63 _ -> Some 8
   | Uint64 _ -> Some 8
   | Int8 -> Some 1
   | Int16 _ -> Some 2
@@ -3313,7 +3300,7 @@ let rec field_wire_size : type a. a typ -> int option = function
 let c_type_of : type a. a typ -> string = function
   | Uint8 | Bits { base = U8; _ } -> "uint8_t"
   | Uint16 _ | Bits { base = U16 _; _ } -> "uint16_t"
-  | Uint32 _ | Uint63 _ | Bits { base = U32 _; _ } -> "uint32_t"
+  | Uint32 _ | Bits { base = U32 _; _ } -> "uint32_t"
   | Uint64 _ -> "uint64_t"
   (* Signed types project to UINT* in 3D so EverParse only sees unsigned
      widths; the same width drives the C field type. *)
@@ -3330,8 +3317,7 @@ let c_type_of : type a. a typ -> string = function
   | _ -> "uint32_t"
 
 let ml_type_of : type a. a typ -> string = function
-  | Uint8 | Uint16 _ | Uint_var _ | Bits _ -> "int"
-  | Uint32 _ | Uint63 _ -> "int"
+  | Uint8 | Uint16 _ | Uint32 _ | Uint_var _ | Bits _ -> "int"
   | Uint64 _ -> "int64"
   | Int8 | Int16 _ | Int32 _ -> "int"
   | Int64 _ -> "int64"
@@ -3357,7 +3343,7 @@ let rec int_slot_of_typ : type a. a typ -> int_slot option = function
   | Uint8 | Int8 -> Some { width = 1; endian = Big }
   | Uint16 e | Int16 e -> Some { width = 2; endian = e }
   | Uint32 e | Int32 e -> Some { width = 4; endian = e }
-  | Uint63 e | Uint64 e | Int64 e -> Some { width = 8; endian = e }
+  | Uint64 e | Int64 e -> Some { width = 8; endian = e }
   | Uint_var { size = Int width; endian } -> Some { width; endian }
   | Enum { base; _ } -> int_slot_of_typ base
   | Where { inner; _ } -> int_slot_of_typ inner

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -275,7 +275,6 @@ and _ typ =
   | Uint8 : int typ  (** 8-bit unsigned. *)
   | Uint16 : endian -> int typ  (** 16-bit unsigned. *)
   | Uint32 : endian -> UInt32.t typ  (** 32-bit unsigned. *)
-  | Uint63 : endian -> UInt63.t typ  (** 63-bit unsigned. *)
   | Uint64 : endian -> int64 typ  (** 64-bit unsigned. *)
   | Int8 : int typ  (** 8-bit signed. *)
   | Int16 : endian -> int typ  (** 16-bit signed. *)
@@ -579,12 +578,6 @@ val uint32 : UInt32.t typ
 
 val uint32be : UInt32.t typ
 (** 32-bit unsigned, big-endian. *)
-
-val uint63 : UInt63.t typ
-(** 63-bit unsigned, little-endian. *)
-
-val uint63be : UInt63.t typ
-(** 63-bit unsigned, big-endian. *)
 
 val uint64 : int64 typ
 (** 64-bit unsigned, little-endian. *)

--- a/lib/uInt63.ml
+++ b/lib/uInt63.ml
@@ -1,48 +1,21 @@
-(* Unsigned 63-bit integer. Reads 8 bytes and masks to 63 bits.
+(* Carrier for [uint ~size], the 1-to-7-byte unsigned integers: 56 bits at the
+   widest, well inside the range Optint.Int63 represents exactly.
 
-   Backed by Optint.Int63: an unboxed native int on a 64-bit host (identical to
-   the old code there), a boxed int64 where the native int is narrower. On such
-   a target the old plain-int composition shifted past the word ([w2 lsl 32],
-   [w3 lsl 48]) and lost the high half entirely. *)
+   Backed by Optint.Int63: an unboxed native int on a 64-bit host, a boxed
+   int64 where the native int is narrower. On such a target a plain-int
+   composition would shift past the word and lose the high half. *)
 
 module I = Optint.Int63
 
 type t = I.t
 
 let pp = I.pp
-let mask16 = I.of_int 0xFFFF
-
-let compose w0 w1 w2 w3 =
-  I.(
-    logand
-      (logor (of_int w0)
-         (logor
-            (shift_left (of_int w1) 16)
-            (logor (shift_left (of_int w2) 32) (shift_left (of_int w3) 48))))
-      max_int)
-
-let le buf off =
-  compose
-    (Bytes.get_uint16_le buf off)
-    (Bytes.get_uint16_le buf (off + 2))
-    (Bytes.get_uint16_le buf (off + 4))
-    (Bytes.get_uint16_le buf (off + 6))
-
-let be buf off =
-  compose
-    (Bytes.get_uint16_be buf (off + 6))
-    (Bytes.get_uint16_be buf (off + 4))
-    (Bytes.get_uint16_be buf (off + 2))
-    (Bytes.get_uint16_be buf off)
-
-let chunk v shift = I.to_int (I.logand (I.shift_right_logical v shift) mask16)
 
 (* A [size]-byte unsigned field owns exactly that many bytes, and the carrier is
-   a signed 63-bit integer. A negative value, or one wider than the field, loses
-   its high bits to [chunk] and reaches the wire as a legal smaller number that
-   no decoder, [validate] or generated C validator can tell from the one the
-   caller meant, so writing refuses instead. Eight bytes hold every non-negative
-   [t], so at that width only the sign can be wrong. *)
+   signed and wider than any width it serves. A negative value, or one wider
+   than the field, loses its high bits on the way out and reaches the wire as a
+   legal smaller number that no decoder, [validate] or generated C validator can
+   tell from the one the caller meant, so writing refuses instead. *)
 let check_encode ~size v =
   let too_wide =
     size < 8 && I.compare v (I.shift_left I.one (8 * max size 0)) >= 0
@@ -50,22 +23,6 @@ let check_encode ~size v =
   if I.compare v I.zero < 0 || too_wide then
     Fmt.invalid_arg
       "Wire.encode: value %a does not fit an unsigned %d-byte field" I.pp v size
-
-(* Every encoder path -- typ-level, compiled field, [Codec.set] -- writes a
-   uint63 through here, so the width check belongs here too. *)
-let set_le buf off v =
-  check_encode ~size:8 v;
-  Bytes.set_uint16_le buf off (chunk v 0);
-  Bytes.set_uint16_le buf (off + 2) (chunk v 16);
-  Bytes.set_uint16_le buf (off + 4) (chunk v 32);
-  Bytes.set_uint16_le buf (off + 6) (chunk v 48)
-
-let set_be buf off v =
-  check_encode ~size:8 v;
-  Bytes.set_uint16_be buf off (chunk v 48);
-  Bytes.set_uint16_be buf (off + 2) (chunk v 32);
-  Bytes.set_uint16_be buf (off + 4) (chunk v 16);
-  Bytes.set_uint16_be buf (off + 6) (chunk v 0)
 
 let to_int = I.to_int
 let of_int = I.of_int

--- a/lib/uInt63.mli
+++ b/lib/uInt63.mli
@@ -1,4 +1,6 @@
-(** Unsigned 63-bit integer. Reads 8 bytes, masks to 63 bits.
+(** Carrier for [uint ~size], the 1-to-7-byte unsigned integers. Seven bytes
+    need 56 bits, so every value of every width it serves is represented exactly
+    and nothing is masked.
 
     Backed by {!Optint.Int63}: an unboxed native [int] on a 64-bit host, a boxed
     [int64] where the native [int] is narrower (there a plain-[int] composition
@@ -7,31 +9,16 @@
 type t = Optint.Int63.t
 
 val pp : Format.formatter -> t -> unit
-(** Pretty-printer for unsigned 63-bit values. *)
-
-val le : bytes -> int -> t
-(** [le buf off] reads a little-endian value from [buf] at offset [off]. *)
-
-val be : bytes -> int -> t
-(** [be buf off] reads a big-endian value from [buf] at offset [off]. *)
+(** Pretty-printer. *)
 
 val check_encode : size:int -> t -> unit
 (** [check_encode ~size v] raises [Invalid_argument] when [v] is negative or
     needs more than [size] bytes. Truncating it would leave a legal [size]-byte
     number on the wire that nothing downstream can tell from the one the caller
-    meant. Shared by every [size]-byte unsigned field: the eight-byte {!set_le}
-    and {!set_be} below, and the narrower [uint ~size]. *)
-
-val set_le : bytes -> int -> t -> unit
-(** [set_le buf off v] writes [v] as little-endian into [buf] at offset [off].
-    Raises [Invalid_argument] on a value {!check_encode} rejects. *)
-
-val set_be : bytes -> int -> t -> unit
-(** [set_be buf off v] writes [v] as big-endian into [buf] at offset [off].
-    Raises [Invalid_argument] on a value {!check_encode} rejects. *)
+    meant. *)
 
 val to_int : t -> int
 (** [to_int t] is the value as a native [int]. Exact on a 64-bit host. *)
 
 val of_int : int -> t
-(** [of_int n] is [n] as a 63-bit value. *)
+(** [of_int n] is [n] as a {!type-t}. *)

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -249,8 +249,6 @@ let rec parse_direct : type a. a typ -> bytes -> int -> int -> a * int =
   | Uint16 Big -> parse_fixed 2 Bytes.get_uint16_be buf off len
   | Uint32 Little -> parse_fixed 4 UInt32.le buf off len
   | Uint32 Big -> parse_fixed 4 UInt32.be buf off len
-  | Uint63 Little -> parse_fixed 8 UInt63.le buf off len
-  | Uint63 Big -> parse_fixed 8 UInt63.be buf off len
   | Uint64 Little -> parse_fixed 8 Bytes.get_int64_le buf off len
   | Uint64 Big -> parse_fixed 8 Bytes.get_int64_be buf off len
   | Int8 -> parse_fixed 1 Bytes.get_int8 buf off len
@@ -647,16 +645,6 @@ let[@inline] write_int64_be enc v =
   Bytes.set_int64_be enc.o enc.o_next v;
   enc.o_next <- enc.o_next + 8
 
-let[@inline] write_uint63_le enc v =
-  ensure enc 8;
-  UInt63.set_le enc.o enc.o_next v;
-  enc.o_next <- enc.o_next + 8
-
-let[@inline] write_uint63_be enc v =
-  ensure enc 8;
-  UInt63.set_be enc.o enc.o_next v;
-  enc.o_next <- enc.o_next + 8
-
 let write_string enc s =
   let len = String.length s in
   if len <= enc.o_max + 1 - enc.o_next then begin
@@ -696,8 +684,6 @@ let rec encode_into : type a. a typ -> a -> encoder -> unit =
       write_uint16_be enc v
   | Uint32 Little -> write_uint32_le enc v
   | Uint32 Big -> write_uint32_be enc v
-  | Uint63 Little -> write_uint63_le enc v
-  | Uint63 Big -> write_uint63_be enc v
   | Uint64 Little -> write_int64_le enc v
   | Uint64 Big -> write_int64_be enc v
   | Int8 ->
@@ -898,12 +884,6 @@ let rec encode_direct : type a. a typ -> bytes -> int -> a -> int =
   | Uint32 Big ->
       UInt32.set_be buf off v;
       off + 4
-  | Uint63 Little ->
-      UInt63.set_le buf off v;
-      off + 8
-  | Uint63 Big ->
-      UInt63.set_be buf off v;
-      off + 8
   | Uint64 Little ->
       Bytes.set_int64_le buf off v;
       off + 8

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -557,17 +557,6 @@ val uint32 : Optint.t typ
 val uint32be : Optint.t typ
 (** Unsigned 32-bit big-endian integer. Decodes to an [Optint.t]. *)
 
-val uint63 : Optint.Int63.t typ
-(** Unsigned 63-bit little-endian integer carried on 8 bytes. Decodes to an
-    [Optint.Int63.t], whose range starts at zero, so encoding refuses a negative
-    value. The eight wire bytes hold more than the carrier does: the decoder
-    keeps the low bits, so the widest value that round-trips is
-    [Optint.Int63.max_int]. *)
-
-val uint63be : Optint.Int63.t typ
-(** Unsigned 63-bit big-endian integer carried on 8 bytes. Decodes to an
-    [Optint.Int63.t]. *)
-
 val uint64 : int64 typ
 (** [uint64] is an unsigned 64-bit little-endian integer represented as an OCaml
     64-bit integer. The representation is exactly the eight bytes written, so

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -1788,10 +1788,10 @@ let test_array_repeat_reject_non_nz_codec () =
 let projects c = match render_3d c with _ -> true | exception _ -> false
 let arr_field elem = Codec.v "Arr" Fun.id Codec.[ Field.v "x" elem $ Fun.id ]
 
-(* An [array] over a float, signed integer, or [uint63] element builds,
-   round-trips, and projects to a verified 3D schema: [inner_wire_size] sizes
-   every fixed-width scalar element (unsigned and signed ints, floats, [uint63],
-   and bitfields), so the projector can size it. *)
+(* An [array] over a float or signed integer element builds, round-trips, and
+   projects to a verified 3D schema: [inner_wire_size] sizes every fixed-width
+   scalar element (unsigned and signed ints, floats, and bitfields), so the
+   projector can size it. *)
 let test_array_scalar_element_projects () =
   let yes name c =
     Alcotest.(check bool) (name ^ " array projects") true (projects c)
@@ -1802,7 +1802,7 @@ let test_array_scalar_element_projects () =
   yes "int16be" (arr_field (array ~len:(int 2) int16be));
   yes "int32be" (arr_field (array ~len:(int 2) int32be));
   yes "int64be" (arr_field (array ~len:(int 2) int64be));
-  yes "uint63be" (arr_field (array ~len:(int 2) uint63be));
+  yes "uint64be" (arr_field (array ~len:(int 2) uint64be));
   (* and it still round-trips *)
   let c = arr_field (array ~len:(int 2) float64be) in
   let v = [ 1.5; -2.25 ] in
@@ -2966,17 +2966,6 @@ let test_encode_exact_uint32 () =
           ~outside:[ Optint.of_int (mask + 1); Optint.of_int (-1) ])
       [ ("uint32", uint32); ("uint32be", uint32be) ]
 
-(* [uint63] fills its carrier, so the only unrepresentable value left is a
-   negative one, and that one is unrepresentable on every target. *)
-let test_encode_exact_uint63 () =
-  List.iter
-    (fun (name, typ) ->
-      check_scalar_range ~name ~typ ~sub:"does not fit an unsigned 8-byte field"
-        ~equal:Optint.Int63.equal ~pp:Optint.Int63.pp
-        ~inside:[ Optint.Int63.zero; Optint.Int63.max_int ]
-        ~outside:[ Optint.Int63.of_int (-1); Optint.Int63.min_int ])
-    [ ("uint63", uint63); ("uint63be", uint63be) ]
-
 (* An 8-byte field spans 2^64 wire patterns and the generated C validator hands
    every one of them on unchanged, so the OCaml side must too. A carrier that
    held fewer would mask the top bits and hand back a legal smaller number, one
@@ -2996,8 +2985,6 @@ let check_eight_byte_unsigned name typ =
         wire (Bytes.to_string out)
 
 let test_eight_byte_unsigned_preserves_wire () =
-  check_eight_byte_unsigned "uint63" uint63;
-  check_eight_byte_unsigned "uint63be" uint63be;
   check_eight_byte_unsigned "uint64" uint64;
   check_eight_byte_unsigned "uint64be" uint64be
 
@@ -8135,7 +8122,6 @@ let test_repeat_validate_allocation_is_bounded () =
         repeat_budget_case "uint32be" uint32be;
         repeat_budget_case "int8" int8;
         repeat_budget_case "int16be" int16be;
-        repeat_budget_case "uint63be" uint63be;
         repeat_budget_case "uint64be" uint64be;
         repeat_budget_case "int64be" int64be;
         repeat_budget_case "float32be" float32be;
@@ -8812,7 +8798,6 @@ let suite =
       Alcotest.test_case "exact width: signed scalars" `Quick
         test_encode_exact_signed_scalar;
       Alcotest.test_case "exact width: uint32" `Quick test_encode_exact_uint32;
-      Alcotest.test_case "exact width: uint63" `Quick test_encode_exact_uint63;
       Alcotest.test_case "exact width: int64 carrier has no range" `Quick
         test_encode_int64_carrier_has_no_range;
       Alcotest.test_case "8-byte unsigned fields preserve the wire" `Quick

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -2733,6 +2733,33 @@ let test_set_exact_uint_width () =
         uint_endians)
     uint_width_cases
 
+(* The decode half of the same rule, at every width [uint ~size] accepts. A
+   full-width frame must come back as the number those bytes spell and go out
+   again byte for byte: a carrier too narrow for the field would mask the top
+   bits and hand back a legal smaller number instead. Widths are compared
+   through [Int64] because a 7-byte maximum overflows the native [int] where it
+   is 31 bits wide. *)
+let test_uint_width_decodes_exactly () =
+  List.iter
+    (fun size ->
+      List.iter
+        (fun (endian, ename) ->
+          let codec, _ = uint_width_codec ~endian size in
+          let label = Fmt.str "uint(%d,%s)" size ename in
+          let wire = String.make size '\xff' in
+          let widest = Int64.sub (Int64.shift_left 1L (8 * size)) 1L in
+          let v = Codec.decode_exn codec (Bytes.of_string wire) 0 in
+          Alcotest.(check int64)
+            (label ^ ": full-width frame decodes to the number it spells")
+            widest (Optint.Int63.to_int64 v);
+          let out = Bytes.make size '\x00' in
+          Codec.encode codec v out 0;
+          Alcotest.(check string)
+            (label ^ ": full-width frame re-encodes unchanged")
+            wire (Bytes.to_string out))
+        uint_endians)
+    [ 1; 2; 3; 4; 5; 6; 7 ]
+
 let bits_width_bases =
   [
     (U8, "U8", 8);
@@ -2949,6 +2976,30 @@ let test_encode_exact_uint63 () =
         ~inside:[ Optint.Int63.zero; Optint.Int63.max_int ]
         ~outside:[ Optint.Int63.of_int (-1); Optint.Int63.min_int ])
     [ ("uint63", uint63); ("uint63be", uint63be) ]
+
+(* An 8-byte field spans 2^64 wire patterns and the generated C validator hands
+   every one of them on unchanged, so the OCaml side must too. A carrier that
+   held fewer would mask the top bits and hand back a legal smaller number, one
+   nothing downstream can tell from the value the sender meant. Refusing the
+   frame would be sound; altering it is not. *)
+let check_eight_byte_unsigned name typ =
+  let wire = String.make 8 '\xff' in
+  let cf = Codec.(Field.v "v" typ $ Fun.id) in
+  let codec = Codec.v "EightByteUnsigned" Fun.id Codec.[ cf ] in
+  match Codec.decode codec (Bytes.of_string wire) 0 with
+  | Error _ -> ()
+  | Ok v ->
+      let out = Bytes.make 8 '\x00' in
+      Codec.encode codec v out 0;
+      Alcotest.(check string)
+        (name ^ ": all-ones frame re-encodes unchanged")
+        wire (Bytes.to_string out)
+
+let test_eight_byte_unsigned_preserves_wire () =
+  check_eight_byte_unsigned "uint63" uint63;
+  check_eight_byte_unsigned "uint63be" uint63be;
+  check_eight_byte_unsigned "uint64" uint64;
+  check_eight_byte_unsigned "uint64be" uint64be
 
 (* [array] and [repeat] elements are written by an encoder of their own, so a
    value no element can hold has to be refused on that path too. *)
@@ -8746,6 +8797,8 @@ let suite =
         test_encode_exact_uint_width;
       Alcotest.test_case "exact width: uint set" `Quick
         test_set_exact_uint_width;
+      Alcotest.test_case "exact width: uint decodes exactly" `Quick
+        test_uint_width_decodes_exactly;
       Alcotest.test_case "exact width: bits encode" `Quick
         test_encode_exact_bits_width;
       Alcotest.test_case "exact width: bits set" `Quick
@@ -8762,6 +8815,8 @@ let suite =
       Alcotest.test_case "exact width: uint63" `Quick test_encode_exact_uint63;
       Alcotest.test_case "exact width: int64 carrier has no range" `Quick
         test_encode_int64_carrier_has_no_range;
+      Alcotest.test_case "8-byte unsigned fields preserve the wire" `Quick
+        test_eight_byte_unsigned_preserves_wire;
       Alcotest.test_case "exact width: array and repeat elements" `Quick
         test_element_exact_width;
       Alcotest.test_case "exact byte field: literal size" `Quick

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -153,30 +153,6 @@ let test_pretty_print () =
     "contains UINT16BE" true
     (contains ~sub:"UINT16BE" output)
 
-let test_3d_uint63_projects_to_uint64 () =
-  (* 3D has no 63-bit type. uint63/uint63be must project to the 8-byte UINT64,
-     not an invalid UINT63 that EverParse rejects (leaving the codec with no
-     verified validator at all). *)
-  let c =
-    Codec.v "U63"
-      (fun a b -> (a, b))
-      Codec.
-        [
-          (Field.v "a" uint63 $ fun (a, _) -> a);
-          (Field.v "b" uint63be $ fun (_, b) -> b);
-        ]
-  in
-  let output = to_3d (module_ [ typedef (Everparse.Raw.struct_of_codec c) ]) in
-  Alcotest.(check bool)
-    "no invalid UINT63" false
-    (contains ~sub:"UINT63" output);
-  Alcotest.(check bool)
-    "uint63 projects to UINT64" true
-    (contains ~sub:"UINT64 a" output);
-  Alcotest.(check bool)
-    "uint63be projects to UINT64BE" true
-    (contains ~sub:"UINT64BE b" output)
-
 let test_3d_signed_float_setters () =
   (* Signed-int and float fields each route to a width-typed setter, not the
      generic SetBytes (whose single value type cannot hold two scalar fields of
@@ -1485,8 +1461,6 @@ let suite =
         test_reserved_word_escaping;
       Alcotest.test_case "3d: byte_array_where synth typedef" `Quick
         test_3d_byte_array_where;
-      Alcotest.test_case "3d: uint63 projects to UINT64" `Quick
-        test_3d_uint63_projects_to_uint64;
       Alcotest.test_case "3d: signed and float setters" `Quick
         test_3d_signed_float_setters;
       Alcotest.test_case "3d: arithmetic constraint widens operands" `Quick

--- a/test/test_uint63.ml
+++ b/test/test_uint63.ml
@@ -1,68 +1,56 @@
-(* Tests for UInt63: unsigned 63-bit get/set over bytes (8-byte slot).
-   Values above 31 bits are written as [Int64] literals and compared through
-   [Optint.Int63.to_int64]: an int literal would itself truncate on a
+(* Tests for UInt63, the carrier [uint ~size] decodes into. Widths are built
+   from [Int64] literals and compared through [Optint.Int63.to_int64]: a
+   7-byte maximum written as an int literal would itself truncate on a
    narrow-int target (wasm_of_ocaml, js_of_ocaml), and these tests run there
    too. *)
 
 open Wire.Private
 
 let of_int64 = Optint.Int63.of_int64
-let to_int64 = Optint.Int63.to_int64
+let sizes = [ 1; 2; 3; 4; 5; 6; 7 ]
 
-let check_roundtrip name ~set ~get v =
-  let buf = Bytes.create 8 in
-  set buf 0 (of_int64 v);
-  Alcotest.(check int64) name v (to_int64 (get buf 0))
-
-let test_roundtrip_le () =
-  check_roundtrip "le roundtrip" ~set:UInt63.set_le ~get:UInt63.le
-    0x1234_5678_9ABCL
-
-let test_roundtrip_be () =
-  check_roundtrip "be roundtrip" ~set:UInt63.set_be ~get:UInt63.be
-    0x1234_5678_9ABCL
+let refuses name ~size v =
+  match UInt63.check_encode ~size v with
+  | () -> Alcotest.failf "%s: expected Invalid_argument" name
+  | exception Invalid_argument msg ->
+      Alcotest.(check bool)
+        (name ^ ": message names the field width")
+        true
+        (String.ends_with
+           ~suffix:(Fmt.str "does not fit an unsigned %d-byte field" size)
+           msg)
 
 let test_of_int_identity () =
   Alcotest.(check int) "identity" 42 (UInt63.to_int (UInt63.of_int 42))
 
-(* Pin the wire byte order across all eight bytes so the read/write paths
-   cannot drift. *)
-let test_byte_layout () =
-  let buf = Bytes.of_string "\x01\x02\x03\x04\x05\x06\x07\x08" in
-  Alcotest.(check int64)
-    "le read" 0x0807_0605_0403_0201L
-    (to_int64 (UInt63.le buf 0));
-  Alcotest.(check int64)
-    "be read" 0x0102_0304_0506_0708L
-    (to_int64 (UInt63.be buf 0));
-  let out = Bytes.create 8 in
-  UInt63.set_le out 0 (of_int64 0x0807_0605_0403_0201L);
-  Alcotest.(check string)
-    "le write" "\x01\x02\x03\x04\x05\x06\x07\x08" (Bytes.to_string out);
-  UInt63.set_be out 0 (of_int64 0x0102_0304_0506_0708L);
-  Alcotest.(check string)
-    "be write" "\x01\x02\x03\x04\x05\x06\x07\x08" (Bytes.to_string out)
-
-let test_boundaries () =
+(* The carrier is wider than every width it serves -- seven bytes need 56 bits,
+   the carrier holds 62 -- so the widest value of each width passes the encode
+   guard untouched. The first value past it is refused rather than truncated to
+   a legal smaller number the wire cannot be told apart from. *)
+let test_check_encode_widths () =
   List.iter
-    (fun v ->
-      check_roundtrip "le" ~set:UInt63.set_le ~get:UInt63.le v;
-      check_roundtrip "be" ~set:UInt63.set_be ~get:UInt63.be v)
-    [
-      0x0L;
-      0x1L;
-      0xFFFFL;
-      0x1_0000_0000L;
-      0x0102_0304_0506_0708L;
-      0x3FFF_FFFF_FFFF_FFFFL (* 63-bit max *);
-    ]
+    (fun size ->
+      let widest = Int64.sub (Int64.shift_left 1L (8 * size)) 1L in
+      UInt63.check_encode ~size (of_int64 widest);
+      refuses
+        (Fmt.str "uint(%d) <- 0x%Lx" size (Int64.add widest 1L))
+        ~size
+        (of_int64 (Int64.add widest 1L)))
+    sizes
+
+(* A negative value would reach the wire as its low bytes, a legal positive
+   number of that width. *)
+let test_check_encode_rejects_negative () =
+  List.iter
+    (fun size ->
+      refuses (Fmt.str "uint(%d) <- -1" size) ~size (UInt63.of_int (-1)))
+    sizes
 
 let suite =
   ( "uint63",
     [
-      Alcotest.test_case "roundtrip le" `Quick test_roundtrip_le;
-      Alcotest.test_case "roundtrip be" `Quick test_roundtrip_be;
       Alcotest.test_case "of_int identity" `Quick test_of_int_identity;
-      Alcotest.test_case "byte layout" `Quick test_byte_layout;
-      Alcotest.test_case "boundaries" `Quick test_boundaries;
+      Alcotest.test_case "check_encode widths" `Quick test_check_encode_widths;
+      Alcotest.test_case "check_encode rejects negative" `Quick
+        test_check_encode_rejects_negative;
     ] )

--- a/test/test_uint63.mli
+++ b/test/test_uint63.mli
@@ -1,4 +1,4 @@
-(** Tests for the [uint63] module. *)
+(** Tests for the [UInt63] carrier module. *)
 
 val suite : string * unit Alcotest.test_case list
 (** Alcotest suite. *)


### PR DESCRIPTION
Eight 0xff bytes through a uint63be field decoded to 0x3fffffffffffffff and re-encoded as different bytes, silently, because the Optint.Int63 carrier holds a quarter of what the 8-byte field does, while the generated C validator passed the same frame through untouched. uint64/uint64be is the exact 8-byte type and always was, so uint63/uint63be are removed; UInt63 stays as the carrier for uint ~size, where nothing is masked.
