### PR TITLE
types: widen enum, variants, lookup and bit to any integer base

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,6 +49,12 @@
 
 ### Changed
 
+- `Wire.enum`, `Wire.enum_open`, `Wire.variants`, `Wire.lookup` and `Wire.bit`
+  accept any integer-valued base, not only one that decodes to a native `int`.
+  An enum, variant mapping, lookup table or flag can now sit over `uint32`,
+  `int32` or `uint64` as readily as over `uint8`, and projects to EverParse the
+  same way (#328, @samoht)
+
 - **Breaking:** `uint64` and `uint64be` decode to an abstract `Wire.UInt64.t`
   rather than `int64`, so an unsigned field can no longer be read where a signed
   one is expected. Convert with `Wire.UInt64.to_int64` and build with

--- a/examples/validate_3d.ml
+++ b/examples/validate_3d.ml
@@ -51,8 +51,29 @@ let doc_cases =
           ] );
   ]
 
+(* [enum], [enum_open], [lookup], [bit] and [variants] read the integer a field
+   decodes to and take nothing else from their base, so they accept one whose
+   OCaml carrier is not [int]. That widening is only shipped if it reaches
+   EverParse, which is what this schema pins: every one of them over a [uint32]
+   or [int32] base, alongside the [uint8] bases the rest of the registry
+   already covers. *)
+let wide_base_struct =
+  let open Wire in
+  Raw.struct_ "WideBases"
+    [
+      Raw.field "c32" (enum "Code32" [ ("Code32A", 1); ("Code32B", 2) ] uint32);
+      Raw.field "c32be"
+        (enum "Code32be" [ ("Code32beA", 1); ("Code32beB", 2) ] uint32be);
+      Raw.field "open32" (enum_open "Open32" [ ("Open32A", 1) ] uint32);
+      Raw.field "flag" (bit uint32);
+      Raw.field "idx" (lookup [ `A; `B; `C ] uint32);
+      Raw.field "sign"
+        (variants "Sign" [ ("Neg", `Neg); ("Zero", `Zero) ] int32);
+    ]
+
 let cases =
   [
+    raw_struct wide_base_struct;
     raw_struct Demo.minimal_struct;
     raw_struct Demo.all_ints_struct;
     raw_struct Demo.bf8_struct;

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -82,12 +82,12 @@ let where_field_encoder cond enc runtime buf off v =
   Types.check_where_encode cond (Eval.expr Eval.empty cond);
   enc runtime buf off v
 
-let enum_field_encoder ~name ~cases ~closed enc =
+let enum_field_encoder ~name ~cases ~closed ~to_int enc =
   if not closed then enc
   else
     let valid = Types.enum_values cases in
     fun runtime buf off v ->
-      Types.check_enum_encode ~name ~valid v;
+      Types.check_enum_encode ~name ~valid (to_int v);
       enc runtime buf off v
 
 (* Pack a fixed-width integer setter into a [bytes -> int -> int -> int]
@@ -219,7 +219,8 @@ and build_field_encoder_ctx : type a.
   | Where { cond; inner } ->
       where_field_encoder cond (build_field_encoder_ctx inner)
   | Enum { name; base; cases; closed } ->
-      enum_field_encoder ~name ~cases ~closed (build_field_encoder_ctx base)
+      enum_field_encoder ~name ~cases ~closed ~to_int:(Types.int_of_exn base)
+        (build_field_encoder_ctx base)
   | Map { inner; encode; _ } ->
       let enc = build_field_encoder_ctx inner in
       fun runtime buf off v -> enc runtime buf off (encode v)
@@ -286,23 +287,23 @@ let build_field_encoder typ =
    [parse_direct] path) does, instead of accepting any base value. The scan
    reads the cases where they lie, so an accepted value costs nothing however
    many cases the enum names. *)
-let enum_checker cases ~at v =
-  Types.check_enum_decode ~at ~cases v;
+let enum_checker ~to_int cases ~at v =
+  Types.check_enum_decode ~at ~cases (to_int v);
   v
 
 (* An open enum ([closed = false]) accepts any base value: the names only
    document known members, so decode does not reject the rest. *)
-let enum_check cases closed =
-  if closed then enum_checker cases else fun ~at:_ v -> v
+let enum_check ~to_int cases closed =
+  if closed then enum_checker ~to_int cases else fun ~at:_ v -> v
 
 (* Encode-side twin of [enum_check], gated on [closed] by the same rule so the
    two halves admit exactly the same values. Encoding an unlisted value raises
    [Invalid_argument]: it is a caller error, not malformed input. *)
-let enum_encode_check ~name ~cases ~closed =
-  if not closed then fun (_ : int) -> ()
+let enum_encode_check ~name ~cases ~closed ~to_int =
+  if not closed then fun _ -> ()
   else
     let valid = Types.enum_values cases in
-    fun v -> Types.check_enum_encode ~name ~valid v
+    fun v -> Types.check_enum_encode ~name ~valid (to_int v)
 
 (* No reader exists for this shape. [Codec.get] is the only caller that can
    reach it, since every field the record decoder reads has a case in the table
@@ -365,7 +366,7 @@ let rec build_field_reader_ctx : type a.
   | Where { inner; _ } -> build_field_reader_ctx inner field_off
   | Enum { base; cases; closed; _ } ->
       let read = build_field_reader_ctx base field_off in
-      let check = enum_check cases closed in
+      let check = enum_check ~to_int:(Types.int_of_exn base) cases closed in
       fun runtime buf base ->
         check ~at:(base + field_off) (read runtime buf base)
   | Map { inner; decode; index_bound; _ } ->
@@ -451,7 +452,7 @@ let rec build_immediate_reader : type a.
       match build_immediate_reader base field_off with
       | None -> None
       | Some read ->
-          let check = enum_check cases closed in
+          let check = enum_check ~to_int:(Types.int_of_exn base) cases closed in
           Some (fun buf base -> check ~at:(at base) (read buf base)))
   | Map { inner; decode; index_bound; _ } -> (
       match build_immediate_reader inner field_off with
@@ -668,7 +669,7 @@ let rec build_populate : type a.
   | Float64 Big -> populate_float64 idx Bytes.get_int64_be
   | Where { inner; _ } -> build_populate inner idx reader
   | Enum { base; cases; closed; _ } ->
-      let check = enum_check cases closed in
+      let check = enum_check ~to_int:(Types.int_of_exn base) cases closed in
       build_populate base idx (fun runtime buf b ->
           check ~at:b (reader runtime buf b))
   | Map { inner; encode; _ } ->
@@ -1687,9 +1688,12 @@ let rec read_elem : type a. a typ -> runtime -> bytes -> int -> a =
   | Enum { base; cases; closed; _ } ->
       (* Applied whole rather than through [enum_check]: an element's check runs
          per element, and staging one here would allocate the closure per
-         element too, on a count the sender picks through the byte budget. *)
+         element too (the integer view included), on a count the sender picks
+         through the byte budget. *)
       let v = read_elem base runtime buf off in
-      if closed then enum_checker cases ~at:off v else v
+      if closed then
+        Types.check_enum_decode ~at:off ~cases (Types.int_of_exn base v);
+      v
   | Casetype { tag; cases; _ } ->
       let tag_val = read_elem tag runtime buf off in
       read_case_body ~at:off ~tag cases tag_val runtime buf
@@ -2880,9 +2884,14 @@ let rec compile_field : type a r.
          the named cases. [compile_field] would otherwise strip the cases and
          accept any base value, unlike the EverParse validator. *)
       let cf = compile_field ctx { fld with typ = base } in
-      let check = enum_check cases closed in
+      let check = enum_check ~to_int:(Types.int_of_exn base) cases closed in
+      (* [populate] reads the field's integer slot rather than its value, so it
+         checks membership on the integer the slot already holds. *)
+      let int_check = enum_check ~to_int:Fun.id cases closed in
       let get = fld.get in
-      let encode_check = enum_encode_check ~name ~cases ~closed in
+      let encode_check =
+        enum_encode_check ~name ~cases ~closed ~to_int:(Types.int_of_exn base)
+      in
       {
         cf with
         raw_reader =
@@ -2898,7 +2907,7 @@ let rec compile_field : type a r.
           (fun arr runtime buf base ->
             cf.populate arr runtime buf base;
             ignore
-              (check
+              (int_check
                  ~at:(at_of base cf.validator_off)
                  (cf.int_reader runtime buf base)));
       }
@@ -4562,7 +4571,7 @@ let rec build_staged_reader : type a.
   | Where { inner; _ }, _ -> build_staged_reader inner access
   | Enum { base; cases; closed; _ }, _ ->
       let read = build_staged_reader base access in
-      let check = enum_check cases closed in
+      let check = enum_check ~to_int:(Types.int_of_exn base) cases closed in
       let at = access_at access in
       fun runtime buf base ->
         check ~at:(at runtime buf base) (read runtime buf base)
@@ -4704,7 +4713,7 @@ let rec build_immediate_staged_reader : type a.
       match build_immediate_staged_reader base access with
       | None -> None
       | Some read ->
-          let check = enum_check cases closed in
+          let check = enum_check ~to_int:(Types.int_of_exn base) cases closed in
           let off = immediate_access_off access in
           Some (fun buf base -> check ~at:(base + off) (read buf base)))
   | Map { inner; decode; index_bound; _ }, _ -> (

--- a/lib/eval.ml
+++ b/lib/eval.ml
@@ -1,4 +1,4 @@
-(* Top-level expression evaluator and value-to-int conversion.
+(* Top-level expression evaluator.
 
    The full struct-internal expression machinery (with [Ref]/[Sizeof_this]/
    [Field_pos] resolution against bound fields) lives in [Codec] as the
@@ -31,95 +31,11 @@ let rec lookup name = function
         name
   | b :: tl -> if String.equal b.name name then b.value else lookup name tl
 
-(* Convert a typed value to [int]. Returns [None] for types that don't
-   fit in OCaml int (uint64 over 2^63, non-numeric). *)
-let rec int_of : type a. a typ -> a -> int option =
- fun typ v ->
-  match typ with
-  | Uint8 -> Some v
-  | Uint16 _ -> Some v
-  | Uint_var _ -> Int64.unsigned_to_int (Optint.Int63.to_int64 v)
-  (* On a narrow-int platform a u32 value may not fit either; the unsigned
-     conversion returns [None] exactly then and is identity-exact on a 64-bit
-     host. *)
-  | Uint32 _ -> Int32.unsigned_to_int (UInt32.to_int32 v)
-  | Uint64 _ -> UInt64.to_int_opt v
-  | Int8 -> Some v
-  | Int16 _ -> Some v
-  | Int32 _ -> SInt32.to_int_opt v
-  | Int64 _ -> Int64.unsigned_to_int v
-  | Float32 _ -> None
-  | Float64 _ -> None
-  | Bits _ -> Some v
-  | Enum { base; _ } -> int_of base v
-  | Where { inner; _ } -> int_of inner v
-  | Single_elem { elem; _ } -> int_of elem v
-  | Apply { typ; _ } -> int_of typ v
-  | Map { inner; encode; _ } -> int_of inner (encode v)
-  | Unit | All_bytes | All_zeros | Zeroterm | Zeroterm_at_most _ | Array _
-  | Byte_array _ | Byte_array_where _ | Byte_slice _ | Casetype _ | Struct _
-  | Type_ref _ | Qualified_ref _ | Codec _ | Optional _ | Optional_or _
-  | Repeat _ ->
-      None
-
-(* Hot-path variant of [int_of] for the cross-field size/offset/present
-   readers, which need a plain [int]. Returns it directly (no [Some] box on the
-   numeric path). A [uint64]/[int64] beyond the native int range is adversarial
-   input and raises [Parse_error] ([Value_out_of_range]); a non-integer field
-   referenced where an integer is required is a schema error and raises
-   [Invalid_argument]. *)
-let int_overflow v = raise_out_of_range ~at:0 v
-
-let not_an_integer () =
-  invalid_arg "Wire: non-integer field referenced where an integer is required"
-
-let rec int_of_exn : type a. a typ -> a -> int =
- fun typ v ->
-  match typ with
-  | Uint8 -> v
-  | Uint16 _ -> v
-  | Uint_var _ -> (
-      if Sys.int_size > 56 then UInt63.to_int v
-      else
-        match Int64.unsigned_to_int (Optint.Int63.to_int64 v) with
-        | Some n -> n
-        | None -> int_overflow (Optint.Int63.to_int64 v))
-  (* The narrow-int branches raise the typed overflow error instead of
-     letting [Optint.to_int]'s [Failure] escape; a 64-bit host keeps the
-     direct allocation-free conversion. *)
-  | Uint32 _ -> (
-      if Sys.int_size > 32 then UInt32.to_int v
-      else
-        match Int32.unsigned_to_int (UInt32.to_int32 v) with
-        | Some n -> n
-        | None ->
-            int_overflow
-              (Int64.logand (Int64.of_int32 (UInt32.to_int32 v)) 0xFFFF_FFFFL))
-  | Uint64 _ -> (
-      match UInt64.to_int_opt v with
-      | Some n -> n
-      | None -> int_overflow (UInt64.to_int64 v))
-  | Int8 -> v
-  | Int16 _ -> v
-  | Int32 _ -> (
-      match SInt32.to_int_opt v with
-      | Some n -> n
-      | None -> int_overflow (Int64.of_int32 (SInt32.to_int32 v)))
-  | Int64 _ -> (
-      match Int64.unsigned_to_int v with Some n -> n | None -> int_overflow v)
-  | Float32 _ -> not_an_integer ()
-  | Float64 _ -> not_an_integer ()
-  | Bits _ -> v
-  | Enum { base; _ } -> int_of_exn base v
-  | Where { inner; _ } -> int_of_exn inner v
-  | Single_elem { elem; _ } -> int_of_exn elem v
-  | Apply { typ; _ } -> int_of_exn typ v
-  | Map { inner; encode; _ } -> int_of_exn inner (encode v)
-  | Unit | All_bytes | All_zeros | Zeroterm | Zeroterm_at_most _ | Array _
-  | Byte_array _ | Byte_array_where _ | Byte_slice _ | Casetype _ | Struct _
-  | Type_ref _ | Qualified_ref _ | Codec _ | Optional _ | Optional_or _
-  | Repeat _ ->
-      not_an_integer ()
+(* Value-to-int conversion is a fold over the type description, so it is
+   decided next to the type definitions; re-exported here because the
+   evaluator's callers reach for it alongside [expr]. *)
+let int_of = Types.int_of
+let int_of_exn = Types.int_of_exn
 
 let rec expr : type a. ctx -> a expr -> a =
  fun ctx e ->

--- a/lib/eval.mli
+++ b/lib/eval.mli
@@ -1,4 +1,4 @@
-(** Top-level expression evaluator and value-to-int conversion.
+(** Top-level expression evaluator.
 
     The full struct-internal expression machinery (with [Ref]/[Sizeof_this]/
     [Field_pos] resolution against bound fields) lives in {!Codec} as the
@@ -21,16 +21,13 @@ val bind : string -> int -> ctx -> ctx
 (** [bind name v ctx] extends [ctx] so that [Ref name] evaluates to [v]. *)
 
 val int_of : 'a Types.typ -> 'a -> int option
-(** [int_of typ v] converts a typed value to [int]. Returns [None] for types
-    that don't fit in OCaml int (uint64 > 2^62, non-numeric). *)
+(** {!Types.int_of}, re-exported: the conversion is a fold over the type
+    description and is decided there. *)
 
 val int_of_exn : 'a Types.typ -> 'a -> int
-(** [int_of_exn typ v] is {!val-int_of} without the [option]: it returns the
-    [int] directly (no boxing on the numeric path) and raises
-    {!Types.Parse_error} for the cases {!val-int_of} reports as [None] (a
-    [uint64]/[int64] value beyond the native int range, or a non-integer type).
-    Used by the cross-field size/offset/present readers, where an
-    unrepresentable value must fail the parse. *)
+(** {!Types.int_of_exn}, re-exported. Used by the cross-field
+    size/offset/present readers, where an unrepresentable value must fail the
+    parse. *)
 
 val expr : ctx -> 'a Types.expr -> 'a
 (** [expr ctx e] evaluates a top-level expression. Raises on [Ref] (cross-field

--- a/lib/param.ml
+++ b/lib/param.ml
@@ -4,11 +4,11 @@ type ('a, 'k) t = ('a, 'k) Types.param_handle
 
 let pp ppf (p : (_, _) t) = Fmt.string ppf p.Types.name
 
-(* Per-typ converter from the OCaml representation to [int] and back. One
-   match dispatches both directions; [to_int] and [of_int] just project
-   the relevant field. Avoids drift between the parallel cases. *)
-type 'a int_cvt = { fwd : 'a -> int; bwd : int -> 'a }
-
+(* Reading a bound value as the [int] an environment slot holds. The other
+   direction is [Types.of_int], shared with every other integer view of a type;
+   this one stays separate because a parameter that does not fit the native int
+   is a caller error [bind] reports as [Invalid_argument], not the malformed
+   input the decode-path conversion raises a parse error on. *)
 exception Unfittable_native_int
 
 let id_counter = Atomic.make 0
@@ -18,54 +18,36 @@ let optint_to_int to_int value =
   | value -> value
   | exception (Failure _ | Invalid_argument _) -> raise Unfittable_native_int
 
-let rec int_cvt : type a. a Types.typ -> a int_cvt =
- fun typ ->
-  let id : 'a int_cvt = { fwd = (fun v -> v); bwd = (fun v -> v) } in
+let rec to_int : type a. a Types.typ -> a -> int =
+ fun typ v ->
   match typ with
-  | Uint8 -> id
-  | Uint16 _ -> id
-  | Uint_var _ -> { fwd = optint_to_int UInt63.to_int; bwd = UInt63.of_int }
-  | Uint32 _ -> { fwd = optint_to_int UInt32.to_int; bwd = UInt32.of_int }
-  | Uint64 _ ->
-      {
-        fwd = (fun v -> UInt64.to_int_opt v |> Option.value ~default:max_int);
-        bwd = UInt64.of_int;
-      }
-  | Int8 -> id
-  | Int16 _ -> id
-  | Int32 _ -> { fwd = SInt32.to_int; bwd = SInt32.of_int }
-  | Int64 _ -> { fwd = Int64.to_int; bwd = Int64.of_int }
+  | Uint8 -> v
+  | Uint16 _ -> v
+  | Uint_var _ -> optint_to_int UInt63.to_int v
+  | Uint32 _ -> optint_to_int UInt32.to_int v
+  | Uint64 _ -> UInt64.to_int_opt v |> Option.value ~default:max_int
+  | Int8 -> v
+  | Int16 _ -> v
+  | Int32 _ -> SInt32.to_int v
+  | Int64 _ -> Int64.to_int v
   | Float32 _ -> invalid_arg "Param: floats are not integer-representable"
   | Float64 _ -> invalid_arg "Param: floats are not integer-representable"
-  | Bits _ -> id
-  | Enum { base; _ } -> int_cvt base
-  | Where { inner; _ } -> int_cvt inner
-  | Single_elem { elem; _ } -> int_cvt elem
-  | Map { inner; encode; decode; _ } ->
-      let c = int_cvt inner in
-      { fwd = (fun v -> c.fwd (encode v)); bwd = (fun v -> decode (c.bwd v)) }
-  | Apply { typ; _ } -> int_cvt typ
+  | Bits _ -> v
+  | Enum { base; _ } -> to_int base v
+  | Where { inner; _ } -> to_int inner v
+  | Single_elem { elem; _ } -> to_int elem v
+  | Map { inner; encode; _ } -> to_int inner (encode v)
+  | Apply { typ; _ } -> to_int typ v
   | Unit | All_bytes | All_zeros | Zeroterm | Zeroterm_at_most _ | Array _
   | Byte_array _ | Byte_array_where _ | Byte_slice _ | Casetype _ | Struct _
   | Type_ref _ | Qualified_ref _ | Codec _ | Optional _ | Optional_or _
   | Repeat _ ->
       invalid_arg "Param: unsupported parameter type"
 
-let to_int typ v = (int_cvt typ).fwd v
-let of_int typ v = (int_cvt typ).bwd v
-
-let rec is_int_representable : type a. a Types.typ -> bool = function
-  | Types.Uint8 | Types.Uint16 _ | Types.Uint_var _ | Types.Uint32 _
-  | Types.Uint64 _ | Types.Int8 | Types.Int16 _ | Types.Int32 _ | Types.Int64 _
-  | Types.Bits _ ->
-      true
-  | Types.Enum { base; _ } -> is_int_representable base
-  | Types.Map { inner; _ } -> is_int_representable inner
-  | Types.Where { inner; _ } -> is_int_representable inner
-  | _ -> false
+let of_int = Types.of_int
 
 let check_typ name typ =
-  if not (is_int_representable typ) then
+  if not (Types.is_int_representable typ) then
     Fmt.invalid_arg "Param.%s: only integer-representable types are supported"
       name
 

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -209,13 +209,15 @@ and _ typ =
   | Enum : {
       name : string;
       cases : (string * int) list;
-      base : int typ;
+      base : 'a typ;
+          (* Any type with an integer view: the case values name integers, and
+             [int_of_exn] is what reads one out of a decoded [base] value. *)
       closed : bool;
           (* [true]: only the listed values are valid (decode rejects others, the
              3D projection emits a membership refinement). [false]: an open set,
              the names document known values but any value is accepted. *)
     }
-      -> int typ
+      -> 'a typ
   | Casetype : {
       name : string;
       tag : 'k typ;
@@ -529,6 +531,154 @@ let bits ?(bit_order = Msb_first) ~width base =
 let bit b = Bool.to_int b
 let is_set n = n <> 0
 
+(* -- Integer views --
+
+   [bool], [cases], [enum] and [variants] refine the integer a field decodes to
+   and need nothing else from their base. Which OCaml type carries that integer
+   is the base's own business: [uint32] keeps a 32-bit unsigned value in a
+   module of its own, [uint64] a 64-bit one, and both read as the same [int] a
+   [uint8] does. Deciding that reading here, once, is what keeps [Eval], the
+   codec's enum checks, [Param]'s environments and the 3D projection agreeing
+   on which types have an integer view and what it is. *)
+
+(* Convert a typed value to [int]. Returns [None] for types that don't
+   fit in OCaml int (uint64 over 2^63, non-numeric). *)
+let rec int_of : type a. a typ -> a -> int option =
+ fun typ v ->
+  match typ with
+  | Uint8 -> Some v
+  | Uint16 _ -> Some v
+  | Uint_var _ -> Int64.unsigned_to_int (Optint.Int63.to_int64 v)
+  (* On a narrow-int platform a u32 value may not fit either; the unsigned
+     conversion returns [None] exactly then and is identity-exact on a 64-bit
+     host. *)
+  | Uint32 _ -> Int32.unsigned_to_int (UInt32.to_int32 v)
+  | Uint64 _ -> UInt64.to_int_opt v
+  | Int8 -> Some v
+  | Int16 _ -> Some v
+  | Int32 _ -> SInt32.to_int_opt v
+  | Int64 _ -> Int64.unsigned_to_int v
+  | Float32 _ -> None
+  | Float64 _ -> None
+  | Bits _ -> Some v
+  | Enum { base; _ } -> int_of base v
+  | Where { inner; _ } -> int_of inner v
+  | Single_elem { elem; _ } -> int_of elem v
+  | Apply { typ; _ } -> int_of typ v
+  | Map { inner; encode; _ } -> int_of inner (encode v)
+  | Unit | All_bytes | All_zeros | Zeroterm | Zeroterm_at_most _ | Array _
+  | Byte_array _ | Byte_array_where _ | Byte_slice _ | Casetype _ | Struct _
+  | Type_ref _ | Qualified_ref _ | Codec _ | Optional _ | Optional_or _
+  | Repeat _ ->
+      None
+
+(* Hot-path variant of [int_of] for the cross-field size/offset/present
+   readers, which need a plain [int]. Returns it directly (no [Some] box on the
+   numeric path). A [uint64]/[int64] beyond the native int range is adversarial
+   input and raises [Parse_error] ([Value_out_of_range]); a non-integer field
+   referenced where an integer is required is a schema error and raises
+   [Invalid_argument]. *)
+let int_overflow v = raise_out_of_range ~at:0 v
+
+let not_an_integer () =
+  invalid_arg "Wire: non-integer field referenced where an integer is required"
+
+let rec int_of_exn : type a. a typ -> a -> int =
+ fun typ v ->
+  match typ with
+  | Uint8 -> v
+  | Uint16 _ -> v
+  | Uint_var _ -> (
+      if Sys.int_size > 56 then UInt63.to_int v
+      else
+        match Int64.unsigned_to_int (Optint.Int63.to_int64 v) with
+        | Some n -> n
+        | None -> int_overflow (Optint.Int63.to_int64 v))
+  (* The narrow-int branches raise the typed overflow error instead of
+     letting [Optint.to_int]'s [Failure] escape; a 64-bit host keeps the
+     direct allocation-free conversion. *)
+  | Uint32 _ -> (
+      if Sys.int_size > 32 then UInt32.to_int v
+      else
+        match Int32.unsigned_to_int (UInt32.to_int32 v) with
+        | Some n -> n
+        | None ->
+            int_overflow
+              (Int64.logand (Int64.of_int32 (UInt32.to_int32 v)) 0xFFFF_FFFFL))
+  | Uint64 _ -> (
+      match UInt64.to_int_opt v with
+      | Some n -> n
+      | None -> int_overflow (UInt64.to_int64 v))
+  | Int8 -> v
+  | Int16 _ -> v
+  | Int32 _ -> (
+      match SInt32.to_int_opt v with
+      | Some n -> n
+      | None -> int_overflow (Int64.of_int32 (SInt32.to_int32 v)))
+  | Int64 _ -> (
+      match Int64.unsigned_to_int v with Some n -> n | None -> int_overflow v)
+  | Float32 _ -> not_an_integer ()
+  | Float64 _ -> not_an_integer ()
+  | Bits _ -> v
+  | Enum { base; _ } -> int_of_exn base v
+  | Where { inner; _ } -> int_of_exn inner v
+  | Single_elem { elem; _ } -> int_of_exn elem v
+  | Apply { typ; _ } -> int_of_exn typ v
+  | Map { inner; encode; _ } -> int_of_exn inner (encode v)
+  | Unit | All_bytes | All_zeros | Zeroterm | Zeroterm_at_most _ | Array _
+  | Byte_array _ | Byte_array_where _ | Byte_slice _ | Casetype _ | Struct _
+  | Type_ref _ | Qualified_ref _ | Codec _ | Optional _ | Optional_or _
+  | Repeat _ ->
+      not_an_integer ()
+
+(* The other direction: the value a type carries for a given integer. The
+   narrow constructors raise [Invalid_argument] on a number their field cannot
+   hold, so a case value or table index that does not fit its base is refused
+   where it is written down rather than silently reshaped. *)
+let rec of_int : type a. a typ -> int -> a =
+ fun typ n ->
+  match typ with
+  | Uint8 -> n
+  | Uint16 _ -> n
+  | Uint_var _ -> UInt63.of_int n
+  | Uint32 _ -> UInt32.of_int n
+  | Uint64 _ -> UInt64.of_int n
+  | Int8 -> n
+  | Int16 _ -> n
+  | Int32 _ -> SInt32.of_int n
+  | Int64 _ -> Int64.of_int n
+  | Float32 _ -> not_an_integer ()
+  | Float64 _ -> not_an_integer ()
+  | Bits _ -> n
+  | Enum { base; _ } -> of_int base n
+  | Where { inner; _ } -> of_int inner n
+  | Single_elem { elem; _ } -> of_int elem n
+  | Apply { typ; _ } -> of_int typ n
+  | Map { inner; decode; _ } -> decode (of_int inner n)
+  | Unit | All_bytes | All_zeros | Zeroterm | Zeroterm_at_most _ | Array _
+  | Byte_array _ | Byte_array_where _ | Byte_slice _ | Casetype _ | Struct _
+  | Type_ref _ | Qualified_ref _ | Codec _ | Optional _ | Optional_or _
+  | Repeat _ ->
+      not_an_integer ()
+
+(* The types [int_of_exn] and [of_int] have a conversion for. Checked at
+   construction by every combinator that needs one, so an unusable base fails
+   at the description rather than on the first byte decoded. *)
+let rec is_int_representable : type a. a typ -> bool = function
+  | Uint8 | Uint16 _ | Uint_var _ | Uint32 _ | Uint64 _ | Int8 | Int16 _
+  | Int32 _ | Int64 _ | Bits _ ->
+      true
+  | Enum { base; _ } -> is_int_representable base
+  | Map { inner; _ } -> is_int_representable inner
+  | Where { inner; _ } -> is_int_representable inner
+  | Single_elem { elem; _ } -> is_int_representable elem
+  | Apply { typ; _ } -> is_int_representable typ
+  | _ -> false
+
+let reject_non_integer ~combinator typ =
+  if not (is_int_representable typ) then
+    Fmt.invalid_arg "Wire.%s: base type must be an integer type" combinator
+
 (* Field decorations [Optional], [Optional_or], [Repeat] only have a 3D
    projection when they appear at the top of a struct field's type --
    anywhere else (array elem, casetype case body, [where]/[map]/[apply]
@@ -555,7 +705,15 @@ let map decode encode inner =
   Map { inner; decode; encode; index_bound = None }
 
 let bool inner =
-  Map { inner; decode = is_set; encode = bit; index_bound = None }
+  reject_non_integer ~combinator:"bit" inner;
+  let to_int = int_of_exn inner and of_int = of_int inner in
+  Map
+    {
+      inner;
+      decode = (fun v -> is_set (to_int v));
+      encode = (fun b -> of_int (bit b));
+      index_bound = None;
+    }
 
 (* Top-level so [variants_lookup] does not allocate a closure per call.
    Returns -1 if [v] is not in [arr] (used as a non-allocating sentinel
@@ -566,16 +724,19 @@ let rec variants_lookup arr v i =
   else variants_lookup arr v (i + 1)
 
 let cases variants inner =
+  reject_non_integer ~combinator:"lookup" inner;
+  let to_int = int_of_exn inner and of_int = of_int inner in
   let arr = Array.of_list variants in
   let len = Array.length arr in
-  let decode n =
+  let decode v =
     (* Offset 0 is relative to the value handed in; [map_decode] moves the
        failure to where the reader found that value. *)
+    let n = to_int v in
     if n >= 0 && n < len then arr.(n) else raise_invalid_tag ~at:0 n
   in
   let encode v =
     let i = variants_lookup arr v 0 in
-    if i < 0 then invalid_arg "Wire.lookup: unknown variant" else i
+    if i < 0 then invalid_arg "Wire.lookup: unknown variant" else of_int i
   in
   Map { inner; decode; encode; index_bound = Some len }
 
@@ -896,23 +1057,31 @@ let nested_at_most ~size elem =
   reject_bitfield_element ~combinator:"nested_at_most" elem;
   Single_elem { size = fold_size size; elem; at_most = true }
 
-let enum name cases base = Enum { name; cases; base; closed = true }
-let enum_open name cases base = Enum { name; cases; base; closed = false }
+let enum name cases base =
+  reject_non_integer ~combinator:"enum" base;
+  Enum { name; cases; base; closed = true }
+
+let enum_open name cases base =
+  reject_non_integer ~combinator:"enum_open" base;
+  Enum { name; cases; base; closed = false }
 
 let variants name cases base =
+  reject_non_integer ~combinator:"variants" base;
+  let to_int = int_of_exn base and of_int = of_int base in
   let enum_cases = List.mapi (fun i (s, _) -> (s, i)) cases in
   let arr = Array.of_list (List.map snd cases) in
   let len = Array.length arr in
   (* [enum name enum_cases base] is closed, so [enum_check] rejects any value
      outside [0, len) before [decode] runs; the [else] is a defensive fallback. *)
-  let decode n =
+  let decode v =
+    let n = to_int v in
     if n >= 0 && n < len then arr.(n)
     else raise_invalid_enum ~at:0 ~value:n ~valid:(List.init len Fun.id)
   in
   let encode v =
     let i = variants_lookup arr v 0 in
     if i < 0 then Fmt.invalid_arg "Wire.variants %s: unknown variant" name
-    else i
+    else of_int i
   in
   map decode encode (enum name enum_cases base)
 
@@ -1326,7 +1495,7 @@ let uint_var_case_index k =
    expression. Only called for int-shaped tags; non-int tags don't reach
    here because their casetype field is rewritten away before
    [casetype_decls_of_struct] walks it. *)
-let case_index_to_expr : type k. k typ -> k -> packed_expr =
+let rec case_index_to_expr : type k. k typ -> k -> packed_expr =
  fun tag_typ k ->
   match tag_typ with
   | Uint8 -> Pack_expr (Int k)
@@ -1337,7 +1506,7 @@ let case_index_to_expr : type k. k typ -> k -> packed_expr =
   | Int16 _ -> Pack_expr (Int k)
   | Int32 _ -> Pack_expr (Int (int32_case_index k))
   | Bits _ -> Pack_expr (Int k)
-  | Enum _ -> Pack_expr (Int k)
+  | Enum { base; _ } -> case_index_to_expr base k
   | _ -> assert false (* guarded by [is_int_dispatch_typ] *)
 
 (* Auto-emit a dispatch + wrapper for each [Casetype] used in a struct.

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -325,12 +325,14 @@ and _ typ =
   | Enum : {
       name : string;
       cases : (string * int) list;
-      base : int typ;
+      base : 'a typ;
+          (** Any type with an integer view: the case values name integers, and
+              {!int_of_exn} reads one out of a decoded [base] value. *)
       closed : bool;
           (** [true]: only the listed values are valid. [false]: open set, the
               names document known values but any value is accepted. *)
     }
-      -> int typ  (** Named enumeration. *)
+      -> 'a typ  (** Named enumeration. *)
   | Casetype : {
       name : string;
       tag : 'k typ;
@@ -655,11 +657,47 @@ val bits : ?bit_order:bit_order -> width:int -> bitfield_base -> int typ
 val map : ('w -> 'a) -> ('a -> 'w) -> 'w typ -> 'a typ
 (** Map a wire type to a different OCaml type. *)
 
-val bool : int typ -> bool typ
-(** Map an integer type to boolean (0 = false). *)
+(** {1 Integer views}
 
-val cases : 'a list -> int typ -> 'a typ
-(** Map integer values to a list of cases by index. *)
+    A combinator that refines the integer a field decodes to needs nothing else
+    from its base, so which OCaml type carries that integer is the base's own
+    business. These decide that reading once, for every type that has one, so
+    the codec's checks, {!Eval}, {!Param}'s environments and the 3D projection
+    all agree on it. *)
+
+val int_of : 'a typ -> 'a -> int option
+(** [int_of typ v] converts a typed value to [int]. [None] for a value that does
+    not fit the native int (a {!val-uint64} over 2{^ 62}) and for a type with no
+    integer view. *)
+
+val int_of_exn : 'a typ -> 'a -> int
+(** [int_of_exn typ v] is {!val-int_of} without the [option]: it returns the
+    [int] directly (no boxing on the numeric path) and raises {!Parse_error}
+    ({!constructor-Value_out_of_range}) for a value beyond the native int range,
+    [Invalid_argument] for a type with no integer view. *)
+
+val of_int : 'a typ -> int -> 'a
+(** [of_int typ n] is the value [typ] carries for the integer [n]. Raises
+    [Invalid_argument] when [n] is outside what the type's field can hold, or
+    when the type has no integer view. *)
+
+val is_int_representable : 'a typ -> bool
+(** [is_int_representable typ] is [true] when {!int_of_exn} and {!of_int} have a
+    conversion for [typ]. *)
+
+val reject_non_integer : combinator:string -> 'a typ -> unit
+(** [reject_non_integer ~combinator typ] raises [Invalid_argument] naming
+    [combinator] unless [typ] {!is_int_representable}. Called at construction,
+    so a base a combinator cannot read as an integer fails at the description
+    rather than on the first byte decoded. *)
+
+val bool : 'a typ -> bool typ
+(** Map an integer-valued type to boolean (0 = false). Raises [Invalid_argument]
+    on a base with no integer view. *)
+
+val cases : 'a list -> 'b typ -> 'a typ
+(** Map integer values to a list of cases by index. Raises [Invalid_argument] on
+    a base with no integer view. *)
 
 val unit : unit typ
 (** Zero-width unit type. *)
@@ -742,16 +780,18 @@ val nested : size:int expr -> 'a typ -> 'a typ
 val nested_at_most : size:int expr -> 'a typ -> 'a typ
 (** Single element in a sized region (may be smaller). *)
 
-val enum : string -> (string * int) list -> int typ -> int typ
-(** Named enumeration over an integer base. *)
+val enum : string -> (string * int) list -> 'a typ -> 'a typ
+(** Named enumeration over an integer-valued base. Raises [Invalid_argument] on
+    a base with no integer view. *)
 
-val enum_open : string -> (string * int) list -> int typ -> int typ
+val enum_open : string -> (string * int) list -> 'a typ -> 'a typ
 (** Open enumeration: the named codes are declared in the 3D projection for
     documentation, but any value is accepted (no membership refinement, no
     decode rejection). *)
 
-val variants : string -> (string * 'a) list -> int typ -> 'a typ
-(** Named variant mapping over an integer base. *)
+val variants : string -> (string * 'a) list -> 'b typ -> 'a typ
+(** Named variant mapping over an integer-valued base. Raises [Invalid_argument]
+    on a base with no integer view. *)
 
 type ('a, 'k) case_def
 (** A casetype branch definition. ['k] is the discriminator type. *)

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -194,8 +194,8 @@ let parse_codec_typ codec_decode fixed_size min_size size_of buf off len =
 (* Only a closed enum enforces membership; an open enum names known codes but
    accepts any value. [Codec.decode] gates on [closed] the same way, so the two
    decode paths agree on an unlisted code. *)
-let check_enum_membership ~at ~closed cases v =
-  if closed then Types.check_enum_decode ~at ~cases v
+let check_enum_membership ~at ~closed ~base cases v =
+  if closed then Types.check_enum_decode ~at ~cases (Types.int_of_exn base v)
 
 (* [Codec.validator_of_struct] compiles a struct into a validator whose scratch
    is domain-local, and a domain-local scratch is backed by a [Domain.DLS] key
@@ -332,7 +332,7 @@ let rec parse_direct : type a. a typ -> bytes -> int -> int -> a * int =
   | Where { cond; inner } -> parse_where inner cond buf off len
   | Enum { base; cases; closed; _ } ->
       let v, off' = parse_direct base buf off len in
-      check_enum_membership ~at:off ~closed cases v;
+      check_enum_membership ~at:off ~closed ~base cases v;
       (v, off')
   | Codec { codec_decode; codec_fixed_size; codec_min_size; codec_size_of; _ }
     ->
@@ -839,7 +839,8 @@ let rec encode_into : type a. a typ -> a -> encoder -> unit =
       done
   | Enum { name; base; cases; closed } ->
       if closed then
-        Types.check_enum_encode ~name ~valid:(Types.enum_values cases) v;
+        Types.check_enum_encode ~name ~valid:(Types.enum_values cases)
+          (Types.int_of_exn base v);
       encode_into base v enc
   | Map { inner; encode; _ } -> encode_into inner (encode v) enc
   | Codec { codec_encode; codec_fixed_size; codec_size_of_value; _ } ->
@@ -981,7 +982,8 @@ let rec encode_direct : type a. a typ -> bytes -> int -> a -> int =
       encode_direct inner buf off v
   | Enum { name; base; cases; closed } ->
       if closed then
-        Types.check_enum_encode ~name ~valid:(Types.enum_values cases) v;
+        Types.check_enum_encode ~name ~valid:(Types.enum_values cases)
+          (Types.int_of_exn base v);
       encode_direct base buf off v
   | Codec { codec_encode; _ } -> codec_encode v Types.unbound_eval_ctx buf off
   | _ -> encode_via_writer typ buf off v

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -664,13 +664,19 @@ val map : decode:('w -> 'a) -> encode:('a -> 'w) -> 'w typ -> 'a typ
 val bool : bool -> bool expr
 (** Constant boolean expression. *)
 
-val bit : int typ -> bool typ
+val bit : 'a typ -> bool typ
 (** [bit t] views an integer wire value as a boolean. Zero is [false], non-zero
-    is [true]. *)
+    is [true].
 
-val lookup : 'a list -> int typ -> 'a typ
+    [t] may be any integer-valued description, whatever OCaml type carries the
+    integer: a {!val-uint8}, a bitfield, a {!val-uint32}. A description with no
+    integer reading raises [Invalid_argument] where it is written down. *)
+
+val lookup : 'a list -> 'b typ -> 'a typ
 (** [lookup table t] decodes an integer as a zero-based index into a finite
     table.
+
+    [t] may be any integer-valued description, as for {!bit}.
 
     The decoded integer selects the corresponding element from the list. An
     out-of-range index produces an {!Invalid_tag} parse error (reported via
@@ -802,15 +808,19 @@ val nested_at_most : size:int expr -> 'a typ -> 'a typ
     consume fewer bytes than the available space. Encoding zero-pads the unused
     region; a value larger than [size] raises [Invalid_argument]. *)
 
-val enum : string -> (string * int) list -> int typ -> int typ
+val enum : string -> (string * int) list -> 'a typ -> 'a typ
 (** [enum name cases base] validates that the decoded integer is one of the
     named values, on encode as well as on decode: encoding an unlisted value
-    raises [Invalid_argument]. The result is still an OCaml integer -- use
-    {!variants} instead if you want to decode to proper OCaml values. [enum] is
-    mainly useful for 3D projection where the name and cases appear in the
-    generated [.3d] file. *)
+    raises [Invalid_argument]. The result still decodes to whatever [base]
+    decodes to -- use {!variants} instead if you want proper OCaml values.
+    [enum] is mainly useful for 3D projection where the name and cases appear in
+    the generated [.3d] file.
 
-val enum_open : string -> (string * int) list -> int typ -> int typ
+    [base] may be any integer-valued description, whatever OCaml type carries
+    the integer the case values name. A description with no integer reading
+    raises [Invalid_argument] where it is written down. *)
+
+val enum_open : string -> (string * int) list -> 'a typ -> 'a typ
 (** [enum_open name cases base] is like {!enum} but for an open value set: the
     named cases document the known values, but any value is accepted. Decode
     does not reject unlisted values, and the field projects as its base scalar
@@ -818,9 +828,11 @@ val enum_open : string -> (string * int) list -> int typ -> int typ
     future codes is not wrongly rejected. The known codes are still emitted as a
     3D enum declaration, so they remain documented in the generated [.3d]. *)
 
-val variants : string -> (string * 'a) list -> int typ -> 'a typ
+val variants : string -> (string * 'a) list -> 'b typ -> 'a typ
 (** [variants name cases base] maps integer values to OCaml values via a named
-    enumeration. Unlike {!enum}, this converts to proper OCaml values. *)
+    enumeration. Unlike {!enum}, this converts to proper OCaml values.
+
+    [base] may be any integer-valued description, as for {!enum}. *)
 
 type ('a, 'k) case_def
 

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -2398,6 +2398,112 @@ let test_encode_rejects_unlisted_enum () =
   Codec.encode open_enum_codec 99 buf 0;
   Alcotest.(check string) "open enum" "\099" (Bytes.to_string buf)
 
+(* The compiled codec reaches an enum / lookup / variants / bit field through
+   its own readers, writers and staged accessors, none of which the typ-level
+   [of_string] path shares. A base whose OCaml carrier is not [int] --
+   [uint32], [int32] -- must travel all of them: the integer the refinement is
+   compiled against is the only thing these combinators take from their base. *)
+let carrier_enum_field =
+  Codec.(Field.v "E" (enum "Code32" [ ("A", 1); ("B", 2) ] uint32be) $ Fun.id)
+
+let carrier_enum_codec = Codec.v "CarrierEnum" Fun.id [ carrier_enum_field ]
+
+let test_enum_over_carrier_base () =
+  let buf = Bytes.of_string "\x00\x00\x00\x02" in
+  (match Codec.decode carrier_enum_codec buf 0 with
+  | Ok v -> Alcotest.(check int) "decode listed code" 2 (UInt32.to_int v)
+  | Error e -> Alcotest.failf "%a" pp_parse_error e);
+  Codec.validate carrier_enum_codec buf 0;
+  let get = Staged.unstage (Codec.get carrier_enum_codec carrier_enum_field) in
+  Alcotest.(check int) "get listed code" 2 (UInt32.to_int (get buf 0));
+  expect_decode_rejects "unlisted code" carrier_enum_codec "\x00\x00\x00\x63";
+  expect_encode_rejects "unlisted code" ~names:[ "Code32"; "got 99" ] (fun () ->
+      Codec.encode carrier_enum_codec (UInt32.of_int 99) buf 0);
+  Codec.encode carrier_enum_codec (UInt32.of_int 1) buf 0;
+  Alcotest.(check string)
+    "encode listed code" "\x00\x00\x00\x01" (Bytes.to_string buf);
+  let set = Staged.unstage (Codec.set carrier_enum_codec carrier_enum_field) in
+  set buf 0 (UInt32.of_int 2);
+  Alcotest.(check string) "set" "\x00\x00\x00\x02" (Bytes.to_string buf)
+
+let carrier_variants_field =
+  Codec.(
+    Field.v "V"
+      (variants "Sign"
+         [ ("Neg", `Neg); ("Zero", `Zero); ("Pos", `Pos) ]
+         int32be)
+    $ Fun.id)
+
+let carrier_variants_codec =
+  Codec.v "CarrierVariants" Fun.id [ carrier_variants_field ]
+
+let test_variants_over_carrier_base () =
+  let buf = Bytes.of_string "\x00\x00\x00\x01" in
+  (match Codec.decode carrier_variants_codec buf 0 with
+  | Ok v -> Alcotest.(check bool) "decode variant" true (v = `Zero)
+  | Error e -> Alcotest.failf "%a" pp_parse_error e);
+  Codec.validate carrier_variants_codec buf 0;
+  let get =
+    Staged.unstage (Codec.get carrier_variants_codec carrier_variants_field)
+  in
+  Alcotest.(check bool) "get variant" true (get buf 0 = `Zero);
+  Codec.encode carrier_variants_codec `Pos buf 0;
+  Alcotest.(check string) "encode" "\x00\x00\x00\x02" (Bytes.to_string buf);
+  expect_decode_rejects "index past the variant list" carrier_variants_codec
+    "\x00\x00\x00\x07"
+
+let carrier_lookup_field =
+  Codec.(Field.v "L" (lookup [ "a"; "b"; "c" ] uint32be) $ Fun.id)
+
+let carrier_lookup_codec =
+  Codec.v "CarrierLookup" Fun.id [ carrier_lookup_field ]
+
+let carrier_bit_codec =
+  Codec.v "CarrierBit" Fun.id Codec.[ Field.v "B" (bit uint32be) $ Fun.id ]
+
+let test_lookup_and_bit_over_carrier_base () =
+  let buf = Bytes.of_string "\x00\x00\x00\x02" in
+  (match Codec.decode carrier_lookup_codec buf 0 with
+  | Ok v -> Alcotest.(check string) "lookup decode" "c" v
+  | Error e -> Alcotest.failf "%a" pp_parse_error e);
+  Codec.validate carrier_lookup_codec buf 0;
+  let get =
+    Staged.unstage (Codec.get carrier_lookup_codec carrier_lookup_field)
+  in
+  Alcotest.(check string) "lookup get" "c" (get buf 0);
+  Codec.encode carrier_lookup_codec "b" buf 0;
+  Alcotest.(check string)
+    "lookup encode" "\x00\x00\x00\x01" (Bytes.to_string buf);
+  expect_decode_rejects "index past the table" carrier_lookup_codec
+    "\x00\x00\x00\x07";
+  (match Codec.decode carrier_bit_codec buf 0 with
+  | Ok v -> Alcotest.(check bool) "bit decode" true v
+  | Error e -> Alcotest.failf "%a" pp_parse_error e);
+  Codec.encode carrier_bit_codec false buf 0;
+  Alcotest.(check string) "bit encode" "\x00\x00\x00\x00" (Bytes.to_string buf)
+
+(* An enum over a little-endian [uint32] keeps its named 3D type, exactly as one
+   over [uint8] does; over the big-endian base it falls back to the membership
+   refinement EverParse can type. Both must project, or the widened base would
+   ship an OCaml-only feature. *)
+let test_enum_over_carrier_base_projects () =
+  let le = enum "Code32le" [ ("A", 1); ("B", 2) ] uint32 in
+  let out =
+    to_3d ~enum_as_type:true
+      (module_ [ typedef (struct_ "LeEnum32" [ field "v" le ]) ])
+  in
+  Alcotest.(check bool)
+    "uint32 enum keeps its enum decl" true
+    (contains ~sub:"enum Code32le" out);
+  let be = enum "Code32be" [ ("A", 1); ("B", 2) ] uint32be in
+  let out_be =
+    to_3d ~enum_as_type:true
+      (module_ [ typedef (struct_ "BeEnum32" [ field "v" be ]) ])
+  in
+  Alcotest.(check bool)
+    "uint32be enum carries a membership refinement" true
+    (contains ~sub:"UINT32BE" out_be && contains ~sub:"== 2" out_be)
+
 let zeros_codec =
   Codec.v "Padded"
     (fun tag pad -> (tag, pad))
@@ -8982,6 +9088,14 @@ let suite =
         test_exact_byte_field_expression_size;
       Alcotest.test_case "encode rejects: unlisted enum value" `Quick
         test_encode_rejects_unlisted_enum;
+      Alcotest.test_case "enum: over a non-int carrier base" `Quick
+        test_enum_over_carrier_base;
+      Alcotest.test_case "variants: over a non-int carrier base" `Quick
+        test_variants_over_carrier_base;
+      Alcotest.test_case "lookup/bit: over a non-int carrier base" `Quick
+        test_lookup_and_bit_over_carrier_base;
+      Alcotest.test_case "enum: non-int carrier base projects to 3D" `Quick
+        test_enum_over_carrier_base_projects;
       Alcotest.test_case "encode rejects: non-zero all_zeros" `Quick
         test_encode_rejects_non_zero_padding;
       Alcotest.test_case "encode rejects: refined byte span" `Quick

--- a/test/test_wire.ml
+++ b/test/test_wire.ml
@@ -1280,6 +1280,60 @@ let test_enum_open_of_string_accepts_unlisted () =
   | Ok v -> Alcotest.(check int) "of_string accepts unlisted" 50 v
   | Error e -> Alcotest.failf "of_string rejected unlisted: %a" pp_parse_error e
 
+(* [bit], [lookup], [enum], [enum_open] and [variants] all refine the integer a
+   field decodes to. That integer is the whole of what they need from their
+   base, so which OCaml type carries it is theirs to convert, not a restriction
+   to put on the caller. [uint32] and [int32] carry theirs in a type of their
+   own and are the proof: each combinator decodes, rejects and encodes over
+   them exactly as it does over [uint8]. *)
+let test_bit_over_carrier_base () =
+  let t = bit uint32be in
+  (match of_string t "\x00\x00\x00\x01" with
+  | Ok v -> Alcotest.(check bool) "non-zero decodes true" true v
+  | Error e -> Alcotest.failf "%a" pp_parse_error e);
+  (match of_string t "\x00\x00\x00\x00" with
+  | Ok v -> Alcotest.(check bool) "zero decodes false" false v
+  | Error e -> Alcotest.failf "%a" pp_parse_error e);
+  Alcotest.(check string) "encode true" "\x00\x00\x00\x01" (to_string t true);
+  Alcotest.(check string) "encode false" "\x00\x00\x00\x00" (to_string t false)
+
+let test_lookup_over_carrier_base () =
+  let t = lookup [ "a"; "b"; "c" ] uint32be in
+  (match of_string t "\x00\x00\x00\x02" with
+  | Ok v -> Alcotest.(check string) "index selects entry" "c" v
+  | Error e -> Alcotest.failf "%a" pp_parse_error e);
+  Alcotest.(check string) "encode" "\x00\x00\x00\x01" (to_string t "b");
+  expect_typ_decode_rejects "index past the table" t "\x00\x00\x00\x07";
+  expect_typ_encode_rejects "value not in the table" ~names:[ "lookup" ]
+    (fun () -> to_string t "z")
+
+let test_enum_over_carrier_base () =
+  let closed = enum "Code32" [ ("A", 1); ("B", 2) ] uint32be in
+  (match of_string closed "\x00\x00\x00\x02" with
+  | Ok v -> Alcotest.(check int) "listed code" 2 (UInt32.to_int v)
+  | Error e -> Alcotest.failf "%a" pp_parse_error e);
+  expect_typ_decode_rejects "unlisted code" closed "\x00\x00\x00\x63";
+  expect_typ_encode_rejects "unlisted code" ~names:[ "Code32"; "got 99" ]
+    (fun () -> to_string closed (UInt32.of_int 99));
+  Alcotest.(check string)
+    "encode listed code" "\x00\x00\x00\x01"
+    (to_string closed (UInt32.of_int 1));
+  let open_ = enum_open "Code32" [ ("A", 1); ("B", 2) ] uint32be in
+  match of_string open_ "\x00\x00\x00\x63" with
+  | Ok v ->
+      Alcotest.(check int) "open enum accepts unlisted" 99 (UInt32.to_int v)
+  | Error e -> Alcotest.failf "%a" pp_parse_error e
+
+let test_variants_over_carrier_base () =
+  let t =
+    variants "Sign" [ ("Neg", `Neg); ("Zero", `Zero); ("Pos", `Pos) ] int32be
+  in
+  (match of_string t "\x00\x00\x00\x01" with
+  | Ok v -> Alcotest.(check bool) "variant value" true (v = `Zero)
+  | Error e -> Alcotest.failf "%a" pp_parse_error e);
+  Alcotest.(check string) "encode" "\x00\x00\x00\x02" (to_string t `Pos);
+  expect_typ_decode_rejects "index past the variant list" t "\x00\x00\x00\x07"
+
 (* A variable-size codec computes its span by reading length fields; on a
    truncated buffer that read runs off the end. [of_string] must return a clean
    [Error] (eof), not raise [Invalid_argument], the same way [Codec.decode]
@@ -1401,6 +1455,14 @@ let suite =
         test_validate_rejects_unknown_variant;
       Alcotest.test_case "enum_open: of_string accepts unlisted" `Quick
         test_enum_open_of_string_accepts_unlisted;
+      Alcotest.test_case "bit: over a non-int carrier base" `Quick
+        test_bit_over_carrier_base;
+      Alcotest.test_case "lookup: over a non-int carrier base" `Quick
+        test_lookup_over_carrier_base;
+      Alcotest.test_case "enum: over a non-int carrier base" `Quick
+        test_enum_over_carrier_base;
+      Alcotest.test_case "variants: over a non-int carrier base" `Quick
+        test_variants_over_carrier_base;
       Alcotest.test_case "of_string: truncated variable codec rejects" `Quick
         test_of_string_truncated_variable_codec;
       Alcotest.test_case "expr: equality operators" `Quick


### PR DESCRIPTION
These took `int typ`, so a base with a carrier of its own could not be their base: `variants "Status" [...] uint32` did not typecheck. The requirement was never that the value is carried by `int`, only that it has an integer view, which is the same shape as `rest_bytes` and `Field.int64` in #321 and #323.

`bits` is untouched. The `int typ` in its signature is its result, not its base.

This unblocks giving `uint8`, `uint16`, `int8` and `int16` carriers of their own, which is otherwise impossible while `uint8` is the most common base of these five. `Types.of_int` is the seam their validating constructors will hang off. Stacked on #327.