### PR TITLE
wire.3d: diff the committed schema, do not promote over it

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -105,6 +105,13 @@
 
 ### Fixed
 
+- The single-file documentation build no longer regenerates the committed
+  `<Name>.3d` behind your back. It was a promoted rule target the install stanza
+  depended on, so every build rewrote it before the drift check compared it, and
+  a schema that no longer matched its codec could not fail `runtest`. The
+  committed schema is now a plain source: drift fails `runtest`, and `dune
+  promote` writes the new bytes after an intended codec change (#317, @samoht)
+
 - Fix `Codec.validate` skipping a sub-codec field's constraints, `where`,
   closed-enum membership, `per_byte` refinements and actions, which now reject
   the same bytes as decoding and generated EverParse validators (#311, @samoht)

--- a/lib/3d/wire_3d.ml
+++ b/lib/3d/wire_3d.ml
@@ -1644,26 +1644,26 @@ let host_context = "(= %{context_name} default)"
    it (the one-line form runs past the margin). *)
 let host_context_and cond = Fmt.str "(and\n   %s\n   %s)" host_context cond
 
-(* The [.3d] and [agree.c] are pure OCaml ([gen.exe 3d] / [gen.exe agree]), so
-   they regenerate on demand and never go stale. The C needs [3d.exe], so its
-   rule exists only under [BUILD_EVERPARSE=1] ([mode promote] writes it back into
-   the tree); a plain [dune build] uses the committed C and never invokes
-   [3d.exe], and fails loudly if the C was never committed rather than silently
-   shelling out. A codec change refreshes the [.3d] and [agree.c] while the
-   committed C goes stale -- the runtest differential below catches that, since
-   it regenerates the corpus and [agree.c] from the current codec and runs them
-   against the committed validator. *)
+(* The committed [.3d] is a plain source that no rule names as a target. The
+   install stanza depends on it, so a rule producing it would run on any build
+   that installs anything and promote over the file before the drift check in
+   [emit_drift_check_rules] compares it. Drift is reported there instead, by
+   diffing the committed schema against a scratch [<Base>.3d.gen], and [dune
+   promote] writes the new bytes after an intended codec change, reviewed as a
+   source diff like anything else.
+
+   [agree.c] is pure OCaml and a scratch target, never promoted, so it
+   regenerates on demand. The C needs [3d.exe], so its rule exists only under
+   [BUILD_EVERPARSE=1] ([mode promote] writes it back into the tree); a plain
+   [dune build] uses the committed C and never invokes [3d.exe], and fails
+   loudly if the C was never committed rather than silently shelling out. A
+   codec change refreshes the [.3d] and [agree.c] while the committed C goes
+   stale -- the runtest differential below catches that, since it regenerates
+   the corpus and [agree.c] from the current codec and runs them against the
+   committed validator. *)
 let emit_standalone_gen_rules ppf ~three_d ~c_files ~provenance =
   Fmt.pf ppf
     "(rule\n\
-    \ (alias 3d)\n\
-    \ (enabled_if\n\
-    \  %s)\n\
-    \ (mode promote)\n\
-    \ (targets %s)\n\
-    \ (action\n\
-    \  (run %%{exe:gen.exe} 3d)))\n\n\
-     (rule\n\
     \ (enabled_if\n\
     \  %s)\n\
     \ (targets agree.c)\n\
@@ -1678,7 +1678,7 @@ let emit_standalone_gen_rules ppf ~three_d ~c_files ~provenance =
     \ (deps %s)\n\
     \ (action\n\
     \  (run %%{exe:gen.exe} c)))\n\n"
-    host_context three_d host_context
+    host_context
     (host_context_and "(= %{env:BUILD_EVERPARSE=} \"1\")")
     (String.concat " " c_files)
     provenance three_d

--- a/lib/3d/wire_3d.mli
+++ b/lib/3d/wire_3d.mli
@@ -212,14 +212,16 @@ val generate_standalone :
 val generate_dune_standalone :
   ?name:string -> outdir:string -> package:string -> packed list -> unit
 (** [generate_dune_standalone ?name ~outdir ~package codecs] writes a [dune.inc]
-    for the single-file documentation build: rules that emit [<Name>.3d] and
-    compile it to [<Name>.c], a rule that builds the validator into an installed
-    [lib<name>.a] archive, a [runtest] rule that runs the differential
+    for the single-file documentation build: a rule that compiles the committed
+    [<Name>.3d] to [<Name>.c], a rule that builds the validator into an
+    installed [lib<name>.a] archive, a [runtest] rule that runs the differential
     self-check (see {!generate_corpus} / {!generate_agree}), and an install
     stanza (under opam [package]) for the spec, parser, and archive. The
     [runtest] rules also regenerate the committed [.3d] and [dune.inc] into
-    [.gen] targets and diff them. [name] defaults to [package]; see
-    {!generate_standalone}.
+    [.gen] targets and diff them; neither committed file is a rule target, so a
+    schema that drifted from its codec fails [runtest] instead of being
+    overwritten, and [dune promote] writes the new bytes on request. [name]
+    defaults to [package]; see {!generate_standalone}.
 
     The [c/] archive builds and installs in every dune context through that
     context's own toolchain ([%{ocaml-config:c_compiler}], the [ocaml-config]

--- a/test/3d/test_wire_3d.ml
+++ b/test/3d/test_wire_3d.ml
@@ -324,6 +324,13 @@ let test_generate_dune_standalone () =
   Alcotest.(check bool)
     "runtest diffs the committed spec" true
     (has "(diff MyPkg.3d MyPkg.3d.gen)");
+  (* The install stanza depends on the committed spec, so a rule that produces
+     it runs on any build that installs anything, and promotion overwrites the
+     file the diff above is meant to police. Keep it a plain source: the diff
+     then reports drift, and [dune promote] writes the new bytes on request. *)
+  Alcotest.(check bool)
+    "committed spec is a source, not a rule target" false
+    (has "(targets MyPkg.3d)");
   Alcotest.(check bool)
     "runtest regenerates dune.inc" true
     (has "targets dune.inc.gen");


### PR DESCRIPTION
The single-file pipeline emitted `<Name>.3d` under `(mode promote)` and the install stanza depends on it, so every build regenerated the schema and wrote it back before the drift check compared it. A schema that no longer matched its codec could not fail `runtest`. The committed schema is now a plain source that no rule produces.

Stacked on #316.