### PR TITLE
types: give int16 an exact 16-bit signed carrier

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,6 +53,11 @@
   the field's, rather than a native `int`. Read one with `Wire.SInt8.to_int`,
   build one with the range-checked `Wire.SInt8.v` (#330, @samoht)
 
+- **Breaking:** `int16` and `int16be` decode to `Wire.SInt16.t`, a `private
+  int` whose range is the field's, rather than a native `int`. Read one with
+  `Wire.SInt16.to_int`, build one with the range-checked `Wire.SInt16.v`
+  (#333, @samoht)
+
 - `Wire.enum`, `Wire.enum_open`, `Wire.variants`, `Wire.lookup` and `Wire.bit`
   accept any integer-valued base, not only one that decodes to a native `int`.
   An enum, variant mapping, lookup table or flag can now sit over `uint32`,

--- a/fuzz/gen/fuzz_gen.ml
+++ b/fuzz/gen/fuzz_gen.ml
@@ -166,17 +166,6 @@ let above_bit_width width =
   let mask = (1 lsl width) - 1 in
   Alcobar.map Alcobar.[ Alcobar.int ] (fun n -> n land mask lor (mask + 1))
 
-(* The signed counterpart, drawn from both ends: a signed [width]-bit field
-   holds [-2^(width-1) .. 2^(width-1) - 1], so 40000 into an [int16] is as
-   unrepresentable as -40000 even though its low two bytes are legal ones. *)
-let outside_signed_width width =
-  let limit = 1 lsl (width - 1) in
-  Alcobar.map
-    Alcobar.[ Alcobar.int ]
-    (fun n ->
-      let over = (n land (limit - 1)) + limit in
-      if n < 0 then -over - 1 else over)
-
 (* The [uint ~size] counterpart: a value needing more than [size] bytes. *)
 let above_byte_width size =
   let max_v = (1 lsl (size * 8)) - 1 in
@@ -265,12 +254,16 @@ let scalar_sint32 typ size value_gen boundaries =
   leaf ~equal:Wire.SInt32.equal ~typ ~value_gen ~random:(bytes_fixed size)
     ~adversarial:(Alcobar.choose (List.map Alcobar.const boundaries))
 
-(* [int8] is carried in a [Wire.SInt8.t], whose only constructor refuses a
-   number the byte cannot hold: every value of it is a legal signed 8-bit field,
-   so there is no hostile value to draw and no guard for one to exercise. Same
-   reasoning as [scalar_sint32]. *)
+(* [int8] and [int16] are carried in a [Wire.SInt8.t] and a [Wire.SInt16.t],
+   whose only constructor refuses a number the field cannot hold: every value of
+   them is a legal signed field, so there is no hostile value to draw and no
+   guard for one to exercise. Same reasoning as [scalar_sint32]. *)
 let scalar_sint8 typ size value_gen boundaries =
   leaf ~equal:Wire.SInt8.equal ~typ ~value_gen ~random:(bytes_fixed size)
+    ~adversarial:(Alcobar.choose (List.map Alcobar.const boundaries))
+
+let scalar_sint16 typ size value_gen boundaries =
+  leaf ~equal:Wire.SInt16.equal ~typ ~value_gen ~random:(bytes_fixed size)
     ~adversarial:(Alcobar.choose (List.map Alcobar.const boundaries))
 
 (* [uint32] is carried in a [Wire.UInt32.t], whose only constructors are the
@@ -292,7 +285,7 @@ let u64_boundaries_i64 =
   Int64.[ zero; one; of_int 0xFFFF_FFFF; max_int; min_int; -1L; sub max_int 1L ]
 
 let s8_boundaries = List.map Wire.SInt8.v [ -128; -1; 0; 1; 127 ]
-let s16_boundaries = [ -0x8000; -1; 0; 1; 0x7FFF ]
+let s16_boundaries = List.map Wire.SInt16.v [ -0x8000; -1; 0; 1; 0x7FFF ]
 
 let s32_boundaries =
   List.map Wire.SInt32.of_int32 Int32.[ min_int; minus_one; zero; one; max_int ]
@@ -324,15 +317,9 @@ let uint64 = scalar_uint64 Wire.uint64 8 u64_value_gen u64_boundaries
 let uint64be = scalar_uint64 Wire.uint64be 8 u64_value_gen u64_boundaries
 let s8_value_gen = Alcobar.map Alcobar.[ Alcobar.int8 ] Wire.SInt8.v
 let int8 = scalar_sint8 Wire.int8 1 s8_value_gen s8_boundaries
-
-let int16 =
-  scalar_int ~hostile:(outside_signed_width 16) Wire.int16 2 Alcobar.int16
-    s16_boundaries
-
-let int16be =
-  scalar_int ~hostile:(outside_signed_width 16) Wire.int16be 2 Alcobar.int16
-    s16_boundaries
-
+let s16_value_gen = Alcobar.map Alcobar.[ Alcobar.int16 ] Wire.SInt16.v
+let int16 = scalar_sint16 Wire.int16 2 s16_value_gen s16_boundaries
+let int16be = scalar_sint16 Wire.int16be 2 s16_value_gen s16_boundaries
 let int32_value_gen = Alcobar.map Alcobar.[ Alcobar.int32 ] Wire.SInt32.of_int32
 let int32 = scalar_sint32 Wire.int32 4 int32_value_gen s32_boundaries
 let int32be = scalar_sint32 Wire.int32be 4 int32_value_gen s32_boundaries
@@ -773,6 +760,7 @@ let exact_int64 typ cases = exact_cases ~typ ~equal:Int64.equal cases
 let exact_uint64 typ cases = exact_cases ~typ ~equal:Wire.UInt64.equal cases
 let exact_optint typ cases = exact_cases ~typ ~equal:Wire.UInt32.equal cases
 let exact_sint32 typ cases = exact_cases ~typ ~equal:Wire.SInt32.equal cases
+let exact_sint16 typ cases = exact_cases ~typ ~equal:Wire.SInt16.equal cases
 
 let uint16_endian_edges =
   exact_int Wire.uint16
@@ -828,22 +816,24 @@ let uint64be_endian_edges =
         bytes_of_octets [ 0xFF; 0xFF; 0xFF; 0xFF; 0xFF; 0xFF; 0xFF; 0xFE ] );
     ]
 
+let sint16 = Wire.SInt16.v
+
 let int16_endian_edges =
-  exact_int Wire.int16
+  exact_sint16 Wire.int16
     [
-      (-0x8000, bytes_of_octets [ 0x00; 0x80 ]);
-      (-2, bytes_of_octets [ 0xFE; 0xFF ]);
-      (0x1234, bytes_of_octets [ 0x34; 0x12 ]);
-      (0x7FFF, bytes_of_octets [ 0xFF; 0x7F ]);
+      (sint16 (-0x8000), bytes_of_octets [ 0x00; 0x80 ]);
+      (sint16 (-2), bytes_of_octets [ 0xFE; 0xFF ]);
+      (sint16 0x1234, bytes_of_octets [ 0x34; 0x12 ]);
+      (sint16 0x7FFF, bytes_of_octets [ 0xFF; 0x7F ]);
     ]
 
 let int16be_endian_edges =
-  exact_int Wire.int16be
+  exact_sint16 Wire.int16be
     [
-      (-0x8000, bytes_of_octets [ 0x80; 0x00 ]);
-      (-2, bytes_of_octets [ 0xFF; 0xFE ]);
-      (0x1234, bytes_of_octets [ 0x12; 0x34 ]);
-      (0x7FFF, bytes_of_octets [ 0x7F; 0xFF ]);
+      (sint16 (-0x8000), bytes_of_octets [ 0x80; 0x00 ]);
+      (sint16 (-2), bytes_of_octets [ 0xFF; 0xFE ]);
+      (sint16 0x1234, bytes_of_octets [ 0x12; 0x34 ]);
+      (sint16 0x7FFF, bytes_of_octets [ 0x7F; 0xFF ]);
     ]
 
 let sint32 n = Wire.SInt32.of_int32 (Int32.of_int n)

--- a/fuzz/gen/fuzz_gen.mli
+++ b/fuzz/gen/fuzz_gen.mli
@@ -265,10 +265,10 @@ val uint64be : Wire.UInt64.t t
 val int8 : Wire.SInt8.t t
 (** [int8] generates for {!Wire.int8}. *)
 
-val int16 : int t
+val int16 : Wire.SInt16.t t
 (** [int16] generates for {!Wire.int16}. *)
 
-val int16be : int t
+val int16be : Wire.SInt16.t t
 (** [int16be] generates for {!Wire.int16be}. *)
 
 val int32 : Wire.SInt32.t t

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -210,8 +210,8 @@ and build_field_encoder_ctx : type a.
         UInt64.set_be buf off v;
         off + 8
   | Int8 -> fun _runtime -> setter_off 1 SInt8.set
-  | Int16 Little -> fun _runtime -> setter_off 2 Types.set_int16_le
-  | Int16 Big -> fun _runtime -> setter_off 2 Types.set_int16_be
+  | Int16 Little -> fun _runtime -> setter_off 2 SInt16.set_le
+  | Int16 Big -> fun _runtime -> setter_off 2 SInt16.set_be
   | Int32 Little -> fun _runtime -> setter_off 4 Types.set_int32_le
   | Int32 Big -> fun _runtime -> setter_off 4 Types.set_int32_be
   | Int64 Little -> fun _runtime -> setter_off 8 Bytes.set_int64_le
@@ -339,10 +339,8 @@ let rec build_field_reader_ctx : type a.
   | Uint64 Little -> fun _runtime buf base -> UInt64.le buf (base + field_off)
   | Uint64 Big -> fun _runtime buf base -> UInt64.be buf (base + field_off)
   | Int8 -> fun _runtime buf base -> SInt8.get buf (base + field_off)
-  | Int16 Little ->
-      fun _runtime buf base -> Bytes.get_int16_le buf (base + field_off)
-  | Int16 Big ->
-      fun _runtime buf base -> Bytes.get_int16_be buf (base + field_off)
+  | Int16 Little -> fun _runtime buf base -> SInt16.le buf (base + field_off)
+  | Int16 Big -> fun _runtime buf base -> SInt16.be buf (base + field_off)
   | Int32 Little -> fun _runtime buf base -> SInt32.le buf (base + field_off)
   | Int32 Big -> fun _runtime buf base -> SInt32.be buf (base + field_off)
   | Int64 Little ->
@@ -437,8 +435,8 @@ let rec build_immediate_reader : type a.
   | Uint64 Little -> Some (fun buf base -> UInt64.le buf (at base))
   | Uint64 Big -> Some (fun buf base -> UInt64.be buf (at base))
   | Int8 -> Some (fun buf base -> SInt8.get buf (at base))
-  | Int16 Little -> Some (fun buf base -> Bytes.get_int16_le buf (at base))
-  | Int16 Big -> Some (fun buf base -> Bytes.get_int16_be buf (at base))
+  | Int16 Little -> Some (fun buf base -> SInt16.le buf (at base))
+  | Int16 Big -> Some (fun buf base -> SInt16.be buf (at base))
   | Int32 Little -> Some (fun buf base -> SInt32.le buf (at base))
   | Int32 Big -> Some (fun buf base -> SInt32.be buf (at base))
   | Int64 Little -> Some (fun buf base -> Bytes.get_int64_le buf (at base))
@@ -488,8 +486,8 @@ let rec build_immediate_encoder : type a.
   | Uint64 Little -> Some (setter_off 8 UInt64.set_le)
   | Uint64 Big -> Some (setter_off 8 UInt64.set_be)
   | Int8 -> Some (setter_off 1 SInt8.set)
-  | Int16 Little -> Some (setter_off 2 Types.set_int16_le)
-  | Int16 Big -> Some (setter_off 2 Types.set_int16_be)
+  | Int16 Little -> Some (setter_off 2 SInt16.set_le)
+  | Int16 Big -> Some (setter_off 2 SInt16.set_be)
   | Int32 Little -> Some (setter_off 4 Types.set_int32_le)
   | Int32 Big -> Some (setter_off 4 Types.set_int32_be)
   | Int64 Little -> Some (setter_off 8 Bytes.set_int64_le)
@@ -626,10 +624,14 @@ let populate_uint_var idx reader =
 let populate_int idx reader slots runtime buf base =
   set_int_slot slots idx (reader runtime buf base)
 
-(* [SInt8.t] is a native [int] behind a range, so the slot takes the decoded
-   value unchanged and no platform has a value it cannot hold. *)
+(* [SInt8.t] and [SInt16.t] are native [int]s behind a range, so the slot
+   takes the decoded value unchanged and no platform has a value it cannot
+   hold. *)
 let populate_sint8 idx reader slots runtime buf base =
   set_int_slot slots idx (SInt8.to_int (reader runtime buf base))
+
+let populate_sint16 idx reader slots runtime buf base =
+  set_int_slot slots idx (SInt16.to_int (reader runtime buf base))
 
 (* Floats store their IEEE 754 bit pattern in the int slot so [Ref name] in a
    constraint sees the value the 3D side sees; a float64 also fills the int64
@@ -658,7 +660,7 @@ let rec build_populate : type a.
   | Uint8 -> populate_int idx reader
   | Uint16 _ -> populate_int idx reader
   | Int8 -> populate_sint8 idx reader
-  | Int16 _ -> populate_int idx reader
+  | Int16 _ -> populate_sint16 idx reader
   | Int32 _ -> populate_sint32 idx reader
   | Bits _ -> populate_int idx reader
   | Uint_var _ -> populate_uint_var idx reader
@@ -1684,8 +1686,8 @@ let rec read_elem : type a. a typ -> runtime -> bytes -> int -> a =
   | Uint64 Little -> UInt64.le buf off
   | Uint64 Big -> UInt64.be buf off
   | Int8 -> SInt8.get buf off
-  | Int16 Little -> Bytes.get_int16_le buf off
-  | Int16 Big -> Bytes.get_int16_be buf off
+  | Int16 Little -> SInt16.le buf off
+  | Int16 Big -> SInt16.be buf off
   | Int32 Little -> SInt32.le buf off
   | Int32 Big -> SInt32.be buf off
   | Int64 Little -> Bytes.get_int64_le buf off
@@ -1792,8 +1794,8 @@ let rec write_elem : type a. a typ -> runtime -> bytes -> int -> a -> unit =
   | Uint64 Little -> UInt64.set_le buf off v
   | Uint64 Big -> UInt64.set_be buf off v
   | Int8 -> SInt8.set buf off v
-  | Int16 Little -> Types.set_int16_le buf off v
-  | Int16 Big -> Types.set_int16_be buf off v
+  | Int16 Little -> SInt16.set_le buf off v
+  | Int16 Big -> SInt16.set_be buf off v
   | Int32 Little -> Types.set_int32_le buf off v
   | Int32 Big -> Types.set_int32_be buf off v
   | Int64 Little -> Bytes.set_int64_le buf off v

--- a/lib/param.ml
+++ b/lib/param.ml
@@ -27,7 +27,7 @@ let rec to_int : type a. a Types.typ -> a -> int =
   | Uint32 _ -> optint_to_int UInt32.to_int v
   | Uint64 _ -> UInt64.to_int_opt v |> Option.value ~default:max_int
   | Int8 -> SInt8.to_int v
-  | Int16 _ -> v
+  | Int16 _ -> SInt16.to_int v
   | Int32 _ -> SInt32.to_int v
   | Int64 _ -> Int64.to_int v
   | Float32 _ -> invalid_arg "Param: floats are not integer-representable"

--- a/lib/sInt16.ml
+++ b/lib/sInt16.ml
@@ -1,0 +1,22 @@
+type t = int
+
+let min_int = -0x8000
+let max_int = 0x7FFF
+let zero = 0
+let equal : t -> t -> bool = Int.equal
+let pp = Fmt.int
+
+(* The one place the range is enforced. Every other path takes a [t] and so
+   takes a value the field holds, which is what lets the encoders drop their
+   own width checks instead of carrying one that cannot fire. *)
+let v n =
+  if n < min_int || n > max_int then
+    Fmt.invalid_arg "Wire.SInt16.v: %d is not a signed 16-bit value" n;
+  n
+
+let v_opt n = if n < min_int || n > max_int then None else Some n
+let to_int n = n
+let le buf off = Bytes.get_int16_le buf off
+let be buf off = Bytes.get_int16_be buf off
+let set_le buf off n = Bytes.set_int16_le buf off n
+let set_be buf off n = Bytes.set_int16_be buf off n

--- a/lib/sInt16.mli
+++ b/lib/sInt16.mli
@@ -1,0 +1,58 @@
+(** Signed 16-bit integer.
+
+    A native [int] narrowed to what a signed 16-bit field holds. The range is in
+    the type rather than in a check at every encoder: a number outside
+    [[-32768, 32767]] never becomes a value of this type, so nothing downstream
+    has to ask again, and a case value or table index the field cannot hold is
+    refused where it is written down rather than at the first byte encoded.
+
+    [private int] on purpose. The carrier is exactly the [int] it looks like, on
+    every target: no box, no conversion on the way out, and only the places that
+    build a value have to say which range they are in. *)
+
+type t = private int
+
+val v : int -> t
+(** [v n] is [n] as a signed 16-bit value. Raises [Invalid_argument] when [n] is
+    outside [[-32768, 32767]], rather than masking it to a legal value the
+    caller did not mean: 40000 masks to a perfectly good -25536 that no decoder
+    can tell from the number that was written. *)
+
+val v_opt : int -> t option
+(** [v_opt n] is {!v} as an option, for a caller testing a number rather than
+    asserting it. *)
+
+val to_int : t -> int
+(** [to_int t] is the value as a native [int]. Total and exact on every target:
+    every signed 16-bit value fits every OCaml [int]. *)
+
+val zero : t
+(** [zero] is 0. *)
+
+val min_int : t
+(** [min_int] is -32768, the smallest value a signed 16-bit field holds. *)
+
+val max_int : t
+(** [max_int] is 32767, the largest value a signed 16-bit field holds. *)
+
+val equal : t -> t -> bool
+(** [equal a b] is [true] when [a] and [b] are the same value. *)
+
+val pp : Format.formatter -> t -> unit
+(** Pretty-printer for signed 16-bit values. *)
+
+val le : bytes -> int -> t
+(** [le buf off] reads two little-endian bytes at offset [off]. Total: two bytes
+    spell only values the field holds. *)
+
+val be : bytes -> int -> t
+(** [be buf off] reads two big-endian bytes at offset [off]. Total for the same
+    reason as {!le}. *)
+
+val set_le : bytes -> int -> t -> unit
+(** [set_le buf off v] writes [v] as two signed little-endian bytes at offset
+    [off]. Needs no range check: every {!type-t} is a value the field holds. *)
+
+val set_be : bytes -> int -> t -> unit
+(** [set_be buf off v] writes [v] as two signed big-endian bytes at offset
+    [off]. Needs no range check, as for {!set_le}. *)

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -191,7 +191,7 @@ and _ typ =
   | Uint32 : endian -> UInt32.t typ
   | Uint64 : endian -> UInt64.t typ (* boxed, for full 64-bit *)
   | Int8 : SInt8.t typ
-  | Int16 : endian -> int typ
+  | Int16 : endian -> SInt16.t typ
   | Int32 : endian -> SInt32.t typ
   | Int64 : endian -> int64 typ
   | Float32 :
@@ -575,7 +575,7 @@ let rec int_of : type a. a typ -> a -> int option =
   | Uint32 _ -> Int32.unsigned_to_int (UInt32.to_int32 v)
   | Uint64 _ -> UInt64.to_int_opt v
   | Int8 -> Some (SInt8.to_int v)
-  | Int16 _ -> Some v
+  | Int16 _ -> Some (SInt16.to_int v)
   | Int32 _ -> SInt32.to_int_opt v
   | Int64 _ -> Int64.unsigned_to_int v
   | Float32 _ -> None
@@ -630,7 +630,7 @@ let rec int_of_exn : type a. a typ -> a -> int =
       | Some n -> n
       | None -> int_overflow (UInt64.to_int64 v))
   | Int8 -> SInt8.to_int v
-  | Int16 _ -> v
+  | Int16 _ -> SInt16.to_int v
   | Int32 _ -> (
       match SInt32.to_int_opt v with
       | Some n -> n
@@ -664,7 +664,7 @@ let rec of_int : type a. a typ -> int -> a =
   | Uint32 _ -> UInt32.of_int n
   | Uint64 _ -> UInt64.of_int n
   | Int8 -> SInt8.v n
-  | Int16 _ -> n
+  | Int16 _ -> SInt16.v n
   | Int32 _ -> SInt32.of_int n
   | Int64 _ -> Int64.of_int n
   | Float32 _ -> not_an_integer ()
@@ -1523,7 +1523,7 @@ let rec case_index_to_expr : type k. k typ -> k -> packed_expr =
   | Uint32 _ -> Pack_expr (Int (uint32_case_index k))
   | Uint_var _ -> Pack_expr (Int (uint_var_case_index k))
   | Int8 -> Pack_expr (Int (SInt8.to_int k))
-  | Int16 _ -> Pack_expr (Int k)
+  | Int16 _ -> Pack_expr (Int (SInt16.to_int k))
   | Int32 _ -> Pack_expr (Int (int32_case_index k))
   | Bits _ -> Pack_expr (Int k)
   | Enum { base; _ } -> case_index_to_expr base k
@@ -2095,38 +2095,31 @@ let check_zeroterm_region ~region ~len =
       "Wire.encode: zeroterm string needs %d bytes but region is %d" (len + 1)
       region
 
-(* A field of [bits] bits owns exactly those bits, whether it was declared as a
-   fixed-width scalar or as a [bits ~width] slice of one: both are carried in an
-   OCaml [int], which holds far more than the field does. Masking a wider value
-   is the one truncation nothing downstream can catch, because the masked result
-   is itself a legal field value that decode, [validate] and the EverParse
-   validator all accept, and the number the caller meant is gone without trace.
-   So each width accepts exactly what its decoder produces -- [0, 2^bits - 1]
-   unsigned, [-2^(bits-1), 2^(bits-1) - 1] signed -- and encode stays inverse to
-   decode.
+(* An unsigned field of [bits] bits owns exactly those bits, whether it was
+   declared as a fixed-width scalar or as a [bits ~width] slice of one: both are
+   carried in an OCaml [int], which holds far more than the field does. Masking
+   a wider value is the one truncation nothing downstream can catch, because the
+   masked result is itself a legal field value that decode, [validate] and the
+   EverParse validator all accept, and the number the caller meant is gone
+   without trace. So each width accepts exactly what its decoder produces,
+   [0, 2^bits - 1], and encode stays inverse to decode.
 
    Where the native [int] is no wider than the field (a 32-bit field under
    js_of_ocaml, anything from 31 bits up under wasm_of_ocaml) no [int] is out of
    range, so the guard narrows to what is still checkable there rather than
    rejecting a value the target can represent.
 
-   The wider carriers guard themselves, next to the representation that decides
-   what fits: {!UInt32.check_encode} and {!UInt63.check_encode}. [uint64] and
-   [int64] have no guard, because an [int64] is exactly the eight bytes written
-   and no value of it is out of range. *)
+   The signed widths need nothing here. {!SInt8.t} and {!SInt16.t} carry the
+   field's range in the type, so a value that reaches an encoder is in range by
+   construction; {!SInt32.check_encode} sits next to the representation that
+   decides what fits, as {!UInt32.check_encode} and {!UInt63.check_encode} do on
+   the unsigned side; and [uint64] and [int64] need no guard at all, because an
+   [int64] is exactly the eight bytes written. *)
 let check_unsigned_encode ~bits v =
   let out_of_range = if bits >= Sys.int_size then v < 0 else v lsr bits <> 0 in
   if out_of_range then
     Fmt.invalid_arg
       "Wire.encode: value %d does not fit an unsigned %d-bit field" v bits
-
-let check_signed_encode ~bits v =
-  if bits < Sys.int_size then begin
-    let limit = 1 lsl (bits - 1) in
-    if v < -limit || v >= limit then
-      Fmt.invalid_arg "Wire.encode: value %d does not fit a signed %d-bit field"
-        v bits
-  end
 
 (* The range-checking counterparts of [Bytes.set_*]: every wire encode path
    writes a fixed-width scalar through one of these, because the [Bytes]
@@ -2143,14 +2136,6 @@ let set_uint16_le buf off v =
 let set_uint16_be buf off v =
   check_unsigned_encode ~bits:16 v;
   Bytes.set_uint16_be buf off v
-
-let set_int16_le buf off v =
-  check_signed_encode ~bits:16 v;
-  Bytes.set_int16_le buf off v
-
-let set_int16_be buf off v =
-  check_signed_encode ~bits:16 v;
-  Bytes.set_int16_be buf off v
 
 let set_int32_le = SInt32.set_le
 let set_int32_be = SInt32.set_be

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -180,13 +180,6 @@ val check_unsigned_encode : bits:int -> int -> unit
     Where the native [int] is no wider than the field the guard narrows to what
     is still checkable, so it never rejects a value the target can represent. *)
 
-val check_signed_encode : bits:int -> int -> unit
-(** Check an integer fits a signed [bits]-wide field before encoding it. The
-    accepted range is [[-2^(bits-1), 2^(bits-1) - 1]]: the decoder produces
-    exactly that, so [40000] into an {!val-int16} is refused rather than
-    round-tripping back as [-25536]. Same narrow-target narrowing as
-    {!check_unsigned_encode}. *)
-
 (** {2 Checked scalar writers}
 
     The range-checking counterparts of [Bytes.set_*]. Every wire encode path
@@ -201,12 +194,6 @@ val set_uint16_le : bytes -> int -> int -> unit
 
 val set_uint16_be : bytes -> int -> int -> unit
 (** [set_uint16_be buf off v] writes [v] as two unsigned big-endian bytes. *)
-
-val set_int16_le : bytes -> int -> int -> unit
-(** [set_int16_le buf off v] writes [v] as two signed little-endian bytes. *)
-
-val set_int16_be : bytes -> int -> int -> unit
-(** [set_int16_be buf off v] writes [v] as two signed big-endian bytes. *)
 
 val set_int32_le : bytes -> int -> SInt32.t -> unit
 (** [set_int32_le buf off v] writes [v] as four signed little-endian bytes. *)
@@ -286,7 +273,9 @@ and _ typ =
   | Int8 : SInt8.t typ
       (** 8-bit signed. Carried by {!SInt8.t}, whose range is the field's: a
           number the byte cannot hold is refused where it is built. *)
-  | Int16 : endian -> int typ  (** 16-bit signed. *)
+  | Int16 : endian -> SInt16.t typ
+      (** 16-bit signed. Carried by {!SInt16.t}, whose range is the field's: a
+          number two bytes cannot hold is refused where it is built. *)
   | Int32 : endian -> SInt32.t typ
       (** 32-bit signed. Carried by {!SInt32.t}, which holds the full range on
           every target; a plain [int] drops the top bits where it is narrower
@@ -605,10 +594,10 @@ val uint64be : UInt64.t typ
 val int8 : SInt8.t typ
 (** 8-bit signed two's-complement integer. *)
 
-val int16 : int typ
+val int16 : SInt16.t typ
 (** 16-bit signed, little-endian. *)
 
-val int16be : int typ
+val int16be : SInt16.t typ
 (** 16-bit signed, big-endian. *)
 
 val int32 : SInt32.t typ

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -267,8 +267,8 @@ let rec parse_direct : type a. a typ -> bytes -> int -> int -> a * int =
   | Uint64 Little -> parse_fixed 8 UInt64.le buf off len
   | Uint64 Big -> parse_fixed 8 UInt64.be buf off len
   | Int8 -> parse_fixed 1 SInt8.get buf off len
-  | Int16 Little -> parse_fixed 2 Bytes.get_int16_le buf off len
-  | Int16 Big -> parse_fixed 2 Bytes.get_int16_be buf off len
+  | Int16 Little -> parse_fixed 2 SInt16.le buf off len
+  | Int16 Big -> parse_fixed 2 SInt16.be buf off len
   | Int32 Little -> parse_fixed 4 int32_le buf off len
   | Int32 Big -> parse_fixed 4 int32_be buf off len
   | Int64 Little -> parse_fixed 8 Bytes.get_int64_le buf off len
@@ -691,12 +691,12 @@ let[@inline] write_int8 enc v =
 
 let[@inline] write_int16_le enc v =
   ensure enc 2;
-  Bytes.set_int16_le enc.o enc.o_next v;
+  SInt16.set_le enc.o enc.o_next v;
   enc.o_next <- enc.o_next + 2
 
 let[@inline] write_int16_be enc v =
   ensure enc 2;
-  Bytes.set_int16_be enc.o enc.o_next v;
+  SInt16.set_be enc.o enc.o_next v;
   enc.o_next <- enc.o_next + 2
 
 let[@inline] write_uint16_le enc v =
@@ -781,12 +781,8 @@ let rec encode_into : type a. a typ -> a -> encoder -> unit =
   | Uint64 Little -> write_int64_le enc (UInt64.to_int64 v)
   | Uint64 Big -> write_int64_be enc (UInt64.to_int64 v)
   | Int8 -> write_int8 enc v
-  | Int16 Little ->
-      Types.check_signed_encode ~bits:16 v;
-      write_int16_le enc v
-  | Int16 Big ->
-      Types.check_signed_encode ~bits:16 v;
-      write_int16_be enc v
+  | Int16 Little -> write_int16_le enc v
+  | Int16 Big -> write_int16_be enc v
   | Int32 Little ->
       SInt32.check_encode v;
       write_int32_le enc (SInt32.to_int32 v)
@@ -1048,6 +1044,7 @@ let pp_value (type r) (c : r Codec.t) ppf (v : r) =
 module UInt64 = UInt64
 module SInt32 = SInt32
 module SInt8 = SInt8
+module SInt16 = SInt16
 module Ascii = Ascii
 
 module Private = struct

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -390,6 +390,13 @@ module SInt8 = SInt8
     names the range, and [SInt8.v 200] is refused there rather than at the
     encoder. *)
 
+module SInt16 = SInt16
+(** Signed 16-bit integers, the carrier of {!int16} and {!int16be}.
+
+    A [private int] for the same reason {!SInt8} is: a value reads as the [int]
+    it is, only building one names the range, and [SInt16.v 40000] is refused
+    there rather than at the encoder. *)
+
 module Field : sig
   type 'a t
   (** A named field carrying values of type ['a]. *)
@@ -598,11 +605,16 @@ val int8 : SInt8.t typ
     where the value is built and every encode path takes only values the byte
     holds. *)
 
-val int16 : int typ
-(** Signed 16-bit little-endian integer. Encodes [-32768] to [32767]. *)
+val int16 : SInt16.t typ
+(** Signed 16-bit little-endian integer. Holds [-32768] to [32767]: [40000] is
+    not an [int16], even though its low two bytes are legal ones, and would come
+    back from the decoder as [-25536]. The range is the carrier's, so
+    {!SInt16.v} refuses it where the value is built and every encode path takes
+    only values the field holds. *)
 
-val int16be : int typ
-(** Signed 16-bit big-endian integer. Encodes [-32768] to [32767]. *)
+val int16be : SInt16.t typ
+(** Signed 16-bit big-endian integer. Same range and same carrier as {!int16}.
+*)
 
 val int32 : SInt32.t typ
 (** Signed 32-bit little-endian integer. Encodes [-2{^31}] to [2{^31} - 1], and

--- a/test/test.ml
+++ b/test/test.ml
@@ -12,6 +12,7 @@ let () =
       Test_uint64.suite;
       Test_sint32.suite;
       Test_sint8.suite;
+      Test_sint16.suite;
       Test_uint63.suite;
       Test_types.suite;
       Test_eval.suite;

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -3017,11 +3017,12 @@ let test_map_inherits_exact_width () =
       Bytes.to_string buf)
 
 (* The fixed-width scalars are the same rule at a fixed width. OCaml carries the
-   narrow ones in a plain [int], which holds far more than the field does, so
-   nothing but a runtime check stands between a caller's 0x1FF and an 0xFF on
-   the wire that reads back as a perfectly legal 255. The signed ones accept
-   exactly what their decoder produces, [-2^(n-1) .. 2^(n-1) - 1]: 40000 into
-   an [int16] is refused rather than round-tripped back as -25536. *)
+   narrow unsigned ones in a plain [int], which holds far more than the field
+   does, so nothing but a runtime check stands between a caller's 0x1FF and an
+   0xFF on the wire that reads back as a perfectly legal 255. The signed ones
+   put that range in their carrier instead, so this sweep has no out-of-range
+   value to hand them; [test_sint32_of_int_range] and the [sint8] and [sint16]
+   suites pin that refusal, one step earlier than an encoder can reach. *)
 let scalar_range_codec name typ =
   let cf = Codec.(Field.v "v" typ $ Fun.id) in
   (Codec.v name Fun.id Codec.[ cf ], cf)
@@ -3076,23 +3077,6 @@ let test_encode_exact_unsigned_scalar () =
         ~equal:Int.equal ~pp:Fmt.int ~inside:[ 0; widest ]
         ~outside:[ widest + 1; -1 ])
     [ ("uint8", 8, uint8); ("uint16", 16, uint16); ("uint16be", 16, uint16be) ]
-
-let test_encode_exact_signed_scalar () =
-  List.iter
-    (fun (name, bits, typ) ->
-      if width_is_testable bits then
-        let limit = 1 lsl (bits - 1) in
-        check_scalar_range ~name ~typ
-          ~sub:(Fmt.str "does not fit a signed %d-bit field" bits)
-          ~equal:Int.equal ~pp:Fmt.int
-          ~inside:[ -limit; limit - 1 ]
-          ~outside:[ limit; -limit - 1 ])
-    (* [int8] and [int32] are absent on purpose: their carriers, {!SInt8.t}
-       and {!SInt32.t}, refuse an out-of-range number, so there is no such
-       value to hand the encoder. [test_sint32_of_int_range] and the [sint8]
-       suite pin those refusals instead, one step earlier than this check can
-       reach. *)
-    [ ("int16", 16, int16); ("int16be", 16, int16be) ]
 
 (* The signed 32-bit range is enforced where the value is built rather than
    where it is written, so a number the field cannot hold never becomes an
@@ -3180,16 +3164,12 @@ let test_eight_byte_unsigned_preserves_wire () =
   check_eight_byte_unsigned "uint64be" uint64be
 
 (* The same rule one width down, on the signed side. Four bytes spell 2^32
-   patterns and the generated C validator hands every one of them on unchanged.
-   [int32] carries a native [int], so where that int is narrower than the field
-   ([wasm_of_ocaml] is 31 bits) [Int32.to_int] drops the top bits on the way in,
-   and nothing on the way out objects: [check_signed_encode] guards itself with
-   [bits < Sys.int_size], and 32 < 31 is false, so the check disables itself
-   exactly where it is needed. A frame leaves as different bytes with no error
-   on either path. Refusing it would be sound; altering it is not.
-
-   Native and js_of_ocaml hold 32 bits in an [int] and already pass. This case
-   is the one that fails under wasm_of_ocaml. *)
+   patterns and the generated C validator hands every one of them on unchanged,
+   so the OCaml side has to as well. A frame that leaves as different bytes with
+   no error on either path is the failure this pins: refusing one the target
+   cannot hold would be sound, altering it silently is not. The carrier is what
+   makes it hold, {!SInt32.t} widening to a boxed [int32] wherever the native
+   [int] is narrower than the field, so no target drops the top bits. *)
 let check_four_byte_signed name typ wire =
   let cf = Codec.(Field.v "v" typ $ Fun.id) in
   let codec = Codec.v "FourByteSigned" Fun.id Codec.[ cf ] in
@@ -9164,8 +9144,6 @@ let suite =
         test_map_inherits_exact_width;
       Alcotest.test_case "exact width: unsigned scalars" `Quick
         test_encode_exact_unsigned_scalar;
-      Alcotest.test_case "exact width: signed scalars" `Quick
-        test_encode_exact_signed_scalar;
       Alcotest.test_case "exact width: UInt32.of_int range" `Quick
         test_uint32_of_int_range;
       Alcotest.test_case "exact width: int64 carrier has no range" `Quick

--- a/test/test_sint16.ml
+++ b/test/test_sint16.ml
@@ -1,0 +1,105 @@
+(* Tests for SInt16, the signed 16-bit carrier behind [int16] and [int16be].
+   The range lives in the type, so what is left to check is the constructor's
+   refusal and the two byte layouts: every value of the type is one a signed
+   16-bit field holds, and no encoder downstream has to ask again. *)
+
+open Wire
+
+(* [v] refuses a number the field cannot hold rather than masking it to a legal
+   one the caller did not mean: 40000 masks to a perfectly good -25536 that no
+   decoder, [validate] or generated C validator could tell from the number the
+   caller wrote. *)
+let test_v_refuses_out_of_range () =
+  List.iter
+    (fun n ->
+      match SInt16.v n with
+      | x -> Alcotest.failf "v %d built %a" n SInt16.pp x
+      | exception Invalid_argument _ -> ())
+    [ 0x8000; 40000; 0xFFFF; 0x1_0000; -0x8001; -40000; max_int; min_int ]
+
+let test_v_accepts_the_whole_range () =
+  for n = -0x8000 to 0x7FFF do
+    Fmt.kstr
+      (fun msg -> Alcotest.(check int) msg n)
+      "v %d round-trips" n
+      (SInt16.to_int (SInt16.v n))
+  done
+
+let test_v_opt () =
+  Alcotest.(check (option int))
+    "in range" (Some 0x7FFF)
+    (Option.map SInt16.to_int (SInt16.v_opt 0x7FFF));
+  Alcotest.(check bool) "out of range" true (SInt16.v_opt 0x8000 = None)
+
+(* [min_int] and [max_int] are the field's ends, not the carrier's. *)
+let test_bounds () =
+  Alcotest.(check int) "min_int" (-0x8000) (SInt16.to_int SInt16.min_int);
+  Alcotest.(check int) "max_int" 0x7FFF (SInt16.to_int SInt16.max_int);
+  Alcotest.(check int) "zero" 0 (SInt16.to_int SInt16.zero)
+
+let test_roundtrip () =
+  let buf = Bytes.create 2 in
+  for n = -0x8000 to 0x7FFF do
+    SInt16.set_le buf 0 (SInt16.v n);
+    Fmt.kstr
+      (fun msg -> Alcotest.(check int) msg n)
+      "%d survives two little-endian bytes" n
+      (SInt16.to_int (SInt16.le buf 0));
+    SInt16.set_be buf 0 (SInt16.v n);
+    Fmt.kstr
+      (fun msg -> Alcotest.(check int) msg n)
+      "%d survives two big-endian bytes" n
+      (SInt16.to_int (SInt16.be buf 0))
+  done
+
+(* Pin both byte orders so the read and write paths cannot drift apart, and so
+   one endianness cannot quietly stand in for the other: a pattern with the top
+   bit set is the negative number it spells, not the unsigned one. *)
+let test_byte_layout () =
+  Alcotest.(check int)
+    "0xFE 0xFF reads -2 little-endian" (-2)
+    (SInt16.to_int (SInt16.le (Bytes.of_string "\xFE\xFF") 0));
+  Alcotest.(check int)
+    "0xFF 0xFE reads -2 big-endian" (-2)
+    (SInt16.to_int (SInt16.be (Bytes.of_string "\xFF\xFE") 0));
+  Alcotest.(check int)
+    "0x00 0x80 reads min_int little-endian" (-0x8000)
+    (SInt16.to_int (SInt16.le (Bytes.of_string "\x00\x80") 0));
+  Alcotest.(check int)
+    "0x80 0x00 reads min_int big-endian" (-0x8000)
+    (SInt16.to_int (SInt16.be (Bytes.of_string "\x80\x00") 0));
+  let out = Bytes.create 2 in
+  SInt16.set_le out 0 SInt16.min_int;
+  Alcotest.(check string)
+    "min_int writes 0x00 0x80 little-endian" "\x00\x80" (Bytes.to_string out);
+  SInt16.set_be out 0 SInt16.min_int;
+  Alcotest.(check string)
+    "min_int writes 0x80 0x00 big-endian" "\x80\x00" (Bytes.to_string out)
+
+let test_equal () =
+  Alcotest.(check bool)
+    "reflexive" true
+    (SInt16.equal (SInt16.v 4242) (SInt16.v 4242));
+  Alcotest.(check bool)
+    "min_int <> max_int" false
+    (SInt16.equal SInt16.min_int SInt16.max_int)
+
+let test_pp () =
+  Alcotest.(check string)
+    "min_int" "-32768"
+    (Fmt.str "%a" SInt16.pp SInt16.min_int)
+
+let suite =
+  ( "sint16",
+    [
+      Alcotest.test_case "v refuses out of range" `Quick
+        test_v_refuses_out_of_range;
+      Alcotest.test_case "v accepts the whole range" `Quick
+        test_v_accepts_the_whole_range;
+      Alcotest.test_case "v_opt" `Quick test_v_opt;
+      Alcotest.test_case "bounds" `Quick test_bounds;
+      Alcotest.test_case "roundtrip" `Quick test_roundtrip;
+      Alcotest.test_case "byte layout" `Quick test_byte_layout;
+      Alcotest.test_case "equal" `Quick test_equal;
+      Alcotest.test_case "pp" `Quick test_pp;
+    ] )

--- a/test/test_sint16.mli
+++ b/test/test_sint16.mli
@@ -1,0 +1,4 @@
+(** Tests for the [sint16] module. *)
+
+val suite : string * unit Alcotest.test_case list
+(** Alcotest suite. *)

--- a/test/test_wire.ml
+++ b/test/test_wire.ml
@@ -215,7 +215,7 @@ let test_reader_embedded_zeroterm_scan_is_not_quadratic () =
 
 let test_int16be_negative () =
   let buf = Bytes.of_string "\xFF\xFE" in
-  Alcotest.(check int) "-2 BE" (-2) (of_bytes_exn int16be buf)
+  Alcotest.(check int) "-2 BE" (-2) (SInt16.to_int (of_bytes_exn int16be buf))
 
 let test_int32be_negative () =
   let buf = Bytes.of_string "\xFF\xFF\xFF\xFE" in


### PR DESCRIPTION
`Wire.int16` and `Wire.int16be` used to decode to a native `int` and range-check on the way to the wire; they now decode to `Wire.SInt16.t`, a `private int` whose range is the field's, so a value the field cannot hold is refused where it is built. Read one with `SInt16.to_int` and build one with `SInt16.v`. Follows #330, and retires `check_signed_encode`, whose last caller this was.