### PR TITLE
fuzz: compare decoded field values, not only the verdict

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,12 @@
 
 ### Added
 
+- Add `Wire.Codec.field_readers` and `Wire.Everparse.Raw.int_slots`.
+  `field_readers` is the decoder's own reader for every named int-valued field,
+  keyed by name, so a caller holding a type-erased codec can read a field
+  without a field handle; `int_slots` is the byte slot of every named whole-byte
+  integer field (#PR2, @samoht)
+
 - Add `Wire.Everparse.Raw.field_seeds`, exposing constrained whole-byte integer
   values so generated corpora can construct inputs that uniform bytes would
   never reach (#314, @samoht)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
   `field_readers` is the decoder's own reader for every named int-valued field,
   keyed by name, so a caller holding a type-erased codec can read a field
   without a field handle; `int_slots` is the byte slot of every named whole-byte
-  integer field (#PR2, @samoht)
+  integer field (#318, @samoht)
 
 - Add `Wire.Everparse.Raw.field_seeds`, exposing constrained whole-byte integer
   values so generated corpora can construct inputs that uniform bytes would
@@ -36,6 +36,11 @@
   (#263, @samoht)
 
 ### Changed
+
+- The EverParse differential compares decoded field values, not only the
+  accept/reject verdict. On an input both sides accept, every field the two can
+  both report must carry the same value; two decoders that agree on which bytes
+  are valid and read a different number out of them used to pass (#318, @samoht)
 
 - Seed `Wire_3d.generate_corpus` from accepted inputs and constraint boundaries,
   and refuse one-sided corpora, which cannot distinguish a validator from a

--- a/fuzz/diff/fuzz.ml
+++ b/fuzz/diff/fuzz.ml
@@ -4,51 +4,157 @@
     Boltzmann {!Fuzz_gen.sample} -- not from {!Fuzz_gen.registry}, which the
     OCaml-only suites drive off. For each codec EverParse could generate a
     validator for ({!Diff_index.covered}, looked up in {!Diff_codecs.included}
-    by label), feed the AFL input to both the OCaml {!Wire.Codec.validate} and
-    the generated C validator and flag any accept/reject divergence: both
-    decoders must agree on which inputs are valid. Codecs the candidate filter
-    dropped (variable-size, zero-size, parameterised or casetype) are reported
-    via {!Diff_codecs.excluded}. *)
+    by label), feed the AFL input to both the OCaml codec and the generated C
+    validator and flag any divergence.
+
+    There are two of those. Both sides must agree on which inputs are valid, and
+    on an input they both accept they must agree on what they read out of it:
+    every field {!Diff_codecs.compared_fields} says the two can both hand back
+    is compared value against value, the OCaml side through
+    {!Wire.Codec.field_readers} and the C side through {!Diff_index.values}. An
+    accept/reject check on its own is blind to the more dangerous case, two
+    decoders that accept the same bytes and read a different number out of them.
+
+    Codecs the candidate filter dropped (variable-size, zero-size, parameterised
+    or casetype) are reported via {!Diff_codecs.excluded}. *)
 
 open Fuzz_gen
+
+let accepts f =
+  match f () with () -> true | exception Wire.Parse_error _ -> false
 
 (* The EverParse validator accepts iff the bytes parse (enough input, valid
    structure) and every refinement holds. [Codec.decode_exn] is exactly that:
    it decodes (length + structure) and validates (refinements), raising
    [Parse_error] on a clean rejection. (Plain [Codec.decode]
    returns a [result], so its rejection is easy to drop by mistake.) Any other
-   exception surfaces as a crash, which is itself a divergence to report. *)
-let ocaml_accepts (Pack g) b =
-  match ignore (Wire.Codec.decode_exn (codec g) b 0) with
-  | () -> true
-  | exception Wire.Parse_error _ -> false
+   exception surfaces as a crash, which is itself a divergence to report.
 
-(* Compare both decoders on one codec and flag any accept/reject divergence. *)
-let diff_check label p c_check b =
-  let o = ocaml_accepts p b and c = c_check b in
+   [Codec.validate] is the gate a caller actually runs on untrusted input and
+   the closer counterpart of a C validator, since it checks without building a
+   record. Run it alongside, so a refinement that reaches one of the two OCaml
+   paths but not the other is caught here rather than papered over by whichever
+   one the C side happens to agree with. *)
+let ocaml_accepts label (Pack g) b =
+  let c = codec g in
+  let decoded = accepts (fun () -> ignore (Wire.Codec.decode_exn c b 0)) in
+  let validated = accepts (fun () -> Wire.Codec.validate c b 0) in
+  if decoded <> validated then
+    Alcobar.failf "%s: OCaml decode accepts=%b but Codec.validate accepts=%b"
+      label decoded validated;
+  decoded
+
+type field_check = {
+  fname : string;
+  width : int;  (** Bytes the field occupies on the wire. *)
+  read : bytes -> int -> int;  (** The OCaml decoder's reader for it. *)
+}
+(** One field both sides report, with what the OCaml side needs to read it. *)
+
+(* Both sides report a field as a host integer, so the only thing left to
+   reconcile is the width: an [int8] the OCaml decoder returns as [-1] and the C
+   plug reports as [255] carry the same wire byte. Compare the field's own bytes
+   and nothing above them. *)
+let to_slot width v =
+  if width >= 8 then v
+  else Int64.logand v (Int64.pred (Int64.shift_left 1L (8 * width)))
+
+let diff_field label b c_fields f =
+  match List.assoc_opt f.fname c_fields with
+  | None ->
+      Alcobar.failf "%s: EverParse C reported no value for field %s" label
+        f.fname
+  | Some raw -> (
+      let c = to_slot f.width raw in
+      match f.read b 0 with
+      | v ->
+          let o = to_slot f.width (Int64.of_int v) in
+          if not (Int64.equal o c) then
+            Alcobar.failf
+              "%s: field %s: OCaml decoded 0x%Lx but EverParse C decoded 0x%Lx"
+              label f.fname o c
+      | exception Wire.Parse_error _ ->
+          (* [Codec.field_readers] reports through an OCaml [int], one bit short
+             of an 8-byte field, so past 2^62 it has no [int] to report and
+             raises instead. All the comparison can pin there is that the C side
+             does not fit an [int] either, which still holds the field's top two
+             bits to what the OCaml decoder made of them. *)
+          if Int64.unsigned_to_int c <> None then
+            Alcobar.failf
+              "%s: field %s: OCaml decoded a value too large for an int but \
+               EverParse C decoded 0x%Lx"
+              label f.fname c)
+
+let diff_values label fields c_values b =
+  if fields <> [] then begin
+    let c_fields = c_values b in
+    if List.compare_lengths c_fields fields <> 0 then
+      Alcobar.failf "%s: EverParse C reported %d field values, expected %d"
+        label (List.length c_fields) (List.length fields);
+    List.iter (diff_field label b c_fields) fields
+  end
+
+type case = {
+  label : string;
+  packed : packed;
+  c_check : bytes -> bool;
+  c_values : bytes -> (string * int64) list;
+  fields : field_check list;
+}
+(** One covered codec with both its decoders: the OCaml side ([packed], from
+    {!Diff_codecs.included}) and the generated C validator ([c_check] and
+    [c_values], from {!Diff_index}). *)
+
+(* Compare both decoders on one codec: first on the verdict, then, when both
+   accepted, on every field value they both report. *)
+let diff_check case b =
+  let o = ocaml_accepts case.label case.packed b and c = case.c_check b in
   if o <> c then
-    Alcobar.failf "%s: OCaml accepts=%b but EverParse C accepts=%b" label o c
+    Alcobar.failf "%s: OCaml accepts=%b but EverParse C accepts=%b" case.label o
+      c;
+  if o then diff_values case.label case.fields case.c_values b
 
-(* Each covered codec paired with both its decoders: the OCaml side ([Pack g],
-   from {!Diff_codecs.included}) and the generated C validator ([c_check], from
-   {!Diff_index.covered}). *)
+(* The OCaml half of the value comparison. [Codec.field_readers] keys the
+   decoder's own per-field readers by name, which is what makes this reachable
+   at all: the record type is hidden behind [Pack], so there is no field handle
+   to hand [Codec.get]. A compared field with no reader would mean the two sides
+   disagree about what the schema's fields are, so it fails the run rather than
+   quietly comparing one field fewer. *)
+let field_checks label (Pack g as p) =
+  let readers = Wire.Codec.field_readers (codec g) in
+  List.map
+    (fun (cf : Diff_codecs.compared_field) ->
+      match List.assoc_opt cf.name readers with
+      | Some read -> { fname = cf.name; width = cf.width; read }
+      | None ->
+          Fmt.failwith "diff: %s has no OCaml field reader for %s" label cf.name)
+    (Diff_codecs.compared_fields p)
+
 let covered_cases =
+  let values = Array.to_list Diff_index.values in
   Array.to_list Diff_index.covered
   |> List.map (fun (label, c_check) ->
-      (label, (List.assoc label Diff_codecs.included, c_check)))
+      let packed = List.assoc label Diff_codecs.included in
+      ( label,
+        {
+          label;
+          packed;
+          c_check;
+          c_values = List.assoc label values;
+          fields = field_checks label packed;
+        } ))
 
 (* Normal [dune test]: one case per covered codec, each on its own random bytes,
    so a single run touches every codec. *)
-let sample_case (label, (p, c_check)) =
+let sample_case (label, case) =
   Alcobar.test_case label [ Alcobar.bytes ] (fun buf ->
-      diff_check label p c_check (Bytes.of_string buf))
+      diff_check case (Bytes.of_string buf))
 
 (* AFL file-input mode: the shared framed input picks one codec per input and
    strips the selector/mode header before the bytes reach the decoders. *)
 let afl_case ?(max_len = 256) () =
   afl_contract_cases ~max_len "diff" covered_cases
-    ~check:(fun label (p, c_check) input ->
-      diff_check label p c_check input.payload)
+    ~check:(fun _label case input -> diff_check case input.payload)
 
 let cases =
   if file_input_mode () then afl_case () else List.map sample_case covered_cases

--- a/fuzz/diff/gen/diff_codecs.ml
+++ b/fuzz/diff/gen/diff_codecs.ml
@@ -69,6 +69,38 @@ let included, excluded =
   in
   (List.rev inc, List.rev exc)
 
+type compared_field = { name : string; width : int }
+
+(* Which fields the differential can compare by value. Two conditions, and both
+   are about what the two sides can actually hand back rather than about what is
+   interesting:
+
+   - The field must occupy whole bytes of its own on the wire
+     ([Everparse.Raw.int_slots]). A bitfield shares its base word with its
+     neighbours, so it has no slot; a float is not an integer; a byte span, an
+     array and a nested record are not scalars. None of those are compared.
+   - The default plug must report the field's value. A byte span, a nested
+     region and a variable-width integer all route to [<Name>SetBytes], which
+     hands back the field's byte offset instead, so there is no value on the C
+     side to compare. That drops [uint], the one whole-byte integer the plug
+     does not carry.
+
+   What is left is the fixed-width scalars -- [uint8] .. [uint64], [int8] ..
+   [int64], and the enums, lookups, maps and refinements layered over them. *)
+let compared_fields (Fuzz_gen.Pack g) =
+  let s = Wire.Everparse.Raw.struct_of_codec (Fuzz_gen.codec g) in
+  let schema = Wire.Everparse.Raw.project_struct ~mode:`Ffi s in
+  let reported_as_offset (p : Wire.Everparse.plug_field) =
+    if String.ends_with ~suffix:"SetBytes" p.setter then Some p.name else None
+  in
+  let offsets =
+    List.filter_map reported_as_offset (Wire.Everparse.plug_fields schema)
+  in
+  List.filter_map
+    (fun (name, (slot : Wire.Everparse.Raw.int_slot)) ->
+      if List.mem name offsets then None else Some { name; width = slot.width })
+    (Wire.Everparse.Raw.int_slots s)
+
 let summary =
   let tally =
     List.fold_left

--- a/fuzz/diff/gen/diff_codecs.mli
+++ b/fuzz/diff/gen/diff_codecs.mli
@@ -20,6 +20,17 @@ val excluded : (string * Fuzz_gen.packed * exclusion) list
 (** Sampled codecs skipped, each with the reason it is out of scope, so coverage
     stays explicit. *)
 
+type compared_field = { name : string; width : int }
+(** A named field the differential compares by value, with its byte width on the
+    wire. *)
+
+val compared_fields : Fuzz_gen.packed -> compared_field list
+(** [compared_fields p] is the fields of [p] whose decoded value both sides can
+    hand back, in declaration order: the named whole-byte integer fields, minus
+    the ones the default plug reports as a byte offset rather than a value. A
+    bitfield, a float and a byte span are all left out; see the implementation
+    for why each is. *)
+
 val summary : string
 (** One-line tally: total candidates, included count, and excluded count broken
     down by reason. *)

--- a/lib/everparse.ml
+++ b/lib/everparse.ml
@@ -778,6 +778,7 @@ module Raw = struct
     values : int64 list;
   }
 
+  let int_slots = Types.int_slots
   let field_seeds = Types.field_seeds
   let struct_params (s : Types.struct_) = s.params
 

--- a/lib/everparse.mli
+++ b/lib/everparse.mli
@@ -255,6 +255,13 @@ module Raw : sig
   }
   (** A field whose own declaration singles out particular wire values. *)
 
+  val int_slots : struct_ -> (string * int_slot) list
+  (** [int_slots s] is the byte slot of every named whole-byte integer field of
+      [s], in declaration order. Bitfields (their base word is shared), floats,
+      byte spans and composites have no slot of their own and are left out.
+      {!field_seeds} is this same set narrowed to the fields whose declaration
+      singles out particular values. *)
+
   val field_seeds : struct_ -> field_seed list
   (** [field_seeds s] is, for each named whole-byte integer field of [s] whose
       declaration singles out values, the byte slot it occupies and those

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -3412,6 +3412,14 @@ let rec typ_constraints : type a. string -> a typ -> int64 list =
   | Optional_or { inner; _ } -> typ_constraints name inner
   | _ -> []
 
+let int_slots s =
+  List.filter_map
+    (fun (Field f) ->
+      match (f.field_name, int_slot_of_typ f.field_typ) with
+      | Some name, Some slot -> Some (name, slot)
+      | _ -> None)
+    s.fields
+
 let field_seeds s =
   let of_field (Field f) =
     match (f.field_name, int_slot_of_typ f.field_typ) with

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -1068,6 +1068,13 @@ type int_slot = { width : int; endian : endian }
 type field_seed = { field : string; slot : int_slot; values : int64 list }
 (** A field whose own declaration singles out particular wire values. *)
 
+val int_slots : struct_ -> (string * int_slot) list
+(** [int_slots s] is the byte slot of every named whole-byte integer field of
+    [s], in declaration order. Bitfields (their base word is shared), floats,
+    byte spans and composites have no slot of their own and are left out.
+    {!field_seeds} is this same set narrowed to the fields whose declaration
+    singles out particular values. *)
+
 val field_seeds : struct_ -> field_seed list
 (** [field_seeds s] is, for each named whole-byte integer field of [s] whose
     declaration singles out values, the byte slot it occupies and those values:

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -1125,6 +1125,20 @@ module Codec : sig
   val field_ref : ('a, 'r) field -> int expr
   (** Field reference expression from a bound field handle. *)
 
+  val field_readers : 'r t -> (string * (bytes -> int -> int)) list
+  (** [field_readers c] is the decoder's own reader for every named int-valued
+      field of [c], keyed by field name: [read buf base] is the value
+      {!val-decode} makes of that field's bytes, converted to [int] (a [Map]
+      reports the raw value it was decoded from, which is what the wire
+      carries). Composite fields read as [0].
+
+      Unlike {!get} it needs no field handle, so a caller holding only a
+      type-erased codec can still read a field by name -- which is how the
+      differential fuzzer compares the OCaml decoder against a generated C
+      validator field by field. Raises {!exception-Parse_error} when the field's
+      bytes are out of the buffer, or when the value does not fit an OCaml
+      [int]. *)
+
   (** {2 Slice navigation}
 
       Zero-copy access to the offset/length of a [byte_slice] field. The naive
@@ -1428,6 +1442,13 @@ module Everparse : sig
 
     type field_seed = { field : string; slot : int_slot; values : int64 list }
     (** A field whose own declaration singles out particular wire values. *)
+
+    val int_slots : struct_ -> (string * int_slot) list
+    (** [int_slots s] is the byte slot of every named whole-byte integer field
+        of [s], in declaration order. Bitfields (their base word is shared),
+        floats, byte spans and composites have no slot of their own and are left
+        out. {!field_seeds} is this same set narrowed to the fields whose
+        declaration singles out particular values. *)
 
     val field_seeds : struct_ -> field_seed list
     (** [field_seeds s] is, for each named whole-byte integer field of [s] whose

--- a/test/diff/gen_diff.ml
+++ b/test/diff/gen_diff.ml
@@ -120,6 +120,53 @@ let generate_all schema_dir included =
     seed_fail @ rest_fail
   end
 
+(* The generated OCaml that reads one codec's field values back out of the C
+   plug. [<lower>_parse_k] applies its continuation to one argument per named
+   field, in declaration order and in the OCaml type [field_kinds] gives it, so
+   the continuation only has to name the arguments and keep the compared ones.
+   A field the comparison leaves out ([Diff_codecs.compared_fields]) gets a
+   [_]-prefixed argument, and a codec with nothing to compare never calls into
+   C at all. *)
+let value_reader (label, (Fuzz_gen.Pack g as p)) ppf =
+  let kinds =
+    Wire.Everparse.Raw.field_kinds
+      (Wire.Everparse.Raw.struct_of_codec (Fuzz_gen.codec g))
+    |> List.mapi (fun i (name, kind) -> (i, name, kind))
+  in
+  let compared = Diff_codecs.compared_fields p in
+  let is_compared name =
+    List.exists (fun (c : Diff_codecs.compared_field) -> c.name = name) compared
+  in
+  let int64_of (i, name, kind) =
+    match kind with
+    | Wire.Everparse.Raw.Int -> Fmt.str "Int64.of_int a%d" i
+    | Int64 -> Fmt.str "a%d" i
+    | Float32 | Float64 | Bool | String | Unit ->
+        Fmt.failwith
+          "gen_diff: %s field %s is compared by value, but the FFI hands it \
+           back as a non-integer"
+          label name
+  in
+  let arg ppf (i, name, _) =
+    Fmt.pf ppf "%sa%d" (if is_compared name then "" else "_") i
+  in
+  let binding ppf ((_, name, _) as f) =
+    Fmt.pf ppf "(%S, %s)" name (int64_of f)
+  in
+  if compared = [] then Fmt.pf ppf "    (%S, fun _ -> []);@\n" label
+  else
+    Fmt.pf ppf
+      "    ( %S,@\n\
+      \      fun b ->@\n\
+      \        Stubs.%s_parse_k@\n\
+      \          (fun %a -> [ %a ])@\n\
+      \          b 0 );@\n"
+      label (lower_name g)
+      Fmt.(list ~sep:(any " ") arg)
+      kinds
+      Fmt.(list ~sep:(any "; ") binding)
+      (List.filter (fun (_, name, _) -> is_compared name) kinds)
+
 let () =
   let schema_dir =
     if Array.length Sys.argv > 1 then Sys.argv.(1) else "schemas"
@@ -162,6 +209,14 @@ let () =
          _ -> false);\n"
         label (lower_name g))
     Diff_codecs.included;
+  pr "  |]\n\n";
+  pr "(* Each codec's label paired with a [bytes -> (string * int64) list]\n";
+  pr "   reader of the field values the EverParse validator extracted, taken\n";
+  pr "   from the default <Name>Fields plug through the generated FFI\n";
+  pr "   continuation. Scoped by [Diff_codecs.compared_fields], which the\n";
+  pr "   OCaml side of the comparison scopes off too. *)\n";
+  pr "let values : (string * (bytes -> (string * int64) list)) array =\n  [|\n";
+  List.iter (fun item -> pr "%t" (value_reader item)) Diff_codecs.included;
   pr "  |]\n";
   Format.pp_print_flush ppf ();
   close_out oc


### PR DESCRIPTION
The EverParse differential only asked both sides whether they accept an input, so two decoders that accept the same bytes and read a different number out of them agreed on every input. On an input both accept, every field the two can both report is now compared value against value.

Stacked on #317.