### PR TITLE
codec: size a region's value from the region's own bytes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -168,6 +168,10 @@
   its length, at the top level or inside a codec: a 64 KiB string arriving one
   byte at a time took 1.7 s and now takes a millisecond (#331, @samoht)
 
+- `Wire.nested` now sizes a value from the region's own bytes even when the
+  length field it depends on sits past the region: the end-of-input it reports
+  no longer counts bytes the parse was never handed (#332, @samoht)
+
 - A value with no fixed wire size read through `Wire.of_reader` no longer costs
   time and memory quadratic in its length. The reader rebuilt the whole
   accumulated buffer and re-parsed it from offset zero after every slice, so a

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -12,20 +12,30 @@ let blit_slice_exact n buf off src =
   Bytes.blit (Slice.bytes src) (Slice.first src) buf off n;
   off + n
 
-(* Bytes of [buf] a read starting at [off] can have, which is what
-   {!Types.Unexpected_eof}'s [got] counts. A start before the buffer or past
-   its end has none of them; the count is never negative. *)
-let[@inline] bytes_from buf off =
-  if off < 0 || off > Bytes.length buf then 0 else Bytes.length buf - off
+(* Where the bytes a read may reach stop. The buffer's end, except inside a
+   nested region, which hands the parse fewer bytes than the buffer holds: a
+   read past the region has none of them however many the buffer has left. *)
+let[@inline] input_end ctx buf =
+  let stop = Types.eval_input_end ctx in
+  let len = Bytes.length buf in
+  if stop < len then stop else len
 
-(* A read of [width] bytes at [at] that must stay inside [buf]. Reads whose
-   position was itself computed from the buffer can land past the end on
-   truncated input; reporting the span here keeps the failure a precise
-   end-of-input instead of a raw out-of-bounds [Invalid_argument], which a
-   caller cannot tell apart from a misuse or from a user [map] callback. *)
-let[@inline] check_read_bounds buf ~at ~width =
-  if at < 0 || at + width > Bytes.length buf then
-    raise_eof ~at ~expected:width ~got:(bytes_from buf at)
+(* Bytes a read starting at [off] can have, which is what
+   {!Types.Unexpected_eof}'s [got] counts. A start before the input or past its
+   end has none of them; the count is never negative. *)
+let[@inline] bytes_from ~input_end off =
+  if off < 0 || off > input_end then 0 else input_end - off
+
+(* A read of [width] bytes at [at] that must stay inside the bytes the parse
+   was handed. Reads whose position was itself computed from the buffer can
+   land past the end on truncated input; reporting the span here keeps the
+   failure a precise end-of-input instead of a raw out-of-bounds
+   [Invalid_argument], which a caller cannot tell apart from a misuse or from a
+   user [map] callback. *)
+let[@inline] check_read_bounds ctx buf ~at ~width =
+  let input_end = input_end ctx buf in
+  if at < 0 || at + width > input_end then
+    raise_eof ~at ~expected:width ~got:(bytes_from ~input_end at)
 
 (* Reader for a byte span of constant width. A negative width comes from a size
    expression that underflows or names a negative literal, so it is data rather
@@ -1826,7 +1836,7 @@ let rec elem_size_of : type a. a typ -> runtime -> bytes -> int -> int =
       let tag_size = tag_byte_size tag in
       (* The position comes from a preceding length field, so a truncated
          buffer can put the tag past the end. *)
-      check_read_bounds buf ~at:off ~width:tag_size;
+      check_read_bounds runtime buf ~at:off ~width:tag_size;
       let tag_val = read_elem tag runtime buf off in
       tag_size
       + size_case_body ~at:off ~tag cases tag_val runtime buf (off + tag_size)
@@ -1870,6 +1880,31 @@ and size_case_body : type a k.
   | Case_branch { cb_tag = None; cb_inner; _ } :: _ ->
       elem_size_of cb_inner runtime buf body_off
   | _ :: rest -> size_case_body ~at ~tag rest tag_val runtime buf body_off
+
+(* [elem_size_of] against the bytes the parse was handed rather than against
+   the whole buffer, which a nested region ends before.
+
+   A size walk reads the length and gate fields of the record it is sizing, and
+   those all lie inside that record, so a record that ends by [input_end] was
+   sized from bytes the region holds and the plain walk already answered from
+   them. One that ends past [input_end], or that ran off the buffer while being
+   sized, took at least one of its answers from a byte no region of this length
+   carries: walk it again with the region's end standing in for the end of the
+   buffer, so the size it settles on, or the end-of-input it reports, names a
+   byte the parse was handed. Narrowing is what builds a context, and only the
+   second walk narrows, so a region that holds its record allocates nothing. *)
+let elem_size_within : type a.
+    a typ -> runtime -> bytes -> int -> input_end:int -> int =
+ fun typ runtime buf off ~input_end ->
+  if input_end >= Bytes.length buf then elem_size_of typ runtime buf off
+  else
+    let sz =
+      match elem_size_of typ runtime buf off with
+      | n -> n
+      | exception Types.Parse_error _ -> input_end - off + 1
+    in
+    if off + sz <= input_end then sz
+    else elem_size_of typ (Types.eval_ctx_within ~input_end runtime) buf off
 
 (* -- Compiled field: intermediate plan for one field's contribution -- *)
 
@@ -2229,7 +2264,7 @@ let present_in_bounds ctx present_fn fsize =
   fun runtime buf base ->
     let present = present_fn runtime buf base in
     if present then
-      check_read_bounds buf ~at:(pos runtime buf base) ~width:fsize;
+      check_read_bounds runtime buf ~at:(pos runtime buf base) ~width:fsize;
     present
 
 let optional_compiled : type a r.
@@ -2279,7 +2314,8 @@ let repeat_raw_fixed : type elt seq.
      buffer before reading so an oversized length fails cleanly instead of
      crashing [read_elem] with an out-of-range [Bytes.sub]. *)
   if budget < 0 || start + budget > Bytes.length buf then
-    raise_eof ~at:start ~expected:budget ~got:(bytes_from buf start);
+    raise_eof ~at:start ~expected:budget
+      ~got:(bytes_from ~input_end:(Bytes.length buf) start);
   let remainder = if esz > 0 then budget mod esz else budget in
   if remainder <> 0 then
     raise_eof ~at:(start + budget - remainder) ~expected:esz ~got:remainder;
@@ -2305,7 +2341,8 @@ let repeat_raw_variable : type elt seq.
   let start = base + off_fn runtime buf base in
   (* Bound the untrusted budget to the buffer (see [repeat_raw_fixed]). *)
   if budget < 0 || start + budget > Bytes.length buf then
-    raise_eof ~at:start ~expected:budget ~got:(bytes_from buf start);
+    raise_eof ~at:start ~expected:budget
+      ~got:(bytes_from ~input_end:(Bytes.length buf) start);
   let rec loop acc pos remaining =
     if remaining <= 0 then seq.finish acc
     else
@@ -2586,7 +2623,8 @@ let compile_repeat : type elt seq r.
    as end-of-input instead. *)
 let[@inline] check_span_bounds buf ~first ~sz =
   if sz < 0 || first < 0 || first + sz > Bytes.length buf then
-    raise_eof ~at:first ~expected:sz ~got:(bytes_from buf first)
+    raise_eof ~at:first ~expected:sz
+      ~got:(bytes_from ~input_end:(Bytes.length buf) first)
 
 (* Absolute index of the first NUL at or after [first], searching up to (but
    not including) [limit]. Raises [Parse_error] when the region ends before a
@@ -2611,7 +2649,8 @@ let var_bytes_reader : type a.
          [make_or_eod] with a raw [Invalid_argument] that escapes the decode
          result. Fail cleanly instead. *)
       if sz < 0 || first < 0 then
-        raise_eof ~at:first ~expected:sz ~got:(bytes_from buf first)
+        raise_eof ~at:first ~expected:sz
+          ~got:(bytes_from ~input_end:(Bytes.length buf) first)
   | _ -> check_span_bounds buf ~first ~sz);
   match typ with
   | Byte_slice _ -> Slice.make_or_eod buf ~first:(base + fo) ~length:sz
@@ -2629,7 +2668,9 @@ let var_bytes_reader : type a.
   | Casetype _ -> read_elem typ runtime buf (base + fo)
   | Single_elem { elem; at_most; _ } ->
       let first = base + fo in
-      let consumed = elem_size_of elem runtime buf first in
+      let consumed =
+        elem_size_within elem runtime buf first ~input_end:(first + sz)
+      in
       if consumed > sz || ((not at_most) && consumed <> sz) then
         raise_eof ~at:(first + min consumed sz) ~expected:sz ~got:consumed;
       read_elem elem runtime buf first
@@ -3405,21 +3446,23 @@ let read_guard : type a r.
   | Bitfield { base = word; byte_off; _ } ->
       let width = Bitfield.byte_size word in
       Some
-        (fun _runtime buf base ->
-          check_read_bounds buf ~at:(base + byte_off) ~width)
+        (fun runtime buf base ->
+          check_read_bounds runtime buf ~at:(base + byte_off) ~width)
   | Fixed off -> (
       match field_wire_size typ with
       | Some width when width = cf.size_delta ->
           Some
-            (fun _runtime buf base ->
-              check_read_bounds buf ~at:(base + off) ~width)
+            (fun runtime buf base ->
+              check_read_bounds runtime buf ~at:(base + off) ~width)
       | _ -> None)
   | Dynamic off_fn -> (
       match field_wire_size typ with
       | Some width when width = cf.size_delta ->
           Some
             (fun runtime buf base ->
-              check_read_bounds buf ~at:(base + off_fn runtime buf base) ~width)
+              check_read_bounds runtime buf
+                ~at:(base + off_fn runtime buf base)
+                ~width)
       | _ -> None)
   | Variable _ | Variable_dynamic _ -> None
 
@@ -3830,7 +3873,8 @@ let fill_param_slots tbl param_base handles =
    before a zero-copy [get] reads its fields. *)
 let check_decode_bounds wire_size_info min_size runtime buf off =
   if off + min_size > Bytes.length buf then
-    raise_eof ~at:off ~expected:min_size ~got:(bytes_from buf off);
+    raise_eof ~at:off ~expected:min_size
+      ~got:(bytes_from ~input_end:(Bytes.length buf) off);
   match wire_size_info with
   | Fixed _ -> ()
   | Variable { compute; _ } ->
@@ -3840,9 +3884,11 @@ let check_decode_bounds wire_size_info min_size runtime buf off =
          raise is a real error and propagates. *)
       let end_off = compute runtime buf off in
       if end_off < off + min_size then
-        raise_eof ~at:off ~expected:min_size ~got:(bytes_from buf off);
+        raise_eof ~at:off ~expected:min_size
+          ~got:(bytes_from ~input_end:(Bytes.length buf) off);
       if end_off > Bytes.length buf then
-        raise_eof ~at:off ~expected:(end_off - off) ~got:(bytes_from buf off)
+        raise_eof ~at:off ~expected:(end_off - off)
+          ~got:(bytes_from ~input_end:(Bytes.length buf) off)
 
 let build_checked_decode raw_decode wire_size_info min_size =
  fun runtime buf off ->

--- a/lib/codec.mli
+++ b/lib/codec.mli
@@ -186,6 +186,14 @@ val zeroterm_nul_pos : bytes -> first:int -> limit:int -> int
     [\[first, limit)], raising [Parse_error] on an unterminated run. Internal
     use (shared with the streaming decoders). *)
 
+val elem_size_within :
+  'a Types.typ -> Types.eval_ctx -> bytes -> int -> input_end:int -> int
+(** [elem_size_within t ctx buf off ~input_end] is the wire size of the value of
+    type [t] at [off], sized against the bytes the parse was handed rather than
+    against all of [buf]: a nested region stops at [input_end], and a size a
+    byte past it could not justify is reported as end of input there. Internal
+    use. *)
+
 val raw_decode : 'r t -> bytes -> int -> 'r
 (** [raw_decode c buf off] decodes without validation. Internal use. *)
 

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -30,17 +30,37 @@ type bindings = { param : string -> int; set_param : string -> int -> unit }
 (* The buffer travels as its own argument rather than inside the context, so
    the parameter-free hot path is the constant constructor [Unbound]. Being a
    constant, it is an immediate: an encode or decode without parameters builds
-   no context block and allocates nothing. *)
-type eval_ctx = Unbound | Bound of bindings
+   no context block and allocates nothing.
+
+   [Within] carries where the bytes a parse was handed stop, which a nested
+   region puts short of the end of the buffer. It is the one context a read has
+   to build, and it is built only once a walk has already overrun its region,
+   so a region that holds what it was given still allocates nothing. *)
+type eval_ctx =
+  | Unbound
+  | Bound of bindings
+  | Within of { input_end : int; inner : eval_ctx }
 
 let unbound_eval_ctx = Unbound
 let eval_ctx ?(set_param = fun _ _ -> ()) param = Bound { param; set_param }
+let eval_ctx_within ~input_end inner = Within { input_end; inner }
 
-let eval_param ctx name =
-  match ctx with Unbound -> 0 | Bound b -> b.param name
+(* The innermost region wins: each one wraps the context its enclosing parse
+   handed down, so the outermost [Within] is the narrowest. *)
+let[@inline] eval_input_end ctx =
+  match ctx with Unbound | Bound _ -> max_int | Within w -> w.input_end
 
-let eval_set_param ctx name value =
-  match ctx with Unbound -> () | Bound b -> b.set_param name value
+let rec eval_param ctx name =
+  match ctx with
+  | Unbound -> 0
+  | Bound b -> b.param name
+  | Within w -> eval_param w.inner name
+
+let rec eval_set_param ctx name value =
+  match ctx with
+  | Unbound -> ()
+  | Bound b -> b.set_param name value
+  | Within w -> eval_set_param w.inner name value
 
 (* Parse errors, defined before [typ] so [typ]'s own [Where] / [Field]
    constructors win type-directed disambiguation everywhere below; the

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -18,6 +18,14 @@ val unbound_eval_ctx : eval_ctx
 val eval_ctx : ?set_param:(string -> int -> unit) -> (string -> int) -> eval_ctx
 (** A context with explicit parameter lookup. Internal use. *)
 
+val eval_ctx_within : input_end:int -> eval_ctx -> eval_ctx
+(** [eval_ctx_within ~input_end ctx] is [ctx] with the bytes a read may reach
+    stopping at [input_end], as they do inside a nested region. Internal use. *)
+
+val eval_input_end : eval_ctx -> int
+(** Where the bytes a read may reach stop, or [max_int] when the whole buffer is
+    in play. Internal use. *)
+
 val eval_param : eval_ctx -> string -> int
 (** Look up a parameter, returning 0 in an unbound context. Internal use. *)
 

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -173,20 +173,23 @@ let parse_all_zeros buf off len =
   in
   (check 0, len)
 
-let parse_codec_typ codec_decode fixed_size min_size size_of buf off len =
+let parse_codec_typ codec_decode fixed_size min_size typ buf off len =
   (* A variable-size codec computes its span by reading length / gate fields
      from the buffer. Those reads bound-check themselves against the buffer,
      which inside a nested region holds more than this parse was handed, so
      demand the codec's mandatory extent from the region first: a region too
      short to carry the length fields then reports their shortfall instead of a
-     span sized from bytes outside it. A misuse in the size expression, or an
-     exception from a user [map] callback, reaches the caller unchanged. *)
+     span sized from bytes outside it. That closes off every length field the
+     codec always carries, but not one the data puts wherever a preceding span
+     ends, so hand the region's end to the size walk as well. A misuse in the
+     size expression, or an exception from a user [map] callback, reaches the
+     caller unchanged. *)
   let sz =
     match fixed_size with
     | Some n -> n
     | None ->
         check_eof len ~off ~n:min_size;
-        size_of buf off
+        Codec.elem_size_within typ Types.unbound_eval_ctx buf off ~input_end:len
   in
   check_span len ~off ~n:sz;
   (codec_decode buf off, off + sz)
@@ -334,13 +337,10 @@ let rec parse_direct : type a. a typ -> bytes -> int -> int -> a * int =
       let v, off' = parse_direct base buf off len in
       check_enum_membership ~at:off ~closed ~base cases v;
       (v, off')
-  | Codec { codec_decode; codec_fixed_size; codec_min_size; codec_size_of; _ }
-    ->
+  | Codec { codec_decode; codec_fixed_size; codec_min_size; _ } ->
       parse_codec_typ
         (codec_decode Types.unbound_eval_ctx)
-        codec_fixed_size codec_min_size
-        (codec_size_of Types.unbound_eval_ctx)
-        buf off len
+        codec_fixed_size codec_min_size typ buf off len
   | Struct s -> parse_struct_typ s buf off len
   | Casetype { cases; tag; _ } -> parse_casetype tag cases buf off len
   | Optional { present; inner } ->
@@ -571,9 +571,13 @@ let rec scratch_fill s reader target =
   s.filled >= target || (scratch_read s reader && scratch_fill s reader target)
 
 (* How far to read before retrying a parse that ran short. [expected] is what
-   the value needed and [got] what was left where it starts, so the shortfall is
-   the difference; never less than one byte, or a hint of zero would spin. *)
-let retry_target s ~expected ~got = s.filled + max 1 (expected - got)
+   the read needed and [got] what was already there, so [at] plus the shortfall
+   between them is where that read ends; never less than one byte past what is
+   buffered, or a hint of zero would spin. Taking the end from [at] rather than
+   from what is buffered matters for a read the data places: it can start past
+   everything read so far, and then nothing but [at] says how far ahead the
+   shortfall lies. *)
+let retry_target s ~at ~expected ~got = max (s.filled + 1) (at + expected - got)
 
 (* First NUL at or after [i] among the buffered bytes, or [-1] for none. *)
 let rec nul_at s i =
@@ -626,7 +630,8 @@ let of_reader_incremental typ reader =
            chasing it is not an error. *)
         | Unexpected_eof { expected; got } ->
             ignore
-              (scratch_fill s reader (retry_target s ~expected ~got) : bool);
+              (scratch_fill s reader (retry_target s ~at:e.at ~expected ~got)
+                : bool);
             if s.filled > before then loop () else give_up e
         | _ -> give_up e)
   in

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -8657,6 +8657,31 @@ let test_nested_region_eof_stays_in_region () =
     (Fmt.str "%a" pp_parse_error e)
     (Fmt.str "%a" pp_parse_error (error_for '\x01'))
 
+(* Demanding the codec's mandatory extent from the region closes off a length
+   field the codec always carries, but [two_span_codec]'s second one sits
+   behind a span the first one sizes, so where it falls is data. A region as
+   long as the mandatory extent still stops short of it, and the size walk
+   reads it anyway. Cutting the buffer at the region has to give the answer a
+   buffer that really ends there gives: any other answer was resolved from
+   bytes the parse was never handed. *)
+let test_dynamic_length_field_stays_in_region () =
+  let region = 2 in
+  let error_in buf =
+    Bytes.set_uint8 buf 0 200;
+    match of_bytes (nested ~size:(int region) (codec two_span_codec)) buf with
+    | Ok _ ->
+        Alcotest.fail "decoded a region that cannot reach its length field"
+    | Error e -> Fmt.str "%a" pp_parse_error e
+  in
+  let past_the_region filler = error_in (Bytes.make 512 filler) in
+  Alcotest.(check string)
+    "a region ends the buffer as far as the walk is concerned"
+    (error_in (Bytes.make region '\x00'))
+    (past_the_region '\x99');
+  Alcotest.(check string)
+    "the shortfall ignores the bytes past the region" (past_the_region '\x01')
+    (past_the_region '\xff')
+
 (* [Codec.validate] scans a refined span where it lies rather than copying it,
    so the scan has to refuse everything the reader refuses. A literal width
    below zero is refused before any scan, and by the reader, so both entry
@@ -9581,6 +9606,8 @@ let suite =
         test_truncated_still_reports_eof;
       Alcotest.test_case "diag: a nested region sizes only from its own bytes"
         `Quick test_nested_region_eof_stays_in_region;
+      Alcotest.test_case "diag: a region bounds a length field it cannot reach"
+        `Quick test_dynamic_length_field_stays_in_region;
       Alcotest.test_case "diag: negative span is a parse error" `Quick
         test_negative_span_is_parse_error;
       Alcotest.test_case "diag: eof counts do not move with the base" `Quick


### PR DESCRIPTION
A `Wire.nested` region whose codec has a length field the data places, behind a span an earlier length field sizes, reported an end-of-input resolved from a byte outside the region, and the count moved when the bytes past the region did. Nothing was ever accepted on that basis; only the shortfall a caller saw was wrong. Follow-up to #326, which closed the same defect for a length field at a fixed offset.