### PR TITLE
codec: hang the validator scratch off the validator, not on a DLS key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ocaml-compiler: ['5.4', '5.3', '5.2']
+        ocaml-compiler: ['5.4', '5.3']
         include:
           - os: macos-latest
             ocaml-compiler: '5.4'

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,8 @@
 
 ### Changed
 
+- **Breaking:** Require OCaml 5.3, up from 5.2 (#320, @samoht)
+
 - The EverParse differential compares decoded field values, not only the
   accept/reject verdict. On an input both sides accept, every field the two can
   both report must carry the same value; two decoders that agree on which bytes
@@ -115,6 +117,11 @@
   follow as `<Base>CheckWire<Name>` (#235, @samoht)
 
 ### Fixed
+
+- A fresh domain's first decode or validate no longer costs about a word per
+  compiled validator the program ever built, which reached roughly 1 MB at
+  50,000 validators and was charged even to domains that never decode
+  (#320, @samoht)
 
 - The single-file documentation build no longer regenerates the committed
   `<Name>.3d` behind your back. It was a promoted rule target the install stanza

--- a/dune-project
+++ b/dune-project
@@ -22,7 +22,7 @@
    Define your wire format once, then use it for OCaml parsing via bytesrw or \
    emit .3d files for verified C parser generation via EverParse.")
  (depends
-  (ocaml (>= 5.2))
+  (ocaml (>= 5.3))
   (bytesrw (>= 0.4.0))
   (fmt (>= 0.9))
   (optint (>= 0.3))

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -518,18 +518,54 @@ let clear_slots s n =
   Array.fill s.ints 0 n 0;
   Array.fill s.int64s 0 n 0L
 
+(* Grow [table] until it has a cell for domain index [i]. The new array reuses
+   the existing [Atomic.t] cells rather than their contents, so a domain writing
+   its scratch through the array it read races with nobody: both arrays name the
+   same cell. Losing the CAS means another domain grew it first, so retry and
+   take theirs. *)
+let rec slots_cells table i =
+  let a = Atomic.get table in
+  let len = Array.length a in
+  if i < len then a
+  else
+    let b =
+      Array.init
+        (max (i + 1) (max 8 (2 * len)))
+        (fun j -> if j < len then a.(j) else Atomic.make None)
+    in
+    if Atomic.compare_and_set table a b then b else slots_cells table i
+
 (* A per-domain [slots] scratch. The validators and decoders below reuse one
    scratch across calls to stay allocation-free, but a codec value is shared
    across domains, so a single shared scratch lets two domains decoding at once
    overwrite each other's fields. A misparsed segment is then dropped, which in
-   a TCP stack pinned one flow per core stalls that flow. Domain-local storage
-   gives each domain its own scratch, still reused within the domain: a decode
-   performs no effects, so cooperative fibers never interleave mid-decode.
-   Preemptive systhreads sharing a domain must still not decode one codec at
-   once. *)
+   a TCP stack pinned one flow per core stalls that flow. Per-domain scratch
+   keeps the reuse and drops the sharing: a decode performs no effects, so
+   cooperative fibers never interleave mid-decode. Preemptive systhreads sharing
+   a domain must still not decode one codec at once.
+
+   The scratch hangs off the validator and is indexed by [Domain.self_index ()],
+   rather than living in [Domain.DLS] under a key minted here. A DLS key is
+   drawn from a global counter and a domain sizes its DLS array from that
+   counter, so one key per compiled validator made the first DLS read on a fresh
+   domain cost a word per validator the program ever built, charged even to
+   domains that never decode. [self_index] is dense over live domains instead,
+   so the array here is bounded by the domains actually running.
+
+   An index is reused once its domain terminates, handing the new occupant the
+   old scratch. That is sound because every caller clears the scratch on entry,
+   and two live domains never share an index. *)
 let domain_local_slots n =
-  let key = Domain.DLS.new_key (fun () -> alloc_slots n) in
-  fun () -> Domain.DLS.get key
+  let table = Atomic.make [||] in
+  fun () ->
+    let i = Domain.self_index () in
+    let cell = (slots_cells table i).(i) in
+    match Atomic.get cell with
+    | Some s -> s
+    | None ->
+        let s = alloc_slots n in
+        Atomic.set cell (Some s);
+        s
 
 let set_int_slot s idx v = s.ints.(idx) <- v
 let set_int64_slot s idx v = s.int64s.(idx) <- v

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -526,6 +526,44 @@ let test_validate_check_free_no_alloc () =
        per_call)
     true (per_call < 1.0)
 
+(* A compiled validator keeps a per-domain scratch, and the cost of reaching it
+   on a domain that has not decoded yet must not track how many validators the
+   program ever built. It used to: each validator minted its own
+   [Domain.DLS.new_key], and a domain sizes its DLS array from the global key
+   counter, so the first validate on a fresh domain paid about one word per key
+   ever created. Measured here at 10,000 validators it was 32,792 words, and at
+   50,000 it was 131,096, about 1 MB, charged to domains that never decode.
+
+   [Gc.minor_words] cannot see this. The array is large enough to be allocated
+   straight into the major heap, so read [Gc.allocated_bytes], which counts
+   both. *)
+let test_fresh_domain_validate_flat_in_validator_count () =
+  skip_unless_gc_counters ();
+  let f_x = Field.v "x" uint8 in
+  let mk name =
+    Codec.v name
+      ~where:Expr.(Field.ref f_x <= int 200)
+      (fun x -> x)
+      Codec.[ (Field.v "x" uint8 $ fun x -> x) ]
+  in
+  for i = 1 to 10_000 do
+    ignore (Sys.opaque_identity (Fmt.kstr mk "S%d" i))
+  done;
+  let c = mk "Last" in
+  let buf = Bytes.make 8 '\007' in
+  let words =
+    Domain.join
+      (Domain.spawn (fun () ->
+           let before = Gc.allocated_bytes () in
+           Codec.validate c buf 0;
+           (Gc.allocated_bytes () -. before) /. 8.))
+  in
+  Fmt.kstr
+    (fun msg -> Alcotest.(check bool) msg true (words < 4096.))
+    "a fresh domain's first validate does not track the validator count (got \
+     %.0f words)"
+    words
+
 (* A [Wire.where] cond carried in a field's typ ([where (len < 2) uint8]) must be
    enforced by both decode and validate, not only projected to 3D. The cond
    reaches the EverParse refinement, so leaving it unchecked on the OCaml side
@@ -8636,6 +8674,9 @@ let suite =
         test_error_constructors;
       Alcotest.test_case "validate: check-free codec allocates nothing" `Quick
         test_validate_check_free_no_alloc;
+      Alcotest.test_case
+        "validate: fresh domain cost is flat in validator count" `Quick
+        test_fresh_domain_validate_flat_in_validator_count;
       Alcotest.test_case "validate: matches decode rejections" `Quick
         test_validate_matches_decode_rejections;
       Alcotest.test_case "validate: runs a sub-codec's checks" `Quick

--- a/wire.opam
+++ b/wire.opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/parsimoni-labs/ocaml-wire"
 bug-reports: "https://github.com/parsimoni-labs/ocaml-wire/issues"
 depends: [
   "dune" {>= "3.21"}
-  "ocaml" {>= "5.2"}
+  "ocaml" {>= "5.3"}
   "bytesrw" {>= "0.4.0"}
   "fmt" {>= "0.9"}
   "optint" {>= "0.3"}


### PR DESCRIPTION
Each compiled validator minted its own `Domain.DLS` key, and a domain sizes its DLS array from the global key counter, so a fresh domain paid about a word per key ever created on its first decode or validate, roughly 1 MB at 50,000 validators and charged even to domains that never decode. Indexing by `Domain.self_index ()` makes it flat: 32,792 words at 10,000 validators and 131,096 at 50,000, now 51, with steady-state validate still at 0.000 words/op.

`Domain.self_index` needs OCaml 5.3, so the lower bound moves up from 5.2 and the 5.2 CI lane goes with it. Stacked on #318.