### PR TITLE
types: give int32 an exact 32-bit signed carrier

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ### Added
 
+- Add `Wire.SInt32`, the signed 32-bit carrier behind `int32` and `int32be`. It
+  is deliberately not interchangeable with the unsigned 32-bit carrier: the two
+  share a representation, so a value read with the wrong signedness would be a
+  silent misparse rather than a type error (#321, @samoht)
+
 - Add `Wire.Codec.field_readers` and `Wire.Everparse.Raw.int_slots`.
   `field_readers` is the decoder's own reader for every named int-valued field,
   keyed by name, so a caller holding a type-erased codec can read a field
@@ -36,6 +41,12 @@
   (#263, @samoht)
 
 ### Changed
+
+- **Breaking:** `int32` and `int32be` decode to `Wire.SInt32.t` rather than a
+  native `int`, and `Wire.rest_bytes` accepts a parameter of any integer type
+  rather than only an `int` one. Convert a decoded field with
+  `Wire.SInt32.to_int32`, and build one with `Wire.SInt32.of_int32` or the
+  range-checked `of_int` (#321, @samoht)
 
 - **Breaking:** Require OCaml 5.3, up from 5.2 (#320, @samoht)
 
@@ -117,6 +128,12 @@
   follow as `<Base>CheckWire<Name>` (#235, @samoht)
 
 ### Fixed
+
+- A 4-byte signed field no longer alters the frame it decodes where the native
+  `int` is narrower than the field. Under wasm_of_ocaml an `int` is 31 bits, so
+  `int32` dropped the top bits on the way in and the encode-side range check
+  disabled itself, sending the value back out as different bytes with no error
+  on either path (#321, @samoht)
 
 - A fresh domain's first decode or validate no longer costs about a word per
   compiled validator the program ever built, which reached roughly 1 MB at

--- a/fuzz/gen/fuzz_gen.ml
+++ b/fuzz/gen/fuzz_gen.ml
@@ -258,6 +258,14 @@ let scalar_int64 typ size value_gen boundaries =
   leaf ~equal:Int64.equal ~typ ~value_gen ~random:(bytes_fixed size)
     ~adversarial:(Alcobar.choose (List.map Alcobar.const boundaries))
 
+(* [int32] is carried in a [Wire.SInt32.t], whose only constructors are the
+   4-byte pattern and a checked [of_int]: every value of it is a legal signed
+   32-bit field, so there is no hostile value to draw and no guard for one to
+   exercise. Same reasoning as [scalar_int64]. *)
+let scalar_sint32 typ size value_gen boundaries =
+  leaf ~equal:Wire.SInt32.equal ~typ ~value_gen ~random:(bytes_fixed size)
+    ~adversarial:(Alcobar.choose (List.map Alcobar.const boundaries))
+
 let scalar_optint ~hostile typ size value_gen boundaries =
   let g =
     leaf ~equal:Optint.equal ~typ ~value_gen ~random:(bytes_fixed size)
@@ -279,7 +287,7 @@ let s8_boundaries = [ -128; -1; 0; 1; 127 ]
 let s16_boundaries = [ -0x8000; -1; 0; 1; 0x7FFF ]
 
 let s32_boundaries =
-  [ Int32.to_int Int32.min_int; -1; 0; 1; Int32.to_int Int32.max_int ]
+  List.map Wire.SInt32.of_int32 Int32.[ min_int; minus_one; zero; one; max_int ]
 
 let s64_boundaries_i64 = Int64.[ min_int; -1L; zero; one; max_int ]
 
@@ -321,16 +329,9 @@ let int16be =
   scalar_int ~hostile:(outside_signed_width 16) Wire.int16be 2 Alcobar.int16
     s16_boundaries
 
-let int32_value_gen = Alcobar.map Alcobar.[ Alcobar.int32 ] Int32.to_int
-
-let int32 =
-  scalar_int ~hostile:(outside_signed_width 32) Wire.int32 4 int32_value_gen
-    s32_boundaries
-
-let int32be =
-  scalar_int ~hostile:(outside_signed_width 32) Wire.int32be 4 int32_value_gen
-    s32_boundaries
-
+let int32_value_gen = Alcobar.map Alcobar.[ Alcobar.int32 ] Wire.SInt32.of_int32
+let int32 = scalar_sint32 Wire.int32 4 int32_value_gen s32_boundaries
+let int32be = scalar_sint32 Wire.int32be 4 int32_value_gen s32_boundaries
 let int64 = scalar_int64 Wire.int64 8 Alcobar.int64 s64_boundaries_i64
 let int64be = scalar_int64 Wire.int64be 8 Alcobar.int64 s64_boundaries_i64
 
@@ -766,6 +767,7 @@ let exact_cases ~typ ~equal cases =
 let exact_int typ cases = exact_cases ~typ ~equal:Int.equal cases
 let exact_int64 typ cases = exact_cases ~typ ~equal:Int64.equal cases
 let exact_optint typ cases = exact_cases ~typ ~equal:Optint.equal cases
+let exact_sint32 typ cases = exact_cases ~typ ~equal:Wire.SInt32.equal cases
 
 let uint16_endian_edges =
   exact_int Wire.uint16
@@ -835,22 +837,28 @@ let int16be_endian_edges =
       (0x7FFF, bytes_of_octets [ 0x7F; 0xFF ]);
     ]
 
+let sint32 n = Wire.SInt32.of_int32 (Int32.of_int n)
+
 let int32_endian_edges =
-  exact_int Wire.int32
+  exact_sint32 Wire.int32
     [
-      (Int32.to_int Int32.min_int, bytes_of_octets [ 0x00; 0x00; 0x00; 0x80 ]);
-      (-2, bytes_of_octets [ 0xFE; 0xFF; 0xFF; 0xFF ]);
-      (0x01234567, bytes_of_octets [ 0x67; 0x45; 0x23; 0x01 ]);
-      (Int32.to_int Int32.max_int, bytes_of_octets [ 0xFF; 0xFF; 0xFF; 0x7F ]);
+      ( Wire.SInt32.of_int32 Int32.min_int,
+        bytes_of_octets [ 0x00; 0x00; 0x00; 0x80 ] );
+      (sint32 (-2), bytes_of_octets [ 0xFE; 0xFF; 0xFF; 0xFF ]);
+      (sint32 0x01234567, bytes_of_octets [ 0x67; 0x45; 0x23; 0x01 ]);
+      ( Wire.SInt32.of_int32 Int32.max_int,
+        bytes_of_octets [ 0xFF; 0xFF; 0xFF; 0x7F ] );
     ]
 
 let int32be_endian_edges =
-  exact_int Wire.int32be
+  exact_sint32 Wire.int32be
     [
-      (Int32.to_int Int32.min_int, bytes_of_octets [ 0x80; 0x00; 0x00; 0x00 ]);
-      (-2, bytes_of_octets [ 0xFF; 0xFF; 0xFF; 0xFE ]);
-      (0x01234567, bytes_of_octets [ 0x01; 0x23; 0x45; 0x67 ]);
-      (Int32.to_int Int32.max_int, bytes_of_octets [ 0x7F; 0xFF; 0xFF; 0xFF ]);
+      ( Wire.SInt32.of_int32 Int32.min_int,
+        bytes_of_octets [ 0x80; 0x00; 0x00; 0x00 ] );
+      (sint32 (-2), bytes_of_octets [ 0xFF; 0xFF; 0xFF; 0xFE ]);
+      (sint32 0x01234567, bytes_of_octets [ 0x01; 0x23; 0x45; 0x67 ]);
+      ( Wire.SInt32.of_int32 Int32.max_int,
+        bytes_of_octets [ 0x7F; 0xFF; 0xFF; 0xFF ] );
     ]
 
 let int64_endian_edges =

--- a/fuzz/gen/fuzz_gen.mli
+++ b/fuzz/gen/fuzz_gen.mli
@@ -271,10 +271,10 @@ val int16 : int t
 val int16be : int t
 (** [int16be] generates for {!Wire.int16be}. *)
 
-val int32 : int t
+val int32 : Wire.SInt32.t t
 (** [int32] generates for {!Wire.int32}. *)
 
-val int32be : int t
+val int32be : Wire.SInt32.t t
 (** [int32be] generates for {!Wire.int32be}. *)
 
 val int64 : int64 t

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -334,12 +334,8 @@ let rec build_field_reader_ctx : type a.
       fun _runtime buf base -> Bytes.get_int16_le buf (base + field_off)
   | Int16 Big ->
       fun _runtime buf base -> Bytes.get_int16_be buf (base + field_off)
-  | Int32 Little ->
-      fun _runtime buf base ->
-        Int32.to_int (Bytes.get_int32_le buf (base + field_off))
-  | Int32 Big ->
-      fun _runtime buf base ->
-        Int32.to_int (Bytes.get_int32_be buf (base + field_off))
+  | Int32 Little -> fun _runtime buf base -> SInt32.le buf (base + field_off)
+  | Int32 Big -> fun _runtime buf base -> SInt32.be buf (base + field_off)
   | Int64 Little ->
       fun _runtime buf base -> Bytes.get_int64_le buf (base + field_off)
   | Int64 Big ->
@@ -434,10 +430,8 @@ let rec build_immediate_reader : type a.
   | Int8 -> Some (fun buf base -> Bytes.get_int8 buf (at base))
   | Int16 Little -> Some (fun buf base -> Bytes.get_int16_le buf (at base))
   | Int16 Big -> Some (fun buf base -> Bytes.get_int16_be buf (at base))
-  | Int32 Little ->
-      Some (fun buf base -> Int32.to_int (Bytes.get_int32_le buf (at base)))
-  | Int32 Big ->
-      Some (fun buf base -> Int32.to_int (Bytes.get_int32_be buf (at base)))
+  | Int32 Little -> Some (fun buf base -> SInt32.le buf (at base))
+  | Int32 Big -> Some (fun buf base -> SInt32.be buf (at base))
   | Int64 Little -> Some (fun buf base -> Bytes.get_int64_le buf (at base))
   | Int64 Big -> Some (fun buf base -> Bytes.get_int64_be buf (at base))
   | Float32 Little ->
@@ -602,6 +596,17 @@ let populate_uint32 idx reader =
     Option.iter (set_int_slot slots idx)
       (Int32.unsigned_to_int (UInt32.to_int32 (reader runtime buf base)))
 
+(* Same shape as [populate_uint32] on the signed side: the slot is a native
+   [int], so where that int is narrower than the field only the values it can
+   hold are mirrored, and a constraint over the rest reads an unpopulated zero
+   rather than a truncated number. *)
+let populate_sint32 idx reader =
+  if Sys.int_size > 32 then fun slots runtime buf base ->
+    set_int_slot slots idx (SInt32.to_int (reader runtime buf base))
+  else fun slots runtime buf base ->
+    Option.iter (set_int_slot slots idx)
+      (SInt32.to_int_opt (reader runtime buf base))
+
 let populate_uint_var idx reader =
   if Sys.int_size >= 63 then fun slots runtime buf base ->
     set_int_slot slots idx (UInt63.to_int (reader runtime buf base))
@@ -640,7 +645,7 @@ let rec build_populate : type a.
   | Uint16 _ -> populate_int idx reader
   | Int8 -> populate_int idx reader
   | Int16 _ -> populate_int idx reader
-  | Int32 _ -> populate_int idx reader
+  | Int32 _ -> populate_sint32 idx reader
   | Bits _ -> populate_int idx reader
   | Uint_var _ -> populate_uint_var idx reader
   | Uint32 _ -> populate_uint32 idx reader
@@ -1667,8 +1672,8 @@ let rec read_elem : type a. a typ -> runtime -> bytes -> int -> a =
   | Int8 -> Bytes.get_int8 buf off
   | Int16 Little -> Bytes.get_int16_le buf off
   | Int16 Big -> Bytes.get_int16_be buf off
-  | Int32 Little -> Int32.to_int (Bytes.get_int32_le buf off)
-  | Int32 Big -> Int32.to_int (Bytes.get_int32_be buf off)
+  | Int32 Little -> SInt32.le buf off
+  | Int32 Big -> SInt32.be buf off
   | Int64 Little -> Bytes.get_int64_le buf off
   | Int64 Big -> Bytes.get_int64_be buf off
   | Float32 Little -> Int32.float_of_bits (Bytes.get_int32_le buf off)

--- a/lib/eval.ml
+++ b/lib/eval.ml
@@ -46,7 +46,7 @@ let rec int_of : type a. a typ -> a -> int option =
   | Uint64 _ -> Int64.unsigned_to_int v
   | Int8 -> Some v
   | Int16 _ -> Some v
-  | Int32 _ -> Some v
+  | Int32 _ -> SInt32.to_int_opt v
   | Int64 _ -> Int64.unsigned_to_int v
   | Float32 _ -> None
   | Float64 _ -> None
@@ -99,7 +99,10 @@ let rec int_of_exn : type a. a typ -> a -> int =
       match Int64.unsigned_to_int v with Some n -> n | None -> int_overflow v)
   | Int8 -> v
   | Int16 _ -> v
-  | Int32 _ -> v
+  | Int32 _ -> (
+      match SInt32.to_int_opt v with
+      | Some n -> n
+      | None -> int_overflow (Int64.of_int32 (SInt32.to_int32 v)))
   | Int64 _ -> (
       match Int64.unsigned_to_int v with Some n -> n | None -> int_overflow v)
   | Float32 _ -> not_an_integer ()

--- a/lib/param.ml
+++ b/lib/param.ml
@@ -34,7 +34,7 @@ let rec int_cvt : type a. a Types.typ -> a int_cvt =
       }
   | Int8 -> id
   | Int16 _ -> id
-  | Int32 _ -> id
+  | Int32 _ -> { fwd = SInt32.to_int; bwd = SInt32.of_int }
   | Int64 _ -> { fwd = Int64.to_int; bwd = Int64.of_int }
   | Float32 _ -> invalid_arg "Param: floats are not integer-representable"
   | Float64 _ -> invalid_arg "Param: floats are not integer-representable"

--- a/lib/sInt32.ml
+++ b/lib/sInt32.ml
@@ -1,0 +1,84 @@
+type t = Optint.t
+
+let pp = Optint.pp
+let zero = Optint.zero
+
+(* [Optint.of_int32] keeps the signed view of the word, which is the view this
+   type wants: on a wide native [int] a pattern with bit 31 set arrives as the
+   negative number those four bytes spell, and where [Optint.t] falls back to a
+   boxed [int32] the carrier is the field exactly. This is the one place the
+   unsigned sibling has to correct for, and the signed one does not. *)
+let min_int = Optint.of_int32 Int32.min_int
+let max_int = Optint.of_int32 Int32.max_int
+
+(* Signed on both carriers: a native [int] compares as itself, and [Int32]
+   compares signed, which is what a signed field means. *)
+let compare = Optint.compare
+let equal = Optint.equal
+let mask16 = Optint.of_int 0xFFFF
+let sign_bit = Optint.shift_left Optint.one 31
+
+(* Sign-extend the 32-bit pattern in [w] through whatever the carrier is, with
+   no branch on the platform. Where the native [int] is wide the subtraction
+   turns a pattern with bit 31 set into the negative number it spells; where
+   [Optint.t] is a boxed [int32] the same two steps wrap back to [w], which is
+   already that number. *)
+let of_word w = Optint.sub (Optint.logxor w sign_bit) sign_bit
+
+(* Composed from two unboxed 16-bit reads rather than [Bytes.get_int32_*],
+   which hands back a boxed [int32] on the way to [Optint.of_int32]. [Codec.get]
+   on this field is a hot path the library keeps allocation-free, and the box
+   showed up there. *)
+let le buf off =
+  let lo = Bytes.get_uint16_le buf off in
+  let hi = Bytes.get_uint16_le buf (off + 2) in
+  of_word Optint.(logor (of_int lo) (shift_left (of_int hi) 16))
+
+let be buf off =
+  let hi = Bytes.get_uint16_be buf off in
+  let lo = Bytes.get_uint16_be buf (off + 2) in
+  of_word Optint.(logor (shift_left (of_int hi) 16) (of_int lo))
+
+(* An int32 field owns exactly 32 bits of signed range. Where the native int is
+   wide, [Optint.t] is that int and holds numbers the field cannot; truncating
+   one leaves a legal 32-bit value on the wire that no decoder, [validate] or
+   generated C validator can tell from the number the caller meant. Where
+   [Optint.t] falls back to a boxed [int32] the carrier is exactly the field and
+   the guard never fires. *)
+let check_encode v =
+  if compare v min_int < 0 || compare v max_int > 0 then
+    Fmt.invalid_arg "Wire.encode: value %a does not fit a signed 32-bit field"
+      Optint.pp v
+
+let to_int32 = Optint.to_int32
+let of_int32 = Optint.of_int32
+
+(* Every encoder path (typ-level, compiled field, [Codec.set]) writes an int32
+   through here, so the width check belongs here too. *)
+let low16 v = Optint.to_int (Optint.logand v mask16)
+let high16 v = low16 (Optint.shift_right_logical v 16)
+
+let set_le buf off v =
+  check_encode v;
+  Bytes.set_uint16_le buf off (low16 v);
+  Bytes.set_uint16_le buf (off + 2) (high16 v)
+
+let set_be buf off v =
+  check_encode v;
+  Bytes.set_uint16_be buf off (high16 v);
+  Bytes.set_uint16_be buf (off + 2) (low16 v)
+
+let to_int = Optint.to_int
+
+(* [Int32.to_int] truncates where the native [int] is narrower than 32 bits, so
+   round-trip through it to tell a value it held from one it dropped bits of. *)
+let to_int_opt v =
+  let w = to_int32 v in
+  let i = Int32.to_int w in
+  if Int32.equal (Int32.of_int i) w then Some i else None
+
+let of_int n =
+  let v = Optint.of_int n in
+  if compare v min_int < 0 || compare v max_int > 0 then
+    Fmt.invalid_arg "Wire.SInt32.of_int: %d is not a signed 32-bit value" n;
+  v

--- a/lib/sInt32.mli
+++ b/lib/sInt32.mli
@@ -1,0 +1,74 @@
+(** Signed 32-bit integer.
+
+    Abstract, and deliberately not {!Optint.t} even though that is the carrier:
+    a 32-bit unsigned value uses the same carrier, and the two must not be
+    interchangeable. Where the native [int] is narrower than 32 bits [Optint.t]
+    is [Int32], whose inherited comparison is signed and so wrong for the
+    unsigned view; keeping each side behind its own type stops one being read
+    with the other's meaning.
+
+    The carrier is an unboxed native [int] on a 64-bit host and a boxed [int32]
+    where the native [int] is narrower, so the full signed 32-bit range survives
+    on js_of_ocaml and wasm_of_ocaml, where a plain [int] would drop the top
+    bits. *)
+
+type t
+
+val pp : Format.formatter -> t -> unit
+(** Pretty-printer for signed 32-bit values. *)
+
+val zero : t
+(** [zero] is 0. *)
+
+val min_int : t
+(** [min_int] is -2{^ 31}, the smallest value a 32-bit signed field holds. *)
+
+val max_int : t
+(** [max_int] is 2{^ 31} - 1, the largest value a 32-bit signed field holds. *)
+
+val compare : t -> t -> int
+(** [compare a b] orders two values as signed 32-bit integers. *)
+
+val equal : t -> t -> bool
+(** [equal a b] is [true] when [a] and [b] are the same value. *)
+
+val le : bytes -> int -> t
+(** [le buf off] reads a little-endian value from [buf] at offset [off]. *)
+
+val be : bytes -> int -> t
+(** [be buf off] reads a big-endian value from [buf] at offset [off]. *)
+
+val check_encode : t -> unit
+(** [check_encode v] raises [Invalid_argument] when [v] is not a signed 32-bit
+    value. Only reachable where the native [int] is wider than the field, which
+    is the only place a {!type-t} can hold a number 32 bits cannot. *)
+
+val set_le : bytes -> int -> t -> unit
+(** [set_le buf off v] writes [v] as little-endian into [buf] at offset [off].
+    Raises [Invalid_argument] on a value {!check_encode} rejects. *)
+
+val set_be : bytes -> int -> t -> unit
+(** [set_be buf off v] writes [v] as big-endian into [buf] at offset [off].
+    Raises [Invalid_argument] on a value {!check_encode} rejects. *)
+
+val to_int32 : t -> int32
+(** [to_int32 t] is the value as an [int32], exact on every platform. *)
+
+val of_int32 : int32 -> t
+(** [of_int32 n] is the [int32] as a signed 32-bit value: the same value {!le}
+    and {!be} decode those four bytes to, on every platform. *)
+
+val to_int : t -> int
+(** [to_int t] is the value as a native [int]. Exact on a 64-bit host; where the
+    native [int] is narrower it does not hold the full range, so prefer
+    {!to_int32} across such a boundary. *)
+
+val to_int_opt : t -> int option
+(** [to_int_opt t] is the value as a native [int], or [None] where that [int] is
+    too narrow to hold it. Always [Some] on a 64-bit host. Prefer it to
+    {!to_int} on any path that must not silently drop the top bits. *)
+
+val of_int : int -> t
+(** [of_int n] is [n] as a signed 32-bit value. Raises [Invalid_argument] when
+    [n] is outside the range, rather than masking it to a legal value the caller
+    did not mean. *)

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -172,7 +172,7 @@ and _ typ =
   | Uint64 : endian -> int64 typ (* boxed, for full 64-bit *)
   | Int8 : int typ
   | Int16 : endian -> int typ
-  | Int32 : endian -> int typ (* fits OCaml int on 64-bit hosts *)
+  | Int32 : endian -> SInt32.t typ
   | Int64 : endian -> int64 typ
   | Float32 :
       endian
@@ -1288,6 +1288,14 @@ let is_int_dispatch_typ : type a. a typ -> bool = function
       true
   | _ -> false
 
+let int32_case_index k =
+  match SInt32.to_int_opt k with
+  | Some index -> index
+  | None ->
+      Fmt.invalid_arg
+        "Wire.casetype: case index %ld does not fit this platform's native int"
+        (SInt32.to_int32 k)
+
 let uint32_case_index k =
   match UInt32.to_int k with
   | index -> index
@@ -1320,7 +1328,7 @@ let case_index_to_expr : type k. k typ -> k -> packed_expr =
   | Uint_var _ -> Pack_expr (Int (uint_var_case_index k))
   | Int8 -> Pack_expr (Int k)
   | Int16 _ -> Pack_expr (Int k)
-  | Int32 _ -> Pack_expr (Int k)
+  | Int32 _ -> Pack_expr (Int (int32_case_index k))
   | Bits _ -> Pack_expr (Int k)
   | Enum _ -> Pack_expr (Int k)
   | _ -> assert false (* guarded by [is_int_dispatch_typ] *)
@@ -1952,13 +1960,8 @@ let set_int16_be buf off v =
   check_signed_encode ~bits:16 v;
   Bytes.set_int16_be buf off v
 
-let set_int32_le buf off v =
-  check_signed_encode ~bits:32 v;
-  Bytes.set_int32_le buf off (Int32.of_int v)
-
-let set_int32_be buf off v =
-  check_signed_encode ~bits:32 v;
-  Bytes.set_int32_be buf off (Int32.of_int v)
+let set_int32_le = SInt32.set_le
+let set_int32_be = SInt32.set_be
 
 (* 3D's [var x = a; p] requires [a] to be an atomic action (extern call,
    field_ptr, ...), not an arbitrary expression. Wire's [Action.var name e]

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -203,10 +203,10 @@ val set_int16_le : bytes -> int -> int -> unit
 val set_int16_be : bytes -> int -> int -> unit
 (** [set_int16_be buf off v] writes [v] as two signed big-endian bytes. *)
 
-val set_int32_le : bytes -> int -> int -> unit
+val set_int32_le : bytes -> int -> SInt32.t -> unit
 (** [set_int32_le buf off v] writes [v] as four signed little-endian bytes. *)
 
-val set_int32_be : bytes -> int -> int -> unit
+val set_int32_be : bytes -> int -> SInt32.t -> unit
 (** [set_int32_be buf off v] writes [v] as four signed big-endian bytes. *)
 
 (** {1 Param handles} *)
@@ -278,8 +278,10 @@ and _ typ =
   | Uint64 : endian -> int64 typ  (** 64-bit unsigned. *)
   | Int8 : int typ  (** 8-bit signed. *)
   | Int16 : endian -> int typ  (** 16-bit signed. *)
-  | Int32 : endian -> int typ
-      (** 32-bit signed, returned as OCaml [int] (64-bit hosts only). *)
+  | Int32 : endian -> SInt32.t typ
+      (** 32-bit signed. Carried by {!SInt32.t}, which holds the full range on
+          every target; a plain [int] drops the top bits where it is narrower
+          than the field. *)
   | Int64 : endian -> int64 typ  (** 64-bit signed. *)
   | Float32 : endian -> float typ
       (** IEEE 754 binary32, widened to OCaml [float]. *)
@@ -594,13 +596,13 @@ val int16 : int typ
 val int16be : int typ
 (** 16-bit signed, big-endian. *)
 
-val int32 : int typ
-(** [int32] is a 32-bit signed little-endian integer, returned as an OCaml
-    integer (64-bit hosts only). *)
+val int32 : SInt32.t typ
+(** [int32] is a 32-bit signed little-endian integer, returned as a {!SInt32.t}.
+*)
 
-val int32be : int typ
-(** [int32be] is a 32-bit signed big-endian integer, returned as an OCaml
-    integer. *)
+val int32be : SInt32.t typ
+(** [int32be] is a 32-bit signed big-endian integer, returned as a {!SInt32.t}.
+*)
 
 val int64 : int64 typ
 (** 64-bit signed, little-endian. *)

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -112,7 +112,7 @@ type ('elt, 'seq) seq_map = ('elt, 'seq) Types.seq_map =
 let seq_list = Types.seq_list
 let array_seq = Types.array_seq
 
-let rest_bytes (total : (int, _) Param.t) =
+let rest_bytes total =
   Types.byte_array ~size:Types.(Sub (Param_ref total, Sizeof_this))
 
 let bits ?(bit_order = Types.Msb_first) ~width bf =
@@ -234,8 +234,8 @@ let parse_fixed size get buf off len =
   check_eof len ~off ~n:size;
   (get buf off, off + size)
 
-let int32_le buf off = Int32.to_int (Bytes.get_int32_le buf off)
-let int32_be buf off = Int32.to_int (Bytes.get_int32_be buf off)
+let int32_le = SInt32.le
+let int32_be = SInt32.be
 let float32_le buf off = Int32.float_of_bits (Bytes.get_int32_le buf off)
 let float32_be buf off = Int32.float_of_bits (Bytes.get_int32_be buf off)
 let float64_le buf off = Int64.float_of_bits (Bytes.get_int64_le buf off)
@@ -696,11 +696,11 @@ let rec encode_into : type a. a typ -> a -> encoder -> unit =
       Types.check_signed_encode ~bits:16 v;
       write_int16_be enc v
   | Int32 Little ->
-      Types.check_signed_encode ~bits:32 v;
-      write_int32_le enc (Int32.of_int v)
+      SInt32.check_encode v;
+      write_int32_le enc (SInt32.to_int32 v)
   | Int32 Big ->
-      Types.check_signed_encode ~bits:32 v;
-      write_int32_be enc (Int32.of_int v)
+      SInt32.check_encode v;
+      write_int32_be enc (SInt32.to_int32 v)
   | Int64 Little -> write_int64_le enc v
   | Int64 Big -> write_int64_be enc v
   | Float32 Little -> write_int32_le enc (Int32.bits_of_float v)
@@ -951,6 +951,7 @@ let pp_value (type r) (c : r Codec.t) ppf (v : r) =
     readers;
   Fmt.pf ppf "@ }@]"
 
+module SInt32 = SInt32
 module Ascii = Ascii
 
 module Private = struct

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -361,6 +361,13 @@ end
     Fields carry no buffer position -- that comes from the {!Codec} they are
     bound into. The same field can appear in multiple codecs. *)
 
+module SInt32 = SInt32
+(** Signed 32-bit integers, the carrier of {!int32} and {!int32be}.
+
+    Distinct from the unsigned 32-bit carrier on purpose: the two share a
+    representation, and a value read with the wrong signedness is a silent
+    misparse rather than a type error. *)
+
 module Field : sig
   type 'a t
   (** A named field carrying values of type ['a]. *)
@@ -577,12 +584,12 @@ val int16 : int typ
 val int16be : int typ
 (** Signed 16-bit big-endian integer. Encodes [-32768] to [32767]. *)
 
-val int32 : int typ
-(** [int32] is a signed 32-bit little-endian integer, returned as an OCaml
-    integer (64-bit hosts only: on a 32-bit host, the top bit may not fit).
-    Encodes [-2^31] to [2^31 - 1]. *)
+val int32 : SInt32.t typ
+(** Signed 32-bit little-endian integer. Encodes [-2{^31}] to [2{^31} - 1], and
+    carries the value as a {!SInt32.t} so the whole range survives on a target
+    whose native [int] is narrower than the field. *)
 
-val int32be : int typ
+val int32be : SInt32.t typ
 (** [int32be] is a signed 32-bit big-endian integer, returned as an OCaml
     integer. *)
 
@@ -759,7 +766,7 @@ val byte_slice : size:int expr -> Bytesrw.Bytes.Slice.t typ
     [Invalid_argument] unless the slice is exactly [size] bytes, as for
     {!byte_array}. *)
 
-val rest_bytes : (int, _) Param.t -> string typ
+val rest_bytes : (_, _) Param.t -> string typ
 (** [rest_bytes total] is the trailing payload of a record whose total decoded
     length is bound to [total]. Equivalent to
     [byte_array ~size:Expr.(Param.expr total - sizeof_this)]. Use this as the

--- a/test/test.ml
+++ b/test/test.ml
@@ -9,6 +9,7 @@ let () =
       Test_ascii.suite;
       Test_staged.suite;
       Test_uint32.suite;
+      Test_sint32.suite;
       Test_uint63.suite;
       Test_types.suite;
       Test_eval.suite;

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -3026,6 +3026,39 @@ let test_eight_byte_unsigned_preserves_wire () =
   check_eight_byte_unsigned "uint64" uint64;
   check_eight_byte_unsigned "uint64be" uint64be
 
+(* The same rule one width down, on the signed side. Four bytes spell 2^32
+   patterns and the generated C validator hands every one of them on unchanged.
+   [int32] carries a native [int], so where that int is narrower than the field
+   ([wasm_of_ocaml] is 31 bits) [Int32.to_int] drops the top bits on the way in,
+   and nothing on the way out objects: [check_signed_encode] guards itself with
+   [bits < Sys.int_size], and 32 < 31 is false, so the check disables itself
+   exactly where it is needed. A frame leaves as different bytes with no error
+   on either path. Refusing it would be sound; altering it is not.
+
+   Native and js_of_ocaml hold 32 bits in an [int] and already pass. This case
+   is the one that fails under wasm_of_ocaml. *)
+let check_four_byte_signed name typ wire =
+  let cf = Codec.(Field.v "v" typ $ Fun.id) in
+  let codec = Codec.v "FourByteSigned" Fun.id Codec.[ cf ] in
+  match Codec.decode codec (Bytes.of_string wire) 0 with
+  | Error _ -> ()
+  | Ok v ->
+      let out = Bytes.make 4 '\x00' in
+      Codec.encode codec v out 0;
+      Fmt.kstr
+        (fun msg -> Alcotest.(check string) msg wire (Bytes.to_string out))
+        "%s: frame %a re-encodes unchanged" name
+        Fmt.(list ~sep:nop (fmt "%02x"))
+        (List.map Char.code (List.of_seq (String.to_seq wire)))
+
+let test_four_byte_signed_preserves_wire () =
+  List.iter
+    (fun (name, typ) ->
+      List.iter
+        (check_four_byte_signed name typ)
+        [ String.make 4 '\xff'; "\x80\x00\x00\x00"; "\x7f\xff\xff\xff" ])
+    [ ("int32", int32); ("int32be", int32be) ]
+
 (* [array] and [repeat] elements are written by an encoder of their own, so a
    value no element can hold has to be refused on that path too. *)
 let test_element_exact_width () =
@@ -8843,6 +8876,8 @@ let suite =
         test_encode_int64_carrier_has_no_range;
       Alcotest.test_case "8-byte unsigned fields preserve the wire" `Quick
         test_eight_byte_unsigned_preserves_wire;
+      Alcotest.test_case "4-byte signed fields preserve the wire" `Quick
+        test_four_byte_signed_preserves_wire;
       Alcotest.test_case "exact width: array and repeat elements" `Quick
         test_element_exact_width;
       Alcotest.test_case "exact byte field: literal size" `Quick

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -1625,7 +1625,7 @@ let test_nested_exact_region () =
 
 (* A casetype whose case body is a [nested] region (a scalar in a fixed span):
    the tag-dispatched case decodes and sizes through the region. *)
-type nest_case = N of int | U of int
+type nest_case = N of SInt32.t | U of int
 
 let nest_case_codec =
   let ct =
@@ -1650,7 +1650,7 @@ let test_casetype_nested_case_body () =
       Alcotest.(check bool)
         "roundtrip" true
         (decode_ok (Codec.decode nest_case_codec buf 0) = v))
-    [ N 12345; U 7 ]
+    [ N (SInt32.of_int 12345); U 7 ]
 
 (* Field.repeat over a fixed byte_array element: a list of n-byte chunks within
    a byte budget. Decodes the list and projects to a single [:byte-size]
@@ -2981,13 +2981,45 @@ let test_encode_exact_signed_scalar () =
           ~equal:Int.equal ~pp:Fmt.int
           ~inside:[ -limit; limit - 1 ]
           ~outside:[ limit; -limit - 1 ])
-    [
-      ("int8", 8, int8);
-      ("int16", 16, int16);
-      ("int16be", 16, int16be);
-      ("int32", 32, int32);
-      ("int32be", 32, int32be);
-    ]
+    (* [int32] is absent on purpose: its carrier is {!SInt32.t}, whose
+       constructors refuse an out-of-range number, so there is no such value to
+       hand the encoder. [test_sint32_of_int_range] pins that refusal instead,
+       one step earlier than this check can reach. *)
+    [ ("int8", 8, int8); ("int16", 16, int16); ("int16be", 16, int16be) ]
+
+(* The signed 32-bit range is enforced where the value is built rather than
+   where it is written, so a number the field cannot hold never becomes an
+   [int32] in the first place. [of_int32] needs no such guard: every [int32] is
+   in range by construction. *)
+let test_sint32_of_int_range () =
+  (* Only a native [int] wider than the field can hold a number outside it, so
+     the refusal is reachable only there; where the [int] is narrower every one
+     of its values is a legal signed 32-bit field. *)
+  if width_is_testable 32 then begin
+    let limit = 1 lsl 31 in
+    List.iter
+      (fun n ->
+        match SInt32.of_int n with
+        | v -> Alcotest.failf "SInt32.of_int %d built %a" n SInt32.pp v
+        | exception Invalid_argument _ -> ())
+      [ limit; -limit - 1 ]
+  end;
+  List.iter
+    (fun n ->
+      Fmt.kstr
+        (fun msg -> Alcotest.(check int32) msg (Int32.of_int n))
+        "SInt32.of_int %d round-trips" n
+        (SInt32.to_int32 (SInt32.of_int n)))
+    [ -1; 0; 1 ];
+  (* [of_int32] is total: every [int32] is in range by construction, including
+     the two ends no native [int] is guaranteed to hold. *)
+  List.iter
+    (fun n ->
+      Fmt.kstr
+        (fun msg -> Alcotest.(check int32) msg n)
+        "SInt32.of_int32 %ld round-trips" n
+        (SInt32.to_int32 (SInt32.of_int32 n)))
+    Int32.[ min_int; minus_one; zero; one; max_int ]
 
 (* [uint32] rides an [Optint.t], which is a plain [int] where that is wide
    enough to hold more than 32 bits and a boxed [int32] where it is not. Only
@@ -7869,7 +7901,7 @@ type alloc_accessor = {
   lo : int;
   u8 : int;
   u16 : int;
-  i32 : int;
+  i32 : SInt32.t;
   priority : alloc_priority;
 }
 
@@ -7946,10 +7978,13 @@ let test_set_no_allocation () =
   and set_u16 = set alloc_bf_u16
   and set_i32 = set alloc_bf_i32
   and set_priority = set alloc_bf_priority in
+  (* Built once: the point of the check is the setter's own cost, not the
+     carrier's constructor. *)
+  let i32_v = SInt32.of_int 70_000 in
   check_no_per_call_allocation "set bits" (fun () -> set_hi buf 0 3);
   check_no_per_call_allocation "set uint8" (fun () -> set_u8 buf 0 7);
   check_no_per_call_allocation "set uint16be" (fun () -> set_u16 buf 0 513);
-  check_no_per_call_allocation "set int32be" (fun () -> set_i32 buf 0 70_000);
+  check_no_per_call_allocation "set int32be" (fun () -> set_i32 buf 0 i32_v);
   check_no_per_call_allocation "set map" (fun () -> set_priority buf 0 High)
 
 (* {2 Resource bounds}
@@ -8878,6 +8913,8 @@ let suite =
         test_eight_byte_unsigned_preserves_wire;
       Alcotest.test_case "4-byte signed fields preserve the wire" `Quick
         test_four_byte_signed_preserves_wire;
+      Alcotest.test_case "exact width: SInt32.of_int range" `Quick
+        test_sint32_of_int_range;
       Alcotest.test_case "exact width: array and repeat elements" `Quick
         test_element_exact_width;
       Alcotest.test_case "exact byte field: literal size" `Quick

--- a/test/test_sint32.ml
+++ b/test/test_sint32.ml
@@ -1,0 +1,147 @@
+(* Tests for SInt32: signed 32-bit get/set over bytes. Values are written as
+   [Int32] literals and compared through [to_int32]: an int literal spanning the
+   full range would itself truncate on a narrow-int target (wasm_of_ocaml,
+   js_of_ocaml), and these tests run there too. *)
+
+open Wire
+
+let check_roundtrip name ~set ~get v =
+  let buf = Bytes.create 4 in
+  set buf 0 (SInt32.of_int32 v);
+  Alcotest.(check int32) name v (SInt32.to_int32 (get buf 0))
+
+let test_roundtrip_le () =
+  check_roundtrip "le roundtrip" ~set:SInt32.set_le ~get:SInt32.le 0xDEAD_BEEFl
+
+let test_roundtrip_be () =
+  check_roundtrip "be roundtrip" ~set:SInt32.set_be ~get:SInt32.be 0xCAFE_BABEl
+
+(* Pin the wire byte order so the read and write paths cannot drift apart. *)
+let test_byte_layout () =
+  let buf = Bytes.of_string "\x01\x02\x03\x04" in
+  Alcotest.(check int32)
+    "le read" 0x04030201l
+    (SInt32.to_int32 (SInt32.le buf 0));
+  Alcotest.(check int32)
+    "be read" 0x01020304l
+    (SInt32.to_int32 (SInt32.be buf 0));
+  let out = Bytes.create 4 in
+  SInt32.set_le out 0 (SInt32.of_int32 0x04030201l);
+  Alcotest.(check string) "le write" "\x01\x02\x03\x04" (Bytes.to_string out);
+  SInt32.set_be out 0 (SInt32.of_int32 0x01020304l);
+  Alcotest.(check string) "be write" "\x01\x02\x03\x04" (Bytes.to_string out)
+
+(* The defect this type exists to close: a pattern with bit 31 set is a negative
+   number, and it has to survive the read where the native int is narrower than
+   the field rather than coming back as a legal smaller one. *)
+let test_sign_bit () =
+  let buf = Bytes.of_string "\x80\x00\x00\x00" in
+  Alcotest.(check int32)
+    "min_int be" Int32.min_int
+    (SInt32.to_int32 (SInt32.be buf 0));
+  let out = Bytes.create 4 in
+  SInt32.set_be out 0 (SInt32.of_int32 Int32.min_int);
+  Alcotest.(check string)
+    "min_int re-encodes" "\x80\x00\x00\x00" (Bytes.to_string out)
+
+let test_boundaries () =
+  List.iter
+    (fun v ->
+      check_roundtrip "le" ~set:SInt32.set_le ~get:SInt32.le v;
+      check_roundtrip "be" ~set:SInt32.set_be ~get:SInt32.be v)
+    Int32.
+      [
+        min_int;
+        add min_int one;
+        minus_one;
+        zero;
+        one;
+        0xFFFFl;
+        0x1_0000l;
+        sub max_int one;
+        max_int;
+      ]
+
+(* [compare] must order as a signed 32-bit integer on both carriers: a native
+   int compares as itself, and the boxed fallback is [Int32], whose comparison
+   is already signed. The unsigned sibling is the one that cannot inherit it. *)
+let test_compare_is_signed () =
+  let s = SInt32.of_int32 in
+  Alcotest.(check bool)
+    "min_int < 0" true
+    (SInt32.compare (s Int32.min_int) SInt32.zero < 0);
+  Alcotest.(check bool)
+    "-1 < 0" true
+    (SInt32.compare (s Int32.minus_one) SInt32.zero < 0);
+  Alcotest.(check bool)
+    "max_int > 0" true
+    (SInt32.compare (s Int32.max_int) SInt32.zero > 0);
+  Alcotest.(check bool) "equal reflexive" true (SInt32.equal (s 42l) (s 42l));
+  Alcotest.(check bool)
+    "min_int <> max_int" false
+    (SInt32.equal (s Int32.min_int) (s Int32.max_int))
+
+(* [min_int] and [max_int] are the field's ends, not the carrier's. *)
+let test_bounds () =
+  Alcotest.(check int32)
+    "min_int" Int32.min_int
+    (SInt32.to_int32 SInt32.min_int);
+  Alcotest.(check int32)
+    "max_int" Int32.max_int
+    (SInt32.to_int32 SInt32.max_int);
+  Alcotest.(check int32) "zero" 0l (SInt32.to_int32 SInt32.zero)
+
+(* [of_int] refuses a number the field cannot hold instead of masking it to a
+   legal one the caller did not mean. Only a native int wider than the field can
+   supply such a number, so the refusal is reachable only there. *)
+let test_of_int_refuses_out_of_range () =
+  if Sys.int_size > 32 then begin
+    let limit = 1 lsl 31 in
+    List.iter
+      (fun n ->
+        match SInt32.of_int n with
+        | v -> Alcotest.failf "of_int %d built %a" n SInt32.pp v
+        | exception Invalid_argument _ -> ())
+      [ limit; -limit - 1; max_int; min_int ]
+  end;
+  List.iter
+    (fun n ->
+      Fmt.kstr
+        (fun msg -> Alcotest.(check int32) msg (Int32.of_int n))
+        "of_int %d round-trips" n
+        (SInt32.to_int32 (SInt32.of_int n)))
+    [ -1; 0; 1; 0xFFFF ]
+
+(* [to_int_opt] answers whether the native int held the value, so a caller that
+   must not silently drop the top bits has something total to ask. *)
+let test_to_int_opt () =
+  let ends = SInt32.[ min_int; max_int ] in
+  List.iter
+    (fun v ->
+      match SInt32.to_int_opt v with
+      | Some n when Sys.int_size > 32 ->
+          Alcotest.(check int32)
+            "wide int holds it" (SInt32.to_int32 v) (Int32.of_int n)
+      | Some _ -> ()
+      | None ->
+          Alcotest.(check bool)
+            "None only where the int is too narrow" true (Sys.int_size <= 32))
+    ends;
+  Alcotest.(check (option int))
+    "zero fits" (Some 0)
+    (SInt32.to_int_opt SInt32.zero)
+
+let suite =
+  ( "sint32",
+    [
+      Alcotest.test_case "roundtrip le" `Quick test_roundtrip_le;
+      Alcotest.test_case "roundtrip be" `Quick test_roundtrip_be;
+      Alcotest.test_case "byte layout" `Quick test_byte_layout;
+      Alcotest.test_case "sign bit preserved" `Quick test_sign_bit;
+      Alcotest.test_case "boundaries" `Quick test_boundaries;
+      Alcotest.test_case "compare is signed" `Quick test_compare_is_signed;
+      Alcotest.test_case "bounds" `Quick test_bounds;
+      Alcotest.test_case "of_int refuses out of range" `Quick
+        test_of_int_refuses_out_of_range;
+      Alcotest.test_case "to_int_opt" `Quick test_to_int_opt;
+    ] )

--- a/test/test_sint32.mli
+++ b/test/test_sint32.mli
@@ -1,0 +1,4 @@
+(** Tests for the [sint32] module. *)
+
+val suite : string * unit Alcotest.test_case list
+(** Alcotest suite. *)

--- a/test/test_wire.ml
+++ b/test/test_wire.ml
@@ -130,7 +130,9 @@ let test_int16be_negative () =
 
 let test_int32be_negative () =
   let buf = Bytes.of_string "\xFF\xFF\xFF\xFE" in
-  Alcotest.(check int) "-2 BE" (-2) (of_bytes_exn int32be buf)
+  Alcotest.(check int32)
+    "-2 BE" (-2l)
+    (SInt32.to_int32 (of_bytes_exn int32be buf))
 
 let test_int64le_roundtrip () =
   roundtrip "roundtrip" int64 Alcotest.int64 (-0x0102_0304_0506_0708L)
@@ -188,7 +190,9 @@ let test_rest_of_buffer_codec () =
     Codec.v "RestDemo" (fun h d -> (h, d)) Codec.[ f_h $ fst; f_d $ snd ]
   in
   let buf = Bytes.of_string "\x01HELLO" in
-  let env = Codec.env codec |> Param.bind total (Bytes.length buf) in
+  let env =
+    Codec.env codec |> Param.bind total (SInt32.of_int (Bytes.length buf))
+  in
   match Codec.decode ~env codec buf 0 with
   | Ok (h, d) ->
       Alcotest.(check int) "header" 1 h;


### PR DESCRIPTION
A 4-byte signed field altered the frame it decoded wherever the native `int` is narrower than the field. Under wasm_of_ocaml an `int` is 31 bits, so `int32` dropped the top bits on decode while `check_signed_encode` disabled itself (its guard is `bits < Sys.int_size`, false at 32 < 31), and the frame went back out as different bytes with no error on either path.

`int32` now carries a new `Wire.SInt32`, abstract and distinct from the unsigned 32-bit carrier so neither can be read with the other's meaning, and the range check moves from encode time to construction, which makes an out-of-range `int32` unconstructible.