### PR TITLE
types: give int8 an exact 8-bit signed carrier

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,6 +49,10 @@
 
 ### Changed
 
+- **Breaking:** `int8` decodes to `Wire.SInt8.t`, a `private int` whose range is
+  the field's, rather than a native `int`. Read one with `Wire.SInt8.to_int`,
+  build one with the range-checked `Wire.SInt8.v` (#330, @samoht)
+
 - `Wire.enum`, `Wire.enum_open`, `Wire.variants`, `Wire.lookup` and `Wire.bit`
   accept any integer-valued base, not only one that decodes to a native `int`.
   An enum, variant mapping, lookup table or flag can now sit over `uint32`,

--- a/fuzz/gen/fuzz_gen.ml
+++ b/fuzz/gen/fuzz_gen.ml
@@ -167,8 +167,8 @@ let above_bit_width width =
   Alcobar.map Alcobar.[ Alcobar.int ] (fun n -> n land mask lor (mask + 1))
 
 (* The signed counterpart, drawn from both ends: a signed [width]-bit field
-   holds [-2^(width-1) .. 2^(width-1) - 1], so 200 into an [int8] is as
-   unrepresentable as -200 even though its low byte is a legal one. *)
+   holds [-2^(width-1) .. 2^(width-1) - 1], so 40000 into an [int16] is as
+   unrepresentable as -40000 even though its low two bytes are legal ones. *)
 let outside_signed_width width =
   let limit = 1 lsl (width - 1) in
   Alcobar.map
@@ -265,6 +265,14 @@ let scalar_sint32 typ size value_gen boundaries =
   leaf ~equal:Wire.SInt32.equal ~typ ~value_gen ~random:(bytes_fixed size)
     ~adversarial:(Alcobar.choose (List.map Alcobar.const boundaries))
 
+(* [int8] is carried in a [Wire.SInt8.t], whose only constructor refuses a
+   number the byte cannot hold: every value of it is a legal signed 8-bit field,
+   so there is no hostile value to draw and no guard for one to exercise. Same
+   reasoning as [scalar_sint32]. *)
+let scalar_sint8 typ size value_gen boundaries =
+  leaf ~equal:Wire.SInt8.equal ~typ ~value_gen ~random:(bytes_fixed size)
+    ~adversarial:(Alcobar.choose (List.map Alcobar.const boundaries))
+
 (* [uint32] is carried in a [Wire.UInt32.t], whose only constructors are the
    4-byte pattern and a checked [of_int]: every value of it is a legal unsigned
    32-bit field, so there is no hostile value to draw and no guard for one to
@@ -283,7 +291,7 @@ let u32_boundaries =
 let u64_boundaries_i64 =
   Int64.[ zero; one; of_int 0xFFFF_FFFF; max_int; min_int; -1L; sub max_int 1L ]
 
-let s8_boundaries = [ -128; -1; 0; 1; 127 ]
+let s8_boundaries = List.map Wire.SInt8.v [ -128; -1; 0; 1; 127 ]
 let s16_boundaries = [ -0x8000; -1; 0; 1; 0x7FFF ]
 
 let s32_boundaries =
@@ -314,10 +322,8 @@ let u64_value_gen = Alcobar.map Alcobar.[ Alcobar.int64 ] Wire.UInt64.of_int64
 let u64_boundaries = List.map Wire.UInt64.of_int64 u64_boundaries_i64
 let uint64 = scalar_uint64 Wire.uint64 8 u64_value_gen u64_boundaries
 let uint64be = scalar_uint64 Wire.uint64be 8 u64_value_gen u64_boundaries
-
-let int8 =
-  scalar_int ~hostile:(outside_signed_width 8) Wire.int8 1 Alcobar.int8
-    s8_boundaries
+let s8_value_gen = Alcobar.map Alcobar.[ Alcobar.int8 ] Wire.SInt8.v
+let int8 = scalar_sint8 Wire.int8 1 s8_value_gen s8_boundaries
 
 let int16 =
   scalar_int ~hostile:(outside_signed_width 16) Wire.int16 2 Alcobar.int16
@@ -5597,12 +5603,14 @@ let signed_slice_semantic_codec () =
     {
       codec;
       typ = Wire.codec codec;
-      positive = Alcobar.const ((0, slice_of_string ""), Bytes.of_string "\000");
+      positive =
+        Alcobar.const
+          ((Wire.SInt8.v 0, slice_of_string ""), Bytes.of_string "\000");
       random = bytes_any;
       adversarial = bytes_any;
       equal =
         (fun (l1, s1) (l2, s2) ->
-          Int.equal l1 l2
+          Wire.SInt8.equal l1 l2
           && String.equal (string_of_slice s1) (string_of_slice s2));
       env = None;
       fields = [];

--- a/fuzz/gen/fuzz_gen.mli
+++ b/fuzz/gen/fuzz_gen.mli
@@ -262,7 +262,7 @@ val uint64 : Wire.UInt64.t t
 val uint64be : Wire.UInt64.t t
 (** [uint64be] generates for {!Wire.uint64be}. *)
 
-val int8 : int t
+val int8 : Wire.SInt8.t t
 (** [int8] generates for {!Wire.int8}. *)
 
 val int16 : int t

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -199,7 +199,7 @@ and build_field_encoder_ctx : type a.
       fun _runtime buf off v ->
         UInt64.set_be buf off v;
         off + 8
-  | Int8 -> fun _runtime -> setter_off 1 Types.set_int8
+  | Int8 -> fun _runtime -> setter_off 1 SInt8.set
   | Int16 Little -> fun _runtime -> setter_off 2 Types.set_int16_le
   | Int16 Big -> fun _runtime -> setter_off 2 Types.set_int16_be
   | Int32 Little -> fun _runtime -> setter_off 4 Types.set_int32_le
@@ -328,7 +328,7 @@ let rec build_field_reader_ctx : type a.
   | Uint32 Big -> fun _runtime buf base -> UInt32.be buf (base + field_off)
   | Uint64 Little -> fun _runtime buf base -> UInt64.le buf (base + field_off)
   | Uint64 Big -> fun _runtime buf base -> UInt64.be buf (base + field_off)
-  | Int8 -> fun _runtime buf base -> Bytes.get_int8 buf (base + field_off)
+  | Int8 -> fun _runtime buf base -> SInt8.get buf (base + field_off)
   | Int16 Little ->
       fun _runtime buf base -> Bytes.get_int16_le buf (base + field_off)
   | Int16 Big ->
@@ -426,7 +426,7 @@ let rec build_immediate_reader : type a.
   | Uint32 Big -> Some (fun buf base -> UInt32.be buf (at base))
   | Uint64 Little -> Some (fun buf base -> UInt64.le buf (at base))
   | Uint64 Big -> Some (fun buf base -> UInt64.be buf (at base))
-  | Int8 -> Some (fun buf base -> Bytes.get_int8 buf (at base))
+  | Int8 -> Some (fun buf base -> SInt8.get buf (at base))
   | Int16 Little -> Some (fun buf base -> Bytes.get_int16_le buf (at base))
   | Int16 Big -> Some (fun buf base -> Bytes.get_int16_be buf (at base))
   | Int32 Little -> Some (fun buf base -> SInt32.le buf (at base))
@@ -477,7 +477,7 @@ let rec build_immediate_encoder : type a.
   | Uint32 Big -> Some (setter_off 4 UInt32.set_be)
   | Uint64 Little -> Some (setter_off 8 UInt64.set_le)
   | Uint64 Big -> Some (setter_off 8 UInt64.set_be)
-  | Int8 -> Some (setter_off 1 Types.set_int8)
+  | Int8 -> Some (setter_off 1 SInt8.set)
   | Int16 Little -> Some (setter_off 2 Types.set_int16_le)
   | Int16 Big -> Some (setter_off 2 Types.set_int16_be)
   | Int32 Little -> Some (setter_off 4 Types.set_int32_le)
@@ -616,6 +616,11 @@ let populate_uint_var idx reader =
 let populate_int idx reader slots runtime buf base =
   set_int_slot slots idx (reader runtime buf base)
 
+(* [SInt8.t] is a native [int] behind a range, so the slot takes the decoded
+   value unchanged and no platform has a value it cannot hold. *)
+let populate_sint8 idx reader slots runtime buf base =
+  set_int_slot slots idx (SInt8.to_int (reader runtime buf base))
+
 (* Floats store their IEEE 754 bit pattern in the int slot so [Ref name] in a
    constraint sees the value the 3D side sees; a float64 also fills the int64
    slot with the full pattern, which its predicates read (the int slot cannot
@@ -642,7 +647,7 @@ let rec build_populate : type a.
   match typ with
   | Uint8 -> populate_int idx reader
   | Uint16 _ -> populate_int idx reader
-  | Int8 -> populate_int idx reader
+  | Int8 -> populate_sint8 idx reader
   | Int16 _ -> populate_int idx reader
   | Int32 _ -> populate_sint32 idx reader
   | Bits _ -> populate_int idx reader
@@ -1668,7 +1673,7 @@ let rec read_elem : type a. a typ -> runtime -> bytes -> int -> a =
   | Uint32 Big -> UInt32.be buf off
   | Uint64 Little -> UInt64.le buf off
   | Uint64 Big -> UInt64.be buf off
-  | Int8 -> Bytes.get_int8 buf off
+  | Int8 -> SInt8.get buf off
   | Int16 Little -> Bytes.get_int16_le buf off
   | Int16 Big -> Bytes.get_int16_be buf off
   | Int32 Little -> SInt32.le buf off
@@ -1776,7 +1781,7 @@ let rec write_elem : type a. a typ -> runtime -> bytes -> int -> a -> unit =
   | Uint32 Big -> UInt32.set_be buf off v
   | Uint64 Little -> UInt64.set_le buf off v
   | Uint64 Big -> UInt64.set_be buf off v
-  | Int8 -> Types.set_int8 buf off v
+  | Int8 -> SInt8.set buf off v
   | Int16 Little -> Types.set_int16_le buf off v
   | Int16 Big -> Types.set_int16_be buf off v
   | Int32 Little -> Types.set_int32_le buf off v

--- a/lib/param.ml
+++ b/lib/param.ml
@@ -26,7 +26,7 @@ let rec to_int : type a. a Types.typ -> a -> int =
   | Uint_var _ -> optint_to_int UInt63.to_int v
   | Uint32 _ -> optint_to_int UInt32.to_int v
   | Uint64 _ -> UInt64.to_int_opt v |> Option.value ~default:max_int
-  | Int8 -> v
+  | Int8 -> SInt8.to_int v
   | Int16 _ -> v
   | Int32 _ -> SInt32.to_int v
   | Int64 _ -> Int64.to_int v

--- a/lib/sInt8.ml
+++ b/lib/sInt8.ml
@@ -1,0 +1,20 @@
+type t = int
+
+let min_int = -128
+let max_int = 127
+let zero = 0
+let equal : t -> t -> bool = Int.equal
+let pp = Fmt.int
+
+(* The one place the range is enforced. Every other path takes a [t] and so
+   takes a value the field holds, which is what lets the encoders drop their
+   own width checks instead of carrying one that cannot fire. *)
+let v n =
+  if n < min_int || n > max_int then
+    Fmt.invalid_arg "Wire.SInt8.v: %d is not a signed 8-bit value" n;
+  n
+
+let v_opt n = if n < min_int || n > max_int then None else Some n
+let to_int n = n
+let get buf off = Bytes.get_int8 buf off
+let set buf off n = Bytes.set_int8 buf off n

--- a/lib/sInt8.mli
+++ b/lib/sInt8.mli
@@ -1,0 +1,50 @@
+(** Signed 8-bit integer.
+
+    A native [int] narrowed to what one signed byte holds. The range is in the
+    type rather than in a check at every encoder: a number outside [[-128, 127]]
+    never becomes a value of this type, so nothing downstream has to ask again,
+    and a case value or table index the field cannot hold is refused where it is
+    written down rather than at the first byte encoded.
+
+    [private int] on purpose. The carrier is exactly the [int] it looks like, on
+    every target: no box, no conversion on the way out, and only the places that
+    build a value have to say which range they are in. *)
+
+type t = private int
+
+val v : int -> t
+(** [v n] is [n] as a signed 8-bit value. Raises [Invalid_argument] when [n] is
+    outside [[-128, 127]], rather than masking it to a legal value the caller
+    did not mean: 200 masks to a perfectly good -56 that no decoder can tell
+    from the number that was written. *)
+
+val v_opt : int -> t option
+(** [v_opt n] is {!v} as an option, for a caller testing a number rather than
+    asserting it. *)
+
+val to_int : t -> int
+(** [to_int t] is the value as a native [int]. Total and exact on every target:
+    every signed 8-bit value fits every OCaml [int]. *)
+
+val zero : t
+(** [zero] is 0. *)
+
+val min_int : t
+(** [min_int] is -128, the smallest value a signed byte holds. *)
+
+val max_int : t
+(** [max_int] is 127, the largest value a signed byte holds. *)
+
+val equal : t -> t -> bool
+(** [equal a b] is [true] when [a] and [b] are the same value. *)
+
+val pp : Format.formatter -> t -> unit
+(** Pretty-printer for signed 8-bit values. *)
+
+val get : bytes -> int -> t
+(** [get buf off] reads the signed byte at offset [off]. Total: one byte spells
+    only values the field holds. *)
+
+val set : bytes -> int -> t -> unit
+(** [set buf off v] writes [v] as one signed byte at offset [off]. Needs no
+    range check: every {!type-t} is a value the byte holds. *)

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -170,7 +170,7 @@ and _ typ =
   | Uint16 : endian -> int typ
   | Uint32 : endian -> UInt32.t typ
   | Uint64 : endian -> UInt64.t typ (* boxed, for full 64-bit *)
-  | Int8 : int typ
+  | Int8 : SInt8.t typ
   | Int16 : endian -> int typ
   | Int32 : endian -> SInt32.t typ
   | Int64 : endian -> int64 typ
@@ -554,7 +554,7 @@ let rec int_of : type a. a typ -> a -> int option =
      host. *)
   | Uint32 _ -> Int32.unsigned_to_int (UInt32.to_int32 v)
   | Uint64 _ -> UInt64.to_int_opt v
-  | Int8 -> Some v
+  | Int8 -> Some (SInt8.to_int v)
   | Int16 _ -> Some v
   | Int32 _ -> SInt32.to_int_opt v
   | Int64 _ -> Int64.unsigned_to_int v
@@ -609,7 +609,7 @@ let rec int_of_exn : type a. a typ -> a -> int =
       match UInt64.to_int_opt v with
       | Some n -> n
       | None -> int_overflow (UInt64.to_int64 v))
-  | Int8 -> v
+  | Int8 -> SInt8.to_int v
   | Int16 _ -> v
   | Int32 _ -> (
       match SInt32.to_int_opt v with
@@ -643,7 +643,7 @@ let rec of_int : type a. a typ -> int -> a =
   | Uint_var _ -> UInt63.of_int n
   | Uint32 _ -> UInt32.of_int n
   | Uint64 _ -> UInt64.of_int n
-  | Int8 -> n
+  | Int8 -> SInt8.v n
   | Int16 _ -> n
   | Int32 _ -> SInt32.of_int n
   | Int64 _ -> Int64.of_int n
@@ -1502,7 +1502,7 @@ let rec case_index_to_expr : type k. k typ -> k -> packed_expr =
   | Uint16 _ -> Pack_expr (Int k)
   | Uint32 _ -> Pack_expr (Int (uint32_case_index k))
   | Uint_var _ -> Pack_expr (Int (uint_var_case_index k))
-  | Int8 -> Pack_expr (Int k)
+  | Int8 -> Pack_expr (Int (SInt8.to_int k))
   | Int16 _ -> Pack_expr (Int k)
   | Int32 _ -> Pack_expr (Int (int32_case_index k))
   | Bits _ -> Pack_expr (Int k)
@@ -2123,10 +2123,6 @@ let set_uint16_le buf off v =
 let set_uint16_be buf off v =
   check_unsigned_encode ~bits:16 v;
   Bytes.set_uint16_be buf off v
-
-let set_int8 buf off v =
-  check_signed_encode ~bits:8 v;
-  Bytes.set_int8 buf off v
 
 let set_int16_le buf off v =
   check_signed_encode ~bits:16 v;

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -175,8 +175,8 @@ val check_unsigned_encode : bits:int -> int -> unit
 val check_signed_encode : bits:int -> int -> unit
 (** Check an integer fits a signed [bits]-wide field before encoding it. The
     accepted range is [[-2^(bits-1), 2^(bits-1) - 1]]: the decoder produces
-    exactly that, so [200] into an {!val-int8} is refused rather than
-    round-tripping back as [-56]. Same narrow-target narrowing as
+    exactly that, so [40000] into an {!val-int16} is refused rather than
+    round-tripping back as [-25536]. Same narrow-target narrowing as
     {!check_unsigned_encode}. *)
 
 (** {2 Checked scalar writers}
@@ -193,9 +193,6 @@ val set_uint16_le : bytes -> int -> int -> unit
 
 val set_uint16_be : bytes -> int -> int -> unit
 (** [set_uint16_be buf off v] writes [v] as two unsigned big-endian bytes. *)
-
-val set_int8 : bytes -> int -> int -> unit
-(** [set_int8 buf off v] writes [v] as one signed byte. *)
 
 val set_int16_le : bytes -> int -> int -> unit
 (** [set_int16_le buf off v] writes [v] as two signed little-endian bytes. *)
@@ -278,7 +275,9 @@ and _ typ =
   | Uint64 : endian -> UInt64.t typ
       (** 64-bit unsigned. Carried by {!UInt64.t}, which orders as an unsigned
           number; [int64] would rank the largest value below 1. *)
-  | Int8 : int typ  (** 8-bit signed. *)
+  | Int8 : SInt8.t typ
+      (** 8-bit signed. Carried by {!SInt8.t}, whose range is the field's: a
+          number the byte cannot hold is refused where it is built. *)
   | Int16 : endian -> int typ  (** 16-bit signed. *)
   | Int32 : endian -> SInt32.t typ
       (** 32-bit signed. Carried by {!SInt32.t}, which holds the full range on
@@ -595,7 +594,7 @@ val uint64 : UInt64.t typ
 val uint64be : UInt64.t typ
 (** 64-bit unsigned, big-endian. *)
 
-val int8 : int typ
+val int8 : SInt8.t typ
 (** 8-bit signed two's-complement integer. *)
 
 val int16 : int typ

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -263,7 +263,7 @@ let rec parse_direct : type a. a typ -> bytes -> int -> int -> a * int =
   | Uint32 Big -> parse_fixed 4 UInt32.be buf off len
   | Uint64 Little -> parse_fixed 8 UInt64.le buf off len
   | Uint64 Big -> parse_fixed 8 UInt64.be buf off len
-  | Int8 -> parse_fixed 1 Bytes.get_int8 buf off len
+  | Int8 -> parse_fixed 1 SInt8.get buf off len
   | Int16 Little -> parse_fixed 2 Bytes.get_int16_le buf off len
   | Int16 Big -> parse_fixed 2 Bytes.get_int16_be buf off len
   | Int32 Little -> parse_fixed 4 int32_le buf off len
@@ -652,7 +652,7 @@ let[@inline] write_byte enc b =
 
 let[@inline] write_int8 enc v =
   ensure enc 1;
-  Bytes.set_int8 enc.o enc.o_next v;
+  SInt8.set enc.o enc.o_next v;
   enc.o_next <- enc.o_next + 1
 
 let[@inline] write_int16_le enc v =
@@ -746,9 +746,7 @@ let rec encode_into : type a. a typ -> a -> encoder -> unit =
   | Uint32 Big -> write_uint32_be enc v
   | Uint64 Little -> write_int64_le enc (UInt64.to_int64 v)
   | Uint64 Big -> write_int64_be enc (UInt64.to_int64 v)
-  | Int8 ->
-      Types.check_signed_encode ~bits:8 v;
-      write_int8 enc v
+  | Int8 -> write_int8 enc v
   | Int16 Little ->
       Types.check_signed_encode ~bits:16 v;
       write_int16_le enc v
@@ -1015,6 +1013,7 @@ let pp_value (type r) (c : r Codec.t) ppf (v : r) =
 
 module UInt64 = UInt64
 module SInt32 = SInt32
+module SInt8 = SInt8
 module Ascii = Ascii
 
 module Private = struct

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -383,6 +383,13 @@ module SInt32 = SInt32
     value read with the wrong signedness is a silent misparse rather than a type
     error. *)
 
+module SInt8 = SInt8
+(** Signed 8-bit integers, the carrier of {!int8}.
+
+    A [private int], so a value reads as the [int] it is; only building one
+    names the range, and [SInt8.v 200] is refused there rather than at the
+    encoder. *)
+
 module Field : sig
   type 'a t
   (** A named field carrying values of type ['a]. *)
@@ -584,10 +591,12 @@ val uint64be : UInt64.t typ
 (** [uint64be] is an unsigned 64-bit big-endian integer represented as an OCaml
     64-bit integer. *)
 
-val int8 : int typ
-(** Signed 8-bit two's-complement integer. Encodes [-128] to [127]: [200] is not
+val int8 : SInt8.t typ
+(** Signed 8-bit two's-complement integer. Holds [-128] to [127]: [200] is not
     an [int8], even though its low byte is a legal one, and would come back from
-    the decoder as [-56]. *)
+    the decoder as [-56]. The range is the carrier's, so {!SInt8.v} refuses it
+    where the value is built and every encode path takes only values the byte
+    holds. *)
 
 val int16 : int typ
 (** Signed 16-bit little-endian integer. Encodes [-32768] to [32767]. *)

--- a/test/test.ml
+++ b/test/test.ml
@@ -11,6 +11,7 @@ let () =
       Test_uint32.suite;
       Test_uint64.suite;
       Test_sint32.suite;
+      Test_sint8.suite;
       Test_uint63.suite;
       Test_types.suite;
       Test_eval.suite;

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -3020,8 +3020,8 @@ let test_map_inherits_exact_width () =
    narrow ones in a plain [int], which holds far more than the field does, so
    nothing but a runtime check stands between a caller's 0x1FF and an 0xFF on
    the wire that reads back as a perfectly legal 255. The signed ones accept
-   exactly what their decoder produces, [-2^(n-1) .. 2^(n-1) - 1]: 200 into an
-   [int8] is refused rather than round-tripped back as -56. *)
+   exactly what their decoder produces, [-2^(n-1) .. 2^(n-1) - 1]: 40000 into
+   an [int16] is refused rather than round-tripped back as -25536. *)
 let scalar_range_codec name typ =
   let cf = Codec.(Field.v "v" typ $ Fun.id) in
   (Codec.v name Fun.id Codec.[ cf ], cf)
@@ -3087,11 +3087,12 @@ let test_encode_exact_signed_scalar () =
           ~equal:Int.equal ~pp:Fmt.int
           ~inside:[ -limit; limit - 1 ]
           ~outside:[ limit; -limit - 1 ])
-    (* [int32] is absent on purpose: its carrier is {!SInt32.t}, whose
-       constructors refuse an out-of-range number, so there is no such value to
-       hand the encoder. [test_sint32_of_int_range] pins that refusal instead,
-       one step earlier than this check can reach. *)
-    [ ("int8", 8, int8); ("int16", 16, int16); ("int16be", 16, int16be) ]
+    (* [int8] and [int32] are absent on purpose: their carriers, {!SInt8.t}
+       and {!SInt32.t}, refuse an out-of-range number, so there is no such
+       value to hand the encoder. [test_sint32_of_int_range] and the [sint8]
+       suite pin those refusals instead, one step earlier than this check can
+       reach. *)
+    [ ("int16", 16, int16); ("int16be", 16, int16be) ]
 
 (* The signed 32-bit range is enforced where the value is built rather than
    where it is written, so a number the field cannot hold never becomes an

--- a/test/test_sint8.ml
+++ b/test/test_sint8.ml
@@ -1,0 +1,85 @@
+(* Tests for SInt8, the signed 8-bit carrier behind [int8]. The range lives in
+   the type, so what is left to check is the constructor's refusal and the byte
+   layout: every value of the type is one a signed byte holds, and no encoder
+   downstream has to ask again. *)
+
+open Wire
+
+(* [v] refuses a number the field cannot hold rather than masking it to a legal
+   one the caller did not mean: 200 masks to a perfectly good -56 that no
+   decoder, [validate] or generated C validator could tell from the number the
+   caller wrote. *)
+let test_v_refuses_out_of_range () =
+  List.iter
+    (fun n ->
+      match SInt8.v n with
+      | x -> Alcotest.failf "v %d built %a" n SInt8.pp x
+      | exception Invalid_argument _ -> ())
+    [ 128; 200; 255; -129; -1000; max_int; min_int ]
+
+let test_v_accepts_the_whole_range () =
+  for n = -128 to 127 do
+    Fmt.kstr
+      (fun msg -> Alcotest.(check int) msg n)
+      "v %d round-trips" n
+      (SInt8.to_int (SInt8.v n))
+  done
+
+let test_v_opt () =
+  Alcotest.(check (option int))
+    "in range" (Some 127)
+    (Option.map SInt8.to_int (SInt8.v_opt 127));
+  Alcotest.(check bool) "out of range" true (SInt8.v_opt 128 = None)
+
+(* [min_int] and [max_int] are the field's ends, not the carrier's. *)
+let test_bounds () =
+  Alcotest.(check int) "min_int" (-128) (SInt8.to_int SInt8.min_int);
+  Alcotest.(check int) "max_int" 127 (SInt8.to_int SInt8.max_int);
+  Alcotest.(check int) "zero" 0 (SInt8.to_int SInt8.zero)
+
+let test_roundtrip () =
+  let buf = Bytes.create 1 in
+  for n = -128 to 127 do
+    SInt8.set buf 0 (SInt8.v n);
+    Fmt.kstr
+      (fun msg -> Alcotest.(check int) msg n)
+      "%d survives the byte" n
+      (SInt8.to_int (SInt8.get buf 0))
+  done
+
+(* Pin the byte so the read and write paths cannot drift apart: a pattern with
+   the top bit set is the negative number it spells, not the unsigned one. *)
+let test_byte_layout () =
+  Alcotest.(check int)
+    "0xFE reads -2" (-2)
+    (SInt8.to_int (SInt8.get (Bytes.of_string "\xFE") 0));
+  Alcotest.(check int)
+    "0x80 reads min_int" (-128)
+    (SInt8.to_int (SInt8.get (Bytes.of_string "\x80") 0));
+  let out = Bytes.create 1 in
+  SInt8.set out 0 SInt8.min_int;
+  Alcotest.(check string) "min_int writes 0x80" "\x80" (Bytes.to_string out)
+
+let test_equal () =
+  Alcotest.(check bool) "reflexive" true (SInt8.equal (SInt8.v 42) (SInt8.v 42));
+  Alcotest.(check bool)
+    "min_int <> max_int" false
+    (SInt8.equal SInt8.min_int SInt8.max_int)
+
+let test_pp () =
+  Alcotest.(check string) "min_int" "-128" (Fmt.str "%a" SInt8.pp SInt8.min_int)
+
+let suite =
+  ( "sint8",
+    [
+      Alcotest.test_case "v refuses out of range" `Quick
+        test_v_refuses_out_of_range;
+      Alcotest.test_case "v accepts the whole range" `Quick
+        test_v_accepts_the_whole_range;
+      Alcotest.test_case "v_opt" `Quick test_v_opt;
+      Alcotest.test_case "bounds" `Quick test_bounds;
+      Alcotest.test_case "roundtrip" `Quick test_roundtrip;
+      Alcotest.test_case "byte layout" `Quick test_byte_layout;
+      Alcotest.test_case "equal" `Quick test_equal;
+      Alcotest.test_case "pp" `Quick test_pp;
+    ] )

--- a/test/test_sint8.mli
+++ b/test/test_sint8.mli
@@ -1,0 +1,4 @@
+(** Tests for the [sint8] module. *)
+
+val suite : string * unit Alcotest.test_case list
+(** Alcotest suite. *)

--- a/test/test_wire.ml
+++ b/test/test_wire.ml
@@ -118,12 +118,14 @@ let test_byte_slice_zero () =
 
 let test_int8_negative () =
   let buf = Bytes.of_string "\xFE" in
-  Alcotest.(check int) "-2" (-2) (of_bytes_exn int8 buf)
+  Alcotest.(check int) "-2" (-2) (SInt8.to_int (of_bytes_exn int8 buf))
 
 let test_int8_full_range () =
   for i = -128 to 127 do
-    let s = to_string int8 i in
-    Alcotest.(check int) (Fmt.str "%d" i) i (of_string_exn int8 s)
+    let s = to_string int8 (SInt8.v i) in
+    Alcotest.(check int)
+      (Fmt.str "%d" i) i
+      (SInt8.to_int (of_string_exn int8 s))
   done
 
 (* [of_reader] on a value with no fixed wire size accumulates slices and retries


### PR DESCRIPTION
`Wire.int8` used to decode to a native `int` and range-check on the way to the wire; it now decodes to `Wire.SInt8.t`, a `private int` whose range is the field's, so a value the byte cannot hold is refused where it is built rather than at the first byte encoded. Read one with `SInt8.to_int` and build one with `SInt8.v`; a decoded value still prints, compares and pattern-matches as the `int` it is.