### PR TITLE
codec: bound a sub-codec size walk by the region it parses

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -155,6 +155,13 @@
   4 KiB frame arriving a byte at a time allocated 1,194,134 words where it now
   allocates 19,082 (#325, @samoht)
 
+- A value parsed inside a `nested` region or a `repeat` budget no longer reports
+  an end-of-input whose byte count was read from outside that region. A region
+  too short to carry the length field the value's size depends on was sized from
+  whatever the buffer held past it, so the reported shortfall named bytes the
+  parse never claimed; it now names the length field's own extent (#326,
+  @samoht)
+
 - `uint64` values now order as unsigned numbers. The carrier was `int64`, whose
   comparison reads the top bit as a sign and so ranked
   0xFFFF_FFFF_FFFF_FFFF, the largest `uint64`, below zero (#323, @samoht)

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -249,6 +249,13 @@ and _ typ =
       codec_encode : 'r -> eval_ctx -> bytes -> int -> int;
           (* Returns the offset after the bytes the encoder wrote. *)
       codec_fixed_size : int option;
+      codec_min_size : int;
+          (* Bytes the codec occupies whatever its variable-size fields hold,
+             hence the extent [codec_size_of] has to be able to read before it
+             can resolve a span. A decoder bounds this against the region it
+             was given, so a region too short to carry the length fields fails
+             on their own extent rather than on a span sized from bytes outside
+             it. *)
       codec_size_of : eval_ctx -> bytes -> int -> int;
       codec_size_of_value : 'r -> int;
           (* Encoded byte length of a value, computed from the value rather

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -362,6 +362,10 @@ and _ typ =
               nested struct's validator. *)
       codec_encode : 'r -> eval_ctx -> bytes -> int -> int;
       codec_fixed_size : int option;
+      codec_min_size : int;
+          (** Bytes the codec occupies whatever its variable-size fields hold,
+              hence the extent [codec_size_of] has to read before it can resolve
+              a span. *)
       codec_size_of : eval_ctx -> bytes -> int -> int;
       codec_size_of_value : 'r -> int;
           (** Encoded byte length of a value, computed from the value rather

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -72,6 +72,7 @@ let codec (c : 'r Codec.t) : 'r typ =
   let codec_field_readers = Codec.field_readers_ctx c in
   let codec_struct = Codec.to_struct c in
   let codec_size_of_value = Codec.size_of_value c in
+  let codec_min_size = Codec.min_wire_size c in
   match Codec.wire_size_info_ctx c with
   | `Fixed n ->
       Codec
@@ -81,6 +82,7 @@ let codec (c : 'r Codec.t) : 'r typ =
           codec_validate;
           codec_encode;
           codec_fixed_size = Some n;
+          codec_min_size;
           codec_size_of = (fun _ctx _buf _off -> n);
           codec_size_of_value;
           codec_field_readers;
@@ -94,6 +96,7 @@ let codec (c : 'r Codec.t) : 'r typ =
           codec_validate;
           codec_encode;
           codec_fixed_size = None;
+          codec_min_size;
           codec_size_of = size_of;
           codec_size_of_value;
           codec_field_readers;
@@ -170,13 +173,21 @@ let parse_all_zeros buf off len =
   in
   (check 0, len)
 
-let parse_codec_typ codec_decode fixed_size size_of buf off len =
+let parse_codec_typ codec_decode fixed_size min_size size_of buf off len =
   (* A variable-size codec computes its span by reading length / gate fields
-     from the buffer. Those reads bound-check themselves, so a buffer too short
-     to hold them already fails as end-of-input at the field that was missing;
-     a misuse in the size expression, or an exception from a user [map]
-     callback, reaches the caller unchanged. *)
-  let sz = match fixed_size with Some n -> n | None -> size_of buf off in
+     from the buffer. Those reads bound-check themselves against the buffer,
+     which inside a nested region holds more than this parse was handed, so
+     demand the codec's mandatory extent from the region first: a region too
+     short to carry the length fields then reports their shortfall instead of a
+     span sized from bytes outside it. A misuse in the size expression, or an
+     exception from a user [map] callback, reaches the caller unchanged. *)
+  let sz =
+    match fixed_size with
+    | Some n -> n
+    | None ->
+        check_eof len ~off ~n:min_size;
+        size_of buf off
+  in
   check_span len ~off ~n:sz;
   (codec_decode buf off, off + sz)
 
@@ -225,6 +236,7 @@ let validator_for_struct s =
 
 let parse_struct_typ s buf off len =
   let v = validator_for_struct s in
+  check_eof len ~off ~n:(Codec.struct_min_size v);
   let sz = Codec.struct_size_of v buf off in
   check_span len ~off ~n:sz;
   Codec.validate_struct v buf off;
@@ -322,10 +334,11 @@ let rec parse_direct : type a. a typ -> bytes -> int -> int -> a * int =
       let v, off' = parse_direct base buf off len in
       check_enum_membership ~at:off ~closed cases v;
       (v, off')
-  | Codec { codec_decode; codec_fixed_size; codec_size_of; _ } ->
+  | Codec { codec_decode; codec_fixed_size; codec_min_size; codec_size_of; _ }
+    ->
       parse_codec_typ
         (codec_decode Types.unbound_eval_ctx)
-        codec_fixed_size
+        codec_fixed_size codec_min_size
         (codec_size_of Types.unbound_eval_ctx)
         buf off len
   | Struct s -> parse_struct_typ s buf off len

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -8440,6 +8440,46 @@ let test_truncated_still_reports_eof () =
     (Codec.decode two_span_codec (Bytes.of_string "\010X") 0);
   expect_eof "of_string two-span" (of_string (codec two_span_codec) "\010X")
 
+(* A sub-codec sized from a length field it carries. The field is two bytes
+   wide, so a region of one byte cannot hold it. *)
+let region_len_codec =
+  let f_len = Field.v "len" uint16be in
+  Codec.v "RegionLen"
+    (fun _len body -> body)
+    Codec.
+      [
+        (f_len $ fun body -> String.length body);
+        Field.v "body" (byte_array ~size:(Field.ref f_len)) $ Fun.id;
+      ]
+
+(* A [nested] region declares how many bytes of the buffer the value may
+   occupy; the bytes past it belong to whatever follows, or to nothing at all.
+   Sizing the sub-codec from those bytes makes the [expected] count of the
+   resulting end-of-input a number no byte of the declared region carried, and
+   a caller that sizes its next read from [expected] is then reading on the
+   word of memory outside the region. Pin both halves of that: the reported
+   shortfall is the length field's own extent, and it does not move when the
+   bytes past the region do. *)
+let test_nested_region_eof_stays_in_region () =
+  let region = 1 in
+  let error_for filler =
+    let buf = Bytes.make 64 filler in
+    Bytes.set_uint8 buf 0 0x00;
+    match of_bytes (nested ~size:(int region) (codec region_len_codec)) buf with
+    | Ok _ -> Alcotest.fail "decoded a region too short for its length field"
+    | Error e -> e
+  in
+  let e = error_for '\x99' in
+  (match e.kind with
+  | Unexpected_eof { expected; got } ->
+      Alcotest.(check int) "bytes the length field needed" 2 expected;
+      Alcotest.(check int) "bytes the region had" region got
+  | k -> Alcotest.failf "expected an eof, got %a" pp_error_kind k);
+  Alcotest.(check string)
+    "the shortfall ignores the bytes past the region"
+    (Fmt.str "%a" pp_parse_error e)
+    (Fmt.str "%a" pp_parse_error (error_for '\x01'))
+
 (* [Codec.validate] scans a refined span where it lies rather than copying it,
    so the scan has to refuse everything the reader refuses. A literal width
    below zero is refused before any scan, and by the reader, so both entry
@@ -9351,6 +9391,8 @@ let suite =
         `Quick test_size_misuse_reports_itself;
       Alcotest.test_case "diag: truncated buffer still reports eof" `Quick
         test_truncated_still_reports_eof;
+      Alcotest.test_case "diag: a nested region sizes only from its own bytes"
+        `Quick test_nested_region_eof_stays_in_region;
       Alcotest.test_case "diag: negative span is a parse error" `Quick
         test_negative_span_is_parse_error;
       Alcotest.test_case "diag: eof counts do not move with the base" `Quick


### PR DESCRIPTION
A `nested` region hands the parse a length, but the sub-codec inside it resolved its span by reading its length fields from the whole buffer. Where the region ended before those fields, the reported end-of-input carried a count taken from bytes the region never covered: `nested ~size:0` said `expected 37019 bytes, got 0`. It now says `expected 2`, the length field own extent.

Nothing was ever wrongly accepted, but a caller sizing its next read on that count was sizing it on memory outside the region it had declared, which is what `Wire.of_reader` has to treat the hint as advisory for. Stacked on #325.