### PR TITLE
codec: check a sub-codec in place through every container

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -155,6 +155,11 @@
 
 ### Fixed
 
+- `Codec.validate` no longer decodes a sub-codec reached through an `array`, a
+  `nested` region or a casetype case body: it checks in place, as it already did
+  for a plain field and a `Field.repeat` element, and allocates nothing
+  (#329, @samoht)
+
 - A value with no fixed wire size read through `Wire.of_reader` no longer costs
   time and memory quadratic in its length. The reader rebuilt the whole
   accumulated buffer and re-parsed it from offset zero after every slice, so a

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -2366,6 +2366,51 @@ type 'a elem_strategy =
   | Value_only
   | By of (runtime -> bytes -> int -> unit)
 
+(* An array's walk: every element checked at its own stride. Top level and
+   partially applied while the strategy is chosen, so no closure is built per
+   element. *)
+let array_elem_check ~n ~esz check runtime buf off =
+  for i = 0 to n - 1 do
+    check runtime buf (off + (i * esz))
+  done
+
+(* Run the matched case's check. Mirrors [read_case_body], on cases whose
+   bodies already carry their check, and is a top-level recursion for the same
+   reason: an inner [let rec find] would allocate a closure per casetype
+   checked. *)
+let rec dispatch_case_check : type k.
+    at:int ->
+    tag:k typ ->
+    (k option * (runtime -> bytes -> int -> unit)) list ->
+    k ->
+    runtime ->
+    bytes ->
+    int ->
+    unit =
+ fun ~at ~tag cases tag_val runtime buf body_off ->
+  match cases with
+  | [] ->
+      raise_invalid_tag ~at (Option.value ~default:0 (Eval.int_of tag tag_val))
+  | (Some t, _) :: rest when t <> tag_val ->
+      dispatch_case_check ~at ~tag rest tag_val runtime buf body_off
+  | (_, check) :: _ -> check runtime buf body_off
+
+(* A casetype's check: read the discriminant, then run the selected body's
+   check where the body starts. The tag's own extent was bounded before the
+   walk was reached -- by the budget for a repeat element, by the field's size
+   expression ([elem_size_of], which guards the tag) for a field. *)
+let casetype_elem_check : type k.
+    tag:k typ ->
+    (k option * (runtime -> bytes -> int -> unit)) list ->
+    runtime ->
+    bytes ->
+    int ->
+    unit =
+ fun ~tag cases runtime buf off ->
+  let tag_val = read_elem tag runtime buf off in
+  dispatch_case_check ~at:off ~tag cases tag_val runtime buf
+    (off + tag_byte_size tag)
+
 (* Every constructor is listed and there is deliberately no [| _ -> ...]: a typ
    added later must not pick a strategy by falling through, since picking
    [Value_only] for a reader that checks something is how [Codec.validate] comes
@@ -2378,17 +2423,39 @@ type 'a elem_strategy =
    answer by building the record first. What catches that is
    [test_repeat_validate_allocation_is_bounded] in [test/test_codec.ml], which
    validates one repeat at two byte budgets and requires the words per call to
-   come out equal, with a sub-codec among the element types it measures. *)
-let elem_strategy : type a. a typ -> a elem_strategy = function
+   come out equal, with a sub-codec among the element types it measures.
+
+   A container has nothing of its own to check, so its strategy is its
+   contents': reading one to drop it builds the sequence, the region's value or
+   the case body first, and for a sub-codec body that is exactly the record
+   [codec_validate] exists not to build. Putting one back on [By_reading] also
+   type-checks and keeps every verdict;
+   [test_container_subcodec_validate_no_alloc] is what catches it, by measuring
+   a sub-codec through each container against the same sub-codec as a plain
+   field. *)
+let rec elem_strategy : type a. a typ -> a elem_strategy = function
   | Codec { codec_validate; _ } -> By codec_validate
   | Byte_array { size = Int _ } | Byte_slice { size = Int _ } | Zeroterm ->
       Value_only
   | Uint64 _ | Int64 _ | Float32 _ | Float64 _ -> Value_only
+  | Single_elem { elem; _ } -> By (elem_check elem)
+  | Array { len = Int n; elem; _ } -> (
+      match field_wire_size elem with
+      (* No stride to walk at. Leave it to [read_elem], which is where the
+         missing element size is reported. *)
+      | None -> By_reading
+      | Some esz -> (
+          match elem_strategy elem with
+          | Value_only -> Value_only
+          | By_reading | By _ -> By (array_elem_check ~n ~esz (elem_check elem))
+          ))
+  | Casetype { tag; cases; _ } ->
+      By (casetype_elem_check ~tag (case_checks cases))
   | Uint8 | Uint16 _ | Uint32 _ | Int8 | Int16 _ | Int32 _ | Uint_var _ | Bits _
   | Unit | All_bytes | All_zeros | Zeroterm_at_most _ | Where _ | Array _
-  | Byte_array _ | Byte_array_where _ | Byte_slice _ | Single_elem _ | Enum _
-  | Casetype _ | Struct _ | Type_ref _ | Qualified_ref _ | Map _ | Apply _
-  | Optional _ | Optional_or _ | Repeat _ ->
+  | Byte_array _ | Byte_array_where _ | Byte_slice _ | Enum _ | Struct _
+  | Type_ref _ | Qualified_ref _ | Map _ | Apply _ | Optional _ | Optional_or _
+  | Repeat _ ->
       By_reading
 
 (* The element check the walk runs. Skipping a value-only reader keeps the span
@@ -2397,13 +2464,23 @@ let elem_strategy : type a. a typ -> a elem_strategy = function
    field, so anything built per element is a multiplier the sender sizes on the
    path a server runs once per packet. This is the C's element loop, which calls
    the element validator and keeps one position. *)
-let elem_check : type a. a typ -> runtime -> bytes -> int -> unit =
+and elem_check : type a. a typ -> runtime -> bytes -> int -> unit =
  fun typ ->
   match elem_strategy typ with
   | Value_only -> fun _runtime _buf _off -> ()
   | By check -> check
   | By_reading ->
       fun runtime buf off -> ignore (read_elem typ runtime buf off : a)
+
+(* A casetype's cases with each body's check already chosen, so dispatching one
+   is a tag comparison and a call. *)
+and case_checks : type a k.
+    (a, k) case_branch list ->
+    (k option * (runtime -> bytes -> int -> unit)) list =
+ fun cases ->
+  List.map
+    (fun (Case_branch { cb_tag; cb_inner; _ }) -> (cb_tag, elem_check cb_inner))
+    cases
 
 (* Write a repeat's elements at their own strides. Kept out of
    [compile_repeat] so the writer is staged once, with the sequence, the element
@@ -2600,6 +2677,52 @@ let span_populate : type a.
             ~first:(base + off_fn runtime buf base)
             ~len:(size_fn runtime buf base))
 
+(* Populate for a container field: the walk [elem_check] runs over what the
+   container holds, in place of a reader that decodes the whole of it and drops
+   the result. The region checks are the reader's own (see
+   [var_bytes_reader]), so a truncated or misdeclared region still fails where
+   decode fails; what is left out is the sequence, the nested region's value
+   and the case body's record. [None] leaves the field to the generic
+   [build_populate]. *)
+let container_populate : type a.
+    a typ ->
+    off_fn:(runtime -> bytes -> int -> int) ->
+    size_fn:(runtime -> bytes -> int -> int) ->
+    (slots -> runtime -> bytes -> int -> unit) option =
+ fun typ ~off_fn ~size_fn ->
+  match typ with
+  | Array _ | Casetype _ ->
+      let check = elem_check typ in
+      Some
+        (fun _slots runtime buf base ->
+          let first = base + off_fn runtime buf base in
+          check_span_bounds buf ~first ~sz:(size_fn runtime buf base);
+          check runtime buf first)
+  | Single_elem { elem; at_most; _ } ->
+      let check = elem_check elem in
+      Some
+        (fun _slots runtime buf base ->
+          let first = base + off_fn runtime buf base in
+          let sz = size_fn runtime buf base in
+          check_span_bounds buf ~first ~sz;
+          let consumed = elem_size_of elem runtime buf first in
+          if consumed > sz || ((not at_most) && consumed <> sz) then
+            raise_eof ~at:(first + min consumed sz) ~expected:sz ~got:consumed;
+          check runtime buf first)
+  | _ -> None
+
+(* What a field's validate runs in place of its reader: a span's scan, or a
+   container's walk over its contents. *)
+let check_populate : type a.
+    a typ ->
+    off_fn:(runtime -> bytes -> int -> int) ->
+    size_fn:(runtime -> bytes -> int -> int) ->
+    (slots -> runtime -> bytes -> int -> unit) option =
+ fun typ ~off_fn ~size_fn ->
+  match span_populate typ ~off_fn ~size_fn with
+  | Some p -> Some p
+  | None -> container_populate typ ~off_fn ~size_fn
+
 (* Kept at top level: as local closures they would be heap-allocated on
    every call (two allocations per variable-bytes field on each encode). *)
 let var_bytes_check_len size_fn runtime buf base ~actual =
@@ -2768,7 +2891,7 @@ let compile_var_bytes : type a r.
         (raw_reader, raw_writer, int_reader)
   in
   let populate =
-    match span_populate typ ~off_fn ~size_fn with
+    match check_populate typ ~off_fn ~size_fn with
     | Some p -> p
     | None -> build_populate typ ctx.n_fields raw_reader
   in
@@ -2825,7 +2948,7 @@ let compile_scalar_or_var : type a r.
         match
           if fsize < 0 then None
           else
-            span_populate typ ~off_fn:field_off_fn
+            check_populate typ ~off_fn:field_off_fn
               ~size_fn:(fun _runtime _buf _base -> fsize)
         with
         | Some p -> p

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -8365,6 +8365,76 @@ let test_repeat_validate_allocation_is_bounded () =
   report_span_failures "validate allocation scales with a repeat's budget"
     failures
 
+(* A sub-codec as a plain field runs the sub-codec's own validator, so the
+   record never reaches the heap. Reaching the same sub-codec through a
+   container -- an [array] of them, a [nested] region holding one, a casetype
+   case body -- has to cost the same: a container has nothing of its own to
+   build, so whatever it turns over is the record [Codec.validate] exists not
+   to build. Measured against the same sub-codec as a plain field rather than
+   against a fixed number, so what is pinned is the shape and not this codec's
+   own cost. *)
+let container_elem_codec =
+  Codec.v "ContainerElem"
+    (fun a b -> (a, b))
+    Codec.
+      [
+        ( Field.v "a" uint8 ~self_constraint:(fun r -> Expr.(r <> int 0))
+        $ fun (a, _) -> a );
+        (Field.v "b" uint8 $ fun (_, b) -> b);
+      ]
+
+(* Tag 1 selects the sub-codec body; the second case is there so the tag is
+   dispatched rather than assumed. Neither [inject] allocates, so what the
+   measurement sees is the container and not the case's own injection. *)
+let container_case_typ =
+  casetype "ContainerCase" uint8
+    [
+      case ~index:1 (codec container_elem_codec) ~inject:Fun.id
+        ~project:(fun v -> Some v);
+      case ~index:2 uint16be
+        ~inject:(fun v -> (v lsr 8, v land 0xff))
+        ~project:(fun (a, b) -> Some ((a lsl 8) lor b));
+    ]
+
+let container_words name typ buf =
+  let c = Codec.v name Fun.id Codec.[ Field.v "x" typ $ Fun.id ] in
+  words_per_call ~iters:5000 (fun () -> Codec.validate c buf 0)
+
+let test_container_subcodec_validate_no_alloc () =
+  skip_unless_gc_counters ();
+  let ones n = Bytes.make n '\001' in
+  let direct = container_words "Direct" (codec container_elem_codec) (ones 2) in
+  let failures =
+    List.fold_left
+      (fun acc (name, words) ->
+        if words <> direct then
+          Fmt.str
+            "a sub-codec through %s costs %d words a validate where the same \
+             sub-codec as a field costs %d"
+            name words direct
+          :: acc
+        else acc)
+      []
+      [
+        ( "an array of 4",
+          container_words "ArrayOf4"
+            (array ~len:(int 4) (codec container_elem_codec))
+            (ones 8) );
+        ( "an array of 32",
+          container_words "ArrayOf32"
+            (array ~len:(int 32) (codec container_elem_codec))
+            (ones 64) );
+        ( "a nested region",
+          container_words "NestedOne"
+            (nested ~size:(int 2) (codec container_elem_codec))
+            (ones 2) );
+        ( "a casetype case body",
+          container_words "CaseBody" container_case_typ (ones 3) );
+      ]
+  in
+  report_span_failures "a container decodes a sub-codec validate only checks"
+    failures
+
 (* A closed [enum] checks membership once per decoded element, and both sides of
    that cost are the sender's: the element count comes from the byte budget, and
    a protocol enum names as many codes as it likes. Validating a repeat of them
@@ -9495,6 +9565,9 @@ let suite =
       Alcotest.test_case
         "validate: allocation does not scale with an enum's cases" `Quick
         test_enum_element_validate_allocation_is_bounded;
+      Alcotest.test_case
+        "validate: a sub-codec in a container costs what it costs as a field"
+        `Quick test_container_subcodec_validate_no_alloc;
       Alcotest.test_case
         "validate: a checked param-free codec allocates nothing" `Quick
         test_validate_checked_no_param_no_alloc;


### PR DESCRIPTION
Validating a codec that embeds another allocated the embedded record once per array element, nested region and casetype case body; it now runs the sub-codec's own validator in place, as it already did for a plain field and a `Field.repeat` element.