### PR TITLE
types: seal uint32 behind an abstract carrier that orders unsigned

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ### Added
 
+- Add `Wire.UInt32`, the unsigned 32-bit carrier behind `uint32` and `uint32be`.
+  It was reachable before only as `Wire.Private.UInt32`, with `Optint.t` as the
+  public type (#322, @samoht)
+
 - Add `Wire.SInt32`, the signed 32-bit carrier behind `int32` and `int32be`. It
   is deliberately not interchangeable with the unsigned 32-bit carrier: the two
   share a representation, so a value read with the wrong signedness would be a
@@ -41,6 +45,12 @@
   (#263, @samoht)
 
 ### Changed
+
+- **Breaking:** `uint32` and `uint32be` decode to an abstract `Wire.UInt32.t`
+  rather than `Optint.t`, and `Wire.UInt32.of_int` refuses a number outside the
+  range instead of masking it to a legal value the caller did not mean. Convert
+  a decoded field with `Wire.UInt32.to_int32` or `to_int`, and reinterpret a bit
+  pattern with `of_int32` (#322, @samoht)
 
 - **Breaking:** `int32` and `int32be` decode to `Wire.SInt32.t` rather than a
   native `int`, and `Wire.rest_bytes` accepts a parameter of any integer type
@@ -128,6 +138,11 @@
   follow as `<Base>CheckWire<Name>` (#235, @samoht)
 
 ### Fixed
+
+- `uint32` values now order as unsigned numbers on every target. The carrier was
+  `Optint.t`, which is `Int32` where the native `int` is narrower than the
+  field, so a comparison ranked 0xFFFFFFFF, the largest `uint32`, below 1 under
+  js_of_ocaml and wasm_of_ocaml (#322, @samoht)
 
 - A 4-byte signed field no longer alters the frame it decodes where the native
   `int` is narrower than the field. Under wasm_of_ocaml an `int` is 31 bits, so

--- a/bench/demo/demo_bench_cases.ml
+++ b/bench/demo/demo_bench_cases.ml
@@ -427,10 +427,10 @@ let ipv4_case =
       set;
       write_template = Bytes.copy ipv4_dataset.items.(0);
       write_offset = 0;
-      write_value = Optint.of_int 0x0A00_0001;
-      equal = Optint.equal;
+      write_value = Wire.UInt32.of_int 0x0A00_0001;
+      equal = Wire.UInt32.equal;
       bench_read = true;
-      of_c_field = of_int Optint.of_int;
+      of_c_field = of_int Wire.UInt32.of_int;
     }
 
 let tcp_case =

--- a/bench/demo/demo_bench_cases.mli
+++ b/bench/demo/demo_bench_cases.mli
@@ -74,7 +74,7 @@ val clcw_case : int read_case
 val packet_case : int read_case
 (** CCSDS Space Packet APID (11-bit bitfield). *)
 
-val ipv4_case : Optint.t read_case
+val ipv4_case : Wire.UInt32.t read_case
 (** IPv4 source address (uint32be). *)
 
 val tcp_case : int read_case

--- a/bench/memtrace/bench.ml
+++ b/bench/memtrace/bench.ml
@@ -153,7 +153,7 @@ type kexinit = {
   lang_c2s : Slice.t;
   lang_s2c : Slice.t;
   first_follows : int;
-  reserved : Optint.t;
+  reserved : Wire.UInt32.t;
 }
 
 let kex_len name = Wire.Field.v name Wire.uint32be
@@ -194,25 +194,25 @@ let kexinit_codec =
       [
         ( Wire.Field.v "Cookie" (Wire.byte_slice ~size:(Wire.int 16)) $ fun r ->
           r.cookie );
-        (f_kex_len $ fun r -> Optint.of_int (Slice.length r.kex));
+        (f_kex_len $ fun r -> Wire.UInt32.of_int (Slice.length r.kex));
         (name_list "Kex" f_kex_len $ fun r -> r.kex);
-        (f_hk_len $ fun r -> Optint.of_int (Slice.length r.host_key));
+        (f_hk_len $ fun r -> Wire.UInt32.of_int (Slice.length r.host_key));
         (name_list "HostKey" f_hk_len $ fun r -> r.host_key);
-        (f_ec_len $ fun r -> Optint.of_int (Slice.length r.enc_c2s));
+        (f_ec_len $ fun r -> Wire.UInt32.of_int (Slice.length r.enc_c2s));
         (name_list "EncC2S" f_ec_len $ fun r -> r.enc_c2s);
-        (f_es_len $ fun r -> Optint.of_int (Slice.length r.enc_s2c));
+        (f_es_len $ fun r -> Wire.UInt32.of_int (Slice.length r.enc_s2c));
         (name_list "EncS2C" f_es_len $ fun r -> r.enc_s2c);
-        (f_mc_len $ fun r -> Optint.of_int (Slice.length r.mac_c2s));
+        (f_mc_len $ fun r -> Wire.UInt32.of_int (Slice.length r.mac_c2s));
         (name_list "MacC2S" f_mc_len $ fun r -> r.mac_c2s);
-        (f_ms_len $ fun r -> Optint.of_int (Slice.length r.mac_s2c));
+        (f_ms_len $ fun r -> Wire.UInt32.of_int (Slice.length r.mac_s2c));
         (name_list "MacS2C" f_ms_len $ fun r -> r.mac_s2c);
-        (f_cc_len $ fun r -> Optint.of_int (Slice.length r.comp_c2s));
+        (f_cc_len $ fun r -> Wire.UInt32.of_int (Slice.length r.comp_c2s));
         (name_list "CompC2S" f_cc_len $ fun r -> r.comp_c2s);
-        (f_cs_len $ fun r -> Optint.of_int (Slice.length r.comp_s2c));
+        (f_cs_len $ fun r -> Wire.UInt32.of_int (Slice.length r.comp_s2c));
         (name_list "CompS2C" f_cs_len $ fun r -> r.comp_s2c);
-        (f_lc_len $ fun r -> Optint.of_int (Slice.length r.lang_c2s));
+        (f_lc_len $ fun r -> Wire.UInt32.of_int (Slice.length r.lang_c2s));
         (name_list "LangC2S" f_lc_len $ fun r -> r.lang_c2s);
-        (f_ls_len $ fun r -> Optint.of_int (Slice.length r.lang_s2c));
+        (f_ls_len $ fun r -> Wire.UInt32.of_int (Slice.length r.lang_s2c));
         (name_list "LangS2C" f_ls_len $ fun r -> r.lang_s2c);
         (Wire.Field.v "FirstFollows" Wire.uint8 $ fun r -> r.first_follows);
         (Wire.Field.v "Reserved" Wire.uint32be $ fun r -> r.reserved);

--- a/examples/demo/demo.ml
+++ b/examples/demo/demo.ml
@@ -37,8 +37,8 @@ type all_ints = {
   u8 : int;
   u16 : int;
   u16be : int;
-  u32 : Optint.t;
-  u32be : Optint.t;
+  u32 : UInt32.t;
+  u32be : UInt32.t;
   u64be : int64;
 }
 
@@ -66,8 +66,8 @@ let all_ints_default =
     u8 = 0xFF;
     u16 = 0x1234;
     u16be = 0x5678;
-    u32 = Optint.of_int 0xDEADBEEF;
-    u32be = Optint.of_int 0xCAFEBABE;
+    u32 = UInt32.of_int 0xDEADBEEF;
+    u32be = UInt32.of_int 0xCAFEBABE;
     u64be = 0x0102030405060708L;
   }
 
@@ -202,7 +202,7 @@ let bool_fields_data n =
 (* -- 7. Large mixed: u32be+u8+u8+u16be+u8+u8+u16be+u16be+u32be+u64be = 26 bytes -- *)
 
 type large_mixed = {
-  sync : Optint.t;
+  sync : UInt32.t;
   version : int;
   type_ : int;
   spacecraft : int;
@@ -210,7 +210,7 @@ type large_mixed = {
   count : int;
   offset : int;
   length : int;
-  crc : Optint.t;
+  crc : UInt32.t;
   timestamp : int64;
 }
 
@@ -251,7 +251,7 @@ let large_mixed_size = Codec.wire_size large_mixed_codec
 
 let large_mixed_default =
   {
-    sync = Optint.of_int 0x1ACFFC1D;
+    sync = UInt32.of_int 0x1ACFFC1D;
     version = 2;
     type_ = 0;
     spacecraft = 0x01FF;
@@ -259,7 +259,7 @@ let large_mixed_default =
     count = 66;
     offset = 16;
     length = 1024;
-    crc = Optint.of_int 0xDEADBEEF;
+    crc = UInt32.of_int 0xDEADBEEF;
     timestamp = 0x0102030405060708L;
   }
 

--- a/examples/demo/demo.mli
+++ b/examples/demo/demo.mli
@@ -31,8 +31,8 @@ type all_ints = {
   u8 : int;
   u16 : int;
   u16be : int;
-  u32 : Optint.t;
-  u32be : Optint.t;
+  u32 : Wire.UInt32.t;
+  u32be : Wire.UInt32.t;
   u64be : int64;
 }
 
@@ -162,7 +162,7 @@ val bool_fields_data : int -> bytes array
 (** {1 LargeMixed (26 bytes)} *)
 
 type large_mixed = {
-  sync : Optint.t;
+  sync : Wire.UInt32.t;
   version : int;
   type_ : int;
   spacecraft : int;
@@ -170,7 +170,7 @@ type large_mixed = {
   count : int;
   offset : int;
   length : int;
-  crc : Optint.t;
+  crc : Wire.UInt32.t;
   timestamp : int64;
 }
 

--- a/examples/net/net.ml
+++ b/examples/net/net.ml
@@ -59,8 +59,8 @@ type ipv4 = {
   ttl : int;
   protocol : int;
   checksum : int;
-  src : Optint.t;
-  dst : Optint.t;
+  src : UInt32.t;
+  dst : UInt32.t;
   payload : Slice.t;
 }
 
@@ -180,8 +180,8 @@ let ipv4_size = Codec.wire_size ipv4_codec
 type tcp = {
   src_port : int;
   dst_port : int;
-  seq : Optint.t;
-  ack_num : Optint.t;
+  seq : UInt32.t;
+  ack_num : UInt32.t;
   data_offset : int;
   reserved : int;
   ns : bool;
@@ -289,18 +289,18 @@ let udp_size = Codec.wire_size udp_codec
 
 (* -- Utilities -- *)
 
-(* Addresses stay in [Optint.t] like the [f_ip_src]/[f_ip_dst] fields: an
+(* Addresses stay in [UInt32.t] like the [f_ip_src]/[f_ip_dst] fields: an
    address at or above 128.0.0.0 sets bit 31, which a narrow-int platform
    (wasm_of_ocaml, js_of_ocaml) cannot hold in an int. *)
 let pp_ipv4_addr ppf addr =
-  let v = Optint.to_int32 addr in
+  let v = UInt32.to_int32 addr in
   let octet shift =
     Int32.to_int (Int32.logand (Int32.shift_right_logical v shift) 0xFFl)
   in
   Fmt.pf ppf "%d.%d.%d.%d" (octet 24) (octet 16) (octet 8) (octet 0)
 
 let ipv4_addr a b c d =
-  Optint.of_int32
+  UInt32.of_int32
     (Int32.logor
        (Int32.shift_left (Int32.of_int a) 24)
        (Int32.of_int ((b lsl 16) lor (c lsl 8) lor d)))
@@ -336,8 +336,8 @@ let tcp_frame_data n =
       Bytes.set_uint8 b (ip + 8) 64;
       Bytes.set_uint8 b (ip + 9) 6;
       Bytes.set_uint16_be b (ip + 10) 0;
-      Bytes.set_int32_be b (ip + 12) (Optint.to_int32 (ipv4_addr 192 168 1 100));
-      Bytes.set_int32_be b (ip + 16) (Optint.to_int32 (ipv4_addr 10 0 0 1));
+      Bytes.set_int32_be b (ip + 12) (UInt32.to_int32 (ipv4_addr 192 168 1 100));
+      Bytes.set_int32_be b (ip + 16) (UInt32.to_int32 (ipv4_addr 10 0 0 1));
       (* TCP at offset 34 *)
       let tcp = 34 in
       Bytes.set_uint16_be b tcp (12345 + (i mod 1000));
@@ -375,8 +375,8 @@ let udp_frame_data n =
       Bytes.set_uint8 b (ip + 8) 64;
       Bytes.set_uint8 b (ip + 9) 17;
       Bytes.set_uint16_be b (ip + 10) 0;
-      Bytes.set_int32_be b (ip + 12) (Optint.to_int32 (ipv4_addr 192 168 1 100));
-      Bytes.set_int32_be b (ip + 16) (Optint.to_int32 (ipv4_addr 10 0 0 1));
+      Bytes.set_int32_be b (ip + 12) (UInt32.to_int32 (ipv4_addr 192 168 1 100));
+      Bytes.set_int32_be b (ip + 16) (UInt32.to_int32 (ipv4_addr 10 0 0 1));
       let udp = 34 in
       Bytes.set_uint16_be b udp (5353 + (i mod 100));
       Bytes.set_uint16_be b (udp + 2) 53;

--- a/examples/net/net.mli
+++ b/examples/net/net.mli
@@ -51,10 +51,10 @@ val ipv4_payload_size : int
 val f_ip_protocol : int Wire.Field.t
 (** Zero-copy field accessor for the IPv4 Protocol field. *)
 
-val f_ip_src : Optint.t Wire.Field.t
+val f_ip_src : Wire.UInt32.t Wire.Field.t
 (** Zero-copy field accessor for the IPv4 source address field. *)
 
-val f_ip_dst : Optint.t Wire.Field.t
+val f_ip_dst : Wire.UInt32.t Wire.Field.t
 (** Zero-copy field accessor for the IPv4 destination address field. *)
 
 val f_ip_payload : Bytesrw.Bytes.Slice.t Wire.Field.t
@@ -63,10 +63,10 @@ val f_ip_payload : Bytesrw.Bytes.Slice.t Wire.Field.t
 val bf_ip_protocol : (int, ipv4) Wire.Codec.field
 (** Bound field handle for the IPv4 Protocol field. *)
 
-val bf_ip_src : (Optint.t, ipv4) Wire.Codec.field
+val bf_ip_src : (Wire.UInt32.t, ipv4) Wire.Codec.field
 (** Bound field handle for the IPv4 source address field. *)
 
-val bf_ip_dst : (Optint.t, ipv4) Wire.Codec.field
+val bf_ip_dst : (Wire.UInt32.t, ipv4) Wire.Codec.field
 (** Bound field handle for the IPv4 destination address field. *)
 
 val bf_ip_payload : (Bytesrw.Bytes.Slice.t, ipv4) Wire.Codec.field
@@ -136,11 +136,11 @@ val f_udp_checksum : int Wire.Field.t
 
 (** {2 Utilities} *)
 
-val pp_ipv4_addr : Format.formatter -> Optint.t -> unit
+val pp_ipv4_addr : Format.formatter -> Wire.UInt32.t -> unit
 (** Pretty-printer for a packed 32-bit IPv4 address in dotted-decimal notation.
 *)
 
-val ipv4_addr : int -> int -> int -> int -> Optint.t
+val ipv4_addr : int -> int -> int -> int -> Wire.UInt32.t
 (** [ipv4_addr a b c d] packs four octets into a single 32-bit IPv4 address, in
     the same representation as the {!f_ip_src}/{!f_ip_dst} fields (an address at
     or above 128.0.0.0 sets bit 31, which does not fit an [int] on a narrow-int

--- a/examples/space/space.ml
+++ b/examples/space/space.ml
@@ -314,7 +314,7 @@ type tm_with_ocf = {
   mc_count : int;
   vc_count : int;
   first_hdr : int;
-  ocf : Optint.t option;
+  ocf : UInt32.t option;
 }
 
 let f_tmo_ocf_flag = Field.v "OCFFlag" (bit (bits ~width:1 U16be))

--- a/fuzz/gen/fuzz_gen.ml
+++ b/fuzz/gen/fuzz_gen.ml
@@ -184,14 +184,6 @@ let above_byte_width size =
     Alcobar.[ Alcobar.int ]
     (fun n -> Wire.Private.UInt63.of_int (n land max_v lor (max_v + 1)))
 
-(* [uint32] is carried in an [Optint.t], which on a wide-int host holds numbers
-   32 bits cannot. *)
-let above_uint32 =
-  let mask = Wire.Private.UInt32.mask32 in
-  Alcobar.map
-    Alcobar.[ Alcobar.int ]
-    (fun n -> Optint.of_int (n land mask lor (mask + 1)))
-
 (* A byte string of one of the lengths around [n], for a byte span whose
    declared size is [n]: only the exact length may encode. *)
 let byte_lengths_around n =
@@ -266,18 +258,19 @@ let scalar_sint32 typ size value_gen boundaries =
   leaf ~equal:Wire.SInt32.equal ~typ ~value_gen ~random:(bytes_fixed size)
     ~adversarial:(Alcobar.choose (List.map Alcobar.const boundaries))
 
-let scalar_optint ~hostile typ size value_gen boundaries =
-  let g =
-    leaf ~equal:Optint.equal ~typ ~value_gen ~random:(bytes_fixed size)
-      ~adversarial:(Alcobar.choose (List.map Alcobar.const boundaries))
-  in
-  { g with adversarial_value = Some hostile }
+(* [uint32] is carried in a [Wire.UInt32.t], whose only constructors are the
+   4-byte pattern and a checked [of_int]: every value of it is a legal unsigned
+   32-bit field, so there is no hostile value to draw and no guard for one to
+   exercise. Same reasoning as [scalar_int64] and [scalar_sint32]. *)
+let scalar_optint typ size value_gen boundaries =
+  leaf ~equal:Wire.UInt32.equal ~typ ~value_gen ~random:(bytes_fixed size)
+    ~adversarial:(Alcobar.choose (List.map Alcobar.const boundaries))
 
 let u8_boundaries = [ 0; 1; 0x7F; 0x80; 0xFE; 0xFF ]
 let u16_boundaries = [ 0; 1; 0x7F; 0x80; 0x7FFF; 0x8000; 0xFFFE; 0xFFFF ]
 
 let u32_boundaries =
-  List.map Optint.of_int
+  List.map Wire.UInt32.of_int
     [ 0; 1; 0xFFFF; 0x7FFF_FFFF; 0x8000_0000; 0xFFFF_FFFE; 0xFFFF_FFFF ]
 
 let u64_boundaries_i64 =
@@ -306,14 +299,10 @@ let uint16be =
 let masked_u32 =
   Alcobar.map
     Alcobar.[ Alcobar.int ]
-    (fun n -> Optint.of_int (n land 0xFFFF_FFFF))
+    (fun n -> Wire.UInt32.of_int (n land Wire.Private.UInt32.mask32))
 
-let uint32 =
-  scalar_optint ~hostile:above_uint32 Wire.uint32 4 masked_u32 u32_boundaries
-
-let uint32be =
-  scalar_optint ~hostile:above_uint32 Wire.uint32be 4 masked_u32 u32_boundaries
-
+let uint32 = scalar_optint Wire.uint32 4 masked_u32 u32_boundaries
+let uint32be = scalar_optint Wire.uint32be 4 masked_u32 u32_boundaries
 let uint64 = scalar_int64 Wire.uint64 8 Alcobar.int64 u64_boundaries_i64
 let uint64be = scalar_int64 Wire.uint64be 8 Alcobar.int64 u64_boundaries_i64
 
@@ -766,7 +755,7 @@ let exact_cases ~typ ~equal cases =
 
 let exact_int typ cases = exact_cases ~typ ~equal:Int.equal cases
 let exact_int64 typ cases = exact_cases ~typ ~equal:Int64.equal cases
-let exact_optint typ cases = exact_cases ~typ ~equal:Optint.equal cases
+let exact_optint typ cases = exact_cases ~typ ~equal:Wire.UInt32.equal cases
 let exact_sint32 typ cases = exact_cases ~typ ~equal:Wire.SInt32.equal cases
 
 let uint16_endian_edges =
@@ -790,17 +779,17 @@ let uint16be_endian_edges =
 let uint32_endian_edges =
   exact_optint Wire.uint32
     [
-      (Optint.of_int 0x01234567, bytes_of_octets [ 0x67; 0x45; 0x23; 0x01 ]);
-      (Optint.of_int 0x80000000, bytes_of_octets [ 0x00; 0x00; 0x00; 0x80 ]);
-      (Optint.of_int 0xFFFFFFFF, bytes_of_octets [ 0xFF; 0xFF; 0xFF; 0xFF ]);
+      (Wire.UInt32.of_int 0x01234567, bytes_of_octets [ 0x67; 0x45; 0x23; 0x01 ]);
+      (Wire.UInt32.of_int 0x80000000, bytes_of_octets [ 0x00; 0x00; 0x00; 0x80 ]);
+      (Wire.UInt32.of_int 0xFFFFFFFF, bytes_of_octets [ 0xFF; 0xFF; 0xFF; 0xFF ]);
     ]
 
 let uint32be_endian_edges =
   exact_optint Wire.uint32be
     [
-      (Optint.of_int 0x01234567, bytes_of_octets [ 0x01; 0x23; 0x45; 0x67 ]);
-      (Optint.of_int 0x80000000, bytes_of_octets [ 0x80; 0x00; 0x00; 0x00 ]);
-      (Optint.of_int 0xFFFFFFFF, bytes_of_octets [ 0xFF; 0xFF; 0xFF; 0xFF ]);
+      (Wire.UInt32.of_int 0x01234567, bytes_of_octets [ 0x01; 0x23; 0x45; 0x67 ]);
+      (Wire.UInt32.of_int 0x80000000, bytes_of_octets [ 0x80; 0x00; 0x00; 0x00 ]);
+      (Wire.UInt32.of_int 0xFFFFFFFF, bytes_of_octets [ 0xFF; 0xFF; 0xFF; 0xFF ]);
     ]
 
 let uint64_endian_edges =
@@ -1371,8 +1360,8 @@ let bounded_u16be =
 let bounded_u32be =
   bounded_int ~inner_typ:Wire.uint32be ~size:4
     ~set:(fun b o n -> Bytes.set_int32_be b o (Int32.of_int n))
-    ~max_val:0x7FFF_FFFF ~min:1000 ~max:1_000_000 ~of_int:Optint.of_int
-    ~equal:Optint.equal
+    ~max_val:0x7FFF_FFFF ~min:1000 ~max:1_000_000 ~of_int:Wire.UInt32.of_int
+    ~equal:Wire.UInt32.equal
 
 (* Two-uint8 record with [Codec.v ~where:(a < b)]. Positives keep a < b;
    adversarials sit at the boundary (a = b, a = b+1) so the where clause

--- a/fuzz/gen/fuzz_gen.mli
+++ b/fuzz/gen/fuzz_gen.mli
@@ -250,10 +250,10 @@ val uint16 : int t
 val uint16be : int t
 (** [uint16be] generates for {!Wire.uint16be}. *)
 
-val uint32 : Optint.t t
+val uint32 : Wire.UInt32.t t
 (** [uint32] generates for {!Wire.uint32}. *)
 
-val uint32be : Optint.t t
+val uint32be : Wire.UInt32.t t
 (** [uint32be] generates for {!Wire.uint32be}. *)
 
 val uint64 : int64 t

--- a/lib/uInt32.ml
+++ b/lib/uInt32.ml
@@ -1,7 +1,17 @@
 type t = Optint.t
 
-let compare = Optint.compare
+(* [Optint.t] is the native [int] only where that holds more than 32 bits, and
+   there every uint32 is a non-negative [int] whose natural order is already the
+   unsigned one. Where it falls back to [Int32] the values with bit 31 set are
+   negative, so the unsigned comparison has to be asked for by name: an
+   inherited signed one ranks 0xFFFFFFFF, the largest uint32, below 1. Chosen
+   once at module initialisation, not per call. *)
+let compare =
+  if Sys.int_size > 32 then Optint.compare
+  else fun a b -> Int32.unsigned_compare (Optint.to_int32 a) (Optint.to_int32 b)
+
 let equal = Optint.equal
+let zero = Optint.zero
 let pp = Optint.pp
 
 (* Compose two unboxed 16-bit reads/writes through [Optint]. On a 64-bit host
@@ -54,7 +64,17 @@ let set_be buf off v =
   Bytes.set_uint16_be buf (off + 2) (low16 v)
 
 let to_int = Optint.to_int
-let of_int v = Optint.of_int (v land mask32)
+
+(* Refuses rather than masks. Masking turns a number the field cannot hold into
+   a legal 32-bit value on the wire that nothing downstream can tell from the
+   one the caller meant, which is the failure this library exists to avoid.
+   Only a native [int] wider than the field can supply such a number. *)
+let of_int n =
+  let v = Optint.of_int (n land mask32) in
+  if not (Optint.equal (Optint.of_int n) v) then
+    Fmt.invalid_arg "Wire.UInt32.of_int: %d is not an unsigned 32-bit value" n;
+  v
+
 let to_int32 = Optint.to_int32
 
 (* [Optint.of_int32] keeps the signed view, so where [Optint.t] is a wide native

--- a/lib/uInt32.ml
+++ b/lib/uInt32.ml
@@ -1,5 +1,7 @@
 type t = Optint.t
 
+let compare = Optint.compare
+let equal = Optint.equal
 let pp = Optint.pp
 
 (* Compose two unboxed 16-bit reads/writes through [Optint]. On a 64-bit host

--- a/lib/uInt32.mli
+++ b/lib/uInt32.mli
@@ -7,6 +7,13 @@
 
 type t = Optint.t
 
+val compare : t -> t -> int
+(** [compare a b] orders two values as unsigned 32-bit integers, so 0xFFFFFFFF
+    is the largest. *)
+
+val equal : t -> t -> bool
+(** [equal a b] is [true] when [a] and [b] are the same value. *)
+
 val pp : Format.formatter -> t -> unit
 (** Pretty-printer for unsigned 32-bit values. *)
 

--- a/lib/uInt32.mli
+++ b/lib/uInt32.mli
@@ -5,7 +5,11 @@
     bit 31 set survive decoding on js_of_ocaml / wasm_of_ocaml, where a plain
     [int] would drop it. *)
 
-type t = Optint.t
+type t
+(** Abstract on purpose. The representation is shared with the signed 32-bit
+    carrier {!Wire.SInt32.t}, and where the native [int] is narrower than the
+    field it is [Int32], whose inherited comparison is signed and so wrong here.
+    Keeping the type opaque is what stops either being reached for. *)
 
 val compare : t -> t -> int
 (** [compare a b] orders two values as unsigned 32-bit integers, so 0xFFFFFFFF
@@ -13,6 +17,9 @@ val compare : t -> t -> int
 
 val equal : t -> t -> bool
 (** [equal a b] is [true] when [a] and [b] are the same value. *)
+
+val zero : t
+(** [zero] is 0. *)
 
 val pp : Format.formatter -> t -> unit
 (** Pretty-printer for unsigned 32-bit values. *)
@@ -47,7 +54,9 @@ val to_int : t -> int
     prefer {!to_int32} across such a boundary. *)
 
 val of_int : int -> t
-(** [of_int n] is the low 32 bits of [n]. *)
+(** [of_int n] is [n] as an unsigned 32-bit value. Raises [Invalid_argument]
+    when [n] is outside the range, rather than masking it to a legal value the
+    caller did not mean. Use {!of_int32} to reinterpret a bit pattern. *)
 
 val to_int32 : t -> int32
 (** [to_int32 t] is the value as an [int32] (its bit pattern, exact on every

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -361,12 +361,20 @@ end
     Fields carry no buffer position -- that comes from the {!Codec} they are
     bound into. The same field can appear in multiple codecs. *)
 
+module UInt32 = UInt32
+(** Unsigned 32-bit integers, the carrier of {!uint32} and {!uint32be}.
+
+    Ordered as an unsigned number on every target: the representation is shared
+    with {!SInt32}, and where the native [int] is narrower than the field it is
+    [Int32], whose comparison ranks 0xFFFFFFFF, the largest value here, below 1.
+*)
+
 module SInt32 = SInt32
 (** Signed 32-bit integers, the carrier of {!int32} and {!int32be}.
 
-    Distinct from the unsigned 32-bit carrier on purpose: the two share a
-    representation, and a value read with the wrong signedness is a silent
-    misparse rather than a type error. *)
+    Distinct from {!UInt32} on purpose: the two share a representation, and a
+    value read with the wrong signedness is a silent misparse rather than a type
+    error. *)
 
 module Field : sig
   type 'a t
@@ -551,18 +559,14 @@ val uint16 : int typ
 val uint16be : int typ
 (** Unsigned 16-bit big-endian integer. Encodes [0] to [65535]. *)
 
-val uint32 : Optint.t typ
-(** Unsigned 32-bit little-endian integer. Decodes to an [Optint.t] so a value
-    with bit 31 set survives on a narrow-int target (js/wasm).
+val uint32 : UInt32.t typ
+(** Unsigned 32-bit little-endian integer. Encodes [0] to [2{^32} - 1], and
+    carries the value as a {!UInt32.t} so a word with bit 31 set survives on a
+    target whose native [int] is narrower than the field. Build one with
+    {!UInt32.of_int32} from a bit pattern, or {!UInt32.of_int}. *)
 
-    On a 64-bit host that [Optint.t] is a native [int] wide enough to hold more
-    than 32 bits, so encoding checks the range and refuses a negative value
-    rather than reading it as its two's complement. Build a word with bit 31 set
-    from its bit pattern with [Wire.Private.UInt32.of_int32], not with
-    [Optint.of_int32], which keeps the signed view. *)
-
-val uint32be : Optint.t typ
-(** Unsigned 32-bit big-endian integer. Decodes to an [Optint.t]. *)
+val uint32be : UInt32.t typ
+(** Unsigned 32-bit big-endian integer. Encodes [0] to [2{^32} - 1]. *)
 
 val uint64 : int64 typ
 (** [uint64] is an unsigned 64-bit little-endian integer represented as an OCaml

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -31,7 +31,7 @@ let decode_record codec s =
 
 (* -- Record codec tests -- *)
 
-type simple_record = { a : int; b : int; c : Optint.t }
+type simple_record = { a : int; b : int; c : UInt32.t }
 
 let simple_record_codec =
   let open Codec in
@@ -44,7 +44,7 @@ let simple_record_codec =
     ]
 
 let test_record_encode () =
-  let v = { a = 0x42; b = 0x1234; c = Optint.of_int32 0x56789ABCl } in
+  let v = { a = 0x42; b = 0x1234; c = UInt32.of_int32 0x56789ABCl } in
   match encode_record simple_record_codec v with
   | Error e -> Alcotest.failf "%a" pp_parse_error e
   | Ok encoded ->
@@ -61,11 +61,11 @@ let test_record_decode () =
   | Ok v ->
       Alcotest.(check int) "a" 0x42 v.a;
       Alcotest.(check int) "b" 0x1234 v.b;
-      Alcotest.(check int32) "c" 0x56789ABCl (Optint.to_int32 v.c)
+      Alcotest.(check int32) "c" 0x56789ABCl (UInt32.to_int32 v.c)
   | Error e -> Alcotest.failf "%a" pp_parse_error e
 
 let test_record_roundtrip () =
-  let original = { a = 0xAB; b = 0xCDEF; c = Optint.of_int 0x12345678 } in
+  let original = { a = 0xAB; b = 0xCDEF; c = UInt32.of_int 0x12345678 } in
   match encode_record simple_record_codec original with
   | Error e -> Alcotest.failf "encode: %a" pp_parse_error e
   | Ok encoded -> (
@@ -74,7 +74,7 @@ let test_record_roundtrip () =
           Alcotest.(check int) "a roundtrip" original.a decoded.a;
           Alcotest.(check int) "b roundtrip" original.b decoded.b;
           Alcotest.(check int)
-            "c roundtrip" (Optint.to_int original.c) (Optint.to_int decoded.c)
+            "c roundtrip" (UInt32.to_int original.c) (UInt32.to_int decoded.c)
       | Error e -> Alcotest.failf "%a" pp_parse_error e)
 
 let test_duplicate_names_rejected () =
@@ -703,7 +703,7 @@ let test_record_with_multi () =
       | Error e -> Alcotest.failf "%a" pp_parse_error e)
 
 (* Record with byte_array field *)
-type ba_record = { id : Optint.t; uuid : string; tag : int }
+type ba_record = { id : UInt32.t; uuid : string; tag : int }
 
 let ba_record_codec =
   let open Codec in
@@ -717,7 +717,7 @@ let ba_record_codec =
 
 let test_record_byte_array_roundtrip () =
   let original =
-    { id = Optint.of_int 0x12345678; uuid = "0123456789abcdef"; tag = 0xABCD }
+    { id = UInt32.of_int 0x12345678; uuid = "0123456789abcdef"; tag = 0xABCD }
   in
   match encode_record ba_record_codec original with
   | Error e -> Alcotest.failf "encode: %a" pp_parse_error e
@@ -727,8 +727,8 @@ let test_record_byte_array_roundtrip () =
       | Ok decoded ->
           Alcotest.(check int)
             "id"
-            (Optint.to_int original.id)
-            (Optint.to_int decoded.id);
+            (UInt32.to_int original.id)
+            (UInt32.to_int decoded.id);
           Alcotest.(check string) "uuid" original.uuid decoded.uuid;
           Alcotest.(check int) "tag" original.tag decoded.tag
       | Error e -> Alcotest.failf "%a" pp_parse_error e)
@@ -736,7 +736,7 @@ let test_record_byte_array_roundtrip () =
 let test_record_byte_array_trailing_zeros () =
   (* A caller wanting "short" in a 16-byte span supplies the zeros itself. *)
   let original =
-    { id = Optint.of_int 1; uuid = "short" ^ String.make 11 '\x00'; tag = 2 }
+    { id = UInt32.of_int 1; uuid = "short" ^ String.make 11 '\x00'; tag = 2 }
   in
   match encode_record ba_record_codec original with
   | Error e -> Alcotest.failf "encode: %a" pp_parse_error e
@@ -3021,20 +3021,34 @@ let test_sint32_of_int_range () =
         (SInt32.to_int32 (SInt32.of_int32 n)))
     Int32.[ min_int; minus_one; zero; one; max_int ]
 
-(* [uint32] rides an [Optint.t], which is a plain [int] where that is wide
-   enough to hold more than 32 bits and a boxed [int32] where it is not. Only
-   the first can carry an out-of-range value, so the case exists only there. *)
-let test_encode_exact_uint32 () =
+(* The unsigned 32-bit range is enforced where the value is built rather than
+   where it is written, so a number the field cannot hold never becomes a
+   [uint32] in the first place. Only a native [int] wider than the field can
+   supply one, so the refusal is reachable only there. [of_int32] needs no
+   guard: every [int32] pattern is a legal uint32. *)
+let test_uint32_of_int_range () =
+  let mask = Wire.Private.UInt32.mask32 in
   if width_is_testable 32 then
-    let mask = Wire.Private.UInt32.mask32 in
     List.iter
-      (fun (name, typ) ->
-        check_scalar_range ~name ~typ
-          ~sub:"does not fit an unsigned 32-bit field" ~equal:Optint.equal
-          ~pp:Optint.pp
-          ~inside:[ Optint.zero; Optint.of_int mask ]
-          ~outside:[ Optint.of_int (mask + 1); Optint.of_int (-1) ])
-      [ ("uint32", uint32); ("uint32be", uint32be) ]
+      (fun n ->
+        match UInt32.of_int n with
+        | v -> Alcotest.failf "UInt32.of_int %d built %a" n UInt32.pp v
+        | exception Invalid_argument _ -> ())
+      [ mask + 1; -1; min_int ];
+  List.iter
+    (fun n ->
+      Fmt.kstr
+        (fun msg -> Alcotest.(check int) msg n)
+        "UInt32.of_int %d round-trips" n
+        (UInt32.to_int (UInt32.of_int n)))
+    [ 0; 1; 0xFFFF ];
+  List.iter
+    (fun n ->
+      Fmt.kstr
+        (fun msg -> Alcotest.(check int32) msg n)
+        "UInt32.of_int32 %ld round-trips" n
+        (UInt32.to_int32 (UInt32.of_int32 n)))
+    Int32.[ min_int; minus_one; zero; one; max_int ]
 
 (* An 8-byte field spans 2^64 wire patterns and the generated C validator hands
    every one of them on unchanged, so the OCaml side must too. A carrier that
@@ -4673,7 +4687,7 @@ let test_raw_with_offset () =
     (Wire.Private.UInt32.of_int32 0xDEADBEEFl);
   Alcotest.(check int32)
     "get at offset 10" 0xDEADBEEFl
-    (Optint.to_int32 ((Staged.unstage (Codec.get codec cf_v)) buf 10))
+    (UInt32.to_int32 ((Staged.unstage (Codec.get codec cf_v)) buf 10))
 
 (* -- Dependent-size byte_slice tests -- *)
 
@@ -5256,6 +5270,8 @@ let test_bitfield_load_shared () =
   let wa = load_a buf 0 in
   let wb = load_b buf 0 in
   (* Same base word, same value *)
+  (* [Codec.load_word] hands back the bitfield's raw base word, an [Optint.t],
+     not a uint32 field value. *)
   Alcotest.check (Alcotest.testable Optint.pp Optint.equal) "same word" wa wb;
   let a = Codec.extract a wa in
   let b = Codec.extract b wa in
@@ -5745,7 +5761,7 @@ let test_optional_codec_absent () =
 
 (* Multiple optional fields (TM frame pattern) *)
 
-type multi_opt = { data : int; ocf : Optint.t option; fecf : int option }
+type multi_opt = { data : int; ocf : UInt32.t option; fecf : int option }
 
 let multi_opt_codec ~ocf ~fecf =
   Codec.v "MultiOpt"
@@ -5771,7 +5787,7 @@ let test_optional_both_present () =
   Alcotest.(check int) "data" 0x1111 r.data;
   Alcotest.(check (option int))
     "ocf" (Some 0x22222222)
-    (Option.map Optint.to_int r.ocf);
+    (Option.map UInt32.to_int r.ocf);
   Alcotest.(check (option int)) "fecf" (Some 0x3333) r.fecf
 
 let test_optional_both_absent () =
@@ -5781,7 +5797,7 @@ let test_optional_both_absent () =
   Bytes.set_uint16_be buf 0 0x1111;
   let r = decode_ok (Codec.decode c buf 0) in
   Alcotest.(check int) "data" 0x1111 r.data;
-  Alcotest.(check (option int)) "ocf" None (Option.map Optint.to_int r.ocf);
+  Alcotest.(check (option int)) "ocf" None (Option.map UInt32.to_int r.ocf);
   Alcotest.(check (option int)) "fecf" None r.fecf
 
 let test_optional_mixed () =
@@ -5794,7 +5810,7 @@ let test_optional_mixed () =
   Alcotest.(check int) "data" 0x1111 r.data;
   Alcotest.(check (option int))
     "ocf" (Some 0x22222222)
-    (Option.map Optint.to_int r.ocf);
+    (Option.map UInt32.to_int r.ocf);
   Alcotest.(check (option int)) "fecf" None r.fecf
 
 (* Dynamic optional: presence determined by a previously-parsed field. *)
@@ -5910,7 +5926,7 @@ let test_encode_totality () =
 type tm_opt = {
   ocf_flag : bool;
   data : int;
-  ocf : Optint.t option;
+  ocf : UInt32.t option;
   trail : int;
 }
 
@@ -5942,7 +5958,7 @@ let test_dyn_opt_anyref_present () =
   Alcotest.(check int) "data" 0x1234 r.data;
   Alcotest.(check (option int32))
     "ocf" (Some 0xDEADBEEFl)
-    (Option.map Optint.to_int32 r.ocf);
+    (Option.map UInt32.to_int32 r.ocf);
   Alcotest.(check int) "trail" 0xFF r.trail
 
 let test_dyn_opt_anyref_absent () =
@@ -5953,7 +5969,7 @@ let test_dyn_opt_anyref_absent () =
   let r = decode_ok (Codec.decode tm_opt_codec buf 0) in
   Alcotest.(check bool) "ocf_flag" false r.ocf_flag;
   Alcotest.(check int) "data" 0x1234 r.data;
-  Alcotest.(check (option int)) "ocf" None (Option.map Optint.to_int r.ocf);
+  Alcotest.(check (option int)) "ocf" None (Option.map UInt32.to_int r.ocf);
   Alcotest.(check int) "trail" 0xFF r.trail
 
 (* -- Predicates with bitwise/shift/mod operators in [optional] --
@@ -6300,7 +6316,7 @@ let test_repeat_variable_size_elements () =
 
 (* -- Casetype as a trailing variable-size codec field -- *)
 
-type ev_payload = [ `Login of int | `Logout of Optint.t | `Other of int ]
+type ev_payload = [ `Login of int | `Logout of UInt32.t | `Other of int ]
 
 let casetype_field_event_typ : ev_payload Wire.typ =
   Wire.casetype "EvPayload" Wire.uint8
@@ -6344,7 +6360,7 @@ let test_casetype_field_logout () =
   let r = decode_ok (Codec.decode casetype_field_codec buf 0) in
   Alcotest.(check bool)
     "Logout" true
-    (r.data = `Logout (Optint.of_int32 0x55667788l))
+    (r.data = `Logout (UInt32.of_int32 0x55667788l))
 
 let test_casetype_field_default () =
   let buf = Bytes.create 10 in
@@ -6467,7 +6483,7 @@ type tm_like = {
   hdr : int;
   data_len : int;
   packets : packet list;
-  ocf : Optint.t option;
+  ocf : UInt32.t option;
   fecf : int option;
 }
 
@@ -6515,7 +6531,7 @@ let test_tm_like_full () =
   Alcotest.(check int) "pkt1.id" 0x02 (List.nth r.packets 1).id;
   Alcotest.(check (option int))
     "ocf" (Some 0x33333333)
-    (Option.map Optint.to_int r.ocf);
+    (Option.map UInt32.to_int r.ocf);
   Alcotest.(check (option int)) "fecf" (Some 0x4444) r.fecf
 
 let test_tm_like_no_trailing () =
@@ -6528,7 +6544,7 @@ let test_tm_like_no_trailing () =
   Bytes.set_uint16_be buf 4 0x1111;
   let r = decode_ok (Codec.decode c buf 0) in
   Alcotest.(check int) "packet count" 1 (List.length r.packets);
-  Alcotest.(check (option int)) "ocf" None (Option.map Optint.to_int r.ocf);
+  Alcotest.(check (option int)) "ocf" None (Option.map UInt32.to_int r.ocf);
   Alcotest.(check (option int)) "fecf" None r.fecf
 
 let test_tm_like_roundtrip () =
@@ -6559,8 +6575,8 @@ let test_tm_like_roundtrip () =
     original.packets decoded.packets;
   Alcotest.(check (option int32))
     "ocf"
-    (Option.map Optint.to_int32 original.ocf)
-    (Option.map Optint.to_int32 decoded.ocf);
+    (Option.map UInt32.to_int32 original.ocf)
+    (Option.map UInt32.to_int32 decoded.ocf);
   Alcotest.(check (option int)) "fecf" original.fecf decoded.fecf
 
 (* -- Multiple consecutive variable-size fields (CFDP-style) --
@@ -6695,7 +6711,7 @@ let test_multi_var_fixed_after () =
 
 module Slice = Bytesrw.Bytes.Slice
 
-type ssh_string = { len : Optint.t; data : Slice.t }
+type ssh_string = { len : UInt32.t; data : Slice.t }
 
 let ssh_f_len = Field.v "len" uint32be
 let ssh_f_data = Field.v "data" (byte_slice ~size:(Field.ref ssh_f_len))
@@ -6708,7 +6724,7 @@ let ssh_string_codec =
 let mk_ssh_string s =
   let b = Bytes.of_string s in
   {
-    len = Optint.of_int (String.length s);
+    len = UInt32.of_int (String.length s);
     data = Slice.make b ~first:0 ~length:(Bytes.length b);
   }
 
@@ -6725,19 +6741,19 @@ let test_ssh_two_var_slices () =
       (fun reason _ desc _ lang -> (reason, desc, lang))
       [
         (f_reason $ fun (r, _, _) -> r);
-        (f_desc_len $ fun (_, d, _) -> Optint.of_int (Slice.length d));
+        (f_desc_len $ fun (_, d, _) -> UInt32.of_int (Slice.length d));
         (f_desc $ fun (_, d, _) -> d);
-        (f_lang_len $ fun (_, _, l) -> Optint.of_int (Slice.length l));
+        (f_lang_len $ fun (_, _, l) -> UInt32.of_int (Slice.length l));
         (f_lang $ fun (_, _, l) -> l);
       ]
   in
   let v =
-    (Optint.of_int 11, (mk_ssh_string "bye").data, (mk_ssh_string "en-US").data)
+    (UInt32.of_int 11, (mk_ssh_string "bye").data, (mk_ssh_string "en-US").data)
   in
   let buf = Bytes.create 200 in
   Codec.encode codec v buf 0;
   let r, d, l = decode_ok (Codec.decode codec buf 0) in
-  Alcotest.(check int) "reason" 11 (Optint.to_int r);
+  Alcotest.(check int) "reason" 11 (UInt32.to_int r);
   Alcotest.(check string) "desc" "bye" (Slice.to_string d);
   Alcotest.(check string) "lang" "en-US" (Slice.to_string l)
 
@@ -6754,9 +6770,9 @@ let test_two_var_codecs_embedded () =
   let buf = Bytes.create 200 in
   Codec.encode pair_codec v buf 0;
   let a, b = decode_ok (Codec.decode pair_codec buf 0) in
-  Alcotest.(check int) "a.len" 4 (Optint.to_int a.len);
+  Alcotest.(check int) "a.len" 4 (UInt32.to_int a.len);
   Alcotest.(check string) "a.data" "abcd" (Slice.to_string a.data);
-  Alcotest.(check int) "b.len" 2 (Optint.to_int b.len);
+  Alcotest.(check int) "b.len" 2 (UInt32.to_int b.len);
   Alcotest.(check string) "b.data" "xy" (Slice.to_string b.data)
 
 let test_three_var_codecs_embedded () =
@@ -8906,7 +8922,8 @@ let suite =
         test_encode_exact_unsigned_scalar;
       Alcotest.test_case "exact width: signed scalars" `Quick
         test_encode_exact_signed_scalar;
-      Alcotest.test_case "exact width: uint32" `Quick test_encode_exact_uint32;
+      Alcotest.test_case "exact width: UInt32.of_int range" `Quick
+        test_uint32_of_int_range;
       Alcotest.test_case "exact width: int64 carrier has no range" `Quick
         test_encode_int64_carrier_has_no_range;
       Alcotest.test_case "8-byte unsigned fields preserve the wire" `Quick

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -908,7 +908,7 @@ type tm_like = {
   hdr : int;
   data_len : int;
   packets : packet list;
-  ocf : Optint.t option;
+  ocf : UInt32.t option;
   fecf : int option;
 }
 

--- a/test/test_uint32.ml
+++ b/test/test_uint32.ml
@@ -55,6 +55,23 @@ let test_boundaries () =
       check_roundtrip "be" ~set:UInt32.set_be ~get:UInt32.be v)
     [ 0x0l; 0x1l; 0xFFFFl; 0x1_0000l; 0x7FFF_FFFFl; 0x8000_0000l; 0xFFFF_FFFFl ]
 
+(* [UInt32.compare] is the order of the field, which is unsigned: 0xFFFFFFFF is
+   its largest value. The carrier does not agree on every target. Where the
+   native [int] is narrower than 32 bits [Optint] is [include Int32], so an
+   inherited comparison is signed and puts 0xFFFFFFFF below 1, reversing the
+   order under wasm_of_ocaml while staying right on native. *)
+let test_compare_is_unsigned () =
+  let u = UInt32.of_int32 in
+  let gt name a b =
+    Alcotest.(check bool) name true (UInt32.compare (u a) (u b) > 0)
+  in
+  gt "0xFFFFFFFF > 1" 0xFFFF_FFFFl 1l;
+  gt "0xFFFFFFFF > 0x7FFFFFFF" 0xFFFF_FFFFl 0x7FFF_FFFFl;
+  gt "0x80000000 > 0x7FFFFFFF" 0x8000_0000l 0x7FFF_FFFFl;
+  gt "0x80000000 > 0" 0x8000_0000l 0l;
+  Alcotest.(check bool) "0 < 1" true (UInt32.compare (u 0l) (u 1l) < 0);
+  Alcotest.(check bool) "equal" true (UInt32.equal (u 42l) (u 42l))
+
 let suite =
   ( "uint32",
     [
@@ -64,4 +81,5 @@ let suite =
       Alcotest.test_case "byte layout" `Quick test_byte_layout;
       Alcotest.test_case "high bit preserved" `Quick test_high_bit;
       Alcotest.test_case "boundaries" `Quick test_boundaries;
+      Alcotest.test_case "compare is unsigned" `Quick test_compare_is_unsigned;
     ] )

--- a/test/test_uint32.ml
+++ b/test/test_uint32.ml
@@ -16,14 +16,22 @@ let test_roundtrip_le () =
 let test_roundtrip_be () =
   check_roundtrip "be roundtrip" ~set:UInt32.set_be ~get:UInt32.be 0xCAFE_BABEl
 
-let test_of_int_masks () =
-  Alcotest.(check int) "mask" 0xFF (UInt32.to_int (UInt32.of_int 0xFF));
+let test_of_int_refuses_out_of_range () =
+  Alcotest.(check int) "in range" 0xFF (UInt32.to_int (UInt32.of_int 0xFF));
   Alcotest.(check int) "identity" 42 (UInt32.to_int (UInt32.of_int 42));
-  (* The mask keeps the low 32 bits on every int width: [-1] is the u32
-     all-ones there, and the no-op mask where the int is narrower. *)
+  (* [-1] used to become the all-ones uint32. Turning a number the field cannot
+     hold into a legal one is the coercion this refuses; reinterpreting a bit
+     pattern is what [of_int32] is for. *)
   Alcotest.(check int32)
-    "of_int (-1) is all-ones" (-1l)
-    (UInt32.to_int32 (UInt32.of_int (-1)));
+    "of_int32 (-1) is all-ones" (-1l)
+    (UInt32.to_int32 (UInt32.of_int32 (-1l)));
+  if Sys.int_size > 32 then
+    List.iter
+      (fun n ->
+        match UInt32.of_int n with
+        | v -> Alcotest.failf "of_int %d built %a" n UInt32.pp v
+        | exception Invalid_argument _ -> ())
+      [ -1; UInt32.mask32 + 1; max_int; min_int ];
   Alcotest.(check int64)
     "mask32 low 32 bits" 0xFFFF_FFFFL
     (Int64.logand (Int64.of_int UInt32.mask32) 0xFFFF_FFFFL)
@@ -77,7 +85,8 @@ let suite =
     [
       Alcotest.test_case "roundtrip le" `Quick test_roundtrip_le;
       Alcotest.test_case "roundtrip be" `Quick test_roundtrip_be;
-      Alcotest.test_case "of_int masks" `Quick test_of_int_masks;
+      Alcotest.test_case "of_int refuses out of range" `Quick
+        test_of_int_refuses_out_of_range;
       Alcotest.test_case "byte layout" `Quick test_byte_layout;
       Alcotest.test_case "high bit preserved" `Quick test_high_bit;
       Alcotest.test_case "boundaries" `Quick test_boundaries;

--- a/test/test_wire.ml
+++ b/test/test_wire.ml
@@ -65,13 +65,13 @@ let test_parse_uint16_be () =
 let test_parse_uint32_le () =
   let input = "\x01\x02\x03\x04" in
   match of_string uint32 input with
-  | Ok v -> Alcotest.(check int) "uint32 le value" 0x04030201 (Optint.to_int v)
+  | Ok v -> Alcotest.(check int) "uint32 le value" 0x04030201 (UInt32.to_int v)
   | Error e -> Alcotest.failf "%a" pp_parse_error e
 
 let test_parse_uint32_be () =
   let input = "\x01\x02\x03\x04" in
   match of_string uint32be input with
-  | Ok v -> Alcotest.(check int) "uint32 be value" 0x01020304 (Optint.to_int v)
+  | Ok v -> Alcotest.(check int) "uint32 be value" 0x01020304 (UInt32.to_int v)
   | Error e -> Alcotest.failf "%a" pp_parse_error e
 
 let test_parse_uint64_le () =
@@ -702,11 +702,11 @@ let test_encode_uint16_be () =
   Alcotest.(check string) "uint16 be encoding" "\x01\x02" encoded
 
 let test_encode_uint32_le () =
-  let encoded = to_string uint32 (Optint.of_int 0x04030201) in
+  let encoded = to_string uint32 (UInt32.of_int 0x04030201) in
   Alcotest.(check string) "uint32 le encoding" "\x01\x02\x03\x04" encoded
 
 let test_encode_uint32_be () =
-  let encoded = to_string uint32be (Optint.of_int 0x01020304) in
+  let encoded = to_string uint32be (UInt32.of_int 0x01020304) in
   Alcotest.(check string) "uint32 be encoding" "\x01\x02\x03\x04" encoded
 
 let test_encode_array () =
@@ -966,8 +966,8 @@ let test_roundtrip_uint16 () =
 
 let test_roundtrip_uint32 () =
   roundtrip "roundtrip uint32" uint32
-    (Alcotest.testable Optint.pp Optint.equal)
-    (Optint.of_int 0x12345678)
+    (Alcotest.testable UInt32.pp UInt32.equal)
+    (UInt32.of_int 0x12345678)
 
 let test_roundtrip_array () =
   roundtrip "roundtrip array"
@@ -1097,14 +1097,14 @@ let test_stream_uint32_chunk1 () =
   let encoded = to_string uint32 (Wire.Private.UInt32.of_int32 0xDEADBEEFl) in
   match parse_chunked ~chunk_size:1 uint32 encoded with
   | Ok v ->
-      Alcotest.(check int32) "uint32 chunk=1" 0xDEADBEEFl (Optint.to_int32 v)
+      Alcotest.(check int32) "uint32 chunk=1" 0xDEADBEEFl (UInt32.to_int32 v)
   | Error e -> Alcotest.failf "uint32 chunk=1: %a" pp_parse_error e
 
 let test_stream_uint32_chunk3 () =
   (* chunk=3: 4-byte value straddles at byte 3 *)
-  let encoded = to_string uint32be (Optint.of_int 0x12345678) in
+  let encoded = to_string uint32be (UInt32.of_int 0x12345678) in
   match parse_chunked ~chunk_size:3 uint32be encoded with
-  | Ok v -> Alcotest.(check int) "uint32be chunk=3" 0x12345678 (Optint.to_int v)
+  | Ok v -> Alcotest.(check int) "uint32be chunk=3" 0x12345678 (UInt32.to_int v)
   | Error e -> Alcotest.failf "uint32be chunk=3: %a" pp_parse_error e
 
 let test_stream_uint64_chunk1 () =
@@ -1166,7 +1166,7 @@ let test_stream_rewind_partial_fixed () =
   let reader = Bytesrw.Bytes.Reader.of_string ~slice_length:1 "\x01\x02\x03" in
   (match Wire.of_reader uint32be reader with
   | Error { kind = Unexpected_eof _; _ } -> ()
-  | Ok v -> Alcotest.failf "expected eof, got %d" (Optint.to_int v)
+  | Ok v -> Alcotest.failf "expected eof, got %d" (UInt32.to_int v)
   | Error e -> Alcotest.failf "expected Unexpected_eof: %a" pp_parse_error e);
   Alcotest.(check int) "rewound" 0x0102 (reader_decode_ok uint16be reader);
   Alcotest.(check int) "rest intact" 0x03 (reader_decode_ok uint8 reader)
@@ -1206,15 +1206,15 @@ let test_stream_encode_chunk1 () =
   in
   match of_string uint32be encoded with
   | Ok decoded ->
-      Alcotest.(check int32) "encode chunk=1" v (Optint.to_int32 decoded)
+      Alcotest.(check int32) "encode chunk=1" v (UInt32.to_int32 decoded)
   | Error e -> Alcotest.failf "encode chunk=1: %a" pp_parse_error e
 
 let test_stream_encode_chunk3 () =
   let v = 0x12345678 in
-  let encoded = encode_chunked ~chunk_size:3 uint32be (Optint.of_int v) in
+  let encoded = encode_chunked ~chunk_size:3 uint32be (UInt32.of_int v) in
   match of_string uint32be encoded with
   | Ok decoded ->
-      Alcotest.(check int) "encode chunk=3" v (Optint.to_int decoded)
+      Alcotest.(check int) "encode chunk=3" v (UInt32.to_int decoded)
   | Error e -> Alcotest.failf "encode chunk=3: %a" pp_parse_error e
 
 (* An open enum accepts any value, named or not. The typ-level [of_string] path


### PR DESCRIPTION
A decoded `uint32` was an `Optint.t`, and where the native `int` is narrower than the field `Optint` is `Int32`, whose comparison is signed: it ranked `0xFFFFFFFF`, the largest `uint32`, below `1` under js_of_ocaml and wasm_of_ocaml. The type is now abstract with an unsigned `compare`, and exported as `Wire.UInt32` alongside `Wire.SInt32` rather than living under `Wire.Private`.

`of_int` refuses an out-of-range number instead of masking it, matching `SInt32.of_int`, which makes an out-of-range `uint32` unconstructible. Follow-up to #321.