### PR TITLE
wire: carry the terminator search across reader retries

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -164,6 +164,10 @@
   for a plain field and a `Field.repeat` element, and allocates nothing
   (#329, @samoht)
 
+- A `zeroterm` read through `Wire.of_reader` no longer costs time quadratic in
+  its length, at the top level or inside a codec: a 64 KiB string arriving one
+  byte at a time took 1.7 s and now takes a millisecond (#331, @samoht)
+
 - A value with no fixed wire size read through `Wire.of_reader` no longer costs
   time and memory quadratic in its length. The reader rebuilt the whole
   accumulated buffer and re-parsed it from offset zero after every slice, so a

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -520,14 +520,6 @@ let parse_or_rewind typ reader bytes len =
       push_back_bytes reader bytes 0 len;
       raise (Parse_error e)
 
-let missing_more_input e =
-  (* A truncated zeroterm reports [Missing_terminator] (from
-     [Codec.zeroterm_nul_pos]); both it and an [Unexpected_eof] mean the reader
-     should fetch more input before giving up. *)
-  match e.kind with
-  | Unexpected_eof _ | Missing_terminator -> true
-  | _ -> false
-
 (* A growable scratch the incremental reader accumulates slices into, so
    retrying a parse costs nothing beyond the retry. [Buffer.to_bytes] rebuilt
    everything read so far on every call, which is what made a value arriving in
@@ -536,9 +528,18 @@ let missing_more_input e =
    [Bytes.make] rather than [Bytes.create]: the parse is given a length, but a
    size expression can still read the bytes behind it, and those must not be
    whatever the allocator last held. *)
-type scratch = { mutable buf : bytes; mutable filled : int }
+type scratch = {
+  mutable buf : bytes;
+  mutable filled : int;
+  (* How far the terminator search has looked. A zeroterm cannot know where its
+     NUL is until it sees one, so a retry per slice rescans from the string's
+     start every time, which is what makes a dribbled zeroterm quadratic. The
+     cursor carries the search across retries so each byte is looked at once. *)
+  mutable nul_from : int;
+}
 
-let scratch_create () = { buf = Bytes.make 256 '\000'; filled = 0 }
+let scratch_create () =
+  { buf = Bytes.make 256 '\000'; filled = 0; nul_from = 0 }
 
 let scratch_ensure s n =
   if n > Bytes.length s.buf then begin
@@ -571,13 +572,29 @@ let rec scratch_fill s reader target =
 
 (* How far to read before retrying a parse that ran short. [expected] is what
    the value needed and [got] what was left where it starts, so the shortfall is
-   the difference; never less than one byte, or a hint of zero would spin.
-   [Missing_terminator] carries no count, because a zeroterm cannot know where
-   its NUL is until it sees one, so that case advances a slice at a time. *)
-let retry_target s e =
-  match e.kind with
-  | Unexpected_eof { expected; got } -> s.filled + max 1 (expected - got)
-  | _ -> s.filled + 1
+   the difference; never less than one byte, or a hint of zero would spin. *)
+let retry_target s ~expected ~got = s.filled + max 1 (expected - got)
+
+(* First NUL at or after [i] among the buffered bytes, or [-1] for none. *)
+let rec nul_at s i =
+  if i >= s.filled then -1
+  else if Bytes.get_uint8 s.buf i = 0 then i
+  else nul_at s (i + 1)
+
+(* Read until a NUL turns up at or after the scan cursor, or the reader ends.
+   Returns whether a terminator the retry has not been offered yet is buffered.
+   The cursor makes this one pass over the input however many slices it takes,
+   where a search restarted per slice reads the same bytes over and over. *)
+let rec fill_to_nul s reader =
+  let p = nul_at s s.nul_from in
+  if p >= 0 then begin
+    s.nul_from <- p + 1;
+    true
+  end
+  else begin
+    s.nul_from <- s.filled;
+    scratch_read s reader && fill_to_nul s reader
+  end
 
 let of_reader_incremental typ reader =
   let s = scratch_create () in
@@ -585,21 +602,33 @@ let of_reader_incremental typ reader =
     push_back_bytes reader s.buf 0 s.filled;
     raise (Parse_error e)
   in
+  (* Both recoverable kinds read ahead and retry, and give up only when the read
+     yields nothing at all. What differs is how far ahead to read. *)
   let rec loop () =
     match parse_direct typ s.buf 0 s.filled with
     | v, off ->
         push_back_bytes reader s.buf off (s.filled - off);
         v
-    | exception Parse_error e when missing_more_input e ->
+    | exception Parse_error e -> (
         let before = s.filled in
-        ignore (scratch_fill s reader (retry_target s e) : bool);
-        (* The hint says how far to read ahead, never whether to fail. A size
-           that depends on a field the parse has not reached yet is computed
-           from whatever lies at that offset, so the figure can be far larger
-           than the input, and reaching the end of the reader while chasing it
-           is not an error. Give up only when a read yields nothing at all. *)
-        if s.filled > before then loop () else give_up e
-    | exception Parse_error e -> give_up e
+        match e.kind with
+        (* A search ran the length of the buffer without meeting its terminator,
+           so no retry can succeed until a NUL arrives: read until one does.
+           Waiting on it can only delay a retry, never skip one, since a reader
+           that ends first still retries over everything that arrived. *)
+        | Missing_terminator ->
+            let found = fill_to_nul s reader in
+            if found || s.filled > before then loop () else give_up e
+        (* The shortfall says how far to read ahead, never whether to fail. A
+           size that depends on a field the parse has not reached yet is
+           computed from whatever lies at that offset, so the figure can be far
+           larger than the input, and reaching the end of the reader while
+           chasing it is not an error. *)
+        | Unexpected_eof { expected; got } ->
+            ignore
+              (scratch_fill s reader (retry_target s ~expected ~got) : bool);
+            if s.filled > before then loop () else give_up e
+        | _ -> give_up e)
   in
   loop ()
 

--- a/test/test_wire.ml
+++ b/test/test_wire.ml
@@ -166,6 +166,53 @@ let test_reader_incremental_is_not_quadratic () =
      %.0f words)"
     words
 
+(* The test above pins the re-parse a dribbled value costs; this one pins the
+   terminator search. A [zeroterm] has no length field, so its size is the
+   search itself: retrying once per slice restarts that search at the string's
+   first byte every time. Only wall time separates the two shapes, since the
+   retries allocate the same either way, so this measures the scan directly. *)
+let test_reader_zeroterm_scan_is_not_quadratic () =
+  (match Sys.backend_type with
+  | Sys.Other _ -> Alcotest.skip ()
+  | Sys.Native | Sys.Bytecode -> ());
+  let payload = String.make 65536 'x' in
+  let frame = Wire.to_string zeroterm payload in
+  let reader = Bytesrw.Bytes.Reader.of_string ~slice_length:1 frame in
+  let before = Sys.time () in
+  let got = Wire.of_reader_exn zeroterm reader in
+  let elapsed = Sys.time () -. before in
+  Alcotest.(check string) "payload round-trips" payload got;
+  Fmt.kstr
+    (fun msg -> Alcotest.(check bool) msg true (elapsed < 0.25))
+    "a 64 KiB zeroterm dribbled one byte at a time scans each byte about once \
+     (took %.3f s)"
+    elapsed
+
+(* The same scan, reached through a codec rather than at the top level. A
+   zeroterm has no length field wherever it sits, so an embedded one restarts
+   its terminator search per slice exactly as a top-level one does; pin both, or
+   a cursor that only the top-level path consults would look correct here. *)
+let test_reader_embedded_zeroterm_scan_is_not_quadratic () =
+  (match Sys.backend_type with
+  | Sys.Other _ -> Alcotest.skip ()
+  | Sys.Native | Sys.Bytecode -> ());
+  let inner =
+    Codec.v "EmbeddedZt" (fun s -> s) Codec.[ Field.v "s" zeroterm $ Fun.id ]
+  in
+  let typ = codec inner in
+  let payload = String.make 65536 'x' in
+  let frame = Wire.to_string typ payload in
+  let reader = Bytesrw.Bytes.Reader.of_string ~slice_length:1 frame in
+  let before = Sys.time () in
+  let got = Wire.of_reader_exn typ reader in
+  let elapsed = Sys.time () -. before in
+  Alcotest.(check string) "payload round-trips" payload got;
+  Fmt.kstr
+    (fun msg -> Alcotest.(check bool) msg true (elapsed < 0.25))
+    "a 64 KiB zeroterm inside a codec, dribbled one byte at a time, scans each \
+     byte about once (took %.3f s)"
+    elapsed
+
 let test_int16be_negative () =
   let buf = Bytes.of_string "\xFF\xFE" in
   Alcotest.(check int) "-2 BE" (-2) (of_bytes_exn int16be buf)
@@ -1484,6 +1531,10 @@ let suite =
       Alcotest.test_case "parse: int16be negative" `Quick test_int16be_negative;
       Alcotest.test_case "reader: incremental parse is not quadratic" `Quick
         test_reader_incremental_is_not_quadratic;
+      Alcotest.test_case "reader: zeroterm scan is not quadratic" `Quick
+        test_reader_zeroterm_scan_is_not_quadratic;
+      Alcotest.test_case "reader: embedded zeroterm scan is not quadratic"
+        `Quick test_reader_embedded_zeroterm_scan_is_not_quadratic;
       Alcotest.test_case "parse: int32be negative" `Quick test_int32be_negative;
       Alcotest.test_case "parse: int64le roundtrip" `Quick
         test_int64le_roundtrip;


### PR DESCRIPTION
A `zeroterm` read through `Wire.of_reader` restarted its search for the NUL at the string's first byte after every slice, so 64 KiB arriving a byte at a time took 1.7 s; the scan cursor now survives the retry and the same read takes under a millisecond. This holds through a codec as well as at the top level, and both are pinned, since a cursor only the top-level path consulted would pass the top-level test alone.