### PR TITLE
types: carry uint64 in a module of its own and order it unsigned

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ### Added
 
+- Add `Wire.UInt64`, the unsigned 64-bit carrier behind `uint64` and `uint64be`
+  (#323, @samoht)
+
 - Add `Wire.UInt32`, the unsigned 32-bit carrier behind `uint32` and `uint32be`.
   It was reachable before only as `Wire.Private.UInt32`, with `Optint.t` as the
   public type (#322, @samoht)
@@ -45,6 +48,13 @@
   (#263, @samoht)
 
 ### Changed
+
+- **Breaking:** `uint64` and `uint64be` decode to an abstract `Wire.UInt64.t`
+  rather than `int64`, so an unsigned field can no longer be read where a signed
+  one is expected. Convert with `Wire.UInt64.to_int64` and build with
+  `of_int64`. `Wire.Field.int64` now accepts a field of any type carrying a
+  64-bit slot, which is the set it already checked for at run time (#323,
+  @samoht)
 
 - **Breaking:** `uint32` and `uint32be` decode to an abstract `Wire.UInt32.t`
   rather than `Optint.t`, and `Wire.UInt32.of_int` refuses a number outside the
@@ -138,6 +148,10 @@
   follow as `<Base>CheckWire<Name>` (#235, @samoht)
 
 ### Fixed
+
+- `uint64` values now order as unsigned numbers. The carrier was `int64`, whose
+  comparison reads the top bit as a sign and so ranked
+  0xFFFF_FFFF_FFFF_FFFF, the largest `uint64`, below zero (#323, @samoht)
 
 - `uint32` values now order as unsigned numbers on every target. The carrier was
   `Optint.t`, which is `Int32` where the native `int` is narrower than the

--- a/bench/demo/demo_bench_cases.ml
+++ b/bench/demo/demo_bench_cases.ml
@@ -61,7 +61,7 @@ type write_case = { label : string; run : unit -> unit; verify : unit -> unit }
 
 let of_int f = Int f
 let id_int = Int Fun.id
-let id_int64 = Int64 Fun.id
+let id_uint64 = Int64 Wire.UInt64.of_int64
 let bool_of_int = Int (fun v -> v <> 0)
 
 let priority_decode =
@@ -251,10 +251,10 @@ let all_ints_case =
       set;
       write_template = Bytes.copy ints_dataset.items.(0);
       write_offset = 0;
-      write_value = 0x0102_0304_0506_0708L;
-      equal = Int64.equal;
+      write_value = Wire.UInt64.of_int64 0x0102_0304_0506_0708L;
+      equal = Wire.UInt64.equal;
       bench_read = true;
-      of_c_field = id_int64;
+      of_c_field = id_uint64;
     }
 
 let large_mixed_case =
@@ -276,10 +276,10 @@ let large_mixed_case =
       set;
       write_template = Bytes.copy mixed_dataset.items.(0);
       write_offset = 0;
-      write_value = 0x1122_3344_5566_7788L;
-      equal = Int64.equal;
+      write_value = Wire.UInt64.of_int64 0x1122_3344_5566_7788L;
+      equal = Wire.UInt64.equal;
       bench_read = true;
-      of_c_field = id_int64;
+      of_c_field = id_uint64;
     }
 
 let bitfield8_case =

--- a/bench/demo/demo_bench_cases.mli
+++ b/bench/demo/demo_bench_cases.mli
@@ -50,10 +50,10 @@ type write_case = { label : string; run : unit -> unit; verify : unit -> unit }
 val minimal_case : int read_case
 (** Minimal 1-byte uint8 schema. *)
 
-val all_ints_case : int64 read_case
+val all_ints_case : Wire.UInt64.t read_case
 (** All integer widths, projecting u64be. *)
 
-val large_mixed_case : int64 read_case
+val large_mixed_case : Wire.UInt64.t read_case
 (** Large mixed-field struct, projecting a uint64be timestamp. *)
 
 val bitfield8_case : int read_case

--- a/examples/demo/demo.ml
+++ b/examples/demo/demo.ml
@@ -39,7 +39,7 @@ type all_ints = {
   u16be : int;
   u32 : UInt32.t;
   u32be : UInt32.t;
-  u64be : int64;
+  u64be : UInt64.t;
 }
 
 let f_ints_u64be = Field.v "U64BE" uint64be
@@ -68,7 +68,7 @@ let all_ints_default =
     u16be = 0x5678;
     u32 = UInt32.of_int 0xDEADBEEF;
     u32be = UInt32.of_int 0xCAFEBABE;
-    u64be = 0x0102030405060708L;
+    u64be = UInt64.of_int64 0x0102030405060708L;
   }
 
 let all_ints_data n =
@@ -211,7 +211,7 @@ type large_mixed = {
   offset : int;
   length : int;
   crc : UInt32.t;
-  timestamp : int64;
+  timestamp : UInt64.t;
 }
 
 let f_mixed_timestamp = Field.v "Timestamp" uint64be
@@ -260,7 +260,7 @@ let large_mixed_default =
     offset = 16;
     length = 1024;
     crc = UInt32.of_int 0xDEADBEEF;
-    timestamp = 0x0102030405060708L;
+    timestamp = UInt64.of_int64 0x0102030405060708L;
   }
 
 let large_mixed_data n =

--- a/examples/demo/demo.mli
+++ b/examples/demo/demo.mli
@@ -33,16 +33,16 @@ type all_ints = {
   u16be : int;
   u32 : Wire.UInt32.t;
   u32be : Wire.UInt32.t;
-  u64be : int64;
+  u64be : Wire.UInt64.t;
 }
 
 val all_ints_codec : all_ints Wire.Codec.t
 (** Codec covering all integer widths and endiannesses. *)
 
-val f_ints_u64be : int64 Wire.Field.t
+val f_ints_u64be : Wire.UInt64.t Wire.Field.t
 (** Zero-copy field accessor for the U64BE field (boxed int64). *)
 
-val bf_ints_u64be : (int64, all_ints) Wire.Codec.field
+val bf_ints_u64be : (Wire.UInt64.t, all_ints) Wire.Codec.field
 (** Bound field for Codec.get/set on U64BE. *)
 
 val all_ints_struct : Wire.Everparse.Raw.struct_
@@ -171,17 +171,17 @@ type large_mixed = {
   offset : int;
   length : int;
   crc : Wire.UInt32.t;
-  timestamp : int64;
+  timestamp : Wire.UInt64.t;
 }
 
 val large_mixed_codec : large_mixed Wire.Codec.t
 (** Codec mixing uint8/16/32/64 and bitfield groups. *)
 
-val f_mixed_timestamp : int64 Wire.Field.t
+val f_mixed_timestamp : Wire.UInt64.t Wire.Field.t
 (** Zero-copy field accessor for the Timestamp field (uint64be, last of 10
     fields). *)
 
-val bf_mixed_timestamp : (int64, large_mixed) Wire.Codec.field
+val bf_mixed_timestamp : (Wire.UInt64.t, large_mixed) Wire.Codec.field
 (** Bound field for Codec.get/set on Timestamp. *)
 
 val large_mixed_struct : Wire.Everparse.Raw.struct_

--- a/fuzz/gen/fuzz_gen.ml
+++ b/fuzz/gen/fuzz_gen.ml
@@ -246,6 +246,13 @@ let scalar_int ?hostile typ size value_gen boundaries =
 (* [uint64] and [int64] are carried in an [int64], which is exactly the eight
    bytes written: every value of it is in range, so there is no hostile value to
    draw and no guard for one to exercise. *)
+(* [uint64] is carried in a [Wire.UInt64.t]. Like [scalar_int64] every bit
+   pattern is a legal value, so there is no hostile value to draw; it needs its
+   own equality because the carrier is abstract. *)
+let scalar_uint64 typ size value_gen boundaries =
+  leaf ~equal:Wire.UInt64.equal ~typ ~value_gen ~random:(bytes_fixed size)
+    ~adversarial:(Alcobar.choose (List.map Alcobar.const boundaries))
+
 let scalar_int64 typ size value_gen boundaries =
   leaf ~equal:Int64.equal ~typ ~value_gen ~random:(bytes_fixed size)
     ~adversarial:(Alcobar.choose (List.map Alcobar.const boundaries))
@@ -303,8 +310,10 @@ let masked_u32 =
 
 let uint32 = scalar_optint Wire.uint32 4 masked_u32 u32_boundaries
 let uint32be = scalar_optint Wire.uint32be 4 masked_u32 u32_boundaries
-let uint64 = scalar_int64 Wire.uint64 8 Alcobar.int64 u64_boundaries_i64
-let uint64be = scalar_int64 Wire.uint64be 8 Alcobar.int64 u64_boundaries_i64
+let u64_value_gen = Alcobar.map Alcobar.[ Alcobar.int64 ] Wire.UInt64.of_int64
+let u64_boundaries = List.map Wire.UInt64.of_int64 u64_boundaries_i64
+let uint64 = scalar_uint64 Wire.uint64 8 u64_value_gen u64_boundaries
+let uint64be = scalar_uint64 Wire.uint64be 8 u64_value_gen u64_boundaries
 
 let int8 =
   scalar_int ~hostile:(outside_signed_width 8) Wire.int8 1 Alcobar.int8
@@ -755,6 +764,7 @@ let exact_cases ~typ ~equal cases =
 
 let exact_int typ cases = exact_cases ~typ ~equal:Int.equal cases
 let exact_int64 typ cases = exact_cases ~typ ~equal:Int64.equal cases
+let exact_uint64 typ cases = exact_cases ~typ ~equal:Wire.UInt64.equal cases
 let exact_optint typ cases = exact_cases ~typ ~equal:Wire.UInt32.equal cases
 let exact_sint32 typ cases = exact_cases ~typ ~equal:Wire.SInt32.equal cases
 
@@ -792,20 +802,24 @@ let uint32be_endian_edges =
       (Wire.UInt32.of_int 0xFFFFFFFF, bytes_of_octets [ 0xFF; 0xFF; 0xFF; 0xFF ]);
     ]
 
+let u64 = Wire.UInt64.of_int64
+
 let uint64_endian_edges =
-  exact_int64 Wire.uint64
+  exact_uint64 Wire.uint64
     [
-      ( 0x0123456789ABCDEFL,
+      ( u64 0x0123456789ABCDEFL,
         bytes_of_octets [ 0xEF; 0xCD; 0xAB; 0x89; 0x67; 0x45; 0x23; 0x01 ] );
-      (-2L, bytes_of_octets [ 0xFE; 0xFF; 0xFF; 0xFF; 0xFF; 0xFF; 0xFF; 0xFF ]);
+      ( u64 (-2L),
+        bytes_of_octets [ 0xFE; 0xFF; 0xFF; 0xFF; 0xFF; 0xFF; 0xFF; 0xFF ] );
     ]
 
 let uint64be_endian_edges =
-  exact_int64 Wire.uint64be
+  exact_uint64 Wire.uint64be
     [
-      ( 0x0123456789ABCDEFL,
+      ( u64 0x0123456789ABCDEFL,
         bytes_of_octets [ 0x01; 0x23; 0x45; 0x67; 0x89; 0xAB; 0xCD; 0xEF ] );
-      (-2L, bytes_of_octets [ 0xFF; 0xFF; 0xFF; 0xFF; 0xFF; 0xFF; 0xFF; 0xFE ]);
+      ( u64 (-2L),
+        bytes_of_octets [ 0xFF; 0xFF; 0xFF; 0xFF; 0xFF; 0xFF; 0xFF; 0xFE ] );
     ]
 
 let int16_endian_edges =
@@ -1506,7 +1520,7 @@ let self_int64 =
         let v = Int64.of_int n in
         let buf = Bytes.create 8 in
         Bytes.set_int64_be buf 0 v;
-        (v, buf))
+        (Wire.UInt64.of_int64 v, buf))
   in
   let adversarial =
     Alcobar.map
@@ -1522,7 +1536,7 @@ let self_int64 =
     positive;
     random = bytes_fixed 8;
     adversarial;
-    equal = Int64.equal;
+    equal = Wire.UInt64.equal;
     env = None;
     fields = [];
     adversarial_value = None;

--- a/fuzz/gen/fuzz_gen.mli
+++ b/fuzz/gen/fuzz_gen.mli
@@ -256,10 +256,10 @@ val uint32 : Wire.UInt32.t t
 val uint32be : Wire.UInt32.t t
 (** [uint32be] generates for {!Wire.uint32be}. *)
 
-val uint64 : int64 t
+val uint64 : Wire.UInt64.t t
 (** [uint64] generates for {!Wire.uint64}. *)
 
-val uint64be : int64 t
+val uint64be : Wire.UInt64.t t
 (** [uint64be] generates for {!Wire.uint64be}. *)
 
 val int8 : int t
@@ -427,7 +427,7 @@ val field_constraint : (int * int) t
 val field_int : (int * int) t
 (** [field_int] exercises {!Wire.Field.int} in a field self constraint. *)
 
-val self_int64 : int64 t
+val self_int64 : Wire.UInt64.t t
 (** [self_int64] exercises [Wire.Field.v ~self_int64] over a 64-bit field. *)
 
 val param_input : int t

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -193,11 +193,11 @@ and build_field_encoder_ctx : type a.
         off + 4
   | Uint64 Little ->
       fun _runtime buf off v ->
-        Bytes.set_int64_le buf off v;
+        UInt64.set_le buf off v;
         off + 8
   | Uint64 Big ->
       fun _runtime buf off v ->
-        Bytes.set_int64_be buf off v;
+        UInt64.set_be buf off v;
         off + 8
   | Int8 -> fun _runtime -> setter_off 1 Types.set_int8
   | Int16 Little -> fun _runtime -> setter_off 2 Types.set_int16_le
@@ -325,10 +325,8 @@ let rec build_field_reader_ctx : type a.
       fun _runtime buf base -> Bytes.get_uint16_be buf (base + field_off)
   | Uint32 Little -> fun _runtime buf base -> UInt32.le buf (base + field_off)
   | Uint32 Big -> fun _runtime buf base -> UInt32.be buf (base + field_off)
-  | Uint64 Little ->
-      fun _runtime buf base -> Bytes.get_int64_le buf (base + field_off)
-  | Uint64 Big ->
-      fun _runtime buf base -> Bytes.get_int64_be buf (base + field_off)
+  | Uint64 Little -> fun _runtime buf base -> UInt64.le buf (base + field_off)
+  | Uint64 Big -> fun _runtime buf base -> UInt64.be buf (base + field_off)
   | Int8 -> fun _runtime buf base -> Bytes.get_int8 buf (base + field_off)
   | Int16 Little ->
       fun _runtime buf base -> Bytes.get_int16_le buf (base + field_off)
@@ -425,8 +423,8 @@ let rec build_immediate_reader : type a.
   | Uint16 Big -> Some (fun buf base -> Bytes.get_uint16_be buf (at base))
   | Uint32 Little -> Some (fun buf base -> UInt32.le buf (at base))
   | Uint32 Big -> Some (fun buf base -> UInt32.be buf (at base))
-  | Uint64 Little -> Some (fun buf base -> Bytes.get_int64_le buf (at base))
-  | Uint64 Big -> Some (fun buf base -> Bytes.get_int64_be buf (at base))
+  | Uint64 Little -> Some (fun buf base -> UInt64.le buf (at base))
+  | Uint64 Big -> Some (fun buf base -> UInt64.be buf (at base))
   | Int8 -> Some (fun buf base -> Bytes.get_int8 buf (at base))
   | Int16 Little -> Some (fun buf base -> Bytes.get_int16_le buf (at base))
   | Int16 Big -> Some (fun buf base -> Bytes.get_int16_be buf (at base))
@@ -476,8 +474,8 @@ let rec build_immediate_encoder : type a.
   | Uint16 Big -> Some (setter_off 2 Types.set_uint16_be)
   | Uint32 Little -> Some (setter_off 4 UInt32.set_le)
   | Uint32 Big -> Some (setter_off 4 UInt32.set_be)
-  | Uint64 Little -> Some (setter_off 8 Bytes.set_int64_le)
-  | Uint64 Big -> Some (setter_off 8 Bytes.set_int64_be)
+  | Uint64 Little -> Some (setter_off 8 UInt64.set_le)
+  | Uint64 Big -> Some (setter_off 8 UInt64.set_be)
   | Int8 -> Some (setter_off 1 Types.set_int8)
   | Int16 Little -> Some (setter_off 2 Types.set_int16_le)
   | Int16 Big -> Some (setter_off 2 Types.set_int16_be)
@@ -657,8 +655,8 @@ let rec build_populate : type a.
   | Uint64 _ ->
       fun slots runtime buf base ->
         let v = reader runtime buf base in
-        set_int64_slot slots idx v;
-        Option.iter (set_int_slot slots idx) (Int64.unsigned_to_int v)
+        set_int64_slot slots idx (UInt64.to_int64 v);
+        Option.iter (set_int_slot slots idx) (UInt64.to_int_opt v)
   | Int64 _ ->
       fun slots runtime buf base ->
         let v = reader runtime buf base in
@@ -1667,8 +1665,8 @@ let rec read_elem : type a. a typ -> runtime -> bytes -> int -> a =
   | Uint16 Big -> Bytes.get_uint16_be buf off
   | Uint32 Little -> UInt32.le buf off
   | Uint32 Big -> UInt32.be buf off
-  | Uint64 Little -> Bytes.get_int64_le buf off
-  | Uint64 Big -> Bytes.get_int64_be buf off
+  | Uint64 Little -> UInt64.le buf off
+  | Uint64 Big -> UInt64.be buf off
   | Int8 -> Bytes.get_int8 buf off
   | Int16 Little -> Bytes.get_int16_le buf off
   | Int16 Big -> Bytes.get_int16_be buf off
@@ -1772,8 +1770,8 @@ let rec write_elem : type a. a typ -> runtime -> bytes -> int -> a -> unit =
   | Uint16 Big -> Types.set_uint16_be buf off v
   | Uint32 Little -> UInt32.set_le buf off v
   | Uint32 Big -> UInt32.set_be buf off v
-  | Uint64 Little -> Bytes.set_int64_le buf off v
-  | Uint64 Big -> Bytes.set_int64_be buf off v
+  | Uint64 Little -> UInt64.set_le buf off v
+  | Uint64 Big -> UInt64.set_be buf off v
   | Int8 -> Types.set_int8 buf off v
   | Int16 Little -> Types.set_int16_le buf off v
   | Int16 Big -> Types.set_int16_be buf off v

--- a/lib/eval.ml
+++ b/lib/eval.ml
@@ -43,7 +43,7 @@ let rec int_of : type a. a typ -> a -> int option =
      conversion returns [None] exactly then and is identity-exact on a 64-bit
      host. *)
   | Uint32 _ -> Int32.unsigned_to_int (UInt32.to_int32 v)
-  | Uint64 _ -> Int64.unsigned_to_int v
+  | Uint64 _ -> UInt64.to_int_opt v
   | Int8 -> Some v
   | Int16 _ -> Some v
   | Int32 _ -> SInt32.to_int_opt v
@@ -96,7 +96,9 @@ let rec int_of_exn : type a. a typ -> a -> int =
             int_overflow
               (Int64.logand (Int64.of_int32 (UInt32.to_int32 v)) 0xFFFF_FFFFL))
   | Uint64 _ -> (
-      match Int64.unsigned_to_int v with Some n -> n | None -> int_overflow v)
+      match UInt64.to_int_opt v with
+      | Some n -> n
+      | None -> int_overflow (UInt64.to_int64 v))
   | Int8 -> v
   | Int16 _ -> v
   | Int32 _ -> (

--- a/lib/field.mli
+++ b/lib/field.mli
@@ -112,9 +112,12 @@ val ref : 'a t -> int Types.expr
 val int : 'a t -> int Types.expr
 (** [int f] returns this field as a native-integer expression. *)
 
-val int64 : int64 t -> int64 Types.expr
+val int64 : 'a t -> int64 Types.expr
 (** [int64 f] returns the expression referencing this field's full 64-bit value,
-    without truncating to OCaml's native integer range. *)
+    without truncating to OCaml's native integer range. Raises
+    [Invalid_argument] on a field with no 64-bit slot; the accepted set is the
+    one {!Types.has_int64_slot} names, which is wider than any single carrier
+    type ([uint64], [int64] and [float64] all have one). *)
 
 val name : 'a t -> string
 (** Field name. *)

--- a/lib/param.ml
+++ b/lib/param.ml
@@ -28,9 +28,8 @@ let rec int_cvt : type a. a Types.typ -> a int_cvt =
   | Uint32 _ -> { fwd = optint_to_int UInt32.to_int; bwd = UInt32.of_int }
   | Uint64 _ ->
       {
-        fwd =
-          (fun v -> Int64.unsigned_to_int v |> Option.value ~default:max_int);
-        bwd = Int64.of_int;
+        fwd = (fun v -> UInt64.to_int_opt v |> Option.value ~default:max_int);
+        bwd = UInt64.of_int;
       }
   | Int8 -> id
   | Int16 _ -> id

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -169,7 +169,7 @@ and _ typ =
   | Uint8 : int typ
   | Uint16 : endian -> int typ
   | Uint32 : endian -> UInt32.t typ
-  | Uint64 : endian -> int64 typ (* boxed, for full 64-bit *)
+  | Uint64 : endian -> UInt64.t typ (* boxed, for full 64-bit *)
   | Int8 : int typ
   | Int16 : endian -> int typ
   | Int32 : endian -> SInt32.t typ

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -275,7 +275,9 @@ and _ typ =
   | Uint8 : int typ  (** 8-bit unsigned. *)
   | Uint16 : endian -> int typ  (** 16-bit unsigned. *)
   | Uint32 : endian -> UInt32.t typ  (** 32-bit unsigned. *)
-  | Uint64 : endian -> int64 typ  (** 64-bit unsigned. *)
+  | Uint64 : endian -> UInt64.t typ
+      (** 64-bit unsigned. Carried by {!UInt64.t}, which orders as an unsigned
+          number; [int64] would rank the largest value below 1. *)
   | Int8 : int typ  (** 8-bit signed. *)
   | Int16 : endian -> int typ  (** 16-bit signed. *)
   | Int32 : endian -> SInt32.t typ
@@ -581,10 +583,10 @@ val uint32 : UInt32.t typ
 val uint32be : UInt32.t typ
 (** 32-bit unsigned, big-endian. *)
 
-val uint64 : int64 typ
+val uint64 : UInt64.t typ
 (** 64-bit unsigned, little-endian. *)
 
-val uint64be : int64 typ
+val uint64be : UInt64.t typ
 (** 64-bit unsigned, big-endian. *)
 
 val int8 : int typ

--- a/lib/uInt64.ml
+++ b/lib/uInt64.ml
@@ -1,6 +1,10 @@
 type t = int64
 
-let compare = Int64.compare
+(* Signed on the carrier, unsigned on the field: this is the whole reason the
+   type is abstract. [Int64.compare] reads the top bit as a sign and so ranks
+   0xFFFF_FFFF_FFFF_FFFF, the largest value here, below zero. Wrong on every
+   target, since nothing about the platform is involved. *)
+let compare = Int64.unsigned_compare
 let equal = Int64.equal
 let zero = 0L
 let max_int = -1L

--- a/lib/uInt64.ml
+++ b/lib/uInt64.ml
@@ -1,0 +1,24 @@
+type t = int64
+
+let compare = Int64.compare
+let equal = Int64.equal
+let zero = 0L
+let max_int = -1L
+let pp ppf v = Fmt.pf ppf "%Lu" v
+let le = Bytes.get_int64_le
+let be = Bytes.get_int64_be
+let set_le = Bytes.set_int64_le
+let set_be = Bytes.set_int64_be
+let to_int64 v = v
+let of_int64 v = v
+let to_int = Int64.to_int
+let to_int_opt = Int64.unsigned_to_int
+
+(* Refuses rather than reinterprets. A negative [int] spells a value above
+   2^63 as an unsigned 64-bit number, which is not what a caller writing a
+   negative literal meant; [of_int64] is where a bit pattern is reinterpreted
+   on purpose. *)
+let of_int n =
+  if n < 0 then
+    Fmt.invalid_arg "Wire.UInt64.of_int: %d is not an unsigned 64-bit value" n;
+  Int64.of_int n

--- a/lib/uInt64.mli
+++ b/lib/uInt64.mli
@@ -1,0 +1,66 @@
+(** Unsigned 64-bit integer.
+
+    Abstract, and deliberately not [int64] even though that is the carrier. An
+    8-byte field holds the same bits either way, but not the same order:
+    [Int64.compare] is signed, so it ranks 0xFFFF_FFFF_FFFF_FFFF, the largest
+    value here, below 1. Keeping the type opaque is what stops that comparison
+    being reached, and what stops an unsigned field being read where a signed
+    one is expected.
+
+    Unlike the narrower widths there is no range to enforce: the carrier is
+    exactly the eight bytes on the wire on every target, so every bit pattern is
+    a legal value and none is out of range. *)
+
+type t
+
+val pp : Format.formatter -> t -> unit
+(** Pretty-printer, in the unsigned reading. *)
+
+val zero : t
+(** [zero] is 0. *)
+
+val max_int : t
+(** [max_int] is 2{^ 64} - 1, the largest value an 8-byte unsigned field holds.
+*)
+
+val compare : t -> t -> int
+(** [compare a b] orders two values as unsigned 64-bit integers, so
+    0xFFFF_FFFF_FFFF_FFFF is the largest. *)
+(* TODO: this is [Int64.compare] for now, which is signed. *)
+
+val equal : t -> t -> bool
+(** [equal a b] is [true] when [a] and [b] are the same value. *)
+
+val le : bytes -> int -> t
+(** [le buf off] reads a little-endian value from [buf] at offset [off]. *)
+
+val be : bytes -> int -> t
+(** [be buf off] reads a big-endian value from [buf] at offset [off]. *)
+
+val set_le : bytes -> int -> t -> unit
+(** [set_le buf off v] writes [v] as little-endian into [buf] at offset [off].
+*)
+
+val set_be : bytes -> int -> t -> unit
+(** [set_be buf off v] writes [v] as big-endian into [buf] at offset [off]. *)
+
+val to_int64 : t -> int64
+(** [to_int64 t] is the value's bit pattern as an [int64]. Exact, but read as a
+    signed number: a value above 2{^ 63} - 1 comes back negative. *)
+
+val of_int64 : int64 -> t
+(** [of_int64 n] is the [int64] bit pattern as an unsigned 64-bit value: the
+    same value {!le} and {!be} decode those eight bytes to. *)
+
+val to_int : t -> int
+(** [to_int t] is the value as a native [int]. A value the [int] cannot hold is
+    truncated, so prefer {!to_int_opt} on any path that must not drop bits. *)
+
+val to_int_opt : t -> int option
+(** [to_int_opt t] is the value as a native [int], or [None] where that [int] is
+    too narrow to hold it. *)
+
+val of_int : int -> t
+(** [of_int n] is [n] as an unsigned 64-bit value. Raises [Invalid_argument] on
+    a negative [n], rather than reinterpreting it as the large value its two's
+    complement spells. Use {!of_int64} to reinterpret a bit pattern. *)

--- a/lib/uInt64.mli
+++ b/lib/uInt64.mli
@@ -26,7 +26,6 @@ val max_int : t
 val compare : t -> t -> int
 (** [compare a b] orders two values as unsigned 64-bit integers, so
     0xFFFF_FFFF_FFFF_FFFF is the largest. *)
-(* TODO: this is [Int64.compare] for now, which is signed. *)
 
 val equal : t -> t -> bool
 (** [equal a b] is [true] when [a] and [b] are the same value. *)

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -249,8 +249,8 @@ let rec parse_direct : type a. a typ -> bytes -> int -> int -> a * int =
   | Uint16 Big -> parse_fixed 2 Bytes.get_uint16_be buf off len
   | Uint32 Little -> parse_fixed 4 UInt32.le buf off len
   | Uint32 Big -> parse_fixed 4 UInt32.be buf off len
-  | Uint64 Little -> parse_fixed 8 Bytes.get_int64_le buf off len
-  | Uint64 Big -> parse_fixed 8 Bytes.get_int64_be buf off len
+  | Uint64 Little -> parse_fixed 8 UInt64.le buf off len
+  | Uint64 Big -> parse_fixed 8 UInt64.be buf off len
   | Int8 -> parse_fixed 1 Bytes.get_int8 buf off len
   | Int16 Little -> parse_fixed 2 Bytes.get_int16_le buf off len
   | Int16 Big -> parse_fixed 2 Bytes.get_int16_be buf off len
@@ -684,8 +684,8 @@ let rec encode_into : type a. a typ -> a -> encoder -> unit =
       write_uint16_be enc v
   | Uint32 Little -> write_uint32_le enc v
   | Uint32 Big -> write_uint32_be enc v
-  | Uint64 Little -> write_int64_le enc v
-  | Uint64 Big -> write_int64_be enc v
+  | Uint64 Little -> write_int64_le enc (UInt64.to_int64 v)
+  | Uint64 Big -> write_int64_be enc (UInt64.to_int64 v)
   | Int8 ->
       Types.check_signed_encode ~bits:8 v;
       write_int8 enc v
@@ -885,10 +885,10 @@ let rec encode_direct : type a. a typ -> bytes -> int -> a -> int =
       UInt32.set_be buf off v;
       off + 4
   | Uint64 Little ->
-      Bytes.set_int64_le buf off v;
+      UInt64.set_le buf off v;
       off + 8
   | Uint64 Big ->
-      Bytes.set_int64_be buf off v;
+      UInt64.set_be buf off v;
       off + 8
   | Uint_var { size = Int n; endian } ->
       Uint_var.write endian buf off n v;
@@ -951,6 +951,7 @@ let pp_value (type r) (c : r Codec.t) ppf (v : r) =
     readers;
   Fmt.pf ppf "@ }@]"
 
+module UInt64 = UInt64
 module SInt32 = SInt32
 module Ascii = Ascii
 

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -361,6 +361,13 @@ end
     Fields carry no buffer position -- that comes from the {!Codec} they are
     bound into. The same field can appear in multiple codecs. *)
 
+module UInt64 = UInt64
+(** Unsigned 64-bit integers, the carrier of {!uint64} and {!uint64be}.
+
+    Ordered as an unsigned number, which [int64] is not: [Int64.compare] ranks
+    0xFFFF_FFFF_FFFF_FFFF, the largest value here, below 1, on every target. The
+    carrier holds the eight bytes exactly, so there is no range to enforce. *)
+
 module UInt32 = UInt32
 (** Unsigned 32-bit integers, the carrier of {!uint32} and {!uint32be}.
 
@@ -505,7 +512,7 @@ module Field : sig
   val int : 'a t -> int expr
   (** [int f] returns this field as a native-integer expression. *)
 
-  val int64 : int64 t -> int64 expr
+  val int64 : 'a t -> int64 expr
   (** [int64 f] returns the expression referencing this field's full 64-bit
       value, without truncating to OCaml's native integer range. *)
 
@@ -568,12 +575,12 @@ val uint32 : UInt32.t typ
 val uint32be : UInt32.t typ
 (** Unsigned 32-bit big-endian integer. Encodes [0] to [2{^32} - 1]. *)
 
-val uint64 : int64 typ
+val uint64 : UInt64.t typ
 (** [uint64] is an unsigned 64-bit little-endian integer represented as an OCaml
     64-bit integer. The representation is exactly the eight bytes written, so
     every [int64] encodes and none is out of range. *)
 
-val uint64be : int64 typ
+val uint64be : UInt64.t typ
 (** [uint64be] is an unsigned 64-bit big-endian integer represented as an OCaml
     64-bit integer. *)
 

--- a/test/test.ml
+++ b/test/test.ml
@@ -9,6 +9,7 @@ let () =
       Test_ascii.suite;
       Test_staged.suite;
       Test_uint32.suite;
+      Test_uint64.suite;
       Test_sint32.suite;
       Test_uint63.suite;
       Test_types.suite;

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -1574,12 +1574,12 @@ let test_nested_over_array () =
           $ Fun.id;
         ]
   in
-  let v = [ 1L; 2L ] in
+  let v = List.map UInt64.of_int64 [ 1L; 2L ] in
   let buf = Bytes.create (Codec.size_of_value codec v) in
   Codec.encode codec v buf 0;
   Alcotest.(check bool)
     "roundtrip" true
-    (decode_ok (Codec.decode codec buf 0) = v)
+    (List.equal UInt64.equal (decode_ok (Codec.decode codec buf 0)) v)
 
 let test_nested_at_most_over_array () =
   let codec =
@@ -1592,12 +1592,12 @@ let test_nested_at_most_over_array () =
           $ Fun.id;
         ]
   in
-  let v = [ 7L; 9L ] in
+  let v = List.map UInt64.of_int64 [ 7L; 9L ] in
   let buf = Bytes.create (Codec.size_of_value codec v) in
   Codec.encode codec v buf 0;
   Alcotest.(check bool)
     "roundtrip" true
-    (decode_ok (Codec.decode codec buf 0) = v)
+    (List.equal UInt64.equal (decode_ok (Codec.decode codec buf 0)) v)
 
 let test_nested_exact_region () =
   let make name typ =
@@ -3127,22 +3127,23 @@ let test_element_exact_width () =
    no value of it is out of range and none may be refused. A guard here would be
    dead code that only ever rejected a legal frame. *)
 let test_encode_int64_carrier_has_no_range () =
-  List.iter
-    (fun (name, typ) ->
-      List.iter
-        (fun v ->
-          let s = Wire.to_string typ v in
-          Alcotest.(check int) (name ^ ": eight bytes") 8 (String.length s);
-          Alcotest.(check int64)
-            (Fmt.str "%s <- %Ld round-trips" name v)
-            v (Wire.of_string_exn typ s))
-        Int64.[ min_int; -1L; zero; max_int ])
-    [
-      ("uint64", uint64);
-      ("uint64be", uint64be);
-      ("int64", int64);
-      ("int64be", int64be);
-    ]
+  let check name typ to_i64 of_i64 =
+    List.iter
+      (fun v ->
+        let s = Wire.to_string typ (of_i64 v) in
+        Alcotest.(check int) (name ^ ": eight bytes") 8 (String.length s);
+        Alcotest.(check int64)
+          (Fmt.str "%s <- %Ld round-trips" name v)
+          v
+          (to_i64 (Wire.of_string_exn typ s)))
+      Int64.[ min_int; -1L; zero; max_int ]
+  in
+  (* The two signednesses carry their values in different types now, so the
+     round-trip goes through each one's own conversion. *)
+  check "uint64" uint64 UInt64.to_int64 UInt64.of_int64;
+  check "uint64be" uint64be UInt64.to_int64 UInt64.of_int64;
+  check "int64" int64 Fun.id Fun.id;
+  check "int64be" int64be Fun.id Fun.id
 
 (* A reference-free constant size expression normalises to the literal form at
    construction, so every [Int n] fast path and range guard in the library sees
@@ -5075,7 +5076,7 @@ let test_int64_field_constraint_accepts_signed_magnitude_domain () =
       let decoded =
         decode_ok (Codec.decode signed_magnitude_seek_codec (seek_buf v) 0)
       in
-      Alcotest.(check int64) "seek" v decoded)
+      Alcotest.(check int64) "seek" v (UInt64.to_int64 decoded))
     [ 0L; Int64.max_int; Int64.succ Int64.min_int; -1L ]
 
 let test_int64_field_constraint_rejects_negative_zero () =
@@ -5102,7 +5103,8 @@ let test_int64_mask_constraint_over_map () =
   let accept v =
     Alcotest.(check int64)
       "accept" v
-      (decode_ok (Codec.decode mask_seek_codec (seek_buf v) 0))
+      (UInt64.to_int64
+         (decode_ok (Codec.decode mask_seek_codec (seek_buf v) 0)))
   in
   let reject v =
     match Codec.decode mask_seek_codec (seek_buf v) 0 with
@@ -5130,7 +5132,7 @@ let test_uint64_int_ref_constraint_enforced () =
   in
   Alcotest.(check int64)
     "in-range accepts" 3L
-    (decode_ok (Codec.decode codec (buf 3L) 0));
+    (UInt64.to_int64 (decode_ok (Codec.decode codec (buf 3L) 0)));
   match Codec.decode codec (buf 20L) 0 with
   | Ok _ -> Alcotest.fail "20 exceeds the bound and must be rejected"
   | Error { kind = Constraint_failed _; _ } -> ()
@@ -6065,7 +6067,7 @@ let test_uint64_in_size_expr () =
   Bytes.set_int64_be buf 0 3L;
   Bytes.blit_string "ABC" 0 buf 8 3;
   let len, data = decode_ok (Codec.decode codec buf 0) in
-  Alcotest.(check int64) "len" 3L len;
+  Alcotest.(check int64) "len" 3L (UInt64.to_int64 len);
   Alcotest.(check string) "data" "ABC" data
 
 (* -- Nested: Repeat typ: parse elements until byte budget exhausted --

--- a/test/test_eval.ml
+++ b/test/test_eval.ml
@@ -13,10 +13,10 @@ let test_int_of () =
     (Eval.int_of Types.uint16be 300);
   Alcotest.(check (option int))
     "uint64 small" (Some 42)
-    (Eval.int_of Types.uint64be 42L);
+    (Eval.int_of Types.uint64be (Wire.UInt64.of_int64 42L));
   Alcotest.(check (option int))
     "uint64 overflow" None
-    (Eval.int_of Types.uint64be 0xFFFF_FFFF_FFFF_FFFFL);
+    (Eval.int_of Types.uint64be (Wire.UInt64.of_int64 0xFFFF_FFFF_FFFF_FFFFL));
   Alcotest.(check (option int)) "unit" None (Eval.int_of Types.Unit ())
 
 (* [int_of_exn] returns the same value as [int_of] on the representable cases,
@@ -44,24 +44,29 @@ let raises_invalid_arg name f =
 let test_int_of_exn_ok () =
   Alcotest.(check int) "uint8" 7 (Eval.int_of_exn Types.uint8 7);
   Alcotest.(check int) "uint16be" 300 (Eval.int_of_exn Types.uint16be 300);
-  Alcotest.(check int) "uint64 small" 42 (Eval.int_of_exn Types.uint64be 42L);
+  Alcotest.(check int)
+    "uint64 small" 42
+    (Eval.int_of_exn Types.uint64be (Wire.UInt64.of_int64 42L));
   Alcotest.(check int)
     "int64 small" 100
     (Eval.int_of_exn Types.(Int64 Big) 100L);
   (* [max_int] is the largest value [Int64.unsigned_to_int] accepts. *)
   Alcotest.(check int)
     "uint64 = max_int" max_int
-    (Eval.int_of_exn Types.uint64be (Int64.of_int max_int))
+    (Eval.int_of_exn Types.uint64be (Wire.UInt64.of_int max_int))
 
 let test_int_of_exn_overflow () =
   (* Adversarial 64-bit lengths that do not fit a native int must fail the
      parse rather than be read as 0. *)
   raises_out_of_range "uint64 all-ones" (fun () ->
-      Eval.int_of_exn Types.uint64be 0xFFFF_FFFF_FFFF_FFFFL);
+      Eval.int_of_exn Types.uint64be
+        (Wire.UInt64.of_int64 0xFFFF_FFFF_FFFF_FFFFL));
   raises_out_of_range "uint64 = 2^63" (fun () ->
-      Eval.int_of_exn Types.uint64be 0x8000_0000_0000_0000L);
+      Eval.int_of_exn Types.uint64be
+        (Wire.UInt64.of_int64 0x8000_0000_0000_0000L));
   raises_out_of_range "uint64 = max_int + 1" (fun () ->
-      Eval.int_of_exn Types.uint64be (Int64.add (Int64.of_int max_int) 1L));
+      Eval.int_of_exn Types.uint64be
+        (Wire.UInt64.of_int64 (Int64.add (Int64.of_int max_int) 1L)));
   (* A signed int64 with the top bit set is a huge unsigned value. *)
   raises_out_of_range "int64 = -1" (fun () ->
       Eval.int_of_exn Types.(Int64 Big) (-1L));

--- a/test/test_field.ml
+++ b/test/test_field.ml
@@ -113,7 +113,12 @@ let test_int64_accepts_map_over_uint64 () =
   (* A map over uint64 keeps its int64 slot: [build_populate] fills it with the
      raw pre-map wire value, so an int64 self-constraint over the raw word is
      well defined and is accepted (unlike a map over uint8). *)
-  let mapped = Types.map Int64.neg Int64.neg Types.uint64be in
+  let mapped =
+    Types.map
+      (fun v -> Int64.neg (Wire.UInt64.to_int64 v))
+      (fun v -> Wire.UInt64.of_int64 (Int64.neg v))
+      Types.uint64be
+  in
   ignore
     (Field.v "Seek" mapped ~self_int64:(fun self ->
          Types.Expr.(self <= int64 0L))

--- a/test/test_uint64.ml
+++ b/test/test_uint64.ml
@@ -1,0 +1,94 @@
+(* Tests for UInt64: unsigned 64-bit get/set over bytes. Values above 2^63 - 1
+   are written as [Int64] literals and compared through [to_int64]: they have no
+   [int] literal on any target, and the carrier reads them as negative. *)
+
+open Wire
+
+let check_roundtrip name ~set ~get v =
+  let buf = Bytes.create 8 in
+  set buf 0 (UInt64.of_int64 v);
+  Alcotest.(check int64) name v (UInt64.to_int64 (get buf 0))
+
+let test_roundtrip_le () =
+  check_roundtrip "le roundtrip" ~set:UInt64.set_le ~get:UInt64.le
+    0x0123_4567_89AB_CDEFL
+
+let test_roundtrip_be () =
+  check_roundtrip "be roundtrip" ~set:UInt64.set_be ~get:UInt64.be
+    0xFEDC_BA98_7654_3210L
+
+(* Pin the wire byte order so the read and write paths cannot drift apart. *)
+let test_byte_layout () =
+  let buf = Bytes.of_string "\x01\x02\x03\x04\x05\x06\x07\x08" in
+  Alcotest.(check int64)
+    "le read" 0x0807_0605_0403_0201L
+    (UInt64.to_int64 (UInt64.le buf 0));
+  Alcotest.(check int64)
+    "be read" 0x0102_0304_0506_0708L
+    (UInt64.to_int64 (UInt64.be buf 0));
+  let out = Bytes.create 8 in
+  UInt64.set_le out 0 (UInt64.of_int64 0x0807_0605_0403_0201L);
+  Alcotest.(check string)
+    "le write" "\x01\x02\x03\x04\x05\x06\x07\x08" (Bytes.to_string out);
+  UInt64.set_be out 0 (UInt64.of_int64 0x0102_0304_0506_0708L);
+  Alcotest.(check string)
+    "be write" "\x01\x02\x03\x04\x05\x06\x07\x08" (Bytes.to_string out)
+
+let test_boundaries () =
+  List.iter
+    (fun v ->
+      check_roundtrip "le" ~set:UInt64.set_le ~get:UInt64.le v;
+      check_roundtrip "be" ~set:UInt64.set_be ~get:UInt64.be v)
+    Int64.[ zero; one; 0xFFFFL; max_int; min_int; minus_one; add min_int one ]
+
+(* Every bit pattern is a legal value here, so [of_int64] is total and there is
+   no range to refuse. The ends are the two the carrier reads as negative. *)
+let test_bounds () =
+  Alcotest.(check int64) "zero" 0L (UInt64.to_int64 UInt64.zero);
+  Alcotest.(check int64)
+    "max_int is all ones" (-1L)
+    (UInt64.to_int64 UInt64.max_int)
+
+(* [of_int] refuses a negative number instead of reinterpreting it as the large
+   value its two's complement spells; [of_int64] is where a bit pattern is
+   reinterpreted on purpose. *)
+let test_of_int_refuses_negative () =
+  List.iter
+    (fun n ->
+      match UInt64.of_int n with
+      | v -> Alcotest.failf "of_int %d built %a" n UInt64.pp v
+      | exception Invalid_argument _ -> ())
+    [ -1; min_int ];
+  List.iter
+    (fun n ->
+      Fmt.kstr
+        (fun msg -> Alcotest.(check int) msg n)
+        "of_int %d round-trips" n
+        (UInt64.to_int (UInt64.of_int n)))
+    [ 0; 1; 0xFFFF; max_int ]
+
+(* [to_int_opt] answers whether the native int held the value, so a caller that
+   must not silently drop bits has something total to ask. *)
+let test_to_int_opt () =
+  Alcotest.(check (option int))
+    "zero fits" (Some 0)
+    (UInt64.to_int_opt UInt64.zero);
+  Alcotest.(check (option int))
+    "all ones does not fit any int" None
+    (UInt64.to_int_opt UInt64.max_int);
+  Alcotest.(check (option int))
+    "max_int fits" (Some max_int)
+    (UInt64.to_int_opt (UInt64.of_int max_int))
+
+let suite =
+  ( "uint64",
+    [
+      Alcotest.test_case "roundtrip le" `Quick test_roundtrip_le;
+      Alcotest.test_case "roundtrip be" `Quick test_roundtrip_be;
+      Alcotest.test_case "byte layout" `Quick test_byte_layout;
+      Alcotest.test_case "boundaries" `Quick test_boundaries;
+      Alcotest.test_case "bounds" `Quick test_bounds;
+      Alcotest.test_case "of_int refuses negative" `Quick
+        test_of_int_refuses_negative;
+      Alcotest.test_case "to_int_opt" `Quick test_to_int_opt;
+    ] )

--- a/test/test_uint64.ml
+++ b/test/test_uint64.ml
@@ -80,6 +80,22 @@ let test_to_int_opt () =
     "max_int fits" (Some max_int)
     (UInt64.to_int_opt (UInt64.of_int max_int))
 
+(* [UInt64.compare] is the order of the field, which is unsigned:
+   0xFFFF_FFFF_FFFF_FFFF is its largest value, not its smallest. The carrier
+   disagrees on every target, not just narrow ones: [Int64.compare] reads the
+   top bit as a sign, so it ranks the largest value here below zero. *)
+let test_compare_is_unsigned () =
+  let u = UInt64.of_int64 in
+  let gt name a b =
+    Alcotest.(check bool) name true (UInt64.compare (u a) (u b) > 0)
+  in
+  gt "all ones > 1" (-1L) 1L;
+  gt "all ones > max_int64" (-1L) Int64.max_int;
+  gt "top bit set > max_int64" Int64.min_int Int64.max_int;
+  gt "top bit set > 0" Int64.min_int 0L;
+  Alcotest.(check bool) "0 < 1" true (UInt64.compare (u 0L) (u 1L) < 0);
+  Alcotest.(check bool) "equal" true (UInt64.equal (u 42L) (u 42L))
+
 let suite =
   ( "uint64",
     [
@@ -91,4 +107,5 @@ let suite =
       Alcotest.test_case "of_int refuses negative" `Quick
         test_of_int_refuses_negative;
       Alcotest.test_case "to_int_opt" `Quick test_to_int_opt;
+      Alcotest.test_case "compare is unsigned" `Quick test_compare_is_unsigned;
     ] )

--- a/test/test_uint64.mli
+++ b/test/test_uint64.mli
@@ -1,0 +1,4 @@
+(** Tests for the [uint64] module. *)
+
+val suite : string * unit Alcotest.test_case list
+(** Alcotest suite. *)

--- a/test/test_wire.ml
+++ b/test/test_wire.ml
@@ -77,7 +77,9 @@ let test_parse_uint32_be () =
 let test_parse_uint64_le () =
   let input = "\x01\x02\x03\x04\x05\x06\x07\x08" in
   match of_string uint64 input with
-  | Ok v -> Alcotest.(check int64) "uint64 le value" 0x0807060504030201L v
+  | Ok v ->
+      Alcotest.(check int64)
+        "uint64 le value" 0x0807060504030201L (UInt64.to_int64 v)
   | Error e -> Alcotest.failf "%a" pp_parse_error e
 
 let test_parse_array () =
@@ -1108,21 +1110,27 @@ let test_stream_uint32_chunk3 () =
   | Error e -> Alcotest.failf "uint32be chunk=3: %a" pp_parse_error e
 
 let test_stream_uint64_chunk1 () =
-  let encoded = to_string uint64 0x0102030405060708L in
+  let encoded = to_string uint64 (UInt64.of_int64 0x0102030405060708L) in
   match parse_chunked ~chunk_size:1 uint64 encoded with
-  | Ok v -> Alcotest.(check int64) "uint64 chunk=1" 0x0102030405060708L v
+  | Ok v ->
+      Alcotest.(check int64)
+        "uint64 chunk=1" 0x0102030405060708L (UInt64.to_int64 v)
   | Error e -> Alcotest.failf "uint64 chunk=1: %a" pp_parse_error e
 
 let test_stream_uint64_chunk3 () =
-  let encoded = to_string uint64be 0xFEDCBA9876543210L in
+  let encoded = to_string uint64be (UInt64.of_int64 0xFEDCBA9876543210L) in
   match parse_chunked ~chunk_size:3 uint64be encoded with
-  | Ok v -> Alcotest.(check int64) "uint64be chunk=3" 0xFEDCBA9876543210L v
+  | Ok v ->
+      Alcotest.(check int64)
+        "uint64be chunk=3" 0xFEDCBA9876543210L (UInt64.to_int64 v)
   | Error e -> Alcotest.failf "uint64be chunk=3: %a" pp_parse_error e
 
 let test_stream_uint64_chunk5 () =
-  let encoded = to_string uint64 0xAAAABBBBCCCCDDDDL in
+  let encoded = to_string uint64 (UInt64.of_int64 0xAAAABBBBCCCCDDDDL) in
   match parse_chunked ~chunk_size:5 uint64 encoded with
-  | Ok v -> Alcotest.(check int64) "uint64 chunk=5" 0xAAAABBBBCCCCDDDDL v
+  | Ok v ->
+      Alcotest.(check int64)
+        "uint64 chunk=5" 0xAAAABBBBCCCCDDDDL (UInt64.to_int64 v)
   | Error e -> Alcotest.failf "uint64 chunk=5: %a" pp_parse_error e
 
 let test_stream_reader_sequential_fixed () =


### PR DESCRIPTION
A `uint64` and an `int64` were the same type, so a value decoded from one could be handed to the other unchallenged, and the comparison a caller reached for was `Int64.compare`, which reads the top bit as a sign and ranks `0xFFFF_FFFF_FFFF_FFFF`, the largest `uint64`, below zero. Wrong on every target, not only narrow ones.

`int64` keeps its native carrier: the signed field domain is exactly `int64`, so it needs nothing of its own and the expression layer is untouched. `Field.int64` is widened to `'a t`, matching the runtime gate it already ran, which is wider than the static type it had. Stacked on #322.