### PR TITLE
codec: stop the incremental reader re-parsing from zero

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -149,6 +149,12 @@
 
 ### Fixed
 
+- A value with no fixed wire size read through `Wire.of_reader` no longer costs
+  time and memory quadratic in its length. The reader rebuilt the whole
+  accumulated buffer and re-parsed it from offset zero after every slice, so a
+  4 KiB frame arriving a byte at a time allocated 1,194,134 words where it now
+  allocates 19,082 (#325, @samoht)
+
 - `uint64` values now order as unsigned numbers. The carrier was `int64`, whose
   comparison reads the top bit as a sign and so ranked
   0xFFFF_FFFF_FFFF_FFFF, the largest `uint64`, below zero (#323, @samoht)

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -515,31 +515,78 @@ let missing_more_input e =
   | Unexpected_eof _ | Missing_terminator -> true
   | _ -> false
 
+(* A growable scratch the incremental reader accumulates slices into, so
+   retrying a parse costs nothing beyond the retry. [Buffer.to_bytes] rebuilt
+   everything read so far on every call, which is what made a value arriving in
+   small slices quadratic.
+
+   [Bytes.make] rather than [Bytes.create]: the parse is given a length, but a
+   size expression can still read the bytes behind it, and those must not be
+   whatever the allocator last held. *)
+type scratch = { mutable buf : bytes; mutable filled : int }
+
+let scratch_create () = { buf = Bytes.make 256 '\000'; filled = 0 }
+
+let scratch_ensure s n =
+  if n > Bytes.length s.buf then begin
+    (* [Stdlib.ref]: [ref] here is [Types.ref], the field-reference
+       combinator. *)
+    let cap = Stdlib.ref (Bytes.length s.buf) in
+    while n > !cap do
+      cap := !cap * 2
+    done;
+    let b = Bytes.make !cap '\000' in
+    Bytes.blit s.buf 0 b 0 s.filled;
+    s.buf <- b
+  end
+
+(* Read one slice into [s]. [false] at the end of the reader. *)
+let scratch_read s reader =
+  let slice = Reader.read reader in
+  if Slice.is_eod slice then false
+  else begin
+    let n = Slice.length slice in
+    scratch_ensure s (s.filled + n);
+    Bytes.blit (Slice.bytes slice) (Slice.first slice) s.buf s.filled n;
+    s.filled <- s.filled + n;
+    true
+  end
+
+(* Read until [target] bytes are buffered, or the reader ends first. *)
+let rec scratch_fill s reader target =
+  s.filled >= target || (scratch_read s reader && scratch_fill s reader target)
+
+(* How far to read before retrying a parse that ran short. [expected] is what
+   the value needed and [got] what was left where it starts, so the shortfall is
+   the difference; never less than one byte, or a hint of zero would spin.
+   [Missing_terminator] carries no count, because a zeroterm cannot know where
+   its NUL is until it sees one, so that case advances a slice at a time. *)
+let retry_target s e =
+  match e.kind with
+  | Unexpected_eof { expected; got } -> s.filled + max 1 (expected - got)
+  | _ -> s.filled + 1
+
 let of_reader_incremental typ reader =
-  let buf = Buffer.create 256 in
+  let s = scratch_create () in
+  let give_up e =
+    push_back_bytes reader s.buf 0 s.filled;
+    raise (Parse_error e)
+  in
   let rec loop () =
-    let bytes = Buffer.to_bytes buf in
-    let len = Bytes.length bytes in
-    let read_more on_eod =
-      let slice = Reader.read reader in
-      if Slice.is_eod slice then on_eod ()
-      else begin
-        Buffer.add_subbytes buf (Slice.bytes slice) (Slice.first slice)
-          (Slice.length slice);
-        loop ()
-      end
-    in
-    match parse_direct typ bytes 0 len with
+    match parse_direct typ s.buf 0 s.filled with
     | v, off ->
-        push_back_bytes reader bytes off (len - off);
+        push_back_bytes reader s.buf off (s.filled - off);
         v
     | exception Parse_error e when missing_more_input e ->
-        read_more (fun () ->
-            push_back_bytes reader bytes 0 len;
-            raise (Parse_error e))
-    | exception Parse_error e ->
-        push_back_bytes reader bytes 0 len;
-        raise (Parse_error e)
+        let before = s.filled in
+        ignore (scratch_fill s reader (retry_target s e) : bool);
+        (* The hint says how far to read ahead, never whether to fail. A size
+           that depends on a field the parse has not reached yet is computed
+           from whatever lies at that offset, so the figure can be far larger
+           than the input, and reaching the end of the reader while chasing it
+           is not an error. Give up only when a read yields nothing at all. *)
+        if s.filled > before then loop () else give_up e
+    | exception Parse_error e -> give_up e
   in
   loop ()
 

--- a/test/test_wire.ml
+++ b/test/test_wire.ml
@@ -126,6 +126,44 @@ let test_int8_full_range () =
     Alcotest.(check int) (Fmt.str "%d" i) i (of_string_exn int8 s)
   done
 
+(* [of_reader] on a value with no fixed wire size accumulates slices and retries
+   the parse. It used to rebuild the whole accumulated buffer with
+   [Buffer.to_bytes] and re-parse it from offset 0 after every single slice, so
+   a frame arriving a byte at a time cost O(n^2) in copying and in parsing
+   both. The failing parse already says how many more bytes the value needs
+   ([Unexpected_eof] carries [expected] and [got]), which is enough to read that
+   far before retrying instead of retrying blind.
+
+   [Gc.minor_words] cannot see this: the accumulated buffer is large enough to
+   be allocated straight into the major heap. *)
+let test_reader_incremental_is_not_quadratic () =
+  (match Sys.backend_type with
+  | Sys.Other _ -> Alcotest.skip ()
+  | Sys.Native | Sys.Bytecode -> ());
+  let f_len = Field.v "len" uint16be in
+  let frame_codec =
+    Codec.v "DribbleFrame"
+      (fun _len d -> d)
+      Codec.
+        [
+          (Field.v "len" uint16be $ fun d -> String.length d);
+          Field.v "data" (byte_array ~size:(Field.ref f_len)) $ Fun.id;
+        ]
+  in
+  let typ = Wire.codec frame_codec in
+  let payload = String.make 4096 'x' in
+  let frame = Wire.to_string typ payload in
+  let reader = Bytesrw.Bytes.Reader.of_string ~slice_length:1 frame in
+  let before = Gc.allocated_bytes () in
+  let got = Wire.of_reader_exn typ reader in
+  let words = (Gc.allocated_bytes () -. before) /. 8. in
+  Alcotest.(check string) "payload round-trips" payload got;
+  Fmt.kstr
+    (fun msg -> Alcotest.(check bool) msg true (words < 200_000.))
+    "a 4096-byte frame dribbled one byte at a time stays sub-quadratic (got \
+     %.0f words)"
+    words
+
 let test_int16be_negative () =
   let buf = Bytes.of_string "\xFF\xFE" in
   Alcotest.(check int) "-2 BE" (-2) (of_bytes_exn int16be buf)
@@ -1380,6 +1418,8 @@ let suite =
       Alcotest.test_case "parse: int8 negative" `Quick test_int8_negative;
       Alcotest.test_case "parse: int8 full range" `Quick test_int8_full_range;
       Alcotest.test_case "parse: int16be negative" `Quick test_int16be_negative;
+      Alcotest.test_case "reader: incremental parse is not quadratic" `Quick
+        test_reader_incremental_is_not_quadratic;
       Alcotest.test_case "parse: int32be negative" `Quick test_int32be_negative;
       Alcotest.test_case "parse: int64le roundtrip" `Quick
         test_int64le_roundtrip;


### PR DESCRIPTION
A value with no fixed wire size read through `Wire.of_reader` cost time and memory quadratic in its length: the reader rebuilt the whole accumulated buffer with `Buffer.to_bytes` and re-parsed it from offset zero after every slice. A 4096-byte frame arriving a byte at a time allocated 1,194,134 words; it now allocates 19,082.

The failed parse already carries how many bytes the value needs, so it reads that far before retrying. The hint is advisory rather than load-bearing: a size that depends on a field the parse has not reached yet is computed from whatever lies at that offset, so it can name a figure far larger than the input. Stacked on #323.