### PR TITLE
types: give uint8 an exact 8-bit unsigned carrier

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -63,6 +63,11 @@
   `Wire.UInt16.to_int`, build one with the range-checked `Wire.UInt16.v`
   (#335, @samoht)
 
+- **Breaking:** `uint8` decodes to `Wire.UInt8.t`, a `private int` whose range
+  is the field's, rather than a native `int`. Read one with
+  `Wire.UInt8.to_int`, build one with the range-checked `Wire.UInt8.v`
+  (#336, @samoht)
+
 - `Wire.enum`, `Wire.enum_open`, `Wire.variants`, `Wire.lookup` and `Wire.bit`
   accept any integer-valued base, not only one that decodes to a native `int`.
   An enum, variant mapping, lookup table or flag can now sit over `uint32`,

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ API reference: [wire on ocaml.org](https://ocaml.org/p/wire/latest).
 ```ocaml
 open Wire
 
-type packet = { version : int; flags : int; length : UInt16.t; tag : int }
+type packet = { version : int; flags : int; length : UInt16.t; tag : UInt8.t }
 
 let f_version = Field.v "Version" (bits ~width:4 U8)
 let f_flags   = Field.v "Flags"   (bits ~width:4 U8)
@@ -78,7 +78,7 @@ let set_version = Staged.unstage (Codec.set codec bf_version)
 let buf = Bytes.create (Codec.wire_size codec)
 let () =
   Codec.encode codec
-    { version = 1; flags = 2; length = UInt16.v 1024; tag = 0 }
+    { version = 1; flags = 2; length = UInt16.v 1024; tag = UInt8.zero }
     buf 0
 let v = get_version buf 0        (* read version without allocating a record *)
 let () = set_version buf 0 3     (* mutate version in place *)

--- a/bench/demo/demo_bench_cases.ml
+++ b/bench/demo/demo_bench_cases.ml
@@ -230,10 +230,10 @@ let minimal_case =
       set;
       write_template = Bytes.copy minimal_dataset.packed;
       write_offset = 0;
-      write_value = 42;
-      equal = Int.equal;
+      write_value = Wire.UInt8.v 42;
+      equal = Wire.UInt8.equal;
       bench_read = true;
-      of_c_field = id_int;
+      of_c_field = of_int Wire.UInt8.v;
     }
 
 let all_ints_case =
@@ -553,10 +553,10 @@ let constrained_case =
       set;
       write_template = Bytes.copy constrained_dataset.items.(0);
       write_offset = 0;
-      write_value = 9;
-      equal = Int.equal;
+      write_value = Wire.UInt8.v 9;
+      equal = Wire.UInt8.equal;
       bench_read = true;
-      of_c_field = id_int;
+      of_c_field = of_int Wire.UInt8.v;
     }
 
 let all_cases =

--- a/bench/demo/demo_bench_cases.mli
+++ b/bench/demo/demo_bench_cases.mli
@@ -47,7 +47,7 @@ type 'a read_case =
 type packed_case = C : _ read_case -> packed_case
 type write_case = { label : string; run : unit -> unit; verify : unit -> unit }
 
-val minimal_case : int read_case
+val minimal_case : Wire.UInt8.t read_case
 (** Minimal 1-byte uint8 schema. *)
 
 val all_ints_case : Wire.UInt64.t read_case
@@ -92,7 +92,7 @@ val cases_case : Demo.ptype read_case
 val enum_case : Demo.status read_case
 (** Enum field with mapped status values. *)
 
-val constrained_case : int read_case
+val constrained_case : Wire.UInt8.t read_case
 (** Constrained field with a where-clause predicate. *)
 
 val projection_cases : packed_case list

--- a/bench/memtrace/bench.ml
+++ b/bench/memtrace/bench.ml
@@ -33,8 +33,8 @@ let schema name codec size default make_data =
 (* -- Nested codec schemas for allocation tracking -- *)
 
 (* Codec embed: outer record containing an inner sub-codec *)
-type inner_rec = { tag : int; value : Wire.UInt16.t }
-type outer_rec = { hdr : int; inner : inner_rec; trail : int }
+type inner_rec = { tag : Wire.UInt8.t; value : Wire.UInt16.t }
+type outer_rec = { hdr : Wire.UInt8.t; inner : inner_rec; trail : Wire.UInt8.t }
 
 let inner_codec =
   Wire.Codec.v "Inner"
@@ -58,7 +58,11 @@ let outer_codec =
 let outer_size = 5
 
 let outer_default =
-  { hdr = 0; inner = { tag = 0; value = Wire.UInt16.zero }; trail = 0 }
+  {
+    hdr = Wire.UInt8.zero;
+    inner = { tag = Wire.UInt8.zero; value = Wire.UInt16.zero };
+    trail = Wire.UInt8.zero;
+  }
 
 let outer_data n =
   Array.init n (fun i ->
@@ -105,7 +109,7 @@ let opt_present_data n =
       b)
 
 (* Repeat: container with repeated sub-codec elements *)
-type repeat_rec = { len : int; items : inner_rec list }
+type repeat_rec = { len : Wire.UInt8.t; items : inner_rec list }
 
 let f_r_len = Wire.Field.v "Len" Wire.uint8
 
@@ -124,12 +128,12 @@ let repeat_size = 10 (* 1 + 3*3 = 10 bytes for 3 inner items *)
 
 let repeat_default =
   {
-    len = 9;
+    len = Wire.UInt8.v 9;
     items =
       [
-        { tag = 0; value = Wire.UInt16.zero };
-        { tag = 0; value = Wire.UInt16.zero };
-        { tag = 0; value = Wire.UInt16.zero };
+        { tag = Wire.UInt8.zero; value = Wire.UInt16.zero };
+        { tag = Wire.UInt8.zero; value = Wire.UInt16.zero };
+        { tag = Wire.UInt8.zero; value = Wire.UInt16.zero };
       ];
   }
 
@@ -168,7 +172,7 @@ type kexinit = {
   comp_s2c : Slice.t;
   lang_c2s : Slice.t;
   lang_s2c : Slice.t;
-  first_follows : int;
+  first_follows : Wire.UInt8.t;
   reserved : Wire.UInt32.t;
 }
 

--- a/examples/demo/demo.ml
+++ b/examples/demo/demo.ml
@@ -13,7 +13,7 @@ open Wire.Everparse.Raw
 
 (* -- 1. Minimal: single uint8 = 1 byte -- *)
 
-type minimal = { m_value : int }
+type minimal = { m_value : UInt8.t }
 
 let f_minimal_value = Field.v "Value" uint8
 let bf_minimal_value = Codec.(f_minimal_value $ fun m -> m.m_value)
@@ -23,7 +23,7 @@ let minimal_codec =
 
 let minimal_struct = Everparse.Raw.struct_of_codec minimal_codec
 let minimal_size = Codec.wire_size minimal_codec
-let minimal_default = { m_value = 42 }
+let minimal_default = { m_value = UInt8.v 42 }
 
 let minimal_data n =
   Array.init n (fun i ->
@@ -34,7 +34,7 @@ let minimal_data n =
 (* -- 2. AllInts: all integer widths = 1+2+2+4+4+8 = 21 bytes -- *)
 
 type all_ints = {
-  u8 : int;
+  u8 : UInt8.t;
   u16 : UInt16.t;
   u16be : UInt16.t;
   u32 : UInt32.t;
@@ -63,7 +63,7 @@ let all_ints_size = Codec.wire_size all_ints_codec
 
 let all_ints_default =
   {
-    u8 = 0xFF;
+    u8 = UInt8.v 0xFF;
     u16 = UInt16.v 0x1234;
     u16be = UInt16.v 0x5678;
     u32 = UInt32.of_int 0xDEADBEEF;
@@ -169,7 +169,7 @@ let bf32_data n =
 
 (* -- 6. BoolFields: bool(1bit)+bool(1bit)+6bits+uint8 = 2 bytes -- *)
 
-type bool_fields = { active : bool; valid : bool; mode : int; code : int }
+type bool_fields = { active : bool; valid : bool; mode : int; code : UInt8.t }
 
 let f_bool_active = Field.v "Active" (bit (bits ~width:1 U8))
 let bf_bool_active = Codec.(f_bool_active $ fun b -> b.active)
@@ -189,7 +189,7 @@ let bool_fields_struct = Everparse.Raw.struct_of_codec bool_fields_codec
 let bool_fields_size = Codec.wire_size bool_fields_codec
 
 let bool_fields_default =
-  { active = true; valid = false; mode = 7; code = 0xAB }
+  { active = true; valid = false; mode = 7; code = UInt8.v 0xAB }
 
 let bool_fields_data n =
   Array.init n (fun i ->
@@ -203,11 +203,11 @@ let bool_fields_data n =
 
 type large_mixed = {
   sync : UInt32.t;
-  version : int;
-  type_ : int;
+  version : UInt8.t;
+  type_ : UInt8.t;
   spacecraft : UInt16.t;
-  vcid : int;
-  count : int;
+  vcid : UInt8.t;
+  count : UInt8.t;
   offset : UInt16.t;
   length : UInt16.t;
   crc : UInt32.t;
@@ -252,11 +252,11 @@ let large_mixed_size = Codec.wire_size large_mixed_codec
 let large_mixed_default =
   {
     sync = UInt32.of_int 0x1ACFFC1D;
-    version = 2;
-    type_ = 0;
+    version = UInt8.v 2;
+    type_ = UInt8.v 0;
     spacecraft = UInt16.v 0x01FF;
-    vcid = 3;
-    count = 66;
+    vcid = UInt8.v 3;
+    count = UInt8.v 66;
     offset = UInt16.v 16;
     length = UInt16.v 1024;
     crc = UInt32.of_int 0xDEADBEEF;
@@ -297,10 +297,14 @@ let int_of_priority = function
   | High -> 2
   | Critical -> 3
 
-type mapped = { priority : priority; value : int }
+type mapped = { priority : priority; value : UInt8.t }
 
 let f_mp_priority =
-  Field.v "Priority" (map ~decode:priority_of_int ~encode:int_of_priority uint8)
+  Field.v "Priority"
+    (map
+       ~decode:(fun v -> priority_of_int (UInt8.to_int v))
+       ~encode:(fun p -> UInt8.v (int_of_priority p))
+       uint8)
 
 let f_mp_value = Field.v "Value" uint8
 let bf_mp_priority = Codec.(f_mp_priority $ fun m -> m.priority)
@@ -312,13 +316,13 @@ let mapped_codec =
 
 let mapped_struct = Everparse.Raw.struct_of_codec mapped_codec
 let mapped_size = Codec.wire_size mapped_codec
-let mapped_default = { priority = High; value = 42 }
+let mapped_default = { priority = High; value = UInt8.v 42 }
 
 let mapped_data n =
   let buf = Bytes.create (n * mapped_size) in
   for i = 0 to n - 1 do
     Codec.encode mapped_codec
-      { priority = priority_of_int (i mod 4); value = i mod 256 }
+      { priority = priority_of_int (i mod 4); value = UInt8.v (i mod 256) }
       buf (i * mapped_size)
   done;
   buf
@@ -367,7 +371,7 @@ let cases_demo_data n =
    Codec.get calls the map decode on every read. *)
 
 type status = [ `Ok | `Warn | `Err | `Crit ]
-type enum_demo = { status : status; code : int }
+type enum_demo = { status : status; code : UInt8.t }
 
 let f_en_status =
   Field.v "StatusCode"
@@ -385,14 +389,14 @@ let enum_demo_codec =
 
 let enum_demo_struct = Everparse.Raw.struct_of_codec enum_demo_codec
 let enum_demo_size = Codec.wire_size enum_demo_codec
-let enum_demo_default = { status = `Ok; code = 42 }
+let enum_demo_default = { status = `Ok; code = UInt8.v 42 }
 
 let enum_demo_data n =
   let buf = Bytes.create (n * enum_demo_size) in
   let statuses = [| `Ok; `Warn; `Err; `Crit |] in
   for i = 0 to n - 1 do
     Codec.encode enum_demo_codec
-      { status = statuses.(i mod 4); code = i mod 256 }
+      { status = statuses.(i mod 4); code = UInt8.v (i mod 256) }
       buf (i * enum_demo_size)
   done;
   buf
@@ -402,7 +406,7 @@ let enum_demo_data n =
    (Version must be 0) but Codec.get strips the constraint entirely.
    This measures C constraint-checking overhead vs OCaml unchecked read. *)
 
-type constrained = { version : int; data : int }
+type constrained = { version : UInt8.t; data : UInt8.t }
 
 let f_co_version_c = field "Version" uint8
 
@@ -419,20 +423,20 @@ let constrained_codec =
 
 let constrained_struct = Everparse.Raw.struct_of_codec constrained_codec
 let constrained_size = Codec.wire_size constrained_codec
-let constrained_default = { version = 0; data = 42 }
+let constrained_default = { version = UInt8.zero; data = UInt8.v 42 }
 
 let constrained_data n =
   let buf = Bytes.create (n * constrained_size) in
   for i = 0 to n - 1 do
     Codec.encode constrained_codec
-      { version = 0; data = i mod 256 }
+      { version = UInt8.zero; data = UInt8.v (i mod 256) }
       buf (i * constrained_size)
   done;
   buf
 
 (* -- 12. Lowercase name: exercises filename capitalization -- *)
 
-type lowercase_record = { x : int; y : UInt16.t }
+type lowercase_record = { x : UInt8.t; y : UInt16.t }
 
 let lowercase_codec =
   Codec.v "lowercase_record"
@@ -444,7 +448,7 @@ let lowercase_codec =
 
 (* -- 13. Reserved-word field names -- *)
 
-type reserved_fields = { type_ : int; case : int; value : UInt16.t }
+type reserved_fields = { type_ : UInt8.t; case : UInt8.t; value : UInt16.t }
 
 let reserved_fields_codec =
   let f_type = Field.v "type" uint8 in

--- a/examples/demo/demo.mli
+++ b/examples/demo/demo.mli
@@ -2,15 +2,15 @@
 
 (** {1 Minimal (1 byte)} *)
 
-type minimal = { m_value : int }
+type minimal = { m_value : Wire.UInt8.t }
 
 val minimal_codec : minimal Wire.Codec.t
 (** Codec for the minimal 1-byte schema. *)
 
-val f_minimal_value : int Wire.Field.t
+val f_minimal_value : Wire.UInt8.t Wire.Field.t
 (** Zero-copy field accessor for the Value field. *)
 
-val bf_minimal_value : (int, minimal) Wire.Codec.field
+val bf_minimal_value : (Wire.UInt8.t, minimal) Wire.Codec.field
 (** Bound field for Codec.get/set on Value. *)
 
 val minimal_struct : Wire.Everparse.Raw.struct_
@@ -28,7 +28,7 @@ val minimal_data : int -> bytes array
 (** {1 AllInts (21 bytes)} *)
 
 type all_ints = {
-  u8 : int;
+  u8 : Wire.UInt8.t;
   u16 : Wire.UInt16.t;
   u16be : Wire.UInt16.t;
   u32 : Wire.UInt32.t;
@@ -135,7 +135,12 @@ val bf32_data : int -> bytes array
 
 (** {1 BoolFields (2 bytes)} *)
 
-type bool_fields = { active : bool; valid : bool; mode : int; code : int }
+type bool_fields = {
+  active : bool;
+  valid : bool;
+  mode : int;
+  code : Wire.UInt8.t;
+}
 
 val bool_fields_codec : bool_fields Wire.Codec.t
 (** Codec with boolean and integer bitfields in a uint16be. *)
@@ -163,11 +168,11 @@ val bool_fields_data : int -> bytes array
 
 type large_mixed = {
   sync : Wire.UInt32.t;
-  version : int;
-  type_ : int;
+  version : Wire.UInt8.t;
+  type_ : Wire.UInt8.t;
   spacecraft : Wire.UInt16.t;
-  vcid : int;
-  count : int;
+  vcid : Wire.UInt8.t;
+  count : Wire.UInt8.t;
   offset : Wire.UInt16.t;
   length : Wire.UInt16.t;
   crc : Wire.UInt32.t;
@@ -199,7 +204,7 @@ val large_mixed_data : int -> bytes array
 (** {1 Mapped (2 bytes)} *)
 
 type priority = Low | Medium | High | Critical
-type mapped = { priority : priority; value : int }
+type mapped = { priority : priority; value : Wire.UInt8.t }
 
 val mapped_codec : mapped Wire.Codec.t
 (** Mapped-priority codec. *)
@@ -213,7 +218,7 @@ val f_mp_priority : priority Wire.Field.t
 val bf_mp_priority : (priority, mapped) Wire.Codec.field
 (** Bound field for Codec.get/set on Priority. *)
 
-val f_mp_value : int Wire.Field.t
+val f_mp_value : Wire.UInt8.t Wire.Field.t
 (** Value field. *)
 
 val mapped_size : int
@@ -257,7 +262,7 @@ val cases_demo_data : int -> bytes
 (** {1 EnumDemo (2 bytes)} *)
 
 type status = [ `Ok | `Warn | `Err | `Crit ]
-type enum_demo = { status : status; code : int }
+type enum_demo = { status : status; code : Wire.UInt8.t }
 
 val enum_demo_codec : enum_demo Wire.Codec.t
 (** Enum-demo codec. *)
@@ -271,7 +276,7 @@ val f_en_status : status Wire.Field.t
 val bf_en_status : (status, enum_demo) Wire.Codec.field
 (** Bound field for Codec.get/set on StatusCode. *)
 
-val f_en_code : int Wire.Field.t
+val f_en_code : Wire.UInt8.t Wire.Field.t
 (** Code field. *)
 
 val enum_demo_size : int
@@ -285,7 +290,7 @@ val enum_demo_data : int -> bytes
 
 (** {1 Constrained (2 bytes)} *)
 
-type constrained = { version : int; data : int }
+type constrained = { version : Wire.UInt8.t; data : Wire.UInt8.t }
 
 val constrained_codec : constrained Wire.Codec.t
 (** Constrained codec. *)
@@ -293,13 +298,13 @@ val constrained_codec : constrained Wire.Codec.t
 val constrained_struct : Wire.Everparse.Raw.struct_
 (** 3D struct for constrained. *)
 
-val f_co_version : int Wire.Field.t
+val f_co_version : Wire.UInt8.t Wire.Field.t
 (** Version field. *)
 
-val f_co_data : int Wire.Field.t
+val f_co_data : Wire.UInt8.t Wire.Field.t
 (** Data field. *)
 
-val bf_co_data : (int, constrained) Wire.Codec.field
+val bf_co_data : (Wire.UInt8.t, constrained) Wire.Codec.field
 (** Bound field for Codec.get/set on Data. *)
 
 val constrained_size : int

--- a/examples/net/example.ml
+++ b/examples/net/example.ml
@@ -35,8 +35,8 @@ let () =
     Slice.first
       ((Staged.unstage (Codec.get ipv4_codec bf_ip_payload)) buf ip_off)
   in
-  Fmt.pr "IPv4:     protocol=%d src=%a dst=%a payload_off=%d\n" protocol
-    pp_ipv4_addr src pp_ipv4_addr dst tcp_off;
+  Fmt.pr "IPv4:     protocol=%d src=%a dst=%a payload_off=%d\n"
+    (UInt8.to_int protocol) pp_ipv4_addr src pp_ipv4_addr dst tcp_off;
 
   (* Layer 3: TCP -- read fields *)
   let src_port =

--- a/examples/net/net.ml
+++ b/examples/net/net.ml
@@ -56,8 +56,8 @@ type ipv4 = {
   identification : UInt16.t;
   flags : int;
   fragment_offset : int;
-  ttl : int;
-  protocol : int;
+  ttl : UInt8.t;
+  protocol : UInt8.t;
   checksum : UInt16.t;
   src : UInt32.t;
   dst : UInt32.t;

--- a/examples/net/net.mli
+++ b/examples/net/net.mli
@@ -48,7 +48,7 @@ val ipv4_size : int
 val ipv4_payload_size : int
 (** Fixed payload size carried inside an IPv4 packet in bytes. *)
 
-val f_ip_protocol : int Wire.Field.t
+val f_ip_protocol : Wire.UInt8.t Wire.Field.t
 (** Zero-copy field accessor for the IPv4 Protocol field. *)
 
 val f_ip_src : Wire.UInt32.t Wire.Field.t
@@ -60,7 +60,7 @@ val f_ip_dst : Wire.UInt32.t Wire.Field.t
 val f_ip_payload : Bytesrw.Bytes.Slice.t Wire.Field.t
 (** Zero-copy field accessor for the IPv4 payload byte slice. *)
 
-val bf_ip_protocol : (int, ipv4) Wire.Codec.field
+val bf_ip_protocol : (Wire.UInt8.t, ipv4) Wire.Codec.field
 (** Bound field handle for the IPv4 Protocol field. *)
 
 val bf_ip_src : (Wire.UInt32.t, ipv4) Wire.Codec.field

--- a/examples/space/space.ml
+++ b/examples/space/space.ml
@@ -354,7 +354,7 @@ let tm_with_ocf_codec =
 
 (* -- 4. Nested protocol -- *)
 
-type inner_cmd = { id : int; seq : UInt16.t; flags : int }
+type inner_cmd = { id : UInt8.t; seq : UInt16.t; flags : UInt8.t }
 
 let f_cmd_id = Field.v "CmdId" uint8
 let f_cmd_seq = Field.v "Seq" uint16be
@@ -376,8 +376,8 @@ let inner_cmd_codec =
 let inner_cmd_size = Codec.wire_size inner_cmd_codec
 
 type outer_hdr = {
-  version : int;
-  type_ : int;
+  version : UInt8.t;
+  type_ : UInt8.t;
   length : UInt16.t;
   payload : Bytesrw.Bytes.Slice.t;
 }

--- a/examples/space/space.mli
+++ b/examples/space/space.mli
@@ -140,13 +140,13 @@ val inner_cmd_codec : inner_cmd Wire.Codec.t
 val inner_cmd_size : int
 (** Wire size of an InnerCmd in bytes. *)
 
-val f_cmd_id : int Wire.Field.t
+val f_cmd_id : Wire.UInt8.t Wire.Field.t
 (** Zero-copy field accessor for the InnerCmd CmdId field. *)
 
 val f_cmd_seq : Wire.UInt16.t Wire.Field.t
 (** Zero-copy field accessor for the InnerCmd Seq field. *)
 
-val bf_cmd_id : (int, inner_cmd) Wire.Codec.field
+val bf_cmd_id : (Wire.UInt8.t, inner_cmd) Wire.Codec.field
 (** Bound field for the InnerCmd CmdId field. *)
 
 val bf_cmd_seq : (Wire.UInt16.t, inner_cmd) Wire.Codec.field

--- a/fuzz/gen/fuzz_gen.ml
+++ b/fuzz/gen/fuzz_gen.ml
@@ -158,10 +158,10 @@ let unlisted_enum_gen ~mask valid =
   in
   Alcobar.map Alcobar.[ Alcobar.int ] (fun n -> step (n land mask) 0)
 
-(* A value with bits set above [width], for the unsigned [width]-bit fields
-   still carried in a bare [int]: [uint8] and [bits ~width]. Only the low
-   [width] bits reach the wire, and the masked remainder is itself a legal field
-   value, so encode has to refuse rather than truncate. *)
+(* A value with bits set above [width], for a [bits ~width] slice, the one
+   unsigned shape still carried in a bare [int]. Only the low [width] bits reach
+   the wire, and the masked remainder is itself a legal slice value, so encode
+   has to refuse rather than truncate. *)
 let above_bit_width width =
   let mask = (1 lsl width) - 1 in
   Alcobar.map Alcobar.[ Alcobar.int ] (fun n -> n land mask lor (mask + 1))
@@ -254,17 +254,21 @@ let scalar_sint32 typ size value_gen boundaries =
   leaf ~equal:Wire.SInt32.equal ~typ ~value_gen ~random:(bytes_fixed size)
     ~adversarial:(Alcobar.choose (List.map Alcobar.const boundaries))
 
-(* [int8], [int16] and [uint16] are carried in a [Wire.SInt8.t], a
-   [Wire.SInt16.t] and a [Wire.UInt16.t], whose only constructor refuses a
-   number the field cannot hold: every value of them is a legal field value, so
-   there is no hostile value to draw and no guard for one to exercise. Same
-   reasoning as [scalar_sint32]. *)
+(* [int8], [int16], [uint8] and [uint16] are carried in a [Wire.SInt8.t], a
+   [Wire.SInt16.t], a [Wire.UInt8.t] and a [Wire.UInt16.t], whose only
+   constructor refuses a number the field cannot hold: every value of them is a
+   legal field value, so there is no hostile value to draw and no guard for one
+   to exercise. Same reasoning as [scalar_sint32]. *)
 let scalar_sint8 typ size value_gen boundaries =
   leaf ~equal:Wire.SInt8.equal ~typ ~value_gen ~random:(bytes_fixed size)
     ~adversarial:(Alcobar.choose (List.map Alcobar.const boundaries))
 
 let scalar_sint16 typ size value_gen boundaries =
   leaf ~equal:Wire.SInt16.equal ~typ ~value_gen ~random:(bytes_fixed size)
+    ~adversarial:(Alcobar.choose (List.map Alcobar.const boundaries))
+
+let scalar_uint8 typ size value_gen boundaries =
+  leaf ~equal:Wire.UInt8.equal ~typ ~value_gen ~random:(bytes_fixed size)
     ~adversarial:(Alcobar.choose (List.map Alcobar.const boundaries))
 
 let scalar_uint16 typ size value_gen boundaries =
@@ -279,7 +283,7 @@ let scalar_optint typ size value_gen boundaries =
   leaf ~equal:Wire.UInt32.equal ~typ ~value_gen ~random:(bytes_fixed size)
     ~adversarial:(Alcobar.choose (List.map Alcobar.const boundaries))
 
-let u8_boundaries = [ 0; 1; 0x7F; 0x80; 0xFE; 0xFF ]
+let u8_boundaries = List.map Wire.UInt8.v [ 0; 1; 0x7F; 0x80; 0xFE; 0xFF ]
 
 let u16_boundaries =
   List.map Wire.UInt16.v [ 0; 1; 0x7F; 0x80; 0x7FFF; 0x8000; 0xFFFE; 0xFFFF ]
@@ -298,11 +302,8 @@ let s32_boundaries =
   List.map Wire.SInt32.of_int32 Int32.[ min_int; minus_one; zero; one; max_int ]
 
 let s64_boundaries_i64 = Int64.[ min_int; -1L; zero; one; max_int ]
-
-let uint8 =
-  scalar_int ~hostile:(above_bit_width 8) Wire.uint8 1 Alcobar.uint8
-    u8_boundaries
-
+let u8_value_gen = Alcobar.map Alcobar.[ Alcobar.uint8 ] Wire.UInt8.v
+let uint8 = scalar_uint8 Wire.uint8 1 u8_value_gen u8_boundaries
 let u16_value_gen = Alcobar.map Alcobar.[ Alcobar.uint16 ] Wire.UInt16.v
 let uint16 = scalar_uint16 Wire.uint16 2 u16_value_gen u16_boundaries
 let uint16be = scalar_uint16 Wire.uint16be 2 u16_value_gen u16_boundaries
@@ -1137,7 +1138,7 @@ let enum name cases =
     let n = max 1 (List.length valid_values) in
     Alcobar.map
       Alcobar.[ Alcobar.range ~min:0 n ]
-      (fun i -> List.nth valid_values (i mod n))
+      (fun i -> Wire.UInt8.v (List.nth valid_values (i mod n)))
   in
   let encode v =
     let buf = Bytes.create 1 in
@@ -1151,10 +1152,14 @@ let enum name cases =
     positive;
     random = bytes_fixed 1;
     adversarial = bytes_fixed 1;
-    equal = Int.equal;
+    equal = Wire.UInt8.equal;
     env = None;
     fields = [];
-    adversarial_value = Some (unlisted_enum_gen ~mask:0xFF valid_values);
+    adversarial_value =
+      Some
+        (Alcobar.map
+           Alcobar.[ unlisted_enum_gen ~mask:0xFF valid_values ]
+           Wire.UInt8.v);
   }
 
 (* [Wire.enum_open]: names known codes for documentation but accepts any value,
@@ -1170,7 +1175,7 @@ let enum_open =
     buf
   in
   let positive =
-    Alcobar.map Alcobar.[ Alcobar.uint8 ] (fun v -> (v, encode v))
+    Alcobar.map Alcobar.[ u8_value_gen ] (fun v -> (v, encode v))
   in
   {
     codec;
@@ -1178,7 +1183,7 @@ let enum_open =
     positive;
     random = bytes_fixed 1;
     adversarial = bytes_fixed 1;
-    equal = Int.equal;
+    equal = Wire.UInt8.equal;
     env = None;
     fields = [];
     adversarial_value = None;
@@ -1291,7 +1296,7 @@ let bounded_u8 ~min ~max =
   in
   let typ = Wire.codec codec in
   let value_gen =
-    Alcobar.map Alcobar.[ Alcobar.range ~min (max - min + 1) ] (fun n -> n)
+    Alcobar.map Alcobar.[ Alcobar.range ~min (max - min + 1) ] Wire.UInt8.v
   in
   let encode v =
     let buf = Bytes.create 1 in
@@ -1318,14 +1323,15 @@ let bounded_u8 ~min ~max =
     positive;
     random = bytes_fixed 1;
     adversarial = boundary_bytes;
-    equal = Int.equal;
+    equal = Wire.UInt8.equal;
     env = None;
     (* Out-of-range on both sides of the field's [~self_constraint]. *)
     fields = [];
     adversarial_value =
       Some
         (Alcobar.choose
-           (List.map Alcobar.const
+           (List.map
+              (fun n -> Alcobar.const (Wire.UInt8.v n))
               (List.filter
                  (fun n -> n >= 0 && n <= 0xFF && (n < min || n > max))
                  [ min - 1; max + 1; 0; 0xFF ])));
@@ -1411,7 +1417,7 @@ let codec_where =
         let buf = Bytes.create 2 in
         Bytes.set_uint8 buf 0 a;
         Bytes.set_uint8 buf 1 b;
-        ((a, b), buf))
+        ((Wire.UInt8.v a, Wire.UInt8.v b), buf))
   in
   let boundary =
     Alcobar.map
@@ -1434,7 +1440,11 @@ let codec_where =
     fields = pair_fields ("a", f_a) ("b", f_b);
     adversarial_value =
       Some
-        (Alcobar.map Alcobar.[ Alcobar.range ~min:0 0x100 ] (fun a -> (a, a)));
+        (Alcobar.map
+           Alcobar.[ Alcobar.range ~min:0 0x100 ]
+           (fun a ->
+             let a = Wire.UInt8.v a in
+             (a, a)));
   }
 
 let u8_pair_bytes a b =
@@ -1444,7 +1454,8 @@ let u8_pair_bytes a b =
   buf
 
 let u8_pair_positive gen =
-  Alcobar.map gen (fun a b -> ((a, b), u8_pair_bytes a b))
+  Alcobar.map gen (fun a b ->
+      ((Wire.UInt8.v a, Wire.UInt8.v b), u8_pair_bytes a b))
 
 let u8_pair_adversarial gen = Alcobar.map gen (fun a b -> u8_pair_bytes a b)
 
@@ -1453,7 +1464,7 @@ let u8_pair_adversarial gen = Alcobar.map gen (fun a b -> u8_pair_bytes a b)
 let u8_pair_hostile bytes_gen =
   Alcobar.map
     Alcobar.[ bytes_gen ]
-    (fun b -> (Bytes.get_uint8 b 0, Bytes.get_uint8 b 1))
+    (fun b -> (Wire.UInt8.get b 0, Wire.UInt8.get b 1))
 
 let u8_pair_record name f_a f_b ~positive ~adversarial =
   let codec =
@@ -1816,7 +1827,7 @@ let field_anon =
         let buf = Bytes.create 2 in
         Bytes.set_uint8 buf 0 a;
         Bytes.set_uint8 buf 1 b;
-        ((a, b), buf))
+        ((Wire.UInt8.v a, Wire.UInt8.v b), buf))
   in
   {
     codec;
@@ -1845,10 +1856,10 @@ let param_input =
   let typ = Wire.codec codec in
   let strategy =
     {
-      positive = (fun env -> Wire.Param.bind limit 100 env);
+      positive = (fun env -> Wire.Param.bind limit (Wire.UInt8.v 100) env);
       fuzz =
         Alcobar.map
-          Alcobar.[ Alcobar.uint8 ]
+          Alcobar.[ u8_value_gen ]
           (fun lim env -> Wire.Param.bind limit lim env);
     }
   in
@@ -1858,7 +1869,7 @@ let param_input =
       (fun v ->
         let buf = Bytes.create 1 in
         Bytes.set_uint8 buf 0 v;
-        (v, buf))
+        (Wire.UInt8.v v, buf))
   in
   {
     codec;
@@ -1866,7 +1877,7 @@ let param_input =
     positive;
     random = bytes_fixed 1;
     adversarial = bytes_fixed 1;
-    equal = Int.equal;
+    equal = Wire.UInt8.equal;
     env = Some strategy;
     fields = [];
     adversarial_value = None;
@@ -1879,7 +1890,7 @@ let u8_positive =
     (fun v ->
       let buf = Bytes.create 1 in
       Bytes.set_uint8 buf 0 v;
-      (v, buf))
+      (Wire.UInt8.v v, buf))
 
 (* A single-uint8 codec whose field carries [action], with an env strategy
    that rebuilds the (param-free) env on demand. *)
@@ -1893,7 +1904,7 @@ let action_codec name action =
     positive = u8_positive;
     random = bytes_fixed 1;
     adversarial = bytes_fixed 1;
-    equal = Int.equal;
+    equal = Wire.UInt8.equal;
     env = Some { positive = Fun.id; fuzz = Alcobar.const Fun.id };
     fields = [];
     adversarial_value = None;
@@ -1934,7 +1945,7 @@ let action_abort =
     positive = u8_positive;
     random = bytes_fixed 1;
     adversarial = bytes_fixed 1;
-    equal = Int.equal;
+    equal = Wire.UInt8.equal;
     env = None;
     fields = [];
     adversarial_value = None;
@@ -2084,7 +2095,7 @@ let expr_ops =
         let buf = Bytes.create 2 in
         Bytes.set_uint8 buf 0 a;
         Bytes.set_uint8 buf 1 b;
-        ((a, b), buf))
+        ((Wire.UInt8.v a, Wire.UInt8.v b), buf))
   in
   {
     codec;
@@ -2128,7 +2139,7 @@ let rest_bytes =
         let buf = Bytes.create (1 + tail_len) in
         Bytes.set_uint8 buf 0 h;
         Bytes.blit_string tail 0 buf 1 tail_len;
-        ((h, tail), buf))
+        ((Wire.UInt8.v h, tail), buf))
   in
   {
     codec;
@@ -2210,7 +2221,7 @@ let if_then_else =
             let buf = Bytes.create (1 + sz) in
             Bytes.set_uint8 buf 0 len;
             Bytes.blit_string b 0 buf 1 sz;
-            ((len, b), buf)))
+            ((Wire.UInt8.v len, b), buf)))
   in
   {
     codec;
@@ -2248,7 +2259,7 @@ let sizeof =
         let buf = Bytes.create 2 in
         Bytes.set_uint8 buf 0 a;
         Bytes.set_uint8 buf 1 b;
-        ((a, b), buf))
+        ((Wire.UInt8.v a, Wire.UInt8.v b), buf))
   in
   {
     codec;
@@ -2308,8 +2319,8 @@ let optional_dynamic =
     (fun g ->
       Wire.Field.optional "payload" ~present:(gate_present g) Wire.uint16be)
     (gate_positive
-       ~present_value:(fun v -> (1, Some v))
-       ~absent:(fun () -> ((0, None), bytes_of_octets [ 0 ])))
+       ~present_value:(fun v -> (Wire.UInt8.v 1, Some v))
+       ~absent:(fun () -> ((Wire.UInt8.zero, None), bytes_of_octets [ 0 ])))
 
 (* Dynamic-gate optional_or: same shape, with a default value used when
    absent. *)
@@ -2319,12 +2330,12 @@ let optional_or_dynamic =
       Wire.Field.optional_or "payload" ~present:(gate_present g)
         ~default:(Wire.UInt16.v 0xCAFE) Wire.uint16be)
     (gate_positive
-       ~present_value:(fun v -> (1, v))
+       ~present_value:(fun v -> (Wire.UInt8.v 1, v))
        ~absent:(fun () ->
          let buf = Bytes.create 3 in
          Bytes.set_uint8 buf 0 0;
          Bytes.set_uint16_be buf 1 0xCAFE;
-         ((0, Wire.UInt16.v 0xCAFE), buf)))
+         ((Wire.UInt8.zero, Wire.UInt16.v 0xCAFE), buf)))
 
 (* Present/absent gate, a span of the drawn length, and a zero tail, encoded
    through the codec so the span's length byte and the payload's offset stay
@@ -2340,7 +2351,7 @@ let opt_dyn_span_positive codec =
       ]
     (fun present v span_len tail_len ->
       let value =
-        ( (if present then 1 else 0),
+        ( Wire.UInt8.v (if present then 1 else 0),
           String.make span_len 'x',
           (if present then Some (Wire.UInt16.v v) else None),
           String.make tail_len '\x00' )
@@ -2369,7 +2380,7 @@ let optional_dyn_after_span =
   in
   let f_tail = Wire.Field.v "tail" Wire.all_zeros in
   let gate_of (g, _, _, _) = g in
-  let len_of (_, span, _, _) = String.length span in
+  let len_of (_, span, _, _) = Wire.UInt8.v (String.length span) in
   let span_of (_, span, _, _) = span in
   let payload_of (_, _, payload, _) = payload in
   let tail_of (_, _, _, tail) = tail in
@@ -2449,14 +2460,17 @@ let combine_env_strategies (strategies : env_strategy option list) :
       in
       Some { positive; fuzz }
 
-(* Convert one composer case to a Wire casetype branch. The composer's default
-   branch ignores the matched tag and always re-encodes the fixed [t], so adapt
-   to the tag-aware API. *)
+(* Convert one composer case to a Wire casetype branch. The tag is written as
+   an [int] and lifted into the discriminator's carrier here. The composer's
+   default branch ignores the matched tag and always re-encodes the fixed [t],
+   so adapt to the tag-aware API. *)
 let casetype_case_def (Case c) =
   match (c.index, c.default_tag) with
   | Some i, _ ->
-      Wire.case ~index:i c.inner.typ ~inject:c.inject ~project:c.project
+      Wire.case ~index:(Wire.UInt8.v i) c.inner.typ ~inject:c.inject
+        ~project:c.project
   | None, Some t ->
+      let t = Wire.UInt8.v t in
       Wire.default c.inner.typ
         ~inject:(fun _tag w -> c.inject w)
         ~project:(fun a -> Option.map (fun w -> (t, w)) (c.project a))
@@ -2534,7 +2548,7 @@ let casetype_u16be_default =
               let buf = Bytes.create 3 in
               Bytes.set_uint16_be buf 0 0x0102;
               Bytes.set_uint8 buf 2 v;
-              (`A v, buf))
+              (`A (Wire.UInt8.v v), buf))
       | false ->
           Alcobar.map
             Alcobar.[ Alcobar.uint16; Alcobar.uint16 ]
@@ -4339,14 +4353,14 @@ let sized_source ~of_len name make_len bytes_of_len =
   }
 
 let sized_cases group =
-  (* The u16be source carries its length in a [Wire.UInt16.t] and the rest in
-     an [int], so the sources cannot sit in one list; each is turned into test
-     cases where its own type is still known. *)
+  (* The u8 sources carry their length in a [Wire.UInt8.t] and the u16be one in
+     a [Wire.UInt16.t], so the sources cannot sit in one list; each is turned
+     into test cases where its own type is still known. *)
   let case slabel src = test_cases (group ^ " " ^ slabel) src in
   List.concat
     [
       case "u8"
-        (sized_source ~of_len:Fun.id "U8"
+        (sized_source ~of_len:Wire.UInt8.v "U8"
            (fun () -> Wire.Field.v "Len" Wire.uint8)
            u8_size_bytes);
       case "u16be"
@@ -4354,19 +4368,19 @@ let sized_cases group =
            (fun () -> Wire.Field.v "Len" Wire.uint16be)
            u16be_size_bytes);
       case "map"
-        (sized_source ~of_len:Fun.id "Map"
+        (sized_source ~of_len:Wire.UInt8.v "Map"
            (fun () ->
              Wire.Field.v "Len"
                (Wire.map ~decode:Fun.id ~encode:Fun.id Wire.uint8))
            u8_size_bytes);
       case "optional_or"
-        (sized_source ~of_len:Fun.id "OptOr"
+        (sized_source ~of_len:Wire.UInt8.v "OptOr"
            (fun () ->
-             Wire.Field.optional_or "Len" ~present:Wire.Expr.true_ ~default:0
-               Wire.uint8)
+             Wire.Field.optional_or "Len" ~present:Wire.Expr.true_
+               ~default:Wire.UInt8.zero Wire.uint8)
            u8_size_bytes);
       case "where"
-        (sized_source ~of_len:Fun.id "Where"
+        (sized_source ~of_len:Wire.UInt8.v "Where"
            (fun () ->
              Wire.Field.v "Len" (Wire.where Wire.Expr.true_ Wire.uint8))
            u8_size_bytes);
@@ -4775,7 +4789,11 @@ let bitpack_gens =
 let wrapper_gens =
   [
     ( "map(uint8)",
-      Pack (map ~decode:(fun n -> n * 2) ~encode:(fun n -> n / 2) uint8) );
+      Pack
+        (map
+           ~decode:(fun n -> Wire.UInt8.to_int n * 2)
+           ~encode:(fun n -> Wire.UInt8.v (n / 2))
+           uint8) );
     ("variants", Pack (variants "Flag" [ ("A", `A); ("B", `B); ("C", `C) ]));
     ("variants_u16be", Pack variants_u16be);
     ("enum", Pack (enum "Color" [ ("Red", 1); ("Green", 2); ("Blue", 3) ]));
@@ -4789,8 +4807,9 @@ let wrapper_gens =
     ("lookup", Pack (lookup [ 'a'; 'b'; 'c'; 'd' ] uint8));
     ("optional(uint8)", Pack (optional uint8));
     ("optional(false)", Pack (optional ~present:false uint8));
-    ("optional_or(uint8)", Pack (optional_or ~default:0 uint8));
-    ("optional_or(false)", Pack (optional_or ~present:false ~default:42 uint8));
+    ("optional_or(uint8)", Pack (optional_or ~default:Wire.UInt8.zero uint8));
+    ( "optional_or(false)",
+      Pack (optional_or ~present:false ~default:(Wire.UInt8.v 42) uint8) );
     ("optional_dynamic", Pack optional_dynamic);
     ("optional_or_dynamic", Pack optional_or_dynamic);
     ("optional_dyn_after_span", Pack optional_dyn_after_span);
@@ -5655,7 +5674,7 @@ let semantic_invariant_cases label =
   ]
 
 type api_access = {
-  a : int;
+  a : Wire.UInt8.t;
   hi : int;
   lo : int;
   payload : Bytesrw.Bytes.Slice.t;
@@ -5691,7 +5710,7 @@ let check_api_getters codec bf_a bf_hi bf_lo bf_payload buf base a hi lo
   let get_hi = Wire.Codec.get codec bf_hi |> Wire.Staged.unstage in
   let get_lo = Wire.Codec.get codec bf_lo |> Wire.Staged.unstage in
   let get_payload = Wire.Codec.get codec bf_payload |> Wire.Staged.unstage in
-  check_int "Codec.get scalar" a (get_a buf base);
+  check_int "Codec.get scalar" a (Wire.UInt8.to_int (get_a buf base));
   check_int "Codec.get bitfield hi" hi (get_hi buf base);
   check_int "Codec.get bitfield lo" lo (get_lo buf base);
   check_string "Codec.get slice" payload_s
@@ -5723,11 +5742,11 @@ let check_api_setters codec bf_a bf_hi bf_lo bf_payload buf base next_a next_hi
   let set_hi = Wire.Codec.set codec bf_hi |> Wire.Staged.unstage in
   let set_lo = Wire.Codec.set codec bf_lo |> Wire.Staged.unstage in
   let set_payload = Wire.Codec.set codec bf_payload |> Wire.Staged.unstage in
-  set_a buf base next_a;
+  set_a buf base (Wire.UInt8.v next_a);
   set_hi buf base next_hi;
   set_lo buf base next_lo;
   set_payload buf base (slice_of_string next_payload_s);
-  check_int "Codec.set scalar" next_a (get_a buf base);
+  check_int "Codec.set scalar" next_a (Wire.UInt8.to_int (get_a buf base));
   check_int "Codec.set bitfield hi" next_hi (get_hi buf base);
   check_int "Codec.set bitfield lo" next_lo (get_lo buf base);
   check_string "Codec.set slice" next_payload_s
@@ -5737,7 +5756,8 @@ let check_api_decode_after_set codec buf base next_a next_hi next_lo
     next_payload_s =
   match Wire.Codec.decode codec buf base with
   | Ok decoded ->
-      check_int "Codec.decode after set scalar" next_a decoded.a;
+      check_int "Codec.decode after set scalar" next_a
+        (Wire.UInt8.to_int decoded.a);
       check_int "Codec.decode after set hi" next_hi decoded.hi;
       check_int "Codec.decode after set lo" next_lo decoded.lo;
       check_string "Codec.decode after set slice" next_payload_s
@@ -5751,7 +5771,7 @@ let check_api_accessors a hi lo payload_s next_a next_hi next_lo next_payload_s
   let next_hi = next_hi land 0x7 and next_lo = next_lo land 0x1F in
   let codec, bf_a, bf_hi, bf_lo, bf_payload = api_access_codec () in
   let payload = slice_of_string payload_s in
-  let value = { a; hi; lo; payload } in
+  let value = { a = Wire.UInt8.v a; hi; lo; payload } in
   let base = 1 in
   let sz = Wire.Codec.wire_size codec in
   let buf = Bytes.make (sz + 2) '\xCC' in
@@ -5772,13 +5792,17 @@ let custom_array_seq =
       iter = (fun f arr -> Array.iter f arr);
     }
 
+let u8_array_equal a b =
+  Array.length a = Array.length b && Array.for_all2 Wire.UInt8.equal a b
+
 let check_custom_seq a b c d =
-  let values = [| a; b; c; d |] in
+  let values = Array.map Wire.UInt8.v [| a; b; c; d |] in
   let typ = Wire.array_seq custom_array_seq ~len:(Wire.int 4) Wire.uint8 in
   let encoded = Wire.to_bytes typ values in
   (match Wire.of_bytes typ encoded with
   | Ok decoded ->
-      if decoded <> values then Alcobar.failf "array_seq custom seq mismatch"
+      if not (u8_array_equal decoded values) then
+        Alcobar.failf "array_seq custom seq mismatch"
   | Error e ->
       Alcobar.failf "array_seq custom seq decode failed: %a" Wire.pp_parse_error
         e);
@@ -5790,13 +5814,18 @@ let check_custom_seq a b c d =
   let codec =
     Wire.Codec.v "ApiRepeatSeq"
       (fun _ items -> items)
-      Wire.Codec.[ f_len $ Array.length; (f_items $ fun xs -> xs) ]
+      Wire.Codec.
+        [
+          (f_len $ fun xs -> Wire.UInt8.v (Array.length xs));
+          (f_items $ fun xs -> xs);
+        ]
   in
   let buf = Bytes.create 5 in
   Wire.Codec.encode codec values buf 0;
   match Wire.Codec.decode codec buf 0 with
   | Ok decoded ->
-      if decoded <> values then Alcobar.failf "repeat_seq custom seq mismatch"
+      if not (u8_array_equal decoded values) then
+        Alcobar.failf "repeat_seq custom seq mismatch"
   | Error e ->
       Alcobar.failf "repeat_seq custom seq decode failed: %a"
         Wire.pp_parse_error e
@@ -5900,13 +5929,13 @@ let check_metadata_helpers () =
       (fun src copy -> (src, copy))
       Wire.Codec.[ f_src $ fst; f_copy $ snd ]
   in
-  let env = Wire.Codec.env codec |> Param.bind p_in 9 in
-  check_int "Param.get input" 9 (Param.get env p_in);
+  let env = Wire.Codec.env codec |> Param.bind p_in (UInt8.v 9) in
+  check_int "Param.get input" 9 (UInt8.to_int (Param.get env p_in));
   let env_by_name = Wire.Codec.env codec |> Param.bind_by_name "Limit" 8 in
-  check_int "Param.bind_by_name" 8 (Param.get env_by_name p_in);
+  check_int "Param.bind_by_name" 8 (UInt8.to_int (Param.get env_by_name p_in));
   let buf = bytes_of_octets [ 7; 1 ] in
   (match Wire.Codec.decode ~env codec buf 0 with
-  | Ok _ -> check_int "Param.get output" 7 (Param.get env p_out)
+  | Ok _ -> check_int "Param.get output" 7 (UInt8.to_int (Param.get env p_out))
   | Error e -> Alcobar.failf "param/action decode failed: %a" pp_parse_error e);
   check_string "Codec schema name" "ApiParam"
     (Wire.Everparse.project ~mode:`Ffi codec).Wire.Everparse.name;
@@ -5924,7 +5953,7 @@ let check_metadata_helpers () =
       (fun src copy -> (src, copy))
       Wire.Codec.[ f_src $ fst; f_copy $ snd ]
   in
-  let pp_value = Fmt.str "%a" (pp_value pp_codec) (7, 1) in
+  let pp_value = Fmt.str "%a" (pp_value pp_codec) (UInt8.v 7, UInt8.v 1) in
   if not (String.contains pp_value 'S') then
     Alcobar.failf "pp_value did not include field output: %S" pp_value;
   let _ = Wire.Codec.field_ref Wire.Codec.(f_src $ fst) in

--- a/fuzz/gen/fuzz_gen.mli
+++ b/fuzz/gen/fuzz_gen.mli
@@ -241,7 +241,7 @@ val sized_cases : string -> Alcobar.test_case list
 
 (** {1 Scalar leaves} *)
 
-val uint8 : int t
+val uint8 : Wire.UInt8.t t
 (** [uint8] generates for {!Wire.uint8}. *)
 
 val uint16 : Wire.UInt16.t t
@@ -382,13 +382,13 @@ val array : int -> 'a t -> 'a list t
 (** [array n inner] generates for [Wire.array ~len:(Wire.int n) inner.typ].
     Positives are a fixed-length list of [inner.positive] samples. *)
 
-val enum : string -> (string * int) list -> int t
+val enum : string -> (string * int) list -> Wire.UInt8.t t
 (** [enum name cases] generates for [Wire.enum name cases Wire.uint8]. *)
 
 val enum_u16be : Wire.UInt16.t t
 (** [enum_u16be] generates for [Wire.enum ... Wire.uint16be]. *)
 
-val enum_open : int t
+val enum_open : Wire.UInt8.t t
 (** [enum_open] generates for [Wire.enum_open ... Wire.uint8], accepting
     unlisted values as positives. *)
 
@@ -398,7 +398,7 @@ val enum_open_u16be : Wire.UInt16.t t
 val variants_u16be : [ `High | `One | `Zero ] t
 (** [variants_u16be] generates for [Wire.variants ... Wire.uint16be]. *)
 
-val bounded_u8 : min:int -> max:int -> int t
+val bounded_u8 : min:int -> max:int -> Wire.UInt8.t t
 (** [bounded_u8 ~min ~max] generates for a single-field record whose
     [Wire.uint8] field carries a [~self_constraint] [min <= v <= max].
     Adversarials are bytes at each boundary on both sides of the range. *)
@@ -417,45 +417,45 @@ val repeat_seq : bytes:int -> 'a t -> 'a list t
 (** [repeat_seq ~bytes inner] generates for
     [Field.repeat_seq ~seq:seq_list ~size:(...)]. *)
 
-val field_anon : (int * int) t
+val field_anon : (Wire.UInt8.t * Wire.UInt8.t) t
 (** [field_anon] exercises [Wire.Field.anon]. *)
 
-val field_constraint : (int * int) t
+val field_constraint : (Wire.UInt8.t * Wire.UInt8.t) t
 (** [field_constraint] exercises [Wire.Field.v ~constraint_] with a constraint
     referencing a previous field. *)
 
-val field_int : (int * int) t
+val field_int : (Wire.UInt8.t * Wire.UInt8.t) t
 (** [field_int] exercises {!Wire.Field.int} in a field self constraint. *)
 
 val self_int64 : Wire.UInt64.t t
 (** [self_int64] exercises [Wire.Field.v ~self_int64] over a 64-bit field. *)
 
-val param_input : int t
+val param_input : Wire.UInt8.t t
 (** [param_input] is a codec referencing [Wire.Param.input] in its [~where];
     tests bind the env. *)
 
-val action : int t
+val action : Wire.UInt8.t t
 (** [action] is a codec with [Wire.Field.v ~action:...] exercising the
     {!Wire.Action} surface ([on_success], [var], [assign], [if_],
     [return_bool]). *)
 
-val action_abort : int t
+val action_abort : Wire.UInt8.t t
 (** [action_abort] is a codec whose field's [~action] is {!Wire.Action.abort}:
     every decode is rejected. Use {!reject_cases}. *)
 
-val action_on_act : int t
+val action_on_act : Wire.UInt8.t t
 (** [action_on_act] mirrors {!action} using [Action.on_act]. *)
 
 val nan_float64 : float t
 (** [nan_float64] is a single-float codec with [~where:(is_nan f)]; positives
     are NaN bit patterns, non-NaN bytes are rejected. *)
 
-val optional_dynamic : (int * Wire.UInt16.t option) t
+val optional_dynamic : (Wire.UInt8.t * Wire.UInt16.t option) t
 (** [optional_dynamic] is a codec with
     [Field.optional ~present:(ref gate <> 0)]; the payload is present or absent
     depending on the gate byte. *)
 
-val optional_or_dynamic : (int * Wire.UInt16.t) t
+val optional_or_dynamic : (Wire.UInt8.t * Wire.UInt16.t) t
 (** [optional_or_dynamic] is the {!val-optional_or} equivalent of
     {!optional_dynamic}, using a fixed default value when absent. *)
 
@@ -463,25 +463,25 @@ val finite_float64 : float t
 (** [finite_float64] is a single-float codec with [~self_constraint:is_finite];
     adversarials produce NaN and infinity bit patterns. *)
 
-val expr_ops : (int * int) t
+val expr_ops : (Wire.UInt8.t * Wire.UInt8.t) t
 (** [expr_ops] is a codec whose [~where] uses every integer [Wire.Expr] operator
     (arithmetic, bitwise, comparison, logical, [to_uint*] casts). *)
 
-val rest_bytes : (int * string) t
+val rest_bytes : (Wire.UInt8.t * string) t
 (** [rest_bytes] is a codec whose final field is [Wire.rest_bytes] sized from a
     bound [Wire.Param.input]. *)
 
-val sizeof : (int * int) t
+val sizeof : (Wire.UInt8.t * Wire.UInt8.t) t
 (** [sizeof] is a two-uint8 codec whose second field's [~self_constraint]
     references [Wire.sizeof_this] / [Wire.field_pos] / [Wire.sizeof]. *)
 
-val codec_where : (int * int) t
+val codec_where : (Wire.UInt8.t * Wire.UInt8.t) t
 (** [codec_where] generates for a two-{!val-uint8} record whose
     {!module-Codec.val-v} carries [~where:(a < b)]. Positives satisfy the
     predicate, adversarials sit at the equality boundary so the {!val-where}
     check fires. *)
 
-val typ_where : (int * int) t
+val typ_where : (Wire.UInt8.t * Wire.UInt8.t) t
 (** [typ_where] generates for a two-{!val-uint8} record whose second field's typ
     is [Wire.where (len < 2) uint8]. This exercises the typ-level {!val-where}
     (a refinement carried in the field type), distinct from {!codec_where}'s
@@ -509,7 +509,7 @@ val casetype_u8 : string -> 'a case list -> 'a t
     its tag byte, and append the inner case's positive bytes. *)
 
 val casetype_u16be_default :
-  [ `A of int | `Other of Wire.UInt16.t * Wire.UInt16.t ] t
+  [ `A of Wire.UInt8.t | `Other of Wire.UInt16.t * Wire.UInt16.t ] t
 (** [casetype_u16be_default] generates for [Wire.casetype] over a uint16be
     discriminator and a [Wire.default] branch that preserves the matched tag. *)
 

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -183,7 +183,7 @@ and build_field_encoder_ctx : type a.
   match typ with
   | Uint8 ->
       fun _runtime buf off v ->
-        Types.set_uint8 buf off v;
+        UInt8.set buf off v;
         off + 1
   | Uint16 Little ->
       fun _runtime buf off v ->
@@ -329,7 +329,7 @@ let rec build_field_reader_ctx : type a.
     a typ -> int -> Types.eval_ctx -> bytes -> int -> a =
  fun typ field_off ->
   match typ with
-  | Uint8 -> fun _runtime buf base -> Bytes.get_uint8 buf (base + field_off)
+  | Uint8 -> fun _runtime buf base -> UInt8.get buf (base + field_off)
   | Uint16 Little -> fun _runtime buf base -> UInt16.le buf (base + field_off)
   | Uint16 Big -> fun _runtime buf base -> UInt16.be buf (base + field_off)
   | Uint32 Little -> fun _runtime buf base -> UInt32.le buf (base + field_off)
@@ -425,7 +425,7 @@ let rec build_immediate_reader : type a.
  fun typ field_off ->
   let at base = base + field_off in
   match typ with
-  | Uint8 -> Some (fun buf base -> Bytes.get_uint8 buf (at base))
+  | Uint8 -> Some (fun buf base -> UInt8.get buf (at base))
   | Uint16 Little -> Some (fun buf base -> UInt16.le buf (at base))
   | Uint16 Big -> Some (fun buf base -> UInt16.be buf (at base))
   | Uint32 Little -> Some (fun buf base -> UInt32.le buf (at base))
@@ -472,11 +472,7 @@ let rec build_immediate_reader : type a.
 (* Symmetric bytes-only writer for parameter-independent scalar fields. *)
 let rec build_immediate_encoder : type a.
     a typ -> (bytes -> int -> a -> int) option = function
-  | Uint8 ->
-      Some
-        (fun buf off v ->
-          Types.set_uint8 buf off v;
-          off + 1)
+  | Uint8 -> Some (setter_off 1 UInt8.set)
   | Uint16 Little -> Some (setter_off 2 UInt16.set_le)
   | Uint16 Big -> Some (setter_off 2 UInt16.set_be)
   | Uint32 Little -> Some (setter_off 4 UInt32.set_le)
@@ -622,14 +618,17 @@ let populate_uint_var idx reader =
 let populate_int idx reader slots runtime buf base =
   set_int_slot slots idx (reader runtime buf base)
 
-(* [SInt8.t], [SInt16.t] and [UInt16.t] are native [int]s behind a range, so
-   the slot takes the decoded value unchanged and no platform has a value it
-   cannot hold. *)
+(* [SInt8.t], [SInt16.t], [UInt8.t] and [UInt16.t] are native [int]s behind a
+   range, so the slot takes the decoded value unchanged and no platform has a
+   value it cannot hold. *)
 let populate_sint8 idx reader slots runtime buf base =
   set_int_slot slots idx (SInt8.to_int (reader runtime buf base))
 
 let populate_sint16 idx reader slots runtime buf base =
   set_int_slot slots idx (SInt16.to_int (reader runtime buf base))
+
+let populate_uint8 idx reader slots runtime buf base =
+  set_int_slot slots idx (UInt8.to_int (reader runtime buf base))
 
 let populate_uint16 idx reader slots runtime buf base =
   set_int_slot slots idx (UInt16.to_int (reader runtime buf base))
@@ -658,7 +657,7 @@ let rec build_populate : type a.
     unit =
  fun typ idx reader ->
   match typ with
-  | Uint8 -> populate_int idx reader
+  | Uint8 -> populate_uint8 idx reader
   | Uint16 _ -> populate_uint16 idx reader
   | Int8 -> populate_sint8 idx reader
   | Int16 _ -> populate_sint16 idx reader
@@ -1453,7 +1452,7 @@ let tag_byte_size : type a. a typ -> int =
 let rec read_elem : type a. a typ -> runtime -> bytes -> int -> a =
  fun typ runtime buf off ->
   match typ with
-  | Uint8 -> Bytes.get_uint8 buf off
+  | Uint8 -> UInt8.get buf off
   | Uint16 Little -> UInt16.le buf off
   | Uint16 Big -> UInt16.be buf off
   | Uint32 Little -> UInt32.le buf off
@@ -1561,7 +1560,7 @@ and read_case_body : type a k.
 let rec write_elem : type a. a typ -> runtime -> bytes -> int -> a -> unit =
  fun typ runtime buf off v ->
   match typ with
-  | Uint8 -> Types.set_uint8 buf off v
+  | Uint8 -> UInt8.set buf off v
   | Uint16 Little -> UInt16.set_le buf off v
   | Uint16 Big -> UInt16.set_be buf off v
   | Uint32 Little -> UInt32.set_le buf off v

--- a/lib/codec.mli
+++ b/lib/codec.mli
@@ -112,7 +112,7 @@ val encode : ?env:Param.env -> 'r t -> 'r -> bytes -> int -> unit
           ]
 
     let buf = Bytes.create 12
-    let env = Codec.env codec |> Param.bind p_iv_len 12
+    let env = Codec.env codec |> Param.bind p_iv_len (UInt8.v 12)
 
     let () =
       Codec.encode ~env codec (String.make 12 'a') buf 0;

--- a/lib/param.ml
+++ b/lib/param.ml
@@ -21,7 +21,7 @@ let optint_to_int to_int value =
 let rec to_int : type a. a Types.typ -> a -> int =
  fun typ v ->
   match typ with
-  | Uint8 -> v
+  | Uint8 -> UInt8.to_int v
   | Uint16 _ -> UInt16.to_int v
   | Uint_var _ -> optint_to_int UInt63.to_int v
   | Uint32 _ -> optint_to_int UInt32.to_int v

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -186,7 +186,7 @@ and bitfield_base = U8 | U16 of endian | U32 of endian
 
 (* Types *)
 and _ typ =
-  | Uint8 : int typ
+  | Uint8 : UInt8.t typ
   | Uint16 : endian -> UInt16.t typ
   | Uint32 : endian -> UInt32.t typ
   | Uint64 : endian -> UInt64.t typ (* boxed, for full 64-bit *)
@@ -566,7 +566,7 @@ let is_set n = n <> 0
 let rec int_of : type a. a typ -> a -> int option =
  fun typ v ->
   match typ with
-  | Uint8 -> Some v
+  | Uint8 -> Some (UInt8.to_int v)
   | Uint16 _ -> Some (UInt16.to_int v)
   | Uint_var _ -> Int64.unsigned_to_int (Optint.Int63.to_int64 v)
   (* On a narrow-int platform a u32 value may not fit either; the unsigned
@@ -606,7 +606,7 @@ let not_an_integer () =
 let rec int_of_exn : type a. a typ -> a -> int =
  fun typ v ->
   match typ with
-  | Uint8 -> v
+  | Uint8 -> UInt8.to_int v
   | Uint16 _ -> UInt16.to_int v
   | Uint_var _ -> (
       if Sys.int_size > 56 then UInt63.to_int v
@@ -658,7 +658,7 @@ let rec int_of_exn : type a. a typ -> a -> int =
 let rec of_int : type a. a typ -> int -> a =
  fun typ n ->
   match typ with
-  | Uint8 -> n
+  | Uint8 -> UInt8.v n
   | Uint16 _ -> UInt16.v n
   | Uint_var _ -> UInt63.of_int n
   | Uint32 _ -> UInt32.of_int n
@@ -1518,7 +1518,7 @@ let uint_var_case_index k =
 let rec case_index_to_expr : type k. k typ -> k -> packed_expr =
  fun tag_typ k ->
   match tag_typ with
-  | Uint8 -> Pack_expr (Int k)
+  | Uint8 -> Pack_expr (Int (UInt8.to_int k))
   | Uint16 _ -> Pack_expr (Int (UInt16.to_int k))
   | Uint32 _ -> Pack_expr (Int (uint32_case_index k))
   | Uint_var _ -> Pack_expr (Int (uint_var_case_index k))
@@ -2095,21 +2095,20 @@ let check_zeroterm_region ~region ~len =
       "Wire.encode: zeroterm string needs %d bytes but region is %d" (len + 1)
       region
 
-(* An unsigned field of [bits] bits owns exactly those bits, whether it was
-   declared as a [uint8] or as a [bits ~width] slice of a wider word: both are
-   carried in an OCaml [int], which holds far more than the field does. Masking
-   a wider value is the one truncation nothing downstream can catch, because the
-   masked result is itself a legal field value that decode, [validate] and the
+(* A [bits ~width] slice owns exactly [bits] bits of a wider word and is carried
+   in an OCaml [int], which holds far more than the slice does. Masking a wider
+   value is the one truncation nothing downstream can catch, because the masked
+   result is itself a legal field value that decode, [validate] and the
    EverParse validator all accept, and the number the caller meant is gone
    without trace. So each width accepts exactly what its decoder produces,
    [0, 2^bits - 1], and encode stays inverse to decode.
 
-   Where the native [int] is no wider than the field (a 32-bit field under
+   Where the native [int] is no wider than the slice (a 32-bit slice under
    js_of_ocaml, anything from 31 bits up under wasm_of_ocaml) no [int] is out of
    range, so the guard narrows to what is still checkable there rather than
    rejecting a value the target can represent.
 
-   Every fixed-width scalar but [uint8] needs nothing here. {!UInt16.t},
+   No fixed-width scalar reaches here any more. {!UInt8.t}, {!UInt16.t},
    {!SInt8.t} and {!SInt16.t} carry the field's range in the type, so a value
    that reaches an encoder is in range by construction; {!UInt32.check_encode},
    {!SInt32.check_encode} and {!UInt63.check_encode} sit next to the
@@ -2121,15 +2120,9 @@ let check_unsigned_encode ~bits v =
     Fmt.invalid_arg
       "Wire.encode: value %d does not fit an unsigned %d-bit field" v bits
 
-(* [Bytes.set_uint8] masks rather than refusing ([Bytes.set_uint8 b 0 0x1FF]
-   writes 0xFF), so [uint8] writes through a checked counterpart; the signed
-   32-bit writers stand beside it under the names the encode paths use. Every
-   other fixed-width scalar writes through its own carrier, whose range is
-   already the field's. *)
-
-let set_uint8 buf off v =
-  check_unsigned_encode ~bits:8 v;
-  Bytes.set_uint8 buf off v
+(* The signed 32-bit writers, under the names the encode paths use. Every
+   fixed-width scalar writes through its own carrier, whose range is already the
+   field's. *)
 
 let set_int32_le = SInt32.set_le
 let set_int32_be = SInt32.set_be

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -175,21 +175,16 @@ val check_unsigned_encode : bits:int -> int -> unit
     accepted range is [[0, 2^bits - 1]], exactly what the decoder produces, so
     encode stays inverse to decode; anything else raises [Invalid_argument],
     because masking it would put a different, equally legal, number on the wire
-    that no later check can tell from the one the caller meant. Shared by
-    {!val-uint8} and [bits ~width], the two shapes still carried in a bare
-    [int]. Where the native [int] is no wider than the field the guard narrows
-    to what is still checkable, so it never rejects a value the target can
-    represent. *)
+    that no later check can tell from the one the caller meant. Used by
+    [bits ~width], the one shape still carried in a bare [int]. Where the native
+    [int] is no wider than the slice the guard narrows to what is still
+    checkable, so it never rejects a value the target can represent. *)
 
 (** {2 Checked scalar writers}
 
-    [Bytes.set_uint8] masks silently, so {!val-uint8} writes through a checked
-    counterpart; the signed 32-bit writers stand beside it under the names the
-    encode paths use. Every other fixed-width scalar writes through its own
-    carrier, whose range is already the field's. *)
-
-val set_uint8 : bytes -> int -> int -> unit
-(** [set_uint8 buf off v] writes [v] as one unsigned byte. *)
+    The signed 32-bit writers, under the names the encode paths use. Every
+    fixed-width scalar writes through its own carrier, whose range is already
+    the field's. *)
 
 val set_int32_le : bytes -> int -> SInt32.t -> unit
 (** [set_int32_le buf off v] writes [v] as four signed little-endian bytes. *)
@@ -260,7 +255,9 @@ and _ expr =
 and bitfield_base = U8 | U16 of endian | U32 of endian
 
 and _ typ =
-  | Uint8 : int typ  (** 8-bit unsigned. *)
+  | Uint8 : UInt8.t typ
+      (** 8-bit unsigned. Carried by {!UInt8.t}, whose range is the field's: a
+          number the byte cannot hold is refused where it is built. *)
   | Uint16 : endian -> UInt16.t typ
       (** 16-bit unsigned. Carried by {!UInt16.t}, whose range is the field's: a
           number two bytes cannot hold is refused where it is built. *)
@@ -568,7 +565,7 @@ end
 
 (** {1 Type Constructors} *)
 
-val uint8 : int typ
+val uint8 : UInt8.t typ
 (** 8-bit unsigned, native endian. *)
 
 val uint16 : UInt16.t typ

--- a/lib/uInt8.ml
+++ b/lib/uInt8.ml
@@ -1,0 +1,20 @@
+type t = int
+
+let min_int = 0
+let max_int = 0xFF
+let zero = 0
+let equal : t -> t -> bool = Int.equal
+let pp = Fmt.int
+
+(* The one place the range is enforced. Every other path takes a [t] and so
+   takes a value the field holds, which is what lets the encoders drop their
+   own width checks instead of carrying one that cannot fire. *)
+let v n =
+  if n < min_int || n > max_int then
+    Fmt.invalid_arg "Wire.UInt8.v: %d is not an unsigned 8-bit value" n;
+  n
+
+let v_opt n = if n < min_int || n > max_int then None else Some n
+let to_int n = n
+let get buf off = Bytes.get_uint8 buf off
+let set buf off n = Bytes.set_uint8 buf off n

--- a/lib/uInt8.mli
+++ b/lib/uInt8.mli
@@ -1,0 +1,50 @@
+(** Unsigned 8-bit integer.
+
+    A native [int] narrowed to what one unsigned byte holds. The range is in the
+    type rather than in a check at every encoder: a number outside [[0, 255]]
+    never becomes a value of this type, so nothing downstream has to ask again,
+    and a case value or table index the field cannot hold is refused where it is
+    written down rather than at the first byte encoded.
+
+    [private int] on purpose. The carrier is exactly the [int] it looks like, on
+    every target: no box, no conversion on the way out, and only the places that
+    build a value have to say which range they are in. *)
+
+type t = private int
+
+val v : int -> t
+(** [v n] is [n] as an unsigned 8-bit value. Raises [Invalid_argument] when [n]
+    is outside [[0, 255]], rather than masking it to a legal value the caller
+    did not mean: 511 masks to a perfectly good 255 that no decoder can tell
+    from the number that was written. *)
+
+val v_opt : int -> t option
+(** [v_opt n] is {!v} as an option, for a caller testing a number rather than
+    asserting it. *)
+
+val to_int : t -> int
+(** [to_int t] is the value as a native [int]. Total and exact on every target:
+    every unsigned 8-bit value fits every OCaml [int]. *)
+
+val zero : t
+(** [zero] is 0. *)
+
+val min_int : t
+(** [min_int] is 0, the smallest value an unsigned byte holds. *)
+
+val max_int : t
+(** [max_int] is 255, the largest value an unsigned byte holds. *)
+
+val equal : t -> t -> bool
+(** [equal a b] is [true] when [a] and [b] are the same value. *)
+
+val pp : Format.formatter -> t -> unit
+(** Pretty-printer for unsigned 8-bit values. *)
+
+val get : bytes -> int -> t
+(** [get buf off] reads the unsigned byte at offset [off]. Total: one byte
+    spells only values the field holds. *)
+
+val set : bytes -> int -> t -> unit
+(** [set buf off v] writes [v] as one unsigned byte at offset [off]. Needs no
+    range check: every {!type-t} is a value the byte holds. *)

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -259,7 +259,7 @@ let float64_be buf off = Int64.float_of_bits (Bytes.get_int64_be buf off)
 let rec parse_direct : type a. a typ -> bytes -> int -> int -> a * int =
  fun typ buf off len ->
   match typ with
-  | Uint8 -> parse_fixed 1 Bytes.get_uint8 buf off len
+  | Uint8 -> parse_fixed 1 UInt8.get buf off len
   | Uint16 Little -> parse_fixed 2 UInt16.le buf off len
   | Uint16 Big -> parse_fixed 2 UInt16.be buf off len
   | Uint32 Little -> parse_fixed 4 UInt32.le buf off len
@@ -767,9 +767,7 @@ let check_byte_field_size size ~actual =
 let rec encode_into : type a. a typ -> a -> encoder -> unit =
  fun typ v enc ->
   match typ with
-  | Uint8 ->
-      Types.check_unsigned_encode ~bits:8 v;
-      write_byte enc v
+  | Uint8 -> write_byte enc (UInt8.to_int v)
   | Uint16 Little -> write_uint16_le enc (UInt16.to_int v)
   | Uint16 Big -> write_uint16_be enc (UInt16.to_int v)
   | Uint32 Little -> write_uint32_le enc v
@@ -955,7 +953,7 @@ let rec encode_direct : type a. a typ -> bytes -> int -> a -> int =
  fun typ buf off v ->
   match typ with
   | Uint8 ->
-      Types.set_uint8 buf off v;
+      UInt8.set buf off v;
       off + 1
   | Uint16 Little ->
       UInt16.set_le buf off v;
@@ -1041,6 +1039,7 @@ module UInt64 = UInt64
 module SInt32 = SInt32
 module SInt8 = SInt8
 module SInt16 = SInt16
+module UInt8 = UInt8
 module UInt16 = UInt16
 module Ascii = Ascii
 

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -397,6 +397,13 @@ module SInt16 = SInt16
     it is, only building one names the range, and [SInt16.v 40000] is refused
     there rather than at the encoder. *)
 
+module UInt8 = UInt8
+(** Unsigned 8-bit integers, the carrier of {!uint8}.
+
+    A [private int] for the same reason {!SInt8} is, over the byte's unsigned
+    range: a value reads as the [int] it is, only building one names the range,
+    and [UInt8.v 511] is refused there rather than at the encoder. *)
+
 module UInt16 = UInt16
 (** Unsigned 16-bit integers, the carrier of {!uint16} and {!uint16be}.
 
@@ -454,7 +461,7 @@ module Field : sig
       parent codec. This shape projects to 3D as a gate-selected sub-codec.
 
       {[
-      type ext = { len : int; items : int list }
+      type ext = { len : UInt8.t; items : UInt8.t list }
 
       let f_ext_len = Field.v "ExtLen" uint8
 
@@ -570,16 +577,19 @@ end
 
     Every fixed-width integer accepts exactly the range its decoder produces:
     [0] to [2^n - 1] for an unsigned width, [-2^(n-1)] to [2^(n-1) - 1] for a
-    signed one. Encoding anything else raises [Invalid_argument] rather than
-    dropping the bits that do not fit, on every entry point ({!to_string},
-    {!Codec.encode} and {!Codec.set} alike). OCaml carries the narrow widths in
-    a plain [int], which holds far more than the field does, so [uint8] given
-    [0x1FF] would otherwise put an [0xFF] on the wire that reads back as a
-    perfectly legal [255], with nothing left to say the caller meant something
-    else. *)
+    signed one, and carries that range in its own type, so a number the field
+    cannot hold is refused where the value is built. A {!bits} slice is the one
+    shape left in a plain [int], which holds far more than the slice does, so a
+    four-bit slice given [0x1F] raises [Invalid_argument] on every entry point
+    ({!to_string}, {!Codec.encode} and {!Codec.set} alike) rather than putting
+    an [0xF] on the wire that reads back as a perfectly legal [15], with nothing
+    left to say the caller meant something else. *)
 
-val uint8 : int typ
-(** Unsigned 8-bit integer. Encodes [0] to [255]. *)
+val uint8 : UInt8.t typ
+(** Unsigned 8-bit integer. Holds [0] to [255]: [511] is not a [uint8], even
+    though its low byte is a legal one, and would come back from the decoder as
+    [255]. The range is the carrier's, so {!UInt8.v} refuses it where the value
+    is built and every encode path takes only values the field holds. *)
 
 val uint16 : UInt16.t typ
 (** Unsigned 16-bit little-endian integer. Holds [0] to [65535]: [70000] is not

--- a/test/3d/test_wire_3d.ml
+++ b/test/3d/test_wire_3d.ml
@@ -884,19 +884,19 @@ let e2e_underflow_codec =
    [Casetype], then references the wrapper as the field type. End-to-end
    check that 3d.exe accepts the synthesised module and the generated C
    compiles. *)
-type ep_case_v = [ `U16 of Wire.UInt16.t | `Default of int ]
+type ep_case_v = [ `U16 of Wire.UInt16.t | `Default of Wire.UInt8.t ]
 
 let e2e_casetype_codec =
   let open Wire in
   let body : ep_case_v typ =
     casetype "CtBody" uint8
       [
-        case ~index:1 uint16
+        case ~index:(UInt8.v 1) uint16
           ~inject:(fun v -> `U16 v)
           ~project:(function `U16 v -> Some v | _ -> None);
         default uint8
           ~inject:(fun _tag v -> `Default v)
-          ~project:(function `Default v -> Some (0xFF, v) | _ -> None);
+          ~project:(function `Default v -> Some (UInt8.v 0xFF, v) | _ -> None);
       ]
   in
   let f = Field.v "msg" body in
@@ -906,7 +906,7 @@ let e2e_casetype_codec =
    into two adjacent byte spans (tag and body) so dispatch happens in
    caller code, mirroring OpenSSH's two-step pattern. No 3D-side extern,
    scratch slot or runtime helper -- just two SetBytes setters. *)
-type ssh_auth = [ `Publickey of int | `Other of int ]
+type ssh_auth = [ `Publickey of Wire.UInt8.t | `Other of Wire.UInt8.t ]
 
 let e2e_ssh_casetype_codec =
   let open Wire in
@@ -949,10 +949,10 @@ let e2e_codec_in_casetype =
   let body : channel_confirm typ =
     casetype "Confirm" uint8
       [
-        case ~index:1 (codec session_codec)
+        case ~index:(UInt8.v 1) (codec session_codec)
           ~inject:(fun s -> Session s)
           ~project:(function Session s -> Some s | _ -> None);
-        case ~index:2 uint16be
+        case ~index:(UInt8.v 2) uint16be
           ~inject:(fun n -> Tcpip n)
           ~project:(function Tcpip n -> Some n | _ -> None);
       ]
@@ -972,7 +972,7 @@ let ext_codec =
   Codec.v "Ext"
     (fun _l n -> { name = n })
     [
-      Codec.( $ ) f_len (fun e -> String.length e.name);
+      Codec.( $ ) f_len (fun e -> UInt8.v (String.length e.name));
       Codec.( $ ) f_name (fun e -> e.name);
     ]
 
@@ -986,7 +986,8 @@ let e2e_repeat_var_elem =
     (fun _t xs -> xs)
     [
       Codec.( $ ) f_total (fun xs ->
-          List.fold_left (fun a e -> a + 1 + String.length e.name) 0 xs);
+          UInt8.v
+            (List.fold_left (fun a e -> a + 1 + String.length e.name) 0 xs));
       Codec.( $ ) f_exts (fun xs -> xs);
     ]
 
@@ -1004,7 +1005,7 @@ let dhcp_opt_body_codec =
   Codec.v "DhcpOptBody"
     (fun _l d -> d)
     [
-      Codec.( $ ) f_len (fun d -> String.length d);
+      Codec.( $ ) f_len (fun d -> UInt8.v (String.length d));
       Codec.( $ ) f_data (fun d -> d);
     ]
 
@@ -1013,13 +1014,13 @@ let e2e_repeat_casetype_codec =
   let opt : dhcp_opt typ =
     casetype "DhcpOpt" uint8
       [
-        case ~index:0 empty
+        case ~index:(UInt8.v 0) empty
           ~inject:(fun () -> Pad)
           ~project:(function Pad -> Some () | _ -> None);
-        case ~index:255 empty
+        case ~index:(UInt8.v 255) empty
           ~inject:(fun () -> End)
           ~project:(function End -> Some () | _ -> None);
-        case ~index:53
+        case ~index:(UInt8.v 53)
           (codec dhcp_opt_body_codec)
           ~inject:(fun d -> Generic d)
           ~project:(function Generic d -> Some d | _ -> None);
@@ -1031,7 +1032,8 @@ let e2e_repeat_casetype_codec =
   Codec.v "DhcpOpts"
     (fun _t xs -> xs)
     [
-      Codec.( $ ) f_total (List.fold_left (fun a o -> a + size o) 0);
+      Codec.( $ ) f_total (fun xs ->
+          UInt8.v (List.fold_left (fun a o -> a + size o) 0 xs));
       Codec.( $ ) f_opts (fun xs -> xs);
     ]
 

--- a/test/diff/fuzz_schema.ml
+++ b/test/diff/fuzz_schema.ml
@@ -30,20 +30,21 @@ let decode_record codec s =
 
 (** Test SimpleHeader roundtrip *)
 let test_simple_header_roundtrip version length flags =
-  let version = abs version mod 256 in
+  let version = Wire.UInt8.v (abs version mod 256) in
   let length = Wire.UInt16.v (abs length mod 65536) in
-  let flags = abs flags mod 256 in
+  let flags = Wire.UInt8.v (abs flags mod 256) in
   let original = Schema.{ version; length; flags } in
   match encode_record Schema.simple_header_codec original with
   | Error _ -> Alcobar.fail "encode failed"
   | Ok encoded -> (
       match decode_record Schema.simple_header_codec encoded with
       | Ok decoded ->
-          if original.version <> decoded.version then
+          if not (Wire.UInt8.equal original.version decoded.version) then
             Alcobar.fail "version mismatch";
-          if not (UInt16.equal original.length decoded.length) then
+          if not (Wire.UInt16.equal original.length decoded.length) then
             Alcobar.fail "length mismatch";
-          if original.flags <> decoded.flags then Alcobar.fail "flags mismatch"
+          if not (Wire.UInt8.equal original.flags decoded.flags) then
+            Alcobar.fail "flags mismatch"
       | Error _ -> Alcobar.fail "decode failed")
 
 (** Test SimpleHeader decode crash safety *)
@@ -54,7 +55,7 @@ let test_simple_header_crash buf =
 
 (** Test ConstrainedPacket roundtrip with valid values *)
 let test_constrained_packet_roundtrip pkt_type pkt_length =
-  let type_ = abs pkt_type mod 4 in
+  let type_ = Wire.UInt8.v (abs pkt_type mod 4) in
   let length = Wire.UInt16.v (abs pkt_length mod 1025) in
   let original = Schema.{ type_; length } in
   match encode_record Schema.constrained_packet_codec original with
@@ -62,9 +63,9 @@ let test_constrained_packet_roundtrip pkt_type pkt_length =
   | Ok encoded -> (
       match decode_record Schema.constrained_packet_codec encoded with
       | Ok decoded ->
-          if original.type_ <> decoded.type_ then
+          if not (Wire.UInt8.equal original.type_ decoded.type_) then
             Alcobar.fail "pkt_type mismatch";
-          if not (UInt16.equal original.length decoded.length) then
+          if not (Wire.UInt16.equal original.length decoded.length) then
             Alcobar.fail "pkt_length mismatch"
       | Error _ -> Alcobar.fail "decode failed")
 

--- a/test/diff/schema.ml
+++ b/test/diff/schema.ml
@@ -7,7 +7,7 @@ open Wire
 open Wire.Everparse.Raw
 
 (* Simple header schema: version (u8) + length (u16) + flags (u8) *)
-type simple_header = { version : int; length : UInt16.t; flags : int }
+type simple_header = { version : UInt8.t; length : UInt16.t; flags : UInt8.t }
 
 let simple_header_codec =
   Codec.v "SimpleHeader"
@@ -29,7 +29,7 @@ let simple_header_module =
 (* Constrained schema - constraints are applied in 3D generation,
    the OCaml parser doesn't validate constraints on individual fields.
    For differential testing, we validate manually or use the C parser. *)
-type constrained_packet = { type_ : int; length : UInt16.t }
+type constrained_packet = { type_ : UInt8.t; length : UInt16.t }
 
 let constrained_packet_codec =
   Codec.v "ConstrainedPacket"

--- a/test/diff/schema.mli
+++ b/test/diff/schema.mli
@@ -1,6 +1,10 @@
 (** Schema definitions for differential testing. *)
 
-type simple_header = { version : int; length : Wire.UInt16.t; flags : int }
+type simple_header = {
+  version : Wire.UInt8.t;
+  length : Wire.UInt16.t;
+  flags : Wire.UInt8.t;
+}
 (** A simple packet header with version, length, and flags fields. *)
 
 val simple_header_codec : simple_header Wire.Codec.t
@@ -12,7 +16,7 @@ val simple_header_struct : Wire.Everparse.Raw.struct_
 val simple_header_module : Wire.Everparse.Raw.module_
 (** Module definition for 3D code generation. *)
 
-type constrained_packet = { type_ : int; length : Wire.UInt16.t }
+type constrained_packet = { type_ : Wire.UInt8.t; length : Wire.UInt16.t }
 (** A packet with type and length fields, where length must be >= 4. *)
 
 val constrained_packet_codec : constrained_packet Wire.Codec.t

--- a/test/diff/test_wire_diff.ml
+++ b/test/diff/test_wire_diff.ml
@@ -50,7 +50,9 @@ let test_read_ocaml_override () =
     v ~name:"Override" ~read:c_read ~write:mock_c_write ~project:encode_simple
       ~equal:String.equal ~ocaml_read ()
   in
-  let result = s.Wire_diff.test_read (encode_simple (7, UInt16.v 1000)) in
+  let result =
+    s.Wire_diff.test_read (encode_simple (UInt8.v 7, UInt16.v 1000))
+  in
   Alcotest.(check bool) "read uses override" true (result = Wire_diff.Match)
 
 let check_result label ~expected ~f s buf =
@@ -61,7 +63,7 @@ let test_write () =
   check_result "write result" ~expected:Wire_diff.Match
     ~f:(fun s buf -> s.Wire_diff.test_write buf)
     s
-    (encode_simple (7, UInt16.v 1000))
+    (encode_simple (UInt8.v 7, UInt16.v 1000))
 
 let test_write_ocaml_override () =
   let c_write _ = Some "abc" in
@@ -71,7 +73,7 @@ let test_write_ocaml_override () =
       ~project:(fun _ -> "override")
       ~equal:String.equal ~ocaml_read ()
   in
-  let buf = encode_simple (7, UInt16.v 1000) in
+  let buf = encode_simple (UInt8.v 7, UInt16.v 1000) in
   let result = s.Wire_diff.test_write buf in
   Alcotest.(check bool) "write uses override" true (result = Wire_diff.Match)
 
@@ -80,7 +82,7 @@ let test_full_roundtrip () =
   check_result "full_roundtrip result" ~expected:Wire_diff.Match
     ~f:(fun s buf -> s.Wire_diff.test_roundtrip buf)
     s
-    (encode_simple (3, UInt16.v 512))
+    (encode_simple (UInt8.v 3, UInt16.v 512))
 
 let c_reject_schema name =
   let c_write_reject _ = None in
@@ -92,14 +94,14 @@ let test_full_roundtrip_c_rejects () =
     ~expected:(Wire_diff.Only_ocaml_ok "External write failed")
     ~f:(fun s buf -> s.Wire_diff.test_roundtrip buf)
     (c_reject_schema "CReject")
-    (encode_simple (3, UInt16.v 512))
+    (encode_simple (UInt8.v 3, UInt16.v 512))
 
 let test_write_c_rejects () =
   check_result "write c rejects -> Only_ocaml_ok"
     ~expected:(Wire_diff.Only_ocaml_ok "External write failed")
     ~f:(fun s buf -> s.Wire_diff.test_write buf)
     (c_reject_schema "CRejectW")
-    (encode_simple (3, UInt16.v 512))
+    (encode_simple (UInt8.v 3, UInt16.v 512))
 
 let projection_codec =
   let open Codec in
@@ -108,18 +110,19 @@ let projection_codec =
     [ f_diff_version $ Fun.id; (f_diff_length $ fun _ -> UInt16.zero) ]
 
 let projection_read buf =
-  if String.length buf < 3 then None else Some (String.get_uint8 buf 0)
+  if String.length buf < 3 then None
+  else Some (UInt8.v (String.get_uint8 buf 0))
 
 let projection_write version =
   let buf = Bytes.create 3 in
-  Bytes.set_uint8 buf 0 version;
+  UInt8.set buf 0 version;
   Bytes.set_uint16_be buf 1 0;
   Some (Bytes.unsafe_to_string buf)
 
 let mk_projection () =
   Wire_diff.harness ~name:"Projection" ~codec:projection_codec
     ~read:projection_read ~write:projection_write ~project:Fun.id
-    ~equal:Int.equal ()
+    ~equal:UInt8.equal ()
 
 let test_projection_read () =
   let s = mk_projection () in
@@ -131,7 +134,7 @@ let test_projection_roundtrip () =
   check_result "projection roundtrip" ~expected:Wire_diff.Match
     ~f:(fun s buf -> s.Wire_diff.test_roundtrip buf)
     (mk_projection ())
-    (encode_simple (7, UInt16.zero))
+    (encode_simple (UInt8.v 7, UInt16.zero))
 
 let test_harness () =
   let s =

--- a/test/helpers/test_helpers.ml
+++ b/test/helpers/test_helpers.ml
@@ -1,6 +1,6 @@
 open Wire
 
-type inner = { tag : int; value : UInt16.t }
+type inner = { tag : UInt8.t; value : UInt16.t }
 
 let f_inner_tag = Field.v "Tag" uint8
 let f_inner_value = Field.v "Value" uint16be
@@ -14,7 +14,7 @@ let inner_codec =
         (f_inner_value $ fun (r : inner) -> r.value);
       ]
 
-type outer = { header : int; inner : inner; trailer : int }
+type outer = { header : UInt8.t; inner : inner; trailer : UInt8.t }
 
 let outer_codec =
   Codec.v "Outer"
@@ -26,9 +26,9 @@ let outer_codec =
         (Field.v "Trailer" uint8 $ fun (r : outer) -> r.trailer);
       ]
 
-type l2 = { x : int }
+type l2 = { x : UInt8.t }
 type l1 = { inner : l2; y : UInt16.t }
-type l0 = { inner : l1; z : int }
+type l0 = { inner : l1; z : UInt8.t }
 
 let l2_codec =
   Codec.v "L2"
@@ -53,7 +53,7 @@ let l0_codec =
         (Field.v "Z" uint8 $ fun (r : l0) -> r.z);
       ]
 
-type opt_record = { hdr : int; payload : UInt16.t option; trail : int }
+type opt_record = { hdr : UInt8.t; payload : UInt16.t option; trail : UInt8.t }
 
 let opt_codec ~present =
   Codec.v "OptRecord"
@@ -69,7 +69,7 @@ let opt_codec ~present =
 let opt_codec_present = opt_codec ~present:true
 let opt_codec_absent = opt_codec ~present:false
 
-type container = { length : int; items : inner list }
+type container = { length : UInt8.t; items : inner list }
 
 let f_cnt_length = Field.v "Length" uint8
 
@@ -83,7 +83,7 @@ let repeat_codec =
         $ fun (r : container) -> r.items );
       ]
 
-type packet = { id : int; data : UInt16.t }
+type packet = { id : UInt8.t; data : UInt16.t }
 
 let packet_codec =
   Codec.v "Packet"

--- a/test/helpers/test_helpers.mli
+++ b/test/helpers/test_helpers.mli
@@ -2,9 +2,9 @@
 
 open Wire
 
-type inner = { tag : int; value : UInt16.t }
+type inner = { tag : UInt8.t; value : UInt16.t }
 
-val f_inner_tag : int Field.t
+val f_inner_tag : UInt8.t Field.t
 (** [f_inner_tag] is the field reference for the inner tag; reused by codecs
     that depend on the parsed tag value. *)
 
@@ -15,15 +15,15 @@ val inner_codec : inner Codec.t
 (** [inner_codec] is the tag-prefixed inner record used as the building block
     for {!outer_codec}, {!repeat_codec}, and many test cases. *)
 
-type outer = { header : int; inner : inner; trailer : int }
+type outer = { header : UInt8.t; inner : inner; trailer : UInt8.t }
 
 val outer_codec : outer Codec.t
 (** [outer_codec] embeds {!inner_codec} between a header and trailer byte;
     exercises the [codec] field combinator. *)
 
-type l2 = { x : int }
+type l2 = { x : UInt8.t }
 type l1 = { inner : l2; y : UInt16.t }
-type l0 = { inner : l1; z : int }
+type l0 = { inner : l1; z : UInt8.t }
 
 val l2_codec : l2 Codec.t
 (** [l2_codec] is the innermost level of a 3-deep codec nesting. *)
@@ -35,7 +35,7 @@ val l0_codec : l0 Codec.t
 (** [l0_codec] is the outermost level, embedding {!l1_codec}; exercises
     two-level nesting. *)
 
-type opt_record = { hdr : int; payload : UInt16.t option; trail : int }
+type opt_record = { hdr : UInt8.t; payload : UInt16.t option; trail : UInt8.t }
 
 val opt_codec : present:bool -> opt_record Codec.t
 (** [opt_codec ~present] is a record with an optional middle field; [present]
@@ -47,16 +47,16 @@ val opt_codec_present : opt_record Codec.t
 val opt_codec_absent : opt_record Codec.t
 (** [opt_codec_absent] is [opt_codec ~present:false]. *)
 
-type container = { length : int; items : inner list }
+type container = { length : UInt8.t; items : inner list }
 
-val f_cnt_length : int Field.t
+val f_cnt_length : UInt8.t Field.t
 (** [f_cnt_length] is the field reference for the container length, used to size
     the trailing [repeat] body. *)
 
 val repeat_codec : container Codec.t
 (** [repeat_codec] is a length-prefixed list of {!type:inner} elements. *)
 
-type packet = { id : int; data : UInt16.t }
+type packet = { id : UInt8.t; data : UInt16.t }
 
 val packet_codec : packet Codec.t
 (** [packet_codec] is a fixed-shape packet record reused by TM-frame style

--- a/test/test.ml
+++ b/test/test.ml
@@ -13,6 +13,7 @@ let () =
       Test_sint32.suite;
       Test_sint8.suite;
       Test_sint16.suite;
+      Test_uint8.suite;
       Test_uint16.suite;
       Test_uint63.suite;
       Test_types.suite;

--- a/test/test_action.ml
+++ b/test/test_action.ml
@@ -13,7 +13,11 @@ open Wire
 open Test_helpers
 
 (* Record type for two-field codecs *)
-type xy = { x : int; y : int }
+type xy = { x : UInt8.t; y : UInt8.t }
+
+(* A [bits ~width] slice stays in a plain [int], so the bitfield case gets its
+   own record rather than borrowing the whole-byte one. *)
+type bits_xy = { bx : int; by : int }
 
 (* -- Assign -- *)
 
@@ -38,8 +42,8 @@ let test_assign_propagates () =
   let env = Codec.env codec in
   let buf = Bytes.of_string "\x0A\x14" in
   let r = decode_ok (Codec.decode ~env codec buf 0) in
-  Alcotest.(check int) "x" 10 r.x;
-  Alcotest.(check int) "out" 10 (Param.get env out)
+  Alcotest.(check int) "x" 10 (UInt8.to_int r.x);
+  Alcotest.(check int) "out" 10 (UInt8.to_int (Param.get env out))
 
 let test_assign_propagates_fail () =
   (* Assign out = x, then constraint out + y <= 10 fails. *)
@@ -89,7 +93,7 @@ let test_assign_expr () =
   let env = Codec.env codec in
   let buf = Bytes.of_string "\x2A\x00" in
   ignore (decode_ok (Codec.decode ~env codec buf 0));
-  Alcotest.(check int) "out" 43 (Param.get env out)
+  Alcotest.(check int) "out" 43 (UInt8.to_int (Param.get env out))
 
 (* -- Return -- *)
 
@@ -199,7 +203,7 @@ let test_var_local () =
   let env = Codec.env codec in
   let buf = Bytes.of_string "\x2A\x00" in
   ignore (decode_ok (Codec.decode ~env codec buf 0));
-  Alcotest.(check int) "out" 84 (Param.get env out)
+  Alcotest.(check int) "out" 84 (UInt8.to_int (Param.get env out))
 
 (* -- If -- *)
 
@@ -231,7 +235,7 @@ let check_if_gate name ~threshold ~input ~expected =
   in
   let env = Codec.env codec in
   ignore (decode_ok (Codec.decode ~env codec (Bytes.of_string input) 0));
-  Alcotest.(check int) "out" expected (Param.get env out)
+  Alcotest.(check int) "out" expected (UInt8.to_int (Param.get env out))
 
 let test_if_true_branch () =
   check_if_gate "IfTrue" ~threshold:0 ~input:"\x2A\x00" ~expected:1
@@ -267,7 +271,7 @@ let test_if_else () =
   let env = Codec.env codec in
   let buf = Bytes.of_string "\x01\x00" in
   ignore (decode_ok (Codec.decode ~env codec buf 0));
-  Alcotest.(check int) "out" 20 (Param.get env out)
+  Alcotest.(check int) "out" 20 (UInt8.to_int (Param.get env out))
 
 let test_if_abort_in_else () =
   (* if (x > 0) { out = x } else { abort } *)
@@ -329,7 +333,7 @@ let test_if_nested () =
   let env = Codec.env codec in
   let buf = Bytes.of_string "\x32\x00" in
   ignore (decode_ok (Codec.decode ~env codec buf 0));
-  Alcotest.(check int) "out" 1 (Param.get env out)
+  Alcotest.(check int) "out" 1 (UInt8.to_int (Param.get env out))
 
 (* -- On_act vs On_success -- *)
 
@@ -383,7 +387,7 @@ let test_stmt_sequencing () =
   let env = Codec.env codec in
   let buf = Bytes.of_string "\x2A\x00" in
   ignore (decode_ok (Codec.decode ~env codec buf 0));
-  Alcotest.(check int) "out" 86 (Param.get env out)
+  Alcotest.(check int) "out" 86 (UInt8.to_int (Param.get env out))
 
 let test_return_short_circuits () =
   (* return true; abort => should succeed (abort never reached) *)
@@ -441,19 +445,19 @@ let test_action_on_bitfield () =
   let codec =
     let open Codec in
     v "BFAction"
-      (fun x y -> { x; y })
+      (fun bx by -> { bx; by })
       [
         ( Field.v "x"
             ~action:(Action.on_success [ Action.assign out (Field.ref f_x) ])
             (bits ~width:4 U8)
-        $ fun r -> r.x );
-        (Field.v "y" (bits ~width:4 U8) $ fun r -> r.y);
+        $ fun r -> r.bx );
+        (Field.v "y" (bits ~width:4 U8) $ fun r -> r.by);
       ]
   in
   let env = Codec.env codec in
   let buf = Bytes.of_string "\xAB" in
   ignore (decode_ok (Codec.decode ~env codec buf 0));
-  let out_val = Param.get env out in
+  let out_val = UInt8.to_int (Param.get env out) in
   Alcotest.(check bool) "out <= 15" true (out_val <= 15)
 
 (* -- Encode -- *)
@@ -475,12 +479,15 @@ let test_encode_output_no_env () =
         $ fun x -> x );
       ]
   in
-  let buf = Bytes.create (Codec.size_of_value codec 7) in
-  Codec.encode codec 7 buf 0;
+  let seven = UInt8.v 7 in
+  let buf = Bytes.create (Codec.size_of_value codec seven) in
+  Codec.encode codec seven buf 0;
   Alcotest.(check int) "encoded byte" 7 (Bytes.get_uint8 buf 0);
   let env = Codec.env codec in
-  Alcotest.(check int) "decoded" 7 (decode_ok (Codec.decode ~env codec buf 0));
-  Alcotest.(check int) "out" 7 (Param.get env out)
+  Alcotest.(check int)
+    "decoded" 7
+    (UInt8.to_int (decode_ok (Codec.decode ~env codec buf 0)));
+  Alcotest.(check int) "out" 7 (UInt8.to_int (Param.get env out))
 
 (* An embedded output-param sub-codec encodes from the parent without an env,
    too: the parent forwards no env and the sub-codec needs none. *)
@@ -504,8 +511,9 @@ let test_encode_embedded_output_no_env () =
       (fun i -> i)
       [ (Field.v "inner" (codec inner) $ fun i -> i) ]
   in
-  let buf = Bytes.create (Codec.size_of_value outer 7) in
-  Codec.encode outer 7 buf 0;
+  let seven = UInt8.v 7 in
+  let buf = Bytes.create (Codec.size_of_value outer seven) in
+  Codec.encode outer seven buf 0;
   Alcotest.(check int) "encoded byte" 7 (Bytes.get_uint8 buf 0)
 
 (* -- Suite -- *)

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -31,7 +31,7 @@ let decode_record codec s =
 
 (* -- Record codec tests -- *)
 
-type simple_record = { a : int; b : UInt16.t; c : UInt32.t }
+type simple_record = { a : UInt8.t; b : UInt16.t; c : UInt32.t }
 
 let simple_record_codec =
   let open Codec in
@@ -44,7 +44,9 @@ let simple_record_codec =
     ]
 
 let test_record_encode () =
-  let v = { a = 0x42; b = UInt16.v 0x1234; c = UInt32.of_int32 0x56789ABCl } in
+  let v =
+    { a = UInt8.v 0x42; b = UInt16.v 0x1234; c = UInt32.of_int32 0x56789ABCl }
+  in
   match encode_record simple_record_codec v with
   | Error e -> Alcotest.failf "%a" pp_parse_error e
   | Ok encoded ->
@@ -59,21 +61,22 @@ let test_record_decode () =
   let input = "\x42\x34\x12\xBC\x9A\x78\x56" in
   match decode_record simple_record_codec input with
   | Ok v ->
-      Alcotest.(check int) "a" 0x42 v.a;
+      Alcotest.(check int) "a" 0x42 (UInt8.to_int v.a);
       Alcotest.(check int) "b" 0x1234 (UInt16.to_int v.b);
       Alcotest.(check int32) "c" 0x56789ABCl (UInt32.to_int32 v.c)
   | Error e -> Alcotest.failf "%a" pp_parse_error e
 
 let test_record_roundtrip () =
   let original =
-    { a = 0xAB; b = UInt16.v 0xCDEF; c = UInt32.of_int 0x12345678 }
+    { a = UInt8.v 0xAB; b = UInt16.v 0xCDEF; c = UInt32.of_int 0x12345678 }
   in
   match encode_record simple_record_codec original with
   | Error e -> Alcotest.failf "encode: %a" pp_parse_error e
   | Ok encoded -> (
       match decode_record simple_record_codec encoded with
       | Ok decoded ->
-          Alcotest.(check int) "a roundtrip" original.a decoded.a;
+          Alcotest.(check int)
+            "a roundtrip" (UInt8.to_int original.a) (UInt8.to_int decoded.a);
           Alcotest.(check int)
             "b roundtrip" (UInt16.to_int original.b) (UInt16.to_int decoded.b);
           Alcotest.(check int)
@@ -115,7 +118,7 @@ let test_struct_of_record () =
   Alcotest.(check bool) "contains field b" true (contains ~sub:"b;" output);
   Alcotest.(check bool) "contains field c" true (contains ~sub:"c;" output)
 
-type meta_record = { x : int }
+type meta_record = { x : UInt8.t }
 
 let meta_f_x = Field.v "x" uint8
 
@@ -139,7 +142,7 @@ let meta_codec =
 let test_codec_metadata_decode_ok () =
   let buf = Bytes.of_string "\x08" in
   let v = decode_ok (Codec.decode meta_codec buf 0) in
-  Alcotest.(check int) "x" 8 v.x
+  Alcotest.(check int) "x" 8 (UInt8.to_int v.x)
 
 let test_metadata_constraint_fail () =
   let buf = Bytes.of_string "\x0B" in
@@ -176,14 +179,18 @@ let projection_codec =
     ]
 
 let test_metadata_with_params () =
-  let env = Codec.env projection_codec |> Param.bind projection_limit 10 in
+  let env =
+    Codec.env projection_codec |> Param.bind projection_limit (UInt8.v 10)
+  in
   let buf = Bytes.of_string "\x08" in
   let v = decode_ok (Codec.decode ~env projection_codec buf 0) in
-  Alcotest.(check int) "x" 8 v.x;
-  Alcotest.(check int) "outx" 8 (Param.get env projection_outx)
+  Alcotest.(check int) "x" 8 (UInt8.to_int v.x);
+  Alcotest.(check int) "outx" 8 (UInt8.to_int (Param.get env projection_outx))
 
 let test_metadata_where_fail () =
-  let env = Codec.env projection_codec |> Param.bind projection_limit 7 in
+  let env =
+    Codec.env projection_codec |> Param.bind projection_limit (UInt8.v 7)
+  in
   let buf = Bytes.of_string "\x08" in
   match Codec.decode ~env projection_codec buf 0 with
   | Error { kind = Constraint_failed { which = Where; _ }; _ } -> ()
@@ -211,7 +218,7 @@ let test_validate_rejects_bad_where () =
   let buf = Bytes.of_string "\x07" in
   let get_x = Staged.unstage (Codec.get validate_codec validate_cf_x) in
   (* get returns raw value without checking *)
-  Alcotest.(check int) "get bypasses where" 7 (get_x buf 0);
+  Alcotest.(check int) "get bypasses where" 7 (UInt8.to_int (get_x buf 0));
   (* validate catches the violation *)
   match Codec.validate validate_codec buf 0 with
   | () -> Alcotest.fail "expected validate to reject where violation"
@@ -221,7 +228,7 @@ let test_validate_rejects_bad_constraint () =
   (* constraint requires x <= 10, set x = 11 *)
   let buf = Bytes.of_string "\x0B" in
   let get_x = Staged.unstage (Codec.get validate_codec validate_cf_x) in
-  Alcotest.(check int) "get bypasses constraint" 11 (get_x buf 0);
+  Alcotest.(check int) "get bypasses constraint" 11 (UInt8.to_int (get_x buf 0));
   match Codec.validate validate_codec buf 0 with
   | () -> Alcotest.fail "expected validate to reject constraint violation"
   | exception Parse_error { kind = Constraint_failed _; _ } -> ()
@@ -231,7 +238,7 @@ let test_validate_then_get () =
   let buf = Bytes.of_string "\x08" in
   Codec.validate validate_codec buf 0;
   let get_x = Staged.unstage (Codec.get validate_codec validate_cf_x) in
-  Alcotest.(check int) "validate then get" 8 (get_x buf 0)
+  Alcotest.(check int) "validate then get" 8 (UInt8.to_int (get_x buf 0))
 
 (* [Codec.validate] is the safety gate before a zero-copy [get] on untrusted
    input, so it must run decode's structural bounds check even for a codec with
@@ -659,7 +666,7 @@ let test_reject_nested_where () =
             Field.v "body"
               (casetype "BodyW" uint8
                  [
-                   case ~index:1
+                   case ~index:(UInt8.v 1)
                      (where Expr.(int 1 = int 1) uint8)
                      ~inject:(fun s -> s)
                      ~project:Option.some;
@@ -804,8 +811,10 @@ let test_codec_array_cardinality () =
     Codec.v "ArrayList" Fun.id
       Codec.[ Field.v "values" (array ~len:(int 3) uint8) $ Fun.id ]
   in
-  expect_codec_array_cardinality "short list" list [ 1; 2 ] 3 2;
-  expect_codec_array_cardinality "long list" list [ 1; 2; 3; 4 ] 3 4;
+  expect_codec_array_cardinality "short list" list [ UInt8.v 1; UInt8.v 2 ] 3 2;
+  expect_codec_array_cardinality "long list" list
+    [ UInt8.v 1; UInt8.v 2; UInt8.v 3; UInt8.v 4 ]
+    3 4;
   let custom =
     Codec.v "ArrayCustom" Fun.id
       Codec.
@@ -814,8 +823,11 @@ let test_codec_array_cardinality () =
           $ Fun.id;
         ]
   in
-  expect_codec_array_cardinality "short custom sequence" custom [| 1; 2 |] 3 2;
-  expect_codec_array_cardinality "long custom sequence" custom [| 1; 2; 3; 4 |]
+  expect_codec_array_cardinality "short custom sequence" custom
+    [| UInt8.v 1; UInt8.v 2 |]
+    3 2;
+  expect_codec_array_cardinality "long custom sequence" custom
+    [| UInt8.v 1; UInt8.v 2; UInt8.v 3; UInt8.v 4 |]
     3 4
 
 (* Field.repeat over a zeroterm element: a list of NUL-terminated strings
@@ -849,7 +861,7 @@ let test_repeat_zeroterm_projection () =
 (* Dynamic [Field.optional] over a variable-size inner. Group A: a byte array
    sized by a prior field. The gate drives present/absent, and both round-trip
    (absent consumes no bytes, present consumes the inner). *)
-type opt_var = { gate : int; len : int; body : string option }
+type opt_var = { gate : UInt8.t; len : UInt8.t; body : string option }
 
 let opt_var_codec =
   let f_gate = Field.v "gate" uint8 in
@@ -875,10 +887,15 @@ let roundtrip codec v =
   (n, Codec.decode_exn codec buf 0)
 
 let test_optional_var_byte_array () =
-  let n, d = roundtrip opt_var_codec { gate = 1; len = 3; body = Some "abc" } in
+  let n, d =
+    roundtrip opt_var_codec
+      { gate = UInt8.v 1; len = UInt8.v 3; body = Some "abc" }
+  in
   Alcotest.(check int) "present size" 5 n;
   Alcotest.(check (option string)) "present body" (Some "abc") d.body;
-  let n, d = roundtrip opt_var_codec { gate = 0; len = 0; body = None } in
+  let n, d =
+    roundtrip opt_var_codec { gate = UInt8.v 0; len = UInt8.v 0; body = None }
+  in
   Alcotest.(check int) "absent size" 2 n;
   Alcotest.(check (option string)) "absent body" None d.body
 
@@ -890,11 +907,11 @@ let sub_string_codec =
     (fun _slen s -> s)
     Codec.
       [
-        f_slen $ String.length;
+        (f_slen $ fun x -> UInt8.v (String.length x));
         Field.v "sdata" (byte_array ~size:(Field.ref f_slen)) $ Fun.id;
       ]
 
-type opt_sub = { g : int; desc : string option }
+type opt_sub = { g : UInt8.t; desc : string option }
 
 let opt_sub_codec =
   let f_g = Field.v "g" uint8 in
@@ -908,9 +925,9 @@ let opt_sub_codec =
     Codec.[ (f_g $ fun r -> r.g); (f_desc $ fun r -> r.desc) ]
 
 let test_optional_self_delimiting_codec () =
-  let _, d = roundtrip opt_sub_codec { g = 1; desc = Some "hi" } in
+  let _, d = roundtrip opt_sub_codec { g = UInt8.v 1; desc = Some "hi" } in
   Alcotest.(check (option string)) "present desc" (Some "hi") d.desc;
-  let n, d = roundtrip opt_sub_codec { g = 0; desc = None } in
+  let n, d = roundtrip opt_sub_codec { g = UInt8.v 0; desc = None } in
   Alcotest.(check int) "absent size" 1 n;
   Alcotest.(check (option string)) "absent desc" None d.desc
 
@@ -918,7 +935,7 @@ let test_optional_self_delimiting_codec () =
    Keeping those fields in a sub-codec lets their expressions stay local to
    the group, while a following payload remains in the parent codec. This is
    the shape of an optional secondary header that declares its own length. *)
-type transfer_extensions = { items_len : int; items : int list }
+type transfer_extensions = { items_len : UInt8.t; items : UInt8.t list }
 
 let transfer_extensions_codec =
   let f_len = Field.v "ext_items_len" uint8 in
@@ -928,9 +945,9 @@ let transfer_extensions_codec =
     Codec.[ (f_len $ fun r -> r.items_len); (f_items $ fun r -> r.items) ]
 
 type transfer_segment = {
-  start : int;
+  start : UInt8.t;
   extensions : transfer_extensions option;
-  data_len : int;
+  data_len : UInt8.t;
   data : string;
 }
 
@@ -957,18 +974,22 @@ let transfer_segment_codec =
 let test_optional_length_prefixed_group () =
   let present =
     {
-      start = 1;
-      extensions = Some { items_len = 2; items = [ 0xA1; 0xB2 ] };
-      data_len = 3;
+      start = UInt8.v 1;
+      extensions =
+        Some { items_len = UInt8.v 2; items = [ UInt8.v 0xA1; UInt8.v 0xB2 ] };
+      data_len = UInt8.v 3;
       data = "xyz";
     }
   in
   let n, decoded = roundtrip transfer_segment_codec present in
   Alcotest.(check int) "present size" 8 n;
   Alcotest.(check (list int))
-    "extension items" [ 0xA1; 0xB2 ] (Option.get decoded.extensions).items;
+    "extension items" [ 0xA1; 0xB2 ]
+    (List.map UInt8.to_int (Option.get decoded.extensions).items);
   Alcotest.(check string) "following data" "xyz" decoded.data;
-  let absent = { start = 0; extensions = None; data_len = 2; data = "ok" } in
+  let absent =
+    { start = UInt8.zero; extensions = None; data_len = UInt8.v 2; data = "ok" }
+  in
   let n, decoded = roundtrip transfer_segment_codec absent in
   Alcotest.(check int) "absent size" 4 n;
   Alcotest.(check bool)
@@ -992,7 +1013,7 @@ let test_optional_length_prefixed_group () =
 (* Wire.array over a fixed byte_array element: a fixed-count list of n-byte
    chunks (e.g. an array of IPv4 addresses). Used to project a double
    [:byte-size]; the element is now emitted as bare bytes under the budget. *)
-type arr_chunks = { atag : int; addrs : string list }
+type arr_chunks = { atag : UInt8.t; addrs : string list }
 
 let arr_chunks_codec =
   let f_tag = Field.v "tag" uint8 in
@@ -1004,7 +1025,7 @@ let arr_chunks_codec =
     Codec.[ (f_tag $ fun r -> r.atag); (f_addrs $ fun r -> r.addrs) ]
 
 let test_array_byte_array_element () =
-  let v = { atag = 7; addrs = [ "aaaa"; "bbbb"; "cccc" ] } in
+  let v = { atag = UInt8.v 7; addrs = [ "aaaa"; "bbbb"; "cccc" ] } in
   let sz = Codec.size_of_value arr_chunks_codec v in
   Alcotest.(check int) "wire size" 13 sz;
   let buf = Bytes.create sz in
@@ -1523,7 +1544,7 @@ let test_array_accepts_fixed_byte_span () =
    structs. Decoding raised Failure "build_field_reader: unsupported type"
    because the array element reader had no Codec case. The schema projects the
    element as the sub-struct under a [:byte-size] budget. *)
-type pt = { px : int; py : UInt16.t }
+type pt = { px : UInt8.t; py : UInt16.t }
 
 let pt_codec =
   Codec.v "Pt"
@@ -1534,7 +1555,7 @@ let pt_codec =
         (Field.v "py" uint16be $ fun r -> r.py);
       ]
 
-type arr_recs = { rtag : int; pts : pt list }
+type arr_recs = { rtag : UInt8.t; pts : pt list }
 
 let arr_recs_codec =
   Codec.v "ArrRecs"
@@ -1548,9 +1569,12 @@ let arr_recs_codec =
 let test_array_record_element () =
   let v =
     {
-      rtag = 9;
+      rtag = UInt8.v 9;
       pts =
-        [ { px = 1; py = UInt16.v 0x0203 }; { px = 4; py = UInt16.v 0x0506 } ];
+        [
+          { px = UInt8.v 1; py = UInt16.v 0x0203 };
+          { px = UInt8.v 4; py = UInt16.v 0x0506 };
+        ];
     }
   in
   let sz = Codec.size_of_value arr_recs_codec v in
@@ -1561,8 +1585,8 @@ let test_array_record_element () =
   | Ok d ->
       Alcotest.(check (list (pair int int)))
         "pts"
-        (List.map (fun p -> (p.px, UInt16.to_int p.py)) v.pts)
-        (List.map (fun p -> (p.px, UInt16.to_int p.py)) d.pts)
+        (List.map (fun p -> (UInt8.to_int p.px, UInt16.to_int p.py)) v.pts)
+        (List.map (fun p -> (UInt8.to_int p.px, UInt16.to_int p.py)) d.pts)
   | Error e -> Alcotest.failf "decode: %a" pp_parse_error e
 
 let test_array_record_projection () =
@@ -1645,17 +1669,17 @@ let test_nested_exact_region () =
 
 (* A casetype whose case body is a [nested] region (a scalar in a fixed span):
    the tag-dispatched case decodes and sizes through the region. *)
-type nest_case = N of SInt32.t | U of int
+type nest_case = N of SInt32.t | U of UInt8.t
 
 let nest_case_codec =
   let ct =
     casetype "NcT" uint8
       [
-        case ~index:1
+        case ~index:(UInt8.v 1)
           (nested ~size:(int 4) int32be)
           ~inject:(fun v -> N v)
           ~project:(function N v -> Some v | _ -> None);
-        case ~index:2 uint8
+        case ~index:(UInt8.v 2) uint8
           ~inject:(fun v -> U v)
           ~project:(function U v -> Some v | _ -> None);
       ]
@@ -1670,7 +1694,7 @@ let test_casetype_nested_case_body () =
       Alcotest.(check bool)
         "roundtrip" true
         (decode_ok (Codec.decode nest_case_codec buf 0) = v))
-    [ N (SInt32.of_int 12345); U 7 ]
+    [ N (SInt32.of_int 12345); U (UInt8.v 7) ]
 
 (* Field.repeat over a fixed byte_array element: a list of n-byte chunks within
    a byte budget. Decodes the list and projects to a single [:byte-size]
@@ -1905,7 +1929,9 @@ let test_optional_reject_bitfield () =
 let test_casetype_reject_greedy_case_body () =
   let build inner =
     casetype "Greedy" uint8
-      [ case ~index:1 inner ~inject:(fun s -> s) ~project:Option.some ]
+      [
+        case ~index:(UInt8.v 1) inner ~inject:(fun s -> s) ~project:Option.some;
+      ]
   in
   Alcotest.(check bool)
     "casetype with all_bytes case body rejected" true
@@ -1936,12 +1962,13 @@ let test_greedy_not_last_rejected () =
       (fun a b -> (a, b))
       Codec.[ Field.v "n" uint8 $ fst; Field.v "rest" all_bytes $ snd ]
   in
-  let v = (5, "tail") in
+  let v = (UInt8.v 5, "tail") in
   let buf = Bytes.create (Codec.size_of_value c v) in
   Codec.encode c v buf 0;
   Alcotest.(check bool)
     "greedy last roundtrip" true
-    (decode_ok (Codec.decode c buf 0) = v)
+    (let n, rest = decode_ok (Codec.decode c buf 0) in
+     UInt8.equal n (fst v) && String.equal rest (snd v))
 
 (* A casetype whose case body is a sub-codec ending in a greedy field consumes
    the rest of the buffer when that case is selected; placed before another
@@ -1954,10 +1981,10 @@ let test_casetype_greedy_case_not_last_rejected () =
   let ct =
     casetype "CtG" uint8
       [
-        case ~index:1 uint8
+        case ~index:(UInt8.v 1) uint8
           ~inject:(fun v -> `U v)
           ~project:(function `U v -> Some v | _ -> None);
-        case ~index:2 (codec greedy)
+        case ~index:(UInt8.v 2) (codec greedy)
           ~inject:(fun v -> `G v)
           ~project:(function `G v -> Some v | _ -> None);
       ]
@@ -1986,10 +2013,10 @@ let test_casetype_wrapped_greedy_not_last_rejected () =
   let payload =
     casetype "GreedyCase" uint8
       [
-        case ~index:1 (codec body)
+        case ~index:(UInt8.v 1) (codec body)
           ~inject:(fun v -> `Greedy v)
           ~project:(function `Greedy v -> Some v | _ -> None);
-        case ~index:2 uint8
+        case ~index:(UInt8.v 2) uint8
           ~inject:(fun v -> `Byte v)
           ~project:(function `Byte v -> Some v | _ -> None);
       ]
@@ -2026,7 +2053,7 @@ let test_optional_greedy_not_last_rejected () =
   check_rejected "dynamic optional greedy body before tail rejected"
     (Field.optional "body" ~present:Expr.(int 1 = int 1) (codec greedy));
   check_rejected "optional_or greedy body before tail rejected"
-    (Field.optional_or "body" ~present:Expr.true_ ~default:(0, "")
+    (Field.optional_or "body" ~present:Expr.true_ ~default:(UInt8.zero, "")
        (codec greedy));
   Alcotest.(check bool)
     "statically absent optional greedy body before tail accepted" false
@@ -2107,7 +2134,7 @@ let test_casetype_reject_unprojectable_tag () =
   Alcotest.(check bool)
     "little-endian enum tag accepted" false
     (raises_invalid (fun () ->
-         one_case ~index:1 (enum "TagLe" [ ("A", 0); ("B", 1) ] uint8)))
+         one_case ~index:(UInt8.v 1) (enum "TagLe" [ ("A", 0); ("B", 1) ] uint8)))
 
 (* -- Codec bitfield tests -- *)
 
@@ -2369,14 +2396,14 @@ let exact_vs_codec =
 let test_exact_byte_field_expression_size () =
   let buf = Bytes.create 16 in
   expect_exact_byte_error "byte_array long" ~expected:4 ~actual:6 (fun () ->
-      Codec.encode exact_vb_codec (4, "abcdef") buf 0);
+      Codec.encode exact_vb_codec (UInt8.v 4, "abcdef") buf 0);
   expect_exact_byte_error "byte_array short" ~expected:4 ~actual:2 (fun () ->
-      Codec.encode exact_vb_codec (4, "ab") buf 0);
+      Codec.encode exact_vb_codec (UInt8.v 4, "ab") buf 0);
   expect_exact_byte_error "byte_slice long" ~expected:4 ~actual:6 (fun () ->
-      Codec.encode exact_vs_codec (4, slice_of_string "abcdef") buf 0);
+      Codec.encode exact_vs_codec (UInt8.v 4, slice_of_string "abcdef") buf 0);
   expect_exact_byte_error "byte_slice short" ~expected:4 ~actual:2 (fun () ->
-      Codec.encode exact_vs_codec (4, slice_of_string "ab") buf 0);
-  Codec.encode exact_vb_codec (4, "abcd") buf 0;
+      Codec.encode exact_vs_codec (UInt8.v 4, slice_of_string "ab") buf 0);
+  Codec.encode exact_vb_codec (UInt8.v 4, "abcd") buf 0;
   Alcotest.(check string) "exact string" "\x04abcd" (Bytes.sub_string buf 0 5)
 
 (* Encode must not emit a value its own decoder rejects: a refinement the
@@ -2412,13 +2439,13 @@ let open_enum_codec =
 let test_encode_rejects_unlisted_enum () =
   let buf = Bytes.create 1 in
   expect_encode_rejects "closed enum" ~names:[ "Code"; "got 99" ] (fun () ->
-      Codec.encode closed_enum_codec 99 buf 0);
+      Codec.encode closed_enum_codec (UInt8.v 99) buf 0);
   expect_decode_rejects "closed enum" closed_enum_codec "\099";
-  Codec.encode closed_enum_codec 2 buf 0;
+  Codec.encode closed_enum_codec (UInt8.v 2) buf 0;
   Alcotest.(check string) "listed value" "\002" (Bytes.to_string buf);
   (* An open enum documents its codes without restricting them, so encode
      stays permissive exactly where decode does. *)
-  Codec.encode open_enum_codec 99 buf 0;
+  Codec.encode open_enum_codec (UInt8.v 99) buf 0;
   Alcotest.(check string) "open enum" "\099" (Bytes.to_string buf)
 
 (* The compiled codec reaches an enum / lookup / variants / bit field through
@@ -2535,9 +2562,9 @@ let zeros_codec =
 let test_encode_rejects_non_zero_padding () =
   let buf = Bytes.create 4 in
   expect_encode_rejects "all_zeros" ~names:[ "all_zeros"; "0x61" ] (fun () ->
-      Codec.encode zeros_codec (1, "abc") buf 0);
+      Codec.encode zeros_codec (UInt8.v 1, "abc") buf 0);
   expect_decode_rejects "all_zeros" zeros_codec "\001abc";
-  Codec.encode zeros_codec (1, "\000\000\000") buf 0;
+  Codec.encode zeros_codec (UInt8.v 1, "\000\000\000") buf 0;
   Alcotest.(check string)
     "zero padding" "\001\000\000\000" (Bytes.to_string buf)
 
@@ -2676,15 +2703,15 @@ let codec_where_codec =
 let test_encode_rejects_where_violation () =
   let buf = Bytes.create 2 in
   expect_encode_rejects "typ where" ~names:[ "TypWhereEncode"; "constraint" ]
-    (fun () -> Codec.encode where_codec (6, 0) buf 0);
+    (fun () -> Codec.encode where_codec (UInt8.v 6, UInt8.v 0) buf 0);
   expect_decode_rejects "typ where" where_codec "\006\000";
-  Codec.encode where_codec (1, 0) buf 0;
+  Codec.encode where_codec (UInt8.v 1, UInt8.v 0) buf 0;
   Alcotest.(check string) "satisfied cond" "\001\000" (Bytes.to_string buf);
   expect_encode_rejects "codec where"
     ~names:[ "CodecWhereEncode"; "constraint" ] (fun () ->
-      Codec.encode codec_where_codec (6, 0) buf 0);
+      Codec.encode codec_where_codec (UInt8.v 6, UInt8.v 0) buf 0);
   expect_decode_rejects "codec where" codec_where_codec "\006\000";
-  Codec.encode codec_where_codec (1, 0) buf 0;
+  Codec.encode codec_where_codec (UInt8.v 1, UInt8.v 0) buf 0;
   Alcotest.(check string)
     "satisfied codec where" "\001\000" (Bytes.to_string buf)
 
@@ -3039,63 +3066,10 @@ let test_map_inherits_exact_width () =
       set buf 0 0xFF;
       Bytes.to_string buf)
 
-(* The fixed-width scalars are the same rule at a fixed width. [uint8] is the
-   one still carried in a plain [int], which holds far more than the byte does,
-   so nothing but a runtime check stands between a caller's 0x1FF and an 0xFF on
-   the wire that reads back as a perfectly legal 255. Every wider scalar puts
-   that range in its carrier instead, so this sweep has no out-of-range value to
-   hand it; [test_uint32_of_int_range], [test_sint32_of_int_range] and the
-   [sint8], [sint16] and [uint16] suites pin those refusals, one step earlier
-   than an encoder can reach. *)
-let scalar_range_codec name typ =
-  let cf = Codec.(Field.v "v" typ $ Fun.id) in
-  (Codec.v name Fun.id Codec.[ cf ], cf)
-
-(* Sweep one scalar typ. Every [outside] value must be refused by all three
-   entry points and leave the buffer untouched; every [inside] one must write
-   the same bytes through both encoders and read back through [Codec.get]. *)
-let check_scalar_range ~name ~typ ~sub ~equal ~pp ~inside ~outside =
-  let codec, cf = scalar_range_codec name typ in
-  let size = Codec.wire_size codec in
-  let set = Staged.unstage (Codec.set codec cf) in
-  let get = Staged.unstage (Codec.get codec cf) in
-  List.iter
-    (fun v ->
-      let label = Fmt.str "%s <- %a" name pp v in
-      expect_exact_width_error (label ^ " to_string") ~sub (fun () ->
-          Wire.to_string typ v);
-      expect_exact_width_error (label ^ " Codec.encode") ~sub (fun () ->
-          let buf = Bytes.make size '\x00' in
-          Codec.encode codec v buf 0;
-          Bytes.to_string buf);
-      let buf = Bytes.make size '\x00' in
-      expect_exact_width_error (label ^ " Codec.set") ~sub (fun () ->
-          set buf 0 v;
-          Bytes.to_string buf);
-      Alcotest.(check string)
-        (label ^ ": rejected set left the buffer alone")
-        (String.make size '\x00') (Bytes.to_string buf))
-    outside;
-  List.iter
-    (fun v ->
-      let label = Fmt.str "%s <- %a" name pp v in
-      let buf = Bytes.make size '\x00' in
-      Codec.encode codec v buf 0;
-      Alcotest.(check string)
-        (label ^ ": widest legal value agrees across entry points")
-        (Wire.to_string typ v) (Bytes.to_string buf);
-      Bytes.fill buf 0 size '\x00';
-      set buf 0 v;
-      Alcotest.(check bool)
-        (label ^ ": widest legal value reads back")
-        true
-        (equal (get buf 0) v))
-    inside
-
-let test_encode_exact_unsigned_scalar () =
-  check_scalar_range ~name:"uint8" ~typ:uint8
-    ~sub:"does not fit an unsigned 8-bit field" ~equal:Int.equal ~pp:Fmt.int
-    ~inside:[ 0; 0xFF ] ~outside:[ 0x100; -1 ]
+(* Every fixed-width scalar puts that range in its carrier instead, so there is
+   no out-of-range value left to hand an encoder: [test_uint32_of_int_range],
+   [test_sint32_of_int_range] and the [sint8], [sint16], [uint8] and [uint16]
+   suites pin those refusals, one step earlier than an encoder can reach. *)
 
 (* The signed 32-bit range is enforced where the value is built rather than
    where it is written, so a number the field cannot hold never becomes an
@@ -3211,24 +3185,6 @@ let test_four_byte_signed_preserves_wire () =
         [ String.make 4 '\xff'; "\x80\x00\x00\x00"; "\x7f\xff\xff\xff" ])
     [ ("int32", int32); ("int32be", int32be) ]
 
-(* [array] and [repeat] elements are written by an encoder of their own, so a
-   value no element can hold has to be refused on that path too. *)
-let test_element_exact_width () =
-  let acf = Codec.(Field.v "vs" (array ~len:(int 3) uint8) $ Fun.id) in
-  let acodec = Codec.v "ArrayU8" Fun.id Codec.[ acf ] in
-  expect_exact_width_error "array(3,uint8) <- [0; 0x1FF; 0]"
-    ~sub:"does not fit an unsigned 8-bit field" (fun () ->
-      let buf = Bytes.make 3 '\x00' in
-      Codec.encode acodec [ 0; 0x1FF; 0 ] buf 0;
-      Bytes.to_string buf);
-  let rcf = Codec.(Field.repeat "vs" ~size:(int 3) uint8 $ Fun.id) in
-  let rcodec = Codec.v "RepeatU8" Fun.id Codec.[ rcf ] in
-  expect_exact_width_error "repeat(3,uint8) <- [0; 0x1FF; 0]"
-    ~sub:"does not fit an unsigned 8-bit field" (fun () ->
-      let buf = Bytes.make 3 '\x00' in
-      Codec.encode rcodec [ 0; 0x1FF; 0 ] buf 0;
-      Bytes.to_string buf)
-
 (* The other end of the rule: an [int64] is exactly the eight bytes written, so
    no value of it is out of range and none may be refused. A guard here would be
    dead code that only ever rejected a legal frame. *)
@@ -3325,7 +3281,7 @@ let test_packed_bf_size () =
 
 type packed_bool_header = {
   magic : string;
-  version : int;
+  version : UInt8.t;
   reserved : int;
   flag : bool;
 }
@@ -3342,7 +3298,9 @@ let packed_bool_header_codec =
       ]
 
 let test_packed_mapped_bf_size () =
-  let value = { magic = "dtn!"; version = 4; reserved = 0; flag = true } in
+  let value =
+    { magic = "dtn!"; version = UInt8.v 4; reserved = 0; flag = true }
+  in
   Alcotest.(check int)
     "wire_size counts packed bool bitfield once" 6
     (Codec.wire_size packed_bool_header_codec);
@@ -3653,11 +3611,17 @@ let test_view_shared_set_independent () =
 
 let test_action_fires_decode_env () =
   (* decode_env fires actions and syncs output params *)
-  let env = Codec.env projection_codec |> Param.bind projection_limit 10 in
+  let env =
+    Codec.env projection_codec |> Param.bind projection_limit (UInt8.v 10)
+  in
   let buf = Bytes.of_string "\x05" in
-  Alcotest.(check int) "outx before" 0 (Param.get env projection_outx);
+  Alcotest.(check int)
+    "outx before" 0
+    (UInt8.to_int (Param.get env projection_outx));
   let _v = decode_ok (Codec.decode ~env projection_codec buf 0) in
-  Alcotest.(check int) "outx after decode_env" 5 (Param.get env projection_outx)
+  Alcotest.(check int)
+    "outx after decode_env" 5
+    (UInt8.to_int (Param.get env projection_outx))
 
 let test_action_fires_on_get () =
   (* get fires field actions. A return_bool action that rejects odd values
@@ -3675,7 +3639,9 @@ let test_action_fires_on_get () =
   let codec = Codec.v "ActionGet" (fun v -> v) [ cf_v ] in
   let get_v = Staged.unstage (Codec.get codec cf_v) in
   (* Even value: action passes *)
-  Alcotest.(check int) "get even" 0x42 (get_v (Bytes.of_string "\x42") 0);
+  Alcotest.(check int)
+    "get even" 0x42
+    (UInt8.to_int (get_v (Bytes.of_string "\x42") 0));
   (* Odd value: action rejects *)
   match get_v (Bytes.of_string "\x43") 0 with
   | _ -> Alcotest.fail "expected action to reject odd value"
@@ -3700,7 +3666,7 @@ let test_action_unfired_by_validate () =
   (* validate does NOT fire actions *)
   Alcotest.(check int)
     "action not fired by validate" 0
-    (Param.get env action_out2)
+    (UInt8.to_int (Param.get env action_out2))
 
 let test_get_noaction_zero_overhead () =
   (* get on a field without an action should not allocate.
@@ -3709,7 +3675,7 @@ let test_get_noaction_zero_overhead () =
   let codec = Codec.v "NoAction" (fun v -> v) [ cf_v ] in
   let buf = Bytes.of_string "\x42" in
   let get_v = Staged.unstage (Codec.get codec cf_v) in
-  Alcotest.(check int) "get returns value" 0x42 (get_v buf 0)
+  Alcotest.(check int) "get returns value" 0x42 (UInt8.to_int (get_v buf 0))
 
 let test_get_with_env () =
   (* get ~env fires action and syncs output params to env *)
@@ -3727,8 +3693,10 @@ let test_get_with_env () =
   let buf = Bytes.of_string "\x42" in
   let get_v = Staged.unstage (Codec.get ~env codec cf_v) in
   let v = get_v buf 0 in
-  Alcotest.(check int) "get returns value" 0x42 v;
-  Alcotest.(check int) "output param synced" 0x42 (Param.get env out)
+  Alcotest.(check int) "get returns value" 0x42 (UInt8.to_int v);
+  Alcotest.(check int)
+    "output param synced" 0x42
+    (UInt8.to_int (Param.get env out))
 
 let test_get_action_field_twocodecs () =
   (* Same action field in two codecs -- each codec gets its own action runner *)
@@ -3754,7 +3722,9 @@ let test_get_action_field_twocodecs () =
   in
   let codec2 =
     let open Codec in
-    v "ActTwo2" (fun _pad v -> v) [ (Field.v "pad" uint8 $ fun _ -> 0); cf_v2 ]
+    v "ActTwo2"
+      (fun _pad v -> v)
+      [ (Field.v "pad" uint8 $ fun _ -> UInt8.v 0); cf_v2 ]
   in
   let env1 = Codec.env codec1 in
   let env2 = Codec.env codec2 in
@@ -3762,10 +3732,10 @@ let test_get_action_field_twocodecs () =
   let get1 = Staged.unstage (Codec.get ~env:env1 codec1 cf_v) in
   let get2 = Staged.unstage (Codec.get ~env:env2 codec2 cf_v2) in
   (* codec1 reads offset 0 = 0xAA *)
-  Alcotest.(check int) "codec1 get" 0xAA (get1 buf 0);
-  Alcotest.(check int) "codec1 out" 0xAA (Param.get env1 out1);
+  Alcotest.(check int) "codec1 get" 0xAA (UInt8.to_int (get1 buf 0));
+  Alcotest.(check int) "codec1 out" 0xAA (UInt8.to_int (Param.get env1 out1));
   (* codec2 reads offset 1 = 0xBB *)
-  Alcotest.(check int) "codec2 get" 0xBB (get2 buf 0);
+  Alcotest.(check int) "codec2 get" 0xBB (UInt8.to_int (get2 buf 0));
   Alcotest.(check int) "codec2 out" 0xBB (UInt16.to_int (Param.get env2 out2))
 
 let test_get_action_no_env () =
@@ -3784,8 +3754,10 @@ let test_get_action_no_env () =
   let buf = Bytes.of_string "\x42" in
   (* No ~env: action fires (no crash) but output stays 0 *)
   let get_v = Staged.unstage (Codec.get codec cf_v) in
-  Alcotest.(check int) "get returns value" 0x42 (get_v buf 0);
-  Alcotest.(check int) "output not synced without env" 0 (Param.get env out)
+  Alcotest.(check int) "get returns value" 0x42 (UInt8.to_int (get_v buf 0));
+  Alcotest.(check int)
+    "output not synced without env" 0
+    (UInt8.to_int (Param.get env out))
 
 let test_get_action_abort_field () =
   (* get on a field with abort action always raises *)
@@ -3808,7 +3780,7 @@ let test_get_noaction_ignores_env () =
   let get_v = Staged.unstage (Codec.get ~env codec cf_v) in
   Alcotest.(check int)
     "get returns value" 0x42
-    (get_v (Bytes.of_string "\x42") 0)
+    (UInt8.to_int (get_v (Bytes.of_string "\x42") 0))
 
 let test_get_action_multiple_calls () =
   (* get with ~env updates output on every call *)
@@ -3825,9 +3797,9 @@ let test_get_action_multiple_calls () =
   let env = Codec.env codec in
   let get_v = Staged.unstage (Codec.get ~env codec cf_v) in
   ignore (get_v (Bytes.of_string "\x10") 0);
-  Alcotest.(check int) "after first" 0x10 (Param.get env out);
+  Alcotest.(check int) "after first" 0x10 (UInt8.to_int (Param.get env out));
   ignore (get_v (Bytes.of_string "\x20") 0);
-  Alcotest.(check int) "after second" 0x20 (Param.get env out)
+  Alcotest.(check int) "after second" 0x20 (UInt8.to_int (Param.get env out))
 
 let test_get_action_with_inputparam () =
   (* Action references an input param -- get ~env must blit it into the
@@ -3848,13 +3820,15 @@ let test_get_action_with_inputparam () =
       $ fun v -> v)
   in
   let codec = Codec.v "InputParam" (fun v -> v) [ cf_v ] in
-  let env = Codec.env codec |> Param.bind limit 50 in
+  let env = Codec.env codec |> Param.bind limit (UInt8.v 50) in
   let buf_ok = Bytes.of_string "\x30" in
   let buf_bad = Bytes.of_string "\x40" in
   let get_v = Staged.unstage (Codec.get ~env codec cf_v) in
   (* 0x30 = 48 <= 50: passes *)
-  Alcotest.(check int) "get with input param" 0x30 (get_v buf_ok 0);
-  Alcotest.(check int) "output synced" 0x30 (Param.get env out);
+  Alcotest.(check int)
+    "get with input param" 0x30
+    (UInt8.to_int (get_v buf_ok 0));
+  Alcotest.(check int) "output synced" 0x30 (UInt8.to_int (Param.get env out));
   (* 0x40 = 64 > 50: action rejects *)
   match get_v buf_bad 0 with
   | _ -> Alcotest.fail "expected rejection from input param check"
@@ -3877,7 +3851,9 @@ let test_get_action_inputparam_noenv () =
   (* No env: limit defaults to 0, so any positive value > 0 fails *)
   let get_v = Staged.unstage (Codec.get codec cf_v) in
   (* 0 <= 0: passes *)
-  Alcotest.(check int) "zero passes" 0 (get_v (Bytes.of_string "\x00") 0);
+  Alcotest.(check int)
+    "zero passes" 0
+    (UInt8.to_int (get_v (Bytes.of_string "\x00") 0));
   (* 1 > 0: fails *)
   match get_v (Bytes.of_string "\x01") 0 with
   | _ -> Alcotest.fail "expected rejection without env"
@@ -3898,7 +3874,7 @@ let test_embed_param_sized () =
   let outer =
     Codec.v "EmbOuter" (fun s -> s) Codec.[ Field.v "s" (codec sub) $ Fun.id ]
   in
-  let env = Codec.env outer |> Param.bind elen 3 in
+  let env = Codec.env outer |> Param.bind elen (UInt8.v 3) in
   let n = Codec.size_of_value outer "abc" in
   Alcotest.(check int) "wire size" 3 n;
   let buf = Bytes.create n in
@@ -3922,11 +3898,11 @@ let test_get_embed_param_fixed () =
   let f_sub = Field.v "sub" (codec sub) in
   let cf_sub = Codec.(f_sub $ Fun.id) in
   let outer = Codec.v "GetEmbedOuter" Fun.id Codec.[ cf_sub ] in
-  let env = Codec.env outer |> Param.bind limit 10 in
+  let env = Codec.env outer |> Param.bind limit (UInt8.v 10) in
   let get_sub = Staged.unstage (Codec.get ~env outer cf_sub) in
   Alcotest.(check int)
     "embedded validation sees env" 5
-    (get_sub (Bytes.of_string "\x05") 0)
+    (UInt8.to_int (get_sub (Bytes.of_string "\x05") 0))
 
 (* The outer codec inherits the embedded sub-codec's input param, so encoding it
    without an env is rejected. *)
@@ -3964,7 +3940,7 @@ let test_embed_where_enforced () =
     | _ -> true);
   Alcotest.(check int)
     "satisfying value accepted" 5
-    (decode_ok (Codec.decode outer (Bytes.make 1 '\x05') 0))
+    (UInt8.to_int (decode_ok (Codec.decode outer (Bytes.make 1 '\x05') 0)))
 
 let test_embed_output_param () =
   let out = Param.output "embedded_out" uint8 in
@@ -3984,8 +3960,9 @@ let test_embed_output_param () =
   let env = Codec.env outer in
   Alcotest.(check int)
     "decoded value" 42
-    (decode_ok (Codec.decode ~env outer (Bytes.of_string "\x2A") 0));
-  Alcotest.(check int) "forwarded output" 42 (Param.get env out)
+    (UInt8.to_int
+       (decode_ok (Codec.decode ~env outer (Bytes.of_string "\x2A") 0)));
+  Alcotest.(check int) "forwarded output" 42 (UInt8.to_int (Param.get env out))
 
 (* A list of param-constrained sub-records within a byte budget, the param
    forwarded through the repeat (the shape that first exposed the gap). *)
@@ -4003,14 +3980,16 @@ let test_embed_param_repeat () =
   let outer =
     Codec.v "RepOuter" (fun n xs -> (n, xs)) Codec.[ f_n $ fst; f_items $ snd ]
   in
-  let v = (3, [ 1; 5; 9 ]) in
-  let env = Codec.env outer |> Param.bind rlim 100 in
+  let v = (UInt8.v 3, List.map UInt8.v [ 1; 5; 9 ]) in
+  let env = Codec.env outer |> Param.bind rlim (UInt8.v 100) in
   let n = Codec.size_of_value outer v in
   let buf = Bytes.create n in
   Codec.encode ~env outer v buf 0;
+  let dn, dxs = decode_ok (Codec.decode ~env outer buf 0) in
+  let vn, vxs = v in
   Alcotest.(check bool)
     "roundtrip" true
-    (decode_ok (Codec.decode ~env outer buf 0) = v)
+    (UInt8.equal dn vn && List.equal UInt8.equal dxs vxs)
 
 let test_get_action_output_only () =
   (* Action with only assign (no return_bool/abort) -- should never fail *)
@@ -4027,10 +4006,14 @@ let test_get_action_output_only () =
   let env = Codec.env codec in
   let get_v = Staged.unstage (Codec.get ~env codec cf_v) in
   (* Any value should work -- no validation in this action *)
-  Alcotest.(check int) "get 0xFF" 0xFF (get_v (Bytes.of_string "\xFF") 0);
-  Alcotest.(check int) "output 0xFF" 0xFF (Param.get env out);
-  Alcotest.(check int) "get 0x00" 0x00 (get_v (Bytes.of_string "\x00") 0);
-  Alcotest.(check int) "output 0x00" 0x00 (Param.get env out)
+  Alcotest.(check int)
+    "get 0xFF" 0xFF
+    (UInt8.to_int (get_v (Bytes.of_string "\xFF") 0));
+  Alcotest.(check int) "output 0xFF" 0xFF (UInt8.to_int (Param.get env out));
+  Alcotest.(check int)
+    "get 0x00" 0x00
+    (UInt8.to_int (get_v (Bytes.of_string "\x00") 0));
+  Alcotest.(check int) "output 0x00" 0x00 (UInt8.to_int (Param.get env out))
 
 let test_get_action_varthen_assign () =
   (* Action with local var computation then assign to output *)
@@ -4051,8 +4034,10 @@ let test_get_action_varthen_assign () =
   let codec = Codec.v "VarAssign" (fun v -> v) [ cf_v ] in
   let env = Codec.env codec in
   let get_v = Staged.unstage (Codec.get ~env codec cf_v) in
-  Alcotest.(check int) "get value" 21 (get_v (Bytes.of_string "\x15") 0);
-  Alcotest.(check int) "doubled output" 42 (Param.get env out)
+  Alcotest.(check int)
+    "get value" 21
+    (UInt8.to_int (get_v (Bytes.of_string "\x15") 0));
+  Alcotest.(check int) "doubled output" 42 (UInt8.to_int (Param.get env out))
 
 let test_get_action_crossfield_ref () =
   (* Action on field y references field x's value *)
@@ -4073,9 +4058,11 @@ let test_get_action_crossfield_ref () =
   let buf = Bytes.of_string "\x0A\x14" in
   let get_y = Staged.unstage (Codec.get ~env codec cf_y) in
   let y = get_y buf 0 in
-  Alcotest.(check int) "y value" 0x14 y;
+  Alcotest.(check int) "y value" 0x14 (UInt8.to_int y);
   (* Action computed x + 100 = 10 + 100 = 110 *)
-  Alcotest.(check int) "cross-field output" 110 (Param.get env out)
+  Alcotest.(check int)
+    "cross-field output" 110
+    (UInt8.to_int (Param.get env out))
 
 let test_validate_constraint_only () =
   (* Codec with constraint but no where clause *)
@@ -4128,8 +4115,8 @@ let test_get_twostaged_same_field () =
   (* Each staged getter has its own scratch array and env *)
   ignore (get1 (Bytes.of_string "\xAA") 0);
   ignore (get2 (Bytes.of_string "\xBB") 0);
-  Alcotest.(check int) "env1" 0xAA (Param.get env1 out);
-  Alcotest.(check int) "env2" 0xBB (Param.get env2 out)
+  Alcotest.(check int) "env1" 0xAA (UInt8.to_int (Param.get env1 out));
+  Alcotest.(check int) "env2" 0xBB (UInt8.to_int (Param.get env2 out))
 
 let test_encode_shared_bitfield () =
   (* Encode via a codec that shares a bitfield with another codec.
@@ -4165,15 +4152,15 @@ let test_encode_shared_bitfield () =
    [Invalid_argument] while the same ref in a where clause raised [Failure].
    Every reachable site gets a case, so one that regresses names itself. *)
 
-type misuse_v = A of int | B of int | Other of int
+type misuse_v = A of UInt8.t | B of UInt8.t | Other of int
 
 let misuse_casetype =
   casetype "MisuseCT" uint8
     [
-      case ~index:1 uint8
+      case ~index:(UInt8.v 1) uint8
         ~inject:(fun x -> A x)
         ~project:(function A x -> Some x | _ -> None);
-      case ~index:2 uint8
+      case ~index:(UInt8.v 2) uint8
         ~inject:(fun x -> B x)
         ~project:(function B x -> Some x | _ -> None);
     ]
@@ -4204,7 +4191,8 @@ let test_undecodable_description_is_invalid_argument () =
       ("to_string type_ref", fun () -> ignore (to_string (type_ref "T") 0));
       ( "to_string qualified_ref",
         fun () -> ignore (to_string (qualified_ref "M" "T") 0) );
-      ("to_string apply", fun () -> ignore (to_string (apply uint8 [ int 1 ]) 0));
+      ( "to_string apply",
+        fun () -> ignore (to_string (apply uint8 [ int 1 ]) (UInt8.v 0)) );
       ( "to_string struct_typ",
         fun () ->
           ignore
@@ -4278,8 +4266,8 @@ let test_size_of_value_refuses_unmatched_case () =
   Alcotest.(check (option string))
     "size_of_value refuses in encode's own words" encoded sized;
   (* The control: a value a case does project still sizes what encode writes. *)
-  let n = Codec.size_of_value misuse_casetype_codec (B 9) in
-  Codec.encode misuse_casetype_codec (B 9) buf 0;
+  let n = Codec.size_of_value misuse_casetype_codec (B (UInt8.v 9)) in
+  Codec.encode misuse_casetype_codec (B (UInt8.v 9)) buf 0;
   Alcotest.(check int) "a projected value sizes its tag and its body" 2 n;
   Alcotest.(check string)
     "and encode wrote exactly those bytes" "\002\009" (Bytes.sub_string buf 0 n)
@@ -4310,8 +4298,12 @@ let test_set_field_notin_codec () =
   | exception Invalid_argument _ -> ()
 
 let test_bitfield_on_non_bitfield () =
-  (* bitfield on a uint8 (non-bitfield) field *)
-  let cf_x = Codec.(Field.v "x" uint8 $ fun v -> v) in
+  (* [bitfield] takes an int-valued field; a whole byte mapped to [int] is one
+     that is still not a bitfield. *)
+  let cf_x =
+    Codec.(
+      Field.v "x" (map ~decode:UInt8.to_int ~encode:UInt8.v uint8) $ fun v -> v)
+  in
   let codec = Codec.v "NoBf" (fun v -> v) [ cf_x ] in
   match Codec.bitfield codec cf_x with
   | _ -> Alcotest.fail "expected error for non-bitfield"
@@ -4341,10 +4333,10 @@ let test_foreign_env_codec_operations () =
       Fun.id
       Codec.[ f_b $ Fun.id ]
   in
-  let env_b = Codec.env codec_b |> Param.bind p_b 0xff in
+  let env_b = Codec.env codec_b |> Param.bind p_b (UInt8.v 0xff) in
   let buf = Bytes.of_string "\x01" in
   expect_foreign_env ~op:"Codec.encode" ~codec:"EnvA" (fun () ->
-      Codec.encode ~env:env_b codec_a 1 buf 0);
+      Codec.encode ~env:env_b codec_a (UInt8.v 1) buf 0);
   expect_foreign_env ~op:"Codec.decode" ~codec:"EnvA" (fun () ->
       Codec.decode ~env:env_b codec_a buf 0);
   expect_foreign_env ~op:"Codec.validate" ~codec:"EnvA" (fun () ->
@@ -4360,9 +4352,9 @@ let test_foreign_env_codec_operations () =
       Fun.id
       Codec.[ f_c $ Fun.id ]
   in
-  let env_a = Codec.env codec_a |> Param.bind p_a 0xff in
+  let env_a = Codec.env codec_a |> Param.bind p_a (UInt8.v 0xff) in
   expect_foreign_env ~op:"Codec.encode" ~codec:"EnvC" (fun () ->
-      Codec.encode ~env:env_a codec_c 1 buf 0);
+      Codec.encode ~env:env_a codec_c (UInt8.v 1) buf 0);
   expect_foreign_env ~op:"Codec.decode" ~codec:"EnvC" (fun () ->
       Codec.decode ~env:env_a codec_c buf 0)
 
@@ -4468,21 +4460,25 @@ let test_samefield_twocodecs_set () =
   let cf_v = Codec.(f_v $ fun v -> v) in
   let codec1 =
     let open Codec in
-    v "SetTwo1" (fun v _pad -> v) [ cf_v; (Field.v "pad" uint8 $ fun _ -> 0) ]
+    v "SetTwo1"
+      (fun v _pad -> v)
+      [ cf_v; (Field.v "pad" uint8 $ fun _ -> UInt8.v 0) ]
   in
   let codec2 =
     let open Codec in
-    v "SetTwo2" (fun _pad v -> v) [ (Field.v "pad" uint8 $ fun _ -> 0); cf_v ]
+    v "SetTwo2"
+      (fun _pad v -> v)
+      [ (Field.v "pad" uint8 $ fun _ -> UInt8.v 0); cf_v ]
   in
   let buf = Bytes.make 2 '\x00' in
   (* set via codec1 should write to offset 0 *)
-  (Staged.unstage (Codec.set codec1 cf_v)) buf 0 0xAA;
+  (Staged.unstage (Codec.set codec1 cf_v)) buf 0 (UInt8.v 0xAA);
   Alcotest.(check int) "codec1 set -> byte 0" 0xAA (Bytes.get_uint8 buf 0);
   Alcotest.(check int)
     "codec1 set -> byte 1 untouched" 0 (Bytes.get_uint8 buf 1);
   Bytes.fill buf 0 2 '\x00';
   (* set via codec2 should write to offset 1 *)
-  (Staged.unstage (Codec.set codec2 cf_v)) buf 0 0xBB;
+  (Staged.unstage (Codec.set codec2 cf_v)) buf 0 (UInt8.v 0xBB);
   Alcotest.(check int)
     "codec2 set -> byte 0 untouched" 0 (Bytes.get_uint8 buf 0);
   Alcotest.(check int) "codec2 set -> byte 1" 0xBB (Bytes.get_uint8 buf 1)
@@ -4519,14 +4515,18 @@ let test_samefield_twocodecs_encode () =
   let cf_v = Codec.(f_v $ fun v -> v) in
   let codec1 =
     let open Codec in
-    v "EncTwo1" (fun v _pad -> v) [ cf_v; (Field.v "pad" uint8 $ fun _ -> 0) ]
+    v "EncTwo1"
+      (fun v _pad -> v)
+      [ cf_v; (Field.v "pad" uint8 $ fun _ -> UInt8.v 0) ]
   in
   let _codec2 =
     let open Codec in
-    v "EncTwo2" (fun _pad v -> v) [ (Field.v "pad" uint8 $ fun _ -> 0); cf_v ]
+    v "EncTwo2"
+      (fun _pad v -> v)
+      [ (Field.v "pad" uint8 $ fun _ -> UInt8.v 0); cf_v ]
   in
   let buf = Bytes.make 2 '\x00' in
-  Codec.encode codec1 0xAA buf 0;
+  Codec.encode codec1 (UInt8.v 0xAA) buf 0;
   (* codec1 should write v at offset 0 *)
   Alcotest.(check int) "byte 0" 0xAA (Bytes.get_uint8 buf 0);
   Alcotest.(check int) "byte 1" 0x00 (Bytes.get_uint8 buf 1)
@@ -4569,7 +4569,9 @@ let test_samefield_staged_before_secondseal () =
   let cf_x = Codec.(f_x $ fun x -> x) in
   let codec1 =
     let open Codec in
-    v "StagedTwo1" (fun x _y -> x) [ cf_x; (Field.v "y" uint8 $ fun _ -> 0) ]
+    v "StagedTwo1"
+      (fun x _y -> x)
+      [ cf_x; (Field.v "y" uint8 $ fun _ -> UInt8.v 0) ]
   in
   (* Stage get from codec1 *)
   let get_x_1 = Staged.unstage (Codec.get codec1 cf_x) in
@@ -4578,13 +4580,15 @@ let test_samefield_staged_before_secondseal () =
     let open Codec in
     v "StagedTwo2"
       (fun _pad x -> x)
-      [ (Field.v "pad" uint8 $ fun _ -> 0); cf_x ]
+      [ (Field.v "pad" uint8 $ fun _ -> UInt8.v 0); cf_x ]
   in
   let buf = Bytes.create 2 in
   Bytes.set_uint8 buf 0 0xAA;
   Bytes.set_uint8 buf 1 0xBB;
   (* get_x_1 was staged before codec2 -- should still read offset 0 *)
-  Alcotest.(check int) "staged before second seal" 0xAA (get_x_1 buf 0)
+  Alcotest.(check int)
+    "staged before second seal" 0xAA
+    (UInt8.to_int (get_x_1 buf 0))
 
 (* -- byte_slice tests -- *)
 
@@ -4635,7 +4639,7 @@ let test_view_byte_slice_decode () =
   Bytes.set_uint8 buf 2 0xBB;
   Bytes.set_uint8 buf 3 0xCC;
   let tag, payload = decode_ok (Codec.decode codec buf 0) in
-  Alcotest.(check int) "tag" 0xFF tag;
+  Alcotest.(check int) "tag" 0xFF (UInt8.to_int tag);
   Alcotest.(check int) "payload first" 1 (Bs.first payload);
   Alcotest.(check int) "payload length" 3 (Bs.length payload);
   Alcotest.(check int)
@@ -4683,7 +4687,7 @@ let test_raw_get_uint () =
     (UInt16.to_int ((Staged.unstage (Codec.get codec cf_a)) buf 0));
   Alcotest.(check int)
     "get b" 0xFF
-    ((Staged.unstage (Codec.get codec cf_b)) buf 0)
+    (UInt8.to_int ((Staged.unstage (Codec.get codec cf_b)) buf 0))
 
 let test_raw_get_bitfield () =
   (* Default [bit_order = Msb_first]: [hi] (first declared) is the top nibble,
@@ -4711,7 +4715,7 @@ let test_raw_set_uint () =
   let buf = Bytes.create 3 in
   Bytes.fill buf 0 3 '\x00';
   (Staged.unstage (Codec.set codec cf_a)) buf 0 (UInt16.v 0xABCD);
-  (Staged.unstage (Codec.set codec cf_b)) buf 0 0x42;
+  (Staged.unstage (Codec.set codec cf_b)) buf 0 (UInt8.v 0x42);
   Alcotest.(check int) "set a" 0xABCD (Bytes.get_uint16_be buf 0);
   Alcotest.(check int) "set b" 0x42 (Bytes.get_uint8 buf 2)
 
@@ -4785,7 +4789,7 @@ let test_raw_sub_three_layers () =
   in
   Alcotest.(check int) "inner offset" 3 inner_off;
   let x = (Staged.unstage (Codec.get inner cf_x)) buf inner_off in
-  Alcotest.(check int) "3-layer get" 0xCC x
+  Alcotest.(check int) "3-layer get" 0xCC (UInt8.to_int x)
 
 let test_raw_with_offset () =
   (* get / set work correctly with non-zero base offset *)
@@ -5107,7 +5111,7 @@ let test_dep_codec_ref () =
     Bytes.set_uint8 buf (1 + i) (0x10 + i)
   done;
   let len, data = decode_ok (Codec.decode codec buf 0) in
-  Alcotest.(check int) "ref len" 5 len;
+  Alcotest.(check int) "ref len" 5 (UInt8.to_int len);
   Alcotest.(check int) "ref data length" 5 (Bs.length data);
   Alcotest.(check int)
     "ref data[0]" 0x10
@@ -5275,28 +5279,32 @@ let test_struct_of_dep_trailer () =
 
 (* -- sizeof_this / field_pos in codec -- *)
 
-type pos_record = { pa : int; pb : int; pc : int }
+type pos_record = { pa : UInt8.t; pb : UInt8.t; pc : UInt8.t }
+
+(* [sizeof_this] is only worth checking past a field wider than a byte, so this
+   one carries a two-byte middle field of its own. *)
+type wide_pos_record = { wa : UInt8.t; wb : UInt16.t; wc : UInt8.t }
 
 let test_codec_sizeof_this () =
   let out = Param.output "out" uint8 in
   let codec =
     let open Codec in
     v "SizeofThisCodec"
-      (fun a b c -> { pa = a; pb = UInt16.to_int b; pc = c })
+      (fun wa wb wc -> { wa; wb; wc })
       [
-        (Field.v "a" uint8 $ fun r -> r.pa);
-        (Field.v "b" uint16be $ fun r -> UInt16.v r.pb);
+        (Field.v "a" uint8 $ fun r -> r.wa);
+        (Field.v "b" uint16be $ fun r -> r.wb);
         ( Field.v "c"
             ~action:(Action.on_success [ Action.assign out sizeof_this ])
             uint8
-        $ fun r -> r.pc );
+        $ fun r -> r.wc );
       ]
   in
   let env = Codec.env codec in
   let buf = Bytes.of_string "\x01\x00\x02\x03" in
   let _v = decode_ok (Codec.decode ~env codec buf 0) in
   (* sizeof_this at field c = 1 (uint8) + 2 (uint16be) = 3 *)
-  Alcotest.(check int) "sizeof_this at c" 3 (Param.get env out)
+  Alcotest.(check int) "sizeof_this at c" 3 (UInt8.to_int (Param.get env out))
 
 let test_codec_field_pos () =
   let out = Param.output "out" uint8 in
@@ -5317,7 +5325,7 @@ let test_codec_field_pos () =
   let buf = Bytes.of_string "\x01\x02\x03" in
   let _v = decode_ok (Codec.decode ~env codec buf 0) in
   (* field_pos at c = 2 (third field, zero-indexed) *)
-  Alcotest.(check int) "field_pos at c" 2 (Param.get env out)
+  Alcotest.(check int) "field_pos at c" 2 (UInt8.to_int (Param.get env out))
 
 (* -- Bitfield batch access -- *)
 
@@ -5350,7 +5358,7 @@ let test_bitfield_extract () =
   Alcotest.(check int) "lo" 0x7 lo
 
 let test_bitfield_non_bf_raises () =
-  let f_x = Field.v "x" uint8 in
+  let f_x = Field.v "x" (map ~decode:UInt8.to_int ~encode:UInt8.v uint8) in
   let cf_x = Codec.(f_x $ fun x -> x) in
   let codec = Codec.v "NonBf" (fun x -> x) Codec.[ cf_x ] in
   match Codec.bitfield codec cf_x with
@@ -5407,17 +5415,17 @@ let test_codec_embed_decode () =
   Bytes.set_uint16_be buf 2 0x1234;
   Bytes.set_uint8 buf 4 0xBB;
   let r = decode_ok (Codec.decode outer_codec buf 0) in
-  Alcotest.(check int) "header" 0xAA r.header;
-  Alcotest.(check int) "inner.tag" 0x42 r.inner.tag;
+  Alcotest.(check int) "header" 0xAA (UInt8.to_int r.header);
+  Alcotest.(check int) "inner.tag" 0x42 (UInt8.to_int r.inner.tag);
   Alcotest.(check int) "inner.value" 0x1234 (UInt16.to_int r.inner.value);
-  Alcotest.(check int) "trailer" 0xBB r.trailer
+  Alcotest.(check int) "trailer" 0xBB (UInt8.to_int r.trailer)
 
 let test_codec_embed_encode () =
   let v =
     {
-      header = 0xAA;
-      inner = { tag = 0x42; value = UInt16.v 0x1234 };
-      trailer = 0xBB;
+      header = UInt8.v 0xAA;
+      inner = { tag = UInt8.v 0x42; value = UInt16.v 0x1234 };
+      trailer = UInt8.v 0xBB;
     }
   in
   let buf = Bytes.create 5 in
@@ -5430,21 +5438,30 @@ let test_codec_embed_encode () =
 let test_codec_embed_roundtrip () =
   let original =
     {
-      header = 0x11;
-      inner = { tag = 0x22; value = UInt16.v 0x3344 };
-      trailer = 0x55;
+      header = UInt8.v 0x11;
+      inner = { tag = UInt8.v 0x22; value = UInt16.v 0x3344 };
+      trailer = UInt8.v 0x55;
     }
   in
   let buf = Bytes.create 5 in
   Codec.encode outer_codec original buf 0;
   let decoded = decode_ok (Codec.decode outer_codec buf 0) in
-  Alcotest.(check int) "header" original.header decoded.header;
-  Alcotest.(check int) "inner.tag" original.inner.tag decoded.inner.tag;
+  Alcotest.(check int)
+    "header"
+    (UInt8.to_int original.header)
+    (UInt8.to_int decoded.header);
+  Alcotest.(check int)
+    "inner.tag"
+    (UInt8.to_int original.inner.tag)
+    (UInt8.to_int decoded.inner.tag);
   Alcotest.(check int)
     "inner.value"
     (UInt16.to_int original.inner.value)
     (UInt16.to_int decoded.inner.value);
-  Alcotest.(check int) "trailer" original.trailer decoded.trailer
+  Alcotest.(check int)
+    "trailer"
+    (UInt8.to_int original.trailer)
+    (UInt8.to_int decoded.trailer)
 
 let test_codec_embed_wire_size () =
   Alcotest.(check int) "wire_size" 5 (Codec.wire_size outer_codec);
@@ -5463,7 +5480,7 @@ let bf_inner_codec =
         (Field.v "Flags" (bits ~width:4 U8) $ fun r -> r.flags);
       ]
 
-type bf_outer = { id : UInt16.t; bf : bf_inner; checksum : int }
+type bf_outer = { id : UInt16.t; bf : bf_inner; checksum : UInt8.t }
 
 let bf_outer_codec =
   Codec.v "BfOuter"
@@ -5486,7 +5503,7 @@ let test_codec_embed_bitfield () =
   Alcotest.(check int) "id" 0x1234 (UInt16.to_int r.id);
   Alcotest.(check int) "version" 0xA r.bf.version;
   Alcotest.(check int) "flags" 0x5 r.bf.flags;
-  Alcotest.(check int) "checksum" 0xFF r.checksum
+  Alcotest.(check int) "checksum" 0xFF (UInt8.to_int r.checksum)
 
 (* Two levels of nesting --
    [l0] / [l1] / [l2] and their codecs live in {!Test_helpers}. *)
@@ -5498,30 +5515,36 @@ let test_codec_embed_nested () =
   Bytes.set_uint16_be buf 1 0xABCD;
   Bytes.set_uint8 buf 3 0xFF;
   let r = decode_ok (Codec.decode l0_codec buf 0) in
-  Alcotest.(check int) "l2.x" 0x42 r.inner.inner.x;
+  Alcotest.(check int) "l2.x" 0x42 (UInt8.to_int r.inner.inner.x);
   Alcotest.(check int) "l1.y" 0xABCD (UInt16.to_int r.inner.y);
-  Alcotest.(check int) "l0.z" 0xFF r.z
+  Alcotest.(check int) "l0.z" 0xFF (UInt8.to_int r.z)
 
 let test_codec_embed_nested_roundtrip () =
   let original : l0 =
-    { inner = { inner = { x = 0x42 }; y = UInt16.v 0xABCD }; z = 0xFF }
+    {
+      inner = { inner = { x = UInt8.v 0x42 }; y = UInt16.v 0xABCD };
+      z = UInt8.v 0xFF;
+    }
   in
   let buf = Bytes.create 4 in
   Codec.encode l0_codec original buf 0;
   let decoded = decode_ok (Codec.decode l0_codec buf 0) in
-  Alcotest.(check int) "l2.x" original.inner.inner.x decoded.inner.inner.x;
+  Alcotest.(check int)
+    "l2.x"
+    (UInt8.to_int original.inner.inner.x)
+    (UInt8.to_int decoded.inner.inner.x);
   Alcotest.(check int)
     "l1.y"
     (UInt16.to_int original.inner.y)
     (UInt16.to_int decoded.inner.y);
-  Alcotest.(check int) "l0.z" original.z decoded.z
+  Alcotest.(check int) "l0.z" (UInt8.to_int original.z) (UInt8.to_int decoded.z)
 
 (* -- Cross-codec Field.ref: parent expression references sub-codec field -- *)
 
 (* TC/TM-style frame: header contains a length field, the data field's size
    is computed from that nested header field via Field.ref. *)
 
-type tc_header = { version : int; frame_len : int }
+type tc_header = { version : UInt8.t; frame_len : UInt8.t }
 
 let f_tc_version = Field.v "Version" uint8
 let f_tc_frame_len = Field.v "FrameLen" uint8
@@ -5535,7 +5558,7 @@ let tc_header_codec =
         (f_tc_frame_len $ fun r -> r.frame_len);
       ]
 
-type tc_frame = { hdr : tc_header; data : string; check : int }
+type tc_frame = { hdr : tc_header; data : string; check : UInt8.t }
 
 (* The data field's size is `Field.ref f_tc_frame_len - 2 - 1` (header is 2 bytes,
    trailer is 1 byte). The Field.ref must resolve into the embedded header codec. *)
@@ -5561,10 +5584,10 @@ let test_codec_cross_field_ref () =
   Bytes.blit_string "HELLO" 0 buf 2 5;
   Bytes.set_uint8 buf 7 0xCC;
   let r = decode_ok (Codec.decode tc_frame_codec buf 0) in
-  Alcotest.(check int) "version" 1 r.hdr.version;
-  Alcotest.(check int) "frame_len" 8 r.hdr.frame_len;
+  Alcotest.(check int) "version" 1 (UInt8.to_int r.hdr.version);
+  Alcotest.(check int) "frame_len" 8 (UInt8.to_int r.hdr.frame_len);
   Alcotest.(check string) "data" "HELLO" r.data;
-  Alcotest.(check int) "check" 0xCC r.check
+  Alcotest.(check int) "check" 0xCC (UInt8.to_int r.check)
 
 let test_codec_crossref_field_varying () =
   (* frame_len=5 -> data is 2 bytes *)
@@ -5574,9 +5597,9 @@ let test_codec_crossref_field_varying () =
   Bytes.blit_string "AB" 0 buf 2 2;
   Bytes.set_uint8 buf 4 0xFF;
   let r = decode_ok (Codec.decode tc_frame_codec buf 0) in
-  Alcotest.(check int) "frame_len" 5 r.hdr.frame_len;
+  Alcotest.(check int) "frame_len" 5 (UInt8.to_int r.hdr.frame_len);
   Alcotest.(check string) "data" "AB" r.data;
-  Alcotest.(check int) "check" 0xFF r.check
+  Alcotest.(check int) "check" 0xFF (UInt8.to_int r.check)
 
 (* -- Adversarial: cross-codec Field.ref edge cases -- *)
 
@@ -5620,13 +5643,13 @@ let test_codec_crossref_field_zerodata () =
   Bytes.set_uint8 buf 2 0xCC;
   let r = decode_ok (Codec.decode tc_frame_codec buf 0) in
   Alcotest.(check string) "data" "" r.data;
-  Alcotest.(check int) "check" 0xCC r.check
+  Alcotest.(check int) "check" 0xCC (UInt8.to_int r.check)
 
 (* Sub-codec field name shadowing: parent has its own field with same name as
    a sub-codec field. The parent's name should win for parent-scope expressions
    defined after the parent field. *)
 
-type shadow_inner = { si_x : int }
+type shadow_inner = { si_x : UInt8.t }
 
 let f_si_x = Field.v "Shared" uint8
 
@@ -5635,7 +5658,7 @@ let shadow_inner_codec =
     (fun x -> { si_x = x })
     Codec.[ (f_si_x $ fun r -> r.si_x) ]
 
-type shadow_outer = { inner : shadow_inner; shared : int; data : string }
+type shadow_outer = { inner : shadow_inner; shared : UInt8.t; data : string }
 
 let f_so_shared = Field.v "Shared" uint8
 
@@ -5659,13 +5682,13 @@ let test_codec_field_shadow () =
   (* parent.shared *)
   Bytes.blit_string "ABC" 0 buf 2 3;
   let r = decode_ok (Codec.decode shadow_outer_codec buf 0) in
-  Alcotest.(check int) "inner.shared" 5 r.inner.si_x;
-  Alcotest.(check int) "parent.shared" 3 r.shared;
+  Alcotest.(check int) "inner.shared" 5 (UInt8.to_int r.inner.si_x);
+  Alcotest.(check int) "parent.shared" 3 (UInt8.to_int r.shared);
   Alcotest.(check string) "data" "ABC" r.data
 
 (* Two-level deep nesting: outer references a field three levels down. *)
 
-type inner_l1 = { il1_x : int }
+type inner_l1 = { il1_x : UInt8.t }
 
 let f_il1_x = Field.v "DeepLen" uint8
 
@@ -5674,7 +5697,7 @@ let inner_l1_codec =
     (fun x -> { il1_x = x })
     Codec.[ (f_il1_x $ fun r -> r.il1_x) ]
 
-type middle_l2 = { inner : inner_l1; y : int }
+type middle_l2 = { inner : inner_l1; y : UInt8.t }
 
 let middle_l2_codec =
   Codec.v "MiddleL2"
@@ -5705,8 +5728,8 @@ let test_codec_crossref_field_twolevels () =
   (* l2.y *)
   Bytes.blit_string "ABCD" 0 buf 2 4;
   let r = decode_ok (Codec.decode outer_l3_codec buf 0) in
-  Alcotest.(check int) "deep_len" 4 r.mid.inner.il1_x;
-  Alcotest.(check int) "y" 0xFF r.mid.y;
+  Alcotest.(check int) "deep_len" 4 (UInt8.to_int r.mid.inner.il1_x);
+  Alcotest.(check int) "y" 0xFF (UInt8.to_int r.mid.y);
   Alcotest.(check string) "data" "ABCD" r.data
 
 (* Sub-codec with bitfield referenced from parent. The sub-codec packs a 4-bit
@@ -5756,11 +5779,11 @@ let test_optional_present_decode () =
   Bytes.set_uint16_be buf 1 0x1234;
   Bytes.set_uint8 buf 3 0xBB;
   let r = decode_ok (Codec.decode opt_codec_present buf 0) in
-  Alcotest.(check int) "hdr" 0xAA r.hdr;
+  Alcotest.(check int) "hdr" 0xAA (UInt8.to_int r.hdr);
   Alcotest.(check (option int))
     "payload" (Some 0x1234)
     (Option.map UInt16.to_int r.payload);
-  Alcotest.(check int) "trail" 0xBB r.trail
+  Alcotest.(check int) "trail" 0xBB (UInt8.to_int r.trail)
 
 let test_optional_absent_decode () =
   (* hdr(1) + trail(1) = 2 bytes (no payload) *)
@@ -5768,15 +5791,19 @@ let test_optional_absent_decode () =
   Bytes.set_uint8 buf 0 0xAA;
   Bytes.set_uint8 buf 1 0xBB;
   let r = decode_ok (Codec.decode opt_codec_absent buf 0) in
-  Alcotest.(check int) "hdr" 0xAA r.hdr;
+  Alcotest.(check int) "hdr" 0xAA (UInt8.to_int r.hdr);
   Alcotest.(check (option int))
     "payload" None
     (Option.map UInt16.to_int r.payload);
-  Alcotest.(check int) "trail" 0xBB r.trail
+  Alcotest.(check int) "trail" 0xBB (UInt8.to_int r.trail)
 
 let test_optional_present_encode () =
   let v : opt_record =
-    { hdr = 0xAA; payload = Some (UInt16.v 0x1234); trail = 0xBB }
+    {
+      hdr = UInt8.v 0xAA;
+      payload = Some (UInt16.v 0x1234);
+      trail = UInt8.v 0xBB;
+    }
   in
   let buf = Bytes.create 4 in
   Codec.encode opt_codec_present v buf 0;
@@ -5785,7 +5812,9 @@ let test_optional_present_encode () =
   Alcotest.(check int) "trail" 0xBB (Bytes.get_uint8 buf 3)
 
 let test_optional_absent_encode () =
-  let v : opt_record = { hdr = 0xAA; payload = None; trail = 0xBB } in
+  let v : opt_record =
+    { hdr = UInt8.v 0xAA; payload = None; trail = UInt8.v 0xBB }
+  in
   let buf = Bytes.create 2 in
   Codec.encode opt_codec_absent v buf 0;
   Alcotest.(check int) "hdr" 0xAA (Bytes.get_uint8 buf 0);
@@ -5793,29 +5822,47 @@ let test_optional_absent_encode () =
 
 let test_optional_present_roundtrip () =
   let original : opt_record =
-    { hdr = 0x11; payload = Some (UInt16.v 0x2233); trail = 0x44 }
+    {
+      hdr = UInt8.v 0x11;
+      payload = Some (UInt16.v 0x2233);
+      trail = UInt8.v 0x44;
+    }
   in
   let buf = Bytes.create 4 in
   Codec.encode opt_codec_present original buf 0;
   let decoded = decode_ok (Codec.decode opt_codec_present buf 0) in
-  Alcotest.(check int) "hdr" original.hdr decoded.hdr;
+  Alcotest.(check int)
+    "hdr"
+    (UInt8.to_int original.hdr)
+    (UInt8.to_int decoded.hdr);
   Alcotest.(check (option int))
     "payload"
     (Option.map UInt16.to_int original.payload)
     (Option.map UInt16.to_int decoded.payload);
-  Alcotest.(check int) "trail" original.trail decoded.trail
+  Alcotest.(check int)
+    "trail"
+    (UInt8.to_int original.trail)
+    (UInt8.to_int decoded.trail)
 
 let test_optional_absent_roundtrip () =
-  let original : opt_record = { hdr = 0x11; payload = None; trail = 0x44 } in
+  let original : opt_record =
+    { hdr = UInt8.v 0x11; payload = None; trail = UInt8.v 0x44 }
+  in
   let buf = Bytes.create 2 in
   Codec.encode opt_codec_absent original buf 0;
   let decoded = decode_ok (Codec.decode opt_codec_absent buf 0) in
-  Alcotest.(check int) "hdr" original.hdr decoded.hdr;
+  Alcotest.(check int)
+    "hdr"
+    (UInt8.to_int original.hdr)
+    (UInt8.to_int decoded.hdr);
   Alcotest.(check (option int))
     "payload"
     (Option.map UInt16.to_int original.payload)
     (Option.map UInt16.to_int decoded.payload);
-  Alcotest.(check int) "trail" original.trail decoded.trail
+  Alcotest.(check int)
+    "trail"
+    (UInt8.to_int original.trail)
+    (UInt8.to_int decoded.trail)
 
 (* A byte_array whose ~size reads an optional_or field. The size expression
    reads the optional_or's present-or-default value, so encode and decode agree
@@ -5825,7 +5872,7 @@ let test_bytearray_sized_by_optional_or () =
   let f_len =
     Field.optional_or "len"
       ~present:Expr.(Field.ref f_gate <> int 0)
-      ~default:3 uint8
+      ~default:(UInt8.v 3) uint8
   in
   let f_data = Field.v "data" (byte_array ~size:(Field.ref f_len)) in
   let c =
@@ -5843,13 +5890,17 @@ let test_bytearray_sized_by_optional_or () =
     Codec.encode c v buf 0;
     Alcotest.(check string) "encoded bytes" expected (Bytes.to_string buf);
     match Codec.decode c buf 0 with
-    | Ok d -> Alcotest.(check bool) "round-trip" true (d = v)
+    | Ok (g, l, d) ->
+        let vg, vl, vd = v in
+        Alcotest.(check bool)
+          "round-trip" true
+          (UInt8.equal g vg && UInt8.equal l vl && String.equal d vd)
     | Error e -> Alcotest.failf "decode: %a" pp_parse_error e
   in
   (* gate set: len present (2), data is 2 bytes *)
-  rt (1, 2, "ab") "\x01\x02ab";
+  rt (UInt8.v 1, UInt8.v 2, "ab") "\x01\x02ab";
   (* gate clear: len falls back to the default (3), data is 3 bytes *)
-  rt (0, 3, "xyz") "\x00\x03xyz"
+  rt (UInt8.zero, UInt8.v 3, "xyz") "\x00\x03xyz"
 
 let test_optional_wire_size_present () =
   Alcotest.(check int) "wire_size present" 4 (Codec.wire_size opt_codec_present)
@@ -5859,7 +5910,7 @@ let test_optional_wire_size_absent () =
 
 (* Optional with codec inner type *)
 
-type opt_codec_record = { hdr : int; inner : inner option; trail : int }
+type opt_codec_record = { hdr : UInt8.t; inner : inner option; trail : UInt8.t }
 
 let opt_inner_codec ~present =
   Codec.v "OptCodecRecord"
@@ -5881,13 +5932,13 @@ let test_optional_codec_present () =
   Bytes.set_uint16_be buf 2 0x1234;
   Bytes.set_uint8 buf 4 0xBB;
   let r = decode_ok (Codec.decode c buf 0) in
-  Alcotest.(check int) "hdr" 0xAA r.hdr;
+  Alcotest.(check int) "hdr" 0xAA (UInt8.to_int r.hdr);
   (match r.inner with
   | None -> Alcotest.fail "expected Some"
   | Some inner ->
-      Alcotest.(check int) "inner.tag" 0x42 inner.tag;
+      Alcotest.(check int) "inner.tag" 0x42 (UInt8.to_int inner.tag);
       Alcotest.(check int) "inner.value" 0x1234 (UInt16.to_int inner.value));
-  Alcotest.(check int) "trail" 0xBB r.trail
+  Alcotest.(check int) "trail" 0xBB (UInt8.to_int r.trail)
 
 let test_optional_codec_absent () =
   let c = opt_inner_codec ~present:false in
@@ -5896,11 +5947,11 @@ let test_optional_codec_absent () =
   Bytes.set_uint8 buf 0 0xAA;
   Bytes.set_uint8 buf 1 0xBB;
   let r = decode_ok (Codec.decode c buf 0) in
-  Alcotest.(check int) "hdr" 0xAA r.hdr;
+  Alcotest.(check int) "hdr" 0xAA (UInt8.to_int r.hdr);
   Alcotest.(check (option int))
     "inner" None
-    (Option.map (fun (i : inner) -> i.tag) r.inner);
-  Alcotest.(check int) "trail" 0xBB r.trail
+    (Option.map (fun (i : inner) -> UInt8.to_int i.tag) r.inner);
+  Alcotest.(check int) "trail" 0xBB (UInt8.to_int r.trail)
 
 (* Multiple optional fields (TM frame pattern) *)
 
@@ -5964,7 +6015,7 @@ let test_optional_mixed () =
 
 (* Dynamic optional: presence determined by a previously-parsed field. *)
 
-type dyn_opt = { flags : int; payload : UInt16.t option; trail : int }
+type dyn_opt = { flags : UInt8.t; payload : UInt16.t option; trail : UInt8.t }
 
 let f_do_flags = Field.v "Flags" uint8
 
@@ -5988,11 +6039,11 @@ let test_dyn_opt_present () =
   Bytes.set_uint16_be buf 1 0x1234;
   Bytes.set_uint8 buf 3 0xFF;
   let r = decode_ok (Codec.decode dyn_opt_codec buf 0) in
-  Alcotest.(check int) "flags" 1 r.flags;
+  Alcotest.(check int) "flags" 1 (UInt8.to_int r.flags);
   Alcotest.(check (option int))
     "payload" (Some 0x1234)
     (Option.map UInt16.to_int r.payload);
-  Alcotest.(check int) "trail" 0xFF r.trail
+  Alcotest.(check int) "trail" 0xFF (UInt8.to_int r.trail)
 
 let test_dyn_opt_absent () =
   (* flags=0 -> payload absent. Layout: [00] [FF] *)
@@ -6000,11 +6051,11 @@ let test_dyn_opt_absent () =
   Bytes.set_uint8 buf 0 0;
   Bytes.set_uint8 buf 1 0xFF;
   let r = decode_ok (Codec.decode dyn_opt_codec buf 0) in
-  Alcotest.(check int) "flags" 0 r.flags;
+  Alcotest.(check int) "flags" 0 (UInt8.to_int r.flags);
   Alcotest.(check (option int))
     "payload" None
     (Option.map UInt16.to_int r.payload);
-  Alcotest.(check int) "trail" 0xFF r.trail
+  Alcotest.(check int) "trail" 0xFF (UInt8.to_int r.trail)
 
 let test_dyn_opt_get_trail () =
   let cf_trail = Codec.(Field.v "Trail" uint8 $ fun r -> r.trail) in
@@ -6014,12 +6065,12 @@ let test_dyn_opt_get_trail () =
   Bytes.set_uint8 buf1 0 1;
   Bytes.set_uint16_be buf1 1 0x1234;
   Bytes.set_uint8 buf1 3 0xAA;
-  Alcotest.(check int) "trail (present)" 0xAA (get_trail buf1 0);
+  Alcotest.(check int) "trail (present)" 0xAA (UInt8.to_int (get_trail buf1 0));
   (* Absent: trail at offset 1. *)
   let buf2 = Bytes.create 2 in
   Bytes.set_uint8 buf2 0 0;
   Bytes.set_uint8 buf2 1 0xBB;
-  Alcotest.(check int) "trail (absent)" 0xBB (get_trail buf2 0)
+  Alcotest.(check int) "trail (absent)" 0xBB (UInt8.to_int (get_trail buf2 0))
 
 let check_dyn_opt_roundtrip label expected_len expected_bytes original =
   Alcotest.(check int)
@@ -6033,18 +6084,28 @@ let check_dyn_opt_roundtrip label expected_len expected_bytes original =
     (label ^ " wire_size_at") expected_len
     (Codec.wire_size_at dyn_opt_codec buf 0);
   let decoded = decode_ok (Codec.decode dyn_opt_codec buf 0) in
-  Alcotest.(check int) (label ^ " flags") original.flags decoded.flags;
+  Alcotest.(check int)
+    (label ^ " flags")
+    (UInt8.to_int original.flags)
+    (UInt8.to_int decoded.flags);
   Alcotest.(check (option int))
     (label ^ " payload")
     (Option.map UInt16.to_int original.payload)
     (Option.map UInt16.to_int decoded.payload);
-  Alcotest.(check int) (label ^ " trail") original.trail decoded.trail
+  Alcotest.(check int)
+    (label ^ " trail")
+    (UInt8.to_int original.trail)
+    (UInt8.to_int decoded.trail)
 
 let test_field_optional_dynamic_roundtrip () =
   check_dyn_opt_roundtrip "present" 4 "\x01\x12\x34\xFF"
-    { flags = 1; payload = Some (UInt16.v 0x1234); trail = 0xFF };
+    {
+      flags = UInt8.v 1;
+      payload = Some (UInt16.v 0x1234);
+      trail = UInt8.v 0xFF;
+    };
   check_dyn_opt_roundtrip "absent" 2 "\x00\xEE"
-    { flags = 0; payload = None; trail = 0xEE }
+    { flags = UInt8.v 0; payload = None; trail = UInt8.v 0xEE }
 
 let test_dyn_opt_reject_gate () =
   let check_reject label v =
@@ -6054,9 +6115,13 @@ let test_dyn_opt_reject_gate () =
     | exception Invalid_argument _ -> ()
   in
   check_reject "gate true / value None"
-    { flags = 1; payload = None; trail = 0xEE };
+    { flags = UInt8.v 1; payload = None; trail = UInt8.v 0xEE };
   check_reject "gate false / value Some"
-    { flags = 0; payload = Some (UInt16.v 0x1234); trail = 0xEE }
+    {
+      flags = UInt8.v 0;
+      payload = Some (UInt16.v 0x1234);
+      trail = UInt8.v 0xEE;
+    }
 
 let test_encode_totality () =
   let check_exact label original =
@@ -6072,8 +6137,13 @@ let test_encode_totality () =
       | exception Invalid_argument _ -> ()
   in
   check_exact "present"
-    { flags = 1; payload = Some (UInt16.v 0x1234); trail = 0xFF };
-  check_exact "absent" { flags = 0; payload = None; trail = 0xEE }
+    {
+      flags = UInt8.v 1;
+      payload = Some (UInt16.v 0x1234);
+      trail = UInt8.v 0xFF;
+    };
+  check_exact "absent"
+    { flags = UInt8.v 0; payload = None; trail = UInt8.v 0xEE }
 
 (* Dynamic optional via Field.ref on a bool field -- the TM frame pattern.
    Field.ref now accepts 'a t, so a bool field created with [bit] can be
@@ -6083,7 +6153,7 @@ type tm_opt = {
   ocf_flag : bool;
   data : UInt16.t;
   ocf : UInt32.t option;
-  trail : int;
+  trail : UInt8.t;
 }
 
 let f_to_ocf_flag = Field.v "OCFFlag" (bit (bits ~width:1 U8))
@@ -6115,7 +6185,7 @@ let test_dyn_opt_anyref_present () =
   Alcotest.(check (option int32))
     "ocf" (Some 0xDEADBEEFl)
     (Option.map UInt32.to_int32 r.ocf);
-  Alcotest.(check int) "trail" 0xFF r.trail
+  Alcotest.(check int) "trail" 0xFF (UInt8.to_int r.trail)
 
 let test_dyn_opt_anyref_absent () =
   let buf = Bytes.create 4 in
@@ -6126,7 +6196,7 @@ let test_dyn_opt_anyref_absent () =
   Alcotest.(check bool) "ocf_flag" false r.ocf_flag;
   Alcotest.(check int) "data" 0x1234 (UInt16.to_int r.data);
   Alcotest.(check (option int)) "ocf" None (Option.map UInt32.to_int r.ocf);
-  Alcotest.(check int) "trail" 0xFF r.trail
+  Alcotest.(check int) "trail" 0xFF (UInt8.to_int r.trail)
 
 (* -- Predicates with bitwise/shift/mod operators in [optional] --
    Reproduces the silent miscompile where [compile_bool_expr]'s
@@ -6134,7 +6204,7 @@ let test_dyn_opt_anyref_absent () =
    predicate using [Land] / [Lor] / [Lsr] / [Mod] / [Cast] / etc.,
    so a high-bit-gated optional would always read its payload. *)
 
-type bit_gated = { flags : int; body : int option }
+type bit_gated = { flags : UInt8.t; body : UInt8.t option }
 
 let f_bg_flags = Field.v "Flags" uint8
 
@@ -6153,9 +6223,13 @@ let check_bit_gated ~present ~present_buf ~present_label ~absent_buf
     ~absent_label =
   let c = bg_codec ~present in
   let r = decode_ok (Codec.decode c (Bytes.of_string present_buf) 0) in
-  Alcotest.(check (option int)) present_label (Some 0x2A) r.body;
+  Alcotest.(check (option int))
+    present_label (Some 0x2A)
+    (Option.map UInt8.to_int r.body);
   let r = decode_ok (Codec.decode c (Bytes.of_string absent_buf) 0) in
-  Alcotest.(check (option int)) absent_label None r.body
+  Alcotest.(check (option int))
+    absent_label None
+    (Option.map UInt8.to_int r.body)
 
 let test_optional_land_predicate () =
   check_bit_gated
@@ -6185,7 +6259,7 @@ let test_optional_lor_predicate () =
    int_array slot is populated for [Optional] fields, so a constraint or size
    expression referring to the optional sees the real value. *)
 
-type ref_opt = { x : int option; check : int }
+type ref_opt = { x : UInt8.t option; check : UInt8.t }
 
 let f_ro_x = Field.optional "X" ~present:Expr.true_ uint8
 
@@ -6203,8 +6277,8 @@ let test_field_ref_through_optional () =
      failed; with the fix it reads 0x80 and the decode succeeds. *)
   let buf = Bytes.of_string "\x80\x7F" in
   let r = decode_ok (Codec.decode ref_opt_codec buf 0) in
-  Alcotest.(check (option int)) "x" (Some 0x80) r.x;
-  Alcotest.(check int) "check" 0x7F r.check
+  Alcotest.(check (option int)) "x" (Some 0x80) (Option.map UInt8.to_int r.x);
+  Alcotest.(check int) "check" 0x7F (UInt8.to_int r.check)
 
 let test_uint64_in_size_expr () =
   let f_len = Field.v "Len" uint64be in
@@ -6232,7 +6306,7 @@ let test_repeat_decode_empty () =
   let buf = Bytes.create 1 in
   Bytes.set_uint8 buf 0 0;
   let r = decode_ok (Codec.decode repeat_codec buf 0) in
-  Alcotest.(check int) "length" 0 r.length;
+  Alcotest.(check int) "length" 0 (UInt8.to_int r.length);
   Alcotest.(check int) "item count" 0 (List.length r.items)
 
 let test_repeat_decode_one () =
@@ -6242,10 +6316,10 @@ let test_repeat_decode_one () =
   Bytes.set_uint8 buf 1 0x42;
   Bytes.set_uint16_be buf 2 0x1234;
   let r = decode_ok (Codec.decode repeat_codec buf 0) in
-  Alcotest.(check int) "length" 3 r.length;
+  Alcotest.(check int) "length" 3 (UInt8.to_int r.length);
   Alcotest.(check int) "item count" 1 (List.length r.items);
   let item = List.hd r.items in
-  Alcotest.(check int) "item.tag" 0x42 item.tag;
+  Alcotest.(check int) "item.tag" 0x42 (UInt8.to_int item.tag);
   Alcotest.(check int) "item.value" 0x1234 (UInt16.to_int item.value)
 
 let test_repeat_decode_multiple () =
@@ -6262,11 +6336,12 @@ let test_repeat_decode_multiple () =
   Bytes.set_uint8 buf 7 0x03;
   Bytes.set_uint16_be buf 8 0x0003;
   let r = decode_ok (Codec.decode repeat_codec buf 0) in
-  Alcotest.(check int) "length" 9 r.length;
+  Alcotest.(check int) "length" 9 (UInt8.to_int r.length);
   Alcotest.(check int) "item count" 3 (List.length r.items);
   List.iteri
     (fun i (item : inner) ->
-      Alcotest.(check int) (Fmt.str "item[%d].tag" i) (i + 1) item.tag;
+      Alcotest.(check int)
+        (Fmt.str "item[%d].tag" i) (i + 1) (UInt8.to_int item.tag);
       Alcotest.(check int)
         (Fmt.str "item[%d].value" i)
         (i + 1) (UInt16.to_int item.value))
@@ -6275,11 +6350,11 @@ let test_repeat_decode_multiple () =
 let test_repeat_encode () =
   let v =
     {
-      length = 6;
+      length = UInt8.v 6;
       items =
         [
-          { tag = 0x01; value = UInt16.v 0x0001 };
-          { tag = 0x02; value = UInt16.v 0x0002 };
+          { tag = UInt8.v 0x01; value = UInt16.v 0x0001 };
+          { tag = UInt8.v 0x02; value = UInt16.v 0x0002 };
         ];
     }
   in
@@ -6314,9 +6389,9 @@ let test_repeat_exact_budget () =
   (match Codec.decode fixed (Bytes.of_string "\x01\xaa") 0 with
   | Error _ -> ()
   | Ok _ -> Alcotest.fail "fixed-width repeat accepted a remainder");
-  expect_repeat_encode_error "fixed underrun" fixed (6, [ UInt16.v 1 ]);
+  expect_repeat_encode_error "fixed underrun" fixed (UInt8.v 6, [ UInt16.v 1 ]);
   expect_repeat_encode_error "fixed overshoot" fixed
-    (2, [ UInt16.v 1; UInt16.v 2 ]);
+    (UInt8.v 2, [ UInt16.v 1; UInt16.v 2 ]);
   let f_var_size = Field.v "size" uint8 in
   let variable =
     Codec.v "RepeatVariableBudget"
@@ -6334,27 +6409,30 @@ let test_repeat_exact_budget () =
 let test_repeat_roundtrip () =
   let items =
     [
-      { tag = 0x0A; value = UInt16.v 0x000A };
-      { tag = 0x0B; value = UInt16.v 0x000B };
-      { tag = 0x0C; value = UInt16.v 0x000C };
+      { tag = UInt8.v 0x0A; value = UInt16.v 0x000A };
+      { tag = UInt8.v 0x0B; value = UInt16.v 0x000B };
+      { tag = UInt8.v 0x0C; value = UInt16.v 0x000C };
     ]
   in
-  let original : container = { length = 9; items } in
+  let original : container = { length = UInt8.v 9; items } in
   let buf = Bytes.create 10 in
   Codec.encode repeat_codec original buf 0;
   let decoded = decode_ok (Codec.decode repeat_codec buf 0) in
-  Alcotest.(check int) "length" original.length decoded.length;
+  Alcotest.(check int)
+    "length"
+    (UInt8.to_int original.length)
+    (UInt8.to_int decoded.length);
   Alcotest.(check int) "item count" 3 (List.length decoded.items);
   List.iter2
     (fun (orig : inner) (dec : inner) ->
-      Alcotest.(check int) "tag" orig.tag dec.tag;
+      Alcotest.(check int) "tag" (UInt8.to_int orig.tag) (UInt8.to_int dec.tag);
       Alcotest.(check int)
         "value" (UInt16.to_int orig.value) (UInt16.to_int dec.value))
     original.items decoded.items
 
 (* Repeat with fixed-size primitive elements *)
 
-type int_container = { count : int; values : UInt16.t list }
+type int_container = { count : UInt8.t; values : UInt16.t list }
 
 let f_ic_count = Field.v "Count" uint8
 
@@ -6376,7 +6454,7 @@ let test_repeat_primitive () =
   Bytes.set_uint16_be buf 3 0x2222;
   Bytes.set_uint16_be buf 5 0x3333;
   let r = decode_ok (Codec.decode repeat_int_codec buf 0) in
-  Alcotest.(check int) "count" 6 r.count;
+  Alcotest.(check int) "count" 6 (UInt8.to_int r.count);
   Alcotest.(check int) "n values" 3 (List.length r.values);
   Alcotest.(check (list int))
     "values" [ 0x1111; 0x2222; 0x3333 ]
@@ -6387,7 +6465,7 @@ let test_repeat_primitive () =
    encoding. *)
 let test_repeat_size_of_value () =
   let v =
-    { count = 6; values = List.map UInt16.v [ 0x1111; 0x2222; 0x3333 ] }
+    { count = UInt8.v 6; values = List.map UInt16.v [ 0x1111; 0x2222; 0x3333 ] }
   in
   (* Count (1) + 3 * uint16be (6) = 7 *)
   let n = Codec.size_of_value repeat_int_codec v in
@@ -6405,7 +6483,7 @@ let test_repeat_size_of_value () =
 
 (* Repeat with trailer after *)
 
-type repeat_trailer = { len : int; items : inner list; check : int }
+type repeat_trailer = { len : UInt8.t; items : inner list; check : UInt8.t }
 
 let f_rt_len = Field.v "Len" uint8
 
@@ -6430,13 +6508,13 @@ let test_repeat_with_trailer () =
   Bytes.set_uint16_be buf 5 0x0002;
   Bytes.set_uint8 buf 7 0xFF;
   let r = decode_ok (Codec.decode repeat_trailer_codec buf 0) in
-  Alcotest.(check int) "len" 6 r.len;
+  Alcotest.(check int) "len" 6 (UInt8.to_int r.len);
   Alcotest.(check int) "item count" 2 (List.length r.items);
-  Alcotest.(check int) "check" 0xFF r.check
+  Alcotest.(check int) "check" 0xFF (UInt8.to_int r.check)
 
 (* Variable-size repeat: codec with dependent-size field *)
 
-type var_inner = { len : int; data : string }
+type var_inner = { len : UInt8.t; data : string }
 
 let f_vi_len = Field.v "Len" uint8
 
@@ -6480,27 +6558,28 @@ let test_repeat_variable_size_elements () =
   Alcotest.(check int) "item count" 2 (List.length r.items);
   let i0 = List.nth r.items 0 in
   let i1 = List.nth r.items 1 in
-  Alcotest.(check int) "item0.len" 2 i0.len;
+  Alcotest.(check int) "item0.len" 2 (UInt8.to_int i0.len);
   Alcotest.(check string) "item0.data" "ab" i0.data;
-  Alcotest.(check int) "item1.len" 3 i1.len;
+  Alcotest.(check int) "item1.len" 3 (UInt8.to_int i1.len);
   Alcotest.(check string) "item1.data" "cde" i1.data
 
 (* -- Casetype as a trailing variable-size codec field -- *)
 
-type ev_payload = [ `Login of UInt16.t | `Logout of UInt32.t | `Other of int ]
+type ev_payload =
+  [ `Login of UInt16.t | `Logout of UInt32.t | `Other of UInt8.t ]
 
 let casetype_field_event_typ : ev_payload Wire.typ =
   Wire.casetype "EvPayload" Wire.uint8
     [
-      Wire.case ~index:1 Wire.uint16be
+      Wire.case ~index:(UInt8.v 1) Wire.uint16be
         ~inject:(fun v -> `Login v)
         ~project:(function `Login v -> Some v | _ -> None);
-      Wire.case ~index:2 Wire.uint32be
+      Wire.case ~index:(UInt8.v 2) Wire.uint32be
         ~inject:(fun v -> `Logout v)
         ~project:(function `Logout v -> Some v | _ -> None);
       Wire.default Wire.uint8
         ~inject:(fun _tag v -> `Other v)
-        ~project:(function `Other v -> Some (0xFF, v) | _ -> None);
+        ~project:(function `Other v -> Some (UInt8.v 0xFF, v) | _ -> None);
     ]
 
 type ev_event = { ts : int64; data : ev_payload }
@@ -6539,7 +6618,7 @@ let test_casetype_field_default () =
   Bytes.set_uint8 buf 8 99;
   Bytes.set_uint8 buf 9 7;
   let r = decode_ok (Codec.decode casetype_field_codec buf 0) in
-  Alcotest.(check bool) "Other 7" true (r.data = `Other 7)
+  Alcotest.(check bool) "Other 7" true (r.data = `Other (UInt8.v 7))
 
 (* A casetype whose discriminant matches no case fails with a typed
    [Invalid_tag] carrying the tag value, not a stringly constraint failure. *)
@@ -6547,10 +6626,10 @@ let test_casetype_no_match_invalid_tag () =
   let typ =
     Wire.casetype "Closed" Wire.uint8
       [
-        Wire.case ~index:1 Wire.uint8
+        Wire.case ~index:(UInt8.v 1) Wire.uint8
           ~inject:(fun v -> `A v)
           ~project:(function `A v -> Some v | _ -> None);
-        Wire.case ~index:2 Wire.uint8
+        Wire.case ~index:(UInt8.v 2) Wire.uint8
           ~inject:(fun v -> `B v)
           ~project:(function `B v -> Some v | _ -> None);
       ]
@@ -6564,12 +6643,12 @@ let test_casetype_no_match_invalid_tag () =
 
 (* The default branch recovers the matched tag and re-encodes it, so an
    arbitrary unclaimed tag round-trips (the DHCP / TCP-options shape). *)
-type tlv = Known of UInt16.t | Unknown of (int * string)
+type tlv = Known of UInt16.t | Unknown of (UInt8.t * string)
 
 let tlv_typ : tlv Wire.typ =
   Wire.casetype "Tlv" Wire.uint8
     [
-      Wire.case ~index:1 Wire.uint16be
+      Wire.case ~index:(UInt8.v 1) Wire.uint16be
         ~inject:(fun v -> Known v)
         ~project:(function Known v -> Some v | _ -> None);
       Wire.default
@@ -6582,14 +6661,14 @@ let tlv_codec =
   Codec.v "Tlv" (fun x -> x) Codec.[ (Field.v "v" tlv_typ $ fun x -> x) ]
 
 let test_casetype_default_recovers_tag () =
-  let v = Unknown (0x42, "ab") in
+  let v = Unknown (UInt8.v 0x42, "ab") in
   let buf = Bytes.create (Codec.size_of_value tlv_codec v) in
   Codec.encode tlv_codec v buf 0;
   Alcotest.(check int)
     "encode writes the captured tag" 0x42 (Bytes.get_uint8 buf 0);
   match Codec.decode tlv_codec buf 0 with
   | Ok (Unknown (t, b)) ->
-      Alcotest.(check int) "decode recovers the tag" 0x42 t;
+      Alcotest.(check int) "decode recovers the tag" 0x42 (UInt8.to_int t);
       Alcotest.(check string) "decode body" "ab" b
   | Ok _ -> Alcotest.fail "expected Unknown"
   | Error e -> Alcotest.failf "decode: %a" pp_parse_error e
@@ -6618,7 +6697,7 @@ let test_casetype_size_of_value () =
 (* Length-prefixed casetype dispatch: [tag][length][body] where length
    bounds the inner casetype's tag + body. *)
 
-type lp_event = { tag : int; len : UInt16.t; data : ev_payload }
+type lp_event = { tag : UInt8.t; len : UInt16.t; data : ev_payload }
 
 let lp_event_len = Field.v "Length" uint16be
 
@@ -6642,7 +6721,7 @@ let test_length_prefixed_casetype () =
   Bytes.set_uint8 buf 3 1;
   Bytes.set_uint16_be buf 4 0x4242;
   let r = decode_ok (Codec.decode lp_event_codec buf 0) in
-  Alcotest.(check int) "tag" 0xAA r.tag;
+  Alcotest.(check int) "tag" 0xAA (UInt8.to_int r.tag);
   Alcotest.(check int) "len" 3 (UInt16.to_int r.len);
   Alcotest.(check bool) "data" true (r.data = `Login (UInt16.v 0x4242))
 
@@ -6652,7 +6731,7 @@ let test_length_prefixed_casetype () =
 
 type tm_like = {
   hdr : UInt16.t;
-  data_len : int;
+  data_len : UInt8.t;
   packets : packet list;
   ocf : UInt32.t option;
   fecf : UInt16.t option;
@@ -6696,10 +6775,10 @@ let test_tm_like_full () =
   Bytes.set_uint16_be buf 13 0x4444;
   let r = decode_ok (Codec.decode c buf 0) in
   Alcotest.(check int) "hdr" 0xAAAA (UInt16.to_int r.hdr);
-  Alcotest.(check int) "data_len" 6 r.data_len;
+  Alcotest.(check int) "data_len" 6 (UInt8.to_int r.data_len);
   Alcotest.(check int) "packet count" 2 (List.length r.packets);
-  Alcotest.(check int) "pkt0.id" 0x01 (List.nth r.packets 0).id;
-  Alcotest.(check int) "pkt1.id" 0x02 (List.nth r.packets 1).id;
+  Alcotest.(check int) "pkt0.id" 0x01 (UInt8.to_int (List.nth r.packets 0).id);
+  Alcotest.(check int) "pkt1.id" 0x02 (UInt8.to_int (List.nth r.packets 1).id);
   Alcotest.(check (option int))
     "ocf" (Some 0x33333333)
     (Option.map UInt32.to_int r.ocf);
@@ -6725,12 +6804,12 @@ let test_tm_like_roundtrip () =
   let original =
     {
       hdr = UInt16.v 0xBBBB;
-      data_len = 9;
+      data_len = UInt8.v 9;
       packets =
         [
-          ({ id = 0x0A; data = UInt16.v 0x000A } : packet);
-          ({ id = 0x0B; data = UInt16.v 0x000B } : packet);
-          ({ id = 0x0C; data = UInt16.v 0x000C } : packet);
+          ({ id = UInt8.v 0x0A; data = UInt16.v 0x000A } : packet);
+          ({ id = UInt8.v 0x0B; data = UInt16.v 0x000B } : packet);
+          ({ id = UInt8.v 0x0C; data = UInt16.v 0x000C } : packet);
         ];
       ocf = Some (Wire.Private.UInt32.of_int32 0xDEADBEEFl);
       fecf = Some (UInt16.v 0xCAFE);
@@ -6746,7 +6825,7 @@ let test_tm_like_roundtrip () =
   Alcotest.(check int) "packet count" 3 (List.length decoded.packets);
   List.iter2
     (fun (o : packet) (d : packet) ->
-      Alcotest.(check int) "pkt.id" o.id d.id;
+      Alcotest.(check int) "pkt.id" (UInt8.to_int o.id) (UInt8.to_int d.id);
       Alcotest.(check int)
         "pkt.data" (UInt16.to_int o.data) (UInt16.to_int d.data))
     original.packets decoded.packets;
@@ -6766,8 +6845,8 @@ let test_tm_like_roundtrip () =
    fields. This layout projects, resolving each field's offset at runtime. *)
 
 type cfdp_hdr = {
-  eid_len : int;
-  txseq_len : int;
+  eid_len : UInt8.t;
+  txseq_len : UInt8.t;
   src : string;
   txseq : string;
   dst : string;
@@ -6805,8 +6884,8 @@ let test_multi_var_decode () =
   Bytes.blit_string "\xCC\xDD\xEE" 0 buf 4 3;
   Bytes.blit_string "\xFF\x00" 0 buf 7 2;
   let r = decode_ok (Codec.decode cfdp_codec buf 0) in
-  Alcotest.(check int) "eid_len" 1 r.eid_len;
-  Alcotest.(check int) "txseq_len" 2 r.txseq_len;
+  Alcotest.(check int) "eid_len" 1 (UInt8.to_int r.eid_len);
+  Alcotest.(check int) "txseq_len" 2 (UInt8.to_int r.txseq_len);
   Alcotest.(check string) "src" "\xAA\xBB" r.src;
   Alcotest.(check string) "txseq" "\xCC\xDD\xEE" r.txseq;
   Alcotest.(check string) "dst" "\xFF\x00" r.dst
@@ -6814,8 +6893,8 @@ let test_multi_var_decode () =
 let test_multi_var_roundtrip () =
   let original =
     {
-      eid_len = 1;
-      txseq_len = 2;
+      eid_len = UInt8.v 1;
+      txseq_len = UInt8.v 2;
       src = "\xAA\xBB";
       txseq = "\xCC\xDD\xEE";
       dst = "\xFF\x00";
@@ -7020,9 +7099,9 @@ let test_slice_then_array () =
     v "SliceThenArray"
       (fun _ slice _ array -> (slice, array))
       [
-        (f_slice_len $ fun (slice, _) -> Slice.length slice);
+        (f_slice_len $ fun (slice, _) -> UInt8.v (Slice.length slice));
         (f_slice $ fun (slice, _) -> slice);
-        (f_array_len $ fun (_, array) -> String.length array);
+        (f_array_len $ fun (_, array) -> UInt8.v (String.length array));
         (f_array $ fun (_, array) -> array);
       ]
   in
@@ -7045,7 +7124,7 @@ let test_codec_then_array () =
       (fun msg _ array -> (msg, array))
       [
         (f_msg $ fun (msg, _) -> msg);
-        (f_array_len $ fun (_, array) -> String.length array);
+        (f_array_len $ fun (_, array) -> UInt8.v (String.length array));
         (f_array $ fun (_, array) -> array);
       ]
   in
@@ -7070,9 +7149,9 @@ let test_repeat_after_var_slice () =
     v "PrefixedItems"
       (fun _ prefix _ items -> (prefix, items))
       [
-        (f_prefix_len $ fun (p, _) -> Slice.length p);
+        (f_prefix_len $ fun (p, _) -> UInt8.v (Slice.length p));
         (f_prefix $ fun (p, _) -> p);
-        (f_count $ fun (_, items) -> 2 * List.length items);
+        (f_count $ fun (_, items) -> UInt8.v (2 * List.length items));
         (f_items $ fun (_, items) -> items);
       ]
   in
@@ -7095,7 +7174,7 @@ module UInt63 = Optint.Int63
 
 let u63 = Alcotest.testable UInt63.pp ( = )
 
-type uint_rec = { tag : int; value : UInt63.t }
+type uint_rec = { tag : UInt8.t; value : UInt63.t }
 
 let test_uint_3byte_be () =
   let codec =
@@ -7107,7 +7186,7 @@ let test_uint_3byte_be () =
         (Field.v "Value" (uint (Wire.int 3)) $ fun r -> r.value);
       ]
   in
-  let original = { tag = 0x42; value = UInt63.of_int 0x1A2B3C } in
+  let original = { tag = UInt8.v 0x42; value = UInt63.of_int 0x1A2B3C } in
   let buf = Bytes.create 4 in
   Codec.encode codec original buf 0;
   Alcotest.(check int) "tag byte" 0x42 (Bytes.get_uint8 buf 0);
@@ -7115,7 +7194,10 @@ let test_uint_3byte_be () =
   Alcotest.(check int) "be byte 1" 0x2B (Bytes.get_uint8 buf 2);
   Alcotest.(check int) "be byte 2" 0x3C (Bytes.get_uint8 buf 3);
   let decoded = decode_ok (Codec.decode codec buf 0) in
-  Alcotest.(check int) "tag" original.tag decoded.tag;
+  Alcotest.(check int)
+    "tag"
+    (UInt8.to_int original.tag)
+    (UInt8.to_int decoded.tag);
   Alcotest.check u63 "value" original.value decoded.value
 
 let test_uint_1byte () =
@@ -7166,7 +7248,7 @@ let test_uint_dynamic () =
   Bytes.set_uint8 buf 1 0x12;
   Bytes.set_uint8 buf 2 0x34;
   let n, value = decode_ok (Codec.decode codec buf 0) in
-  Alcotest.(check int) "n" 2 n;
+  Alcotest.(check int) "n" 2 (UInt8.to_int n);
   Alcotest.check u63 "value" (UInt63.of_int 0x1234) value
 
 (* -- Adversarial bit-order tests --
@@ -7281,18 +7363,21 @@ let opt_body_codec =
   Codec.v "OptBody"
     (fun _l d -> { data = d })
     Codec.
-      [ (ob_len $ fun b -> String.length b.data); (ob_data $ fun b -> b.data) ]
+      [
+        (ob_len $ fun b -> UInt8.v (String.length b.data));
+        (ob_data $ fun b -> b.data);
+      ]
 
 let dhcp_opt_typ : dhcp_opt typ =
   casetype "DhcpOpt" uint8
     [
-      case ~index:0 empty
+      case ~index:(UInt8.v 0) empty
         ~inject:(fun () -> Pad)
         ~project:(function Pad -> Some () | _ -> None);
-      case ~index:255 empty
+      case ~index:(UInt8.v 255) empty
         ~inject:(fun () -> End)
         ~project:(function End -> Some () | _ -> None);
-      case ~index:53 (codec opt_body_codec)
+      case ~index:(UInt8.v 53) (codec opt_body_codec)
         ~inject:(fun b -> Generic b.data)
         ~project:(function Generic d -> Some { data = d } | _ -> None);
     ]
@@ -7311,7 +7396,7 @@ let dhcp_codec =
     Codec.
       [
         ( dhcp_f_total $ fun xs ->
-          List.fold_left (fun a o -> a + dhcp_opt_size o) 0 xs );
+          UInt8.v (List.fold_left (fun a o -> a + dhcp_opt_size o) 0 xs) );
         (dhcp_f_opts $ fun xs -> xs);
       ]
 
@@ -7342,16 +7427,16 @@ let test_repeat_casetype_empty () =
    build_field_encoder, and elem_size_of all lacked the zeroterm_at_most case,
    so encode raised "unsupported type" and sizing raised "cannot determine
    element size". *)
-type zt_opt = Str of string | Num of int
+type zt_opt = Str of string | Num of UInt8.t
 
 let zt_opt_typ : zt_opt typ =
   casetype "ZtOpt" uint8
     [
-      case ~index:1
+      case ~index:(UInt8.v 1)
         (zeroterm_at_most ~size:(int 6))
         ~inject:(fun s -> Str s)
         ~project:(function Str s -> Some s | _ -> None);
-      case ~index:2 uint8
+      case ~index:(UInt8.v 2) uint8
         ~inject:(fun n -> Num n)
         ~project:(function Num n -> Some n | _ -> None);
     ]
@@ -7371,7 +7456,7 @@ let zt_codec =
       ]
 
 let test_repeat_casetype_zeroterm_at_most () =
-  let v = [ Str "hi"; Num 7; Str "" ] in
+  let v = [ Str "hi"; Num (UInt8.v 7); Str "" ] in
   let buf = Bytes.create (Codec.size_of_value zt_codec v) in
   Codec.encode zt_codec v buf 0;
   Alcotest.(check bool)
@@ -7384,15 +7469,15 @@ let test_repeat_casetype_zeroterm_at_most () =
    projects to 3D inside a repeated casetype (the casetype packs it into its
    base word); a list of bare bitfields, by contrast, has no projection and is
    rejected. *)
-type bf_opt = Bf of int | Raw of int
+type bf_opt = Bf of int | Raw of UInt8.t
 
 let bf_opt_typ : bf_opt typ =
   casetype "BfOpt" uint8
     [
-      case ~index:1 (bits ~width:3 U8)
+      case ~index:(UInt8.v 1) (bits ~width:3 U8)
         ~inject:(fun b -> Bf b)
         ~project:(function Bf b -> Some b | _ -> None);
-      case ~index:2 uint8
+      case ~index:(UInt8.v 2) uint8
         ~inject:(fun v -> Raw v)
         ~project:(function Raw v -> Some v | _ -> None);
     ]
@@ -7411,7 +7496,7 @@ let bf_codec =
       ]
 
 let test_repeat_casetype_bits_case () =
-  let v = [ Bf 5; Raw 9; Bf 0 ] in
+  let v = [ Bf 5; Raw (UInt8.v 9); Bf 0 ] in
   let buf = Bytes.create (Codec.size_of_value bf_codec v) in
   Codec.encode bf_codec v buf 0;
   Alcotest.(check bool)
@@ -7427,7 +7512,7 @@ let test_repeat_casetype_unprojectable_case_rejected () =
   let nested_case =
     casetype "NestCaseOpt" uint8
       [
-        case ~index:1
+        case ~index:(UInt8.v 1)
           (nested ~size:(int 1) int8)
           ~inject:(fun v -> `N v)
           ~project:(function `N v -> Some v);
@@ -7439,7 +7524,7 @@ let test_repeat_casetype_unprojectable_case_rejected () =
 
 (* -- Zero-terminated strings ([zeroterm] / [zeroterm_at_most]) -- *)
 
-type zt_rec = { name : string; tag : string; n : int }
+type zt_rec = { name : string; tag : string; n : UInt8.t }
 
 let zt_f_name = Field.v "name" zeroterm
 let zt_f_tag = Field.v "tag" (zeroterm_at_most ~size:(int 8))
@@ -7456,7 +7541,7 @@ let zt_codec =
       ]
 
 let test_zeroterm_roundtrip () =
-  let v = { name = "hello"; tag = "ab"; n = 7 } in
+  let v = { name = "hello"; tag = "ab"; n = UInt8.v 7 } in
   (* name(5+1) + tag(8) + n(1) = 15 *)
   let buf = Bytes.create 15 in
   Codec.encode zt_codec v buf 0;
@@ -7465,10 +7550,10 @@ let test_zeroterm_roundtrip () =
   let r = decode_ok (Codec.decode zt_codec buf 0) in
   Alcotest.(check string) "name" "hello" r.name;
   Alcotest.(check string) "tag" "ab" r.tag;
-  Alcotest.(check int) "n" 7 r.n
+  Alcotest.(check int) "n" 7 (UInt8.to_int r.n)
 
 let test_zeroterm_empty () =
-  let v = { name = ""; tag = ""; n = 0 } in
+  let v = { name = ""; tag = ""; n = UInt8.v 0 } in
   let buf = Bytes.create 15 in
   Codec.encode zt_codec v buf 0;
   let r = decode_ok (Codec.decode zt_codec buf 0) in
@@ -7476,7 +7561,7 @@ let test_zeroterm_empty () =
   Alcotest.(check string) "tag" "" r.tag
 
 let test_zeroterm_embedded_nul_rejected () =
-  let v = { name = "a\000b"; tag = ""; n = 0 } in
+  let v = { name = "a\000b"; tag = ""; n = UInt8.v 0 } in
   let buf = Bytes.create 15 in
   match Codec.encode zt_codec v buf 0 with
   | () -> Alcotest.fail "expected Invalid_argument for embedded NUL"
@@ -7489,10 +7574,10 @@ type zt_case = Zt of string | Zt_at_most of string
 let zt_case_typ : zt_case typ =
   casetype "ZtCase" uint8
     [
-      case ~index:1 zeroterm
+      case ~index:(UInt8.v 1) zeroterm
         ~inject:(fun s -> Zt s)
         ~project:(function Zt s -> Some s | _ -> None);
-      case ~index:2
+      case ~index:(UInt8.v 2)
         (zeroterm_at_most ~size:(int 8))
         ~inject:(fun s -> Zt_at_most s)
         ~project:(function Zt_at_most s -> Some s | _ -> None);
@@ -7522,9 +7607,9 @@ let test_zeroterm_nul_message_shared () =
       ignore (Wire.to_string (zeroterm_at_most ~size:(int 8)) nul));
   let field_buf = Bytes.create 15 in
   check "Codec.encode zeroterm field" (fun () ->
-      Codec.encode zt_codec { name = nul; tag = ""; n = 0 } field_buf 0);
+      Codec.encode zt_codec { name = nul; tag = ""; n = UInt8.v 0 } field_buf 0);
   check "Codec.encode zeroterm_at_most field" (fun () ->
-      Codec.encode zt_codec { name = ""; tag = nul; n = 0 } field_buf 0);
+      Codec.encode zt_codec { name = ""; tag = nul; n = UInt8.v 0 } field_buf 0);
   let case_buf = Bytes.create 16 in
   check "Codec.encode zeroterm case body" (fun () ->
       Codec.encode zt_case_codec (Zt nul) case_buf 0);
@@ -7546,7 +7631,9 @@ let test_zeroterm_region_message_shared () =
   check "Wire.to_string" (fun () ->
       ignore (Wire.to_string (zeroterm_at_most ~size:(int 8)) full));
   check "Codec.encode field" (fun () ->
-      Codec.encode zt_codec { name = ""; tag = full; n = 0 } (Bytes.create 15) 0);
+      Codec.encode zt_codec
+        { name = ""; tag = full; n = UInt8.v 0 }
+        (Bytes.create 15) 0);
   check "Codec.encode case body" (fun () ->
       Codec.encode zt_case_codec (Zt_at_most full) (Bytes.create 16) 0)
 
@@ -7559,7 +7646,7 @@ let test_zeroterm_missing_terminator () =
 
 (* -- Codec.rename -- *)
 
-type rename_rec = { ra : int; rb : UInt16.t }
+type rename_rec = { ra : UInt8.t; rb : UInt16.t }
 
 let rename_codec =
   Codec.v "OrigName"
@@ -7588,7 +7675,7 @@ let test_rename_projection () =
 
 let test_rename_roundtrip () =
   let renamed = Codec.rename "NewName" rename_codec in
-  let v = { ra = 7; rb = UInt16.v 1000 } in
+  let v = { ra = UInt8.v 7; rb = UInt16.v 1000 } in
   match (encode_record rename_codec v, encode_record renamed v) with
   | Ok b1, Ok b2 -> (
       Alcotest.(check string) "encode unchanged by rename" b1 b2;
@@ -7628,53 +7715,53 @@ let test_enum_codec_validates () =
    closure per decode, visible under flambda-off. The 8-vs-16 field decode
    must grow only by the 8 extra record slots -- no closure. *)
 type alloc_r8 = {
-  a1 : int;
-  a2 : int;
-  a3 : int;
-  a4 : int;
-  a5 : int;
-  a6 : int;
-  a7 : int;
-  a8 : int;
+  a1 : UInt8.t;
+  a2 : UInt8.t;
+  a3 : UInt8.t;
+  a4 : UInt8.t;
+  a5 : UInt8.t;
+  a6 : UInt8.t;
+  a7 : UInt8.t;
+  a8 : UInt8.t;
 }
 
 type alloc_r16 = {
-  b1 : int;
-  b2 : int;
-  b3 : int;
-  b4 : int;
-  b5 : int;
-  b6 : int;
-  b7 : int;
-  b8 : int;
-  b9 : int;
-  b10 : int;
-  b11 : int;
-  b12 : int;
-  b13 : int;
-  b14 : int;
-  b15 : int;
-  b16 : int;
+  b1 : UInt8.t;
+  b2 : UInt8.t;
+  b3 : UInt8.t;
+  b4 : UInt8.t;
+  b5 : UInt8.t;
+  b6 : UInt8.t;
+  b7 : UInt8.t;
+  b8 : UInt8.t;
+  b9 : UInt8.t;
+  b10 : UInt8.t;
+  b11 : UInt8.t;
+  b12 : UInt8.t;
+  b13 : UInt8.t;
+  b14 : UInt8.t;
+  b15 : UInt8.t;
+  b16 : UInt8.t;
 }
 
 type alloc_r17 = {
-  c1 : int;
-  c2 : int;
-  c3 : int;
-  c4 : int;
-  c5 : int;
-  c6 : int;
-  c7 : int;
-  c8 : int;
-  c9 : int;
-  c10 : int;
-  c11 : int;
-  c12 : int;
-  c13 : int;
-  c14 : int;
-  c15 : int;
-  c16 : int;
-  c17 : int;
+  c1 : UInt8.t;
+  c2 : UInt8.t;
+  c3 : UInt8.t;
+  c4 : UInt8.t;
+  c5 : UInt8.t;
+  c6 : UInt8.t;
+  c7 : UInt8.t;
+  c8 : UInt8.t;
+  c9 : UInt8.t;
+  c10 : UInt8.t;
+  c11 : UInt8.t;
+  c12 : UInt8.t;
+  c13 : UInt8.t;
+  c14 : UInt8.t;
+  c15 : UInt8.t;
+  c16 : UInt8.t;
+  c17 : UInt8.t;
 }
 
 let alloc_codec8 =
@@ -7766,74 +7853,74 @@ let alloc_codec17 =
    [make] call, no closure. 33 fields is the first arity past the table, so it
    makes one partial application and exercises the recursive unroll. *)
 type alloc_r32 = {
-  d1 : int;
-  d2 : int;
-  d3 : int;
-  d4 : int;
-  d5 : int;
-  d6 : int;
-  d7 : int;
-  d8 : int;
-  d9 : int;
-  d10 : int;
-  d11 : int;
-  d12 : int;
-  d13 : int;
-  d14 : int;
-  d15 : int;
-  d16 : int;
-  d17 : int;
-  d18 : int;
-  d19 : int;
-  d20 : int;
-  d21 : int;
-  d22 : int;
-  d23 : int;
-  d24 : int;
-  d25 : int;
-  d26 : int;
-  d27 : int;
-  d28 : int;
-  d29 : int;
-  d30 : int;
-  d31 : int;
-  d32 : int;
+  d1 : UInt8.t;
+  d2 : UInt8.t;
+  d3 : UInt8.t;
+  d4 : UInt8.t;
+  d5 : UInt8.t;
+  d6 : UInt8.t;
+  d7 : UInt8.t;
+  d8 : UInt8.t;
+  d9 : UInt8.t;
+  d10 : UInt8.t;
+  d11 : UInt8.t;
+  d12 : UInt8.t;
+  d13 : UInt8.t;
+  d14 : UInt8.t;
+  d15 : UInt8.t;
+  d16 : UInt8.t;
+  d17 : UInt8.t;
+  d18 : UInt8.t;
+  d19 : UInt8.t;
+  d20 : UInt8.t;
+  d21 : UInt8.t;
+  d22 : UInt8.t;
+  d23 : UInt8.t;
+  d24 : UInt8.t;
+  d25 : UInt8.t;
+  d26 : UInt8.t;
+  d27 : UInt8.t;
+  d28 : UInt8.t;
+  d29 : UInt8.t;
+  d30 : UInt8.t;
+  d31 : UInt8.t;
+  d32 : UInt8.t;
 }
 
 type alloc_r33 = {
-  e1 : int;
-  e2 : int;
-  e3 : int;
-  e4 : int;
-  e5 : int;
-  e6 : int;
-  e7 : int;
-  e8 : int;
-  e9 : int;
-  e10 : int;
-  e11 : int;
-  e12 : int;
-  e13 : int;
-  e14 : int;
-  e15 : int;
-  e16 : int;
-  e17 : int;
-  e18 : int;
-  e19 : int;
-  e20 : int;
-  e21 : int;
-  e22 : int;
-  e23 : int;
-  e24 : int;
-  e25 : int;
-  e26 : int;
-  e27 : int;
-  e28 : int;
-  e29 : int;
-  e30 : int;
-  e31 : int;
-  e32 : int;
-  e33 : int;
+  e1 : UInt8.t;
+  e2 : UInt8.t;
+  e3 : UInt8.t;
+  e4 : UInt8.t;
+  e5 : UInt8.t;
+  e6 : UInt8.t;
+  e7 : UInt8.t;
+  e8 : UInt8.t;
+  e9 : UInt8.t;
+  e10 : UInt8.t;
+  e11 : UInt8.t;
+  e12 : UInt8.t;
+  e13 : UInt8.t;
+  e14 : UInt8.t;
+  e15 : UInt8.t;
+  e16 : UInt8.t;
+  e17 : UInt8.t;
+  e18 : UInt8.t;
+  e19 : UInt8.t;
+  e20 : UInt8.t;
+  e21 : UInt8.t;
+  e22 : UInt8.t;
+  e23 : UInt8.t;
+  e24 : UInt8.t;
+  e25 : UInt8.t;
+  e26 : UInt8.t;
+  e27 : UInt8.t;
+  e28 : UInt8.t;
+  e29 : UInt8.t;
+  e30 : UInt8.t;
+  e31 : UInt8.t;
+  e32 : UInt8.t;
+  e33 : UInt8.t;
 }
 
 let alloc_codec32 =
@@ -8024,31 +8111,31 @@ let test_decode_high_arity_roundtrip () =
   (* Exercise the saturated 16-field case. *)
   let buf16 = Bytes.init 16 (fun i -> Char.chr (i + 1)) in
   let v16 = Codec.decode_exn alloc_codec16 buf16 0 in
-  Alcotest.(check int) "b1" 1 v16.b1;
-  Alcotest.(check int) "b16" 16 v16.b16;
+  Alcotest.(check int) "b1" 1 (UInt8.to_int v16.b1);
+  Alcotest.(check int) "b16" 16 (UInt8.to_int v16.b16);
   (* 17 fields: still saturated after the table was widened to 32. *)
   let buf17 = Bytes.init 17 (fun i -> Char.chr (i + 1)) in
   let v17 = Codec.decode_exn alloc_codec17 buf17 0 in
-  Alcotest.(check int) "c1" 1 v17.c1;
-  Alcotest.(check int) "c16" 16 v17.c16;
-  Alcotest.(check int) "c17" 17 v17.c17;
+  Alcotest.(check int) "c1" 1 (UInt8.to_int v17.c1);
+  Alcotest.(check int) "c16" 16 (UInt8.to_int v17.c16);
+  Alcotest.(check int) "c17" 17 (UInt8.to_int v17.c17);
   let out = Bytes.create 17 in
   Codec.encode alloc_codec17 v17 out 0;
   Alcotest.(check bytes) "17-field roundtrip" buf17 out;
   (* 32 fields: the saturated-table ceiling. *)
   let buf32 = Bytes.init 32 (fun i -> Char.chr (i + 1)) in
   let v32 = Codec.decode_exn alloc_codec32 buf32 0 in
-  Alcotest.(check int) "d1" 1 v32.d1;
-  Alcotest.(check int) "d32" 32 v32.d32;
+  Alcotest.(check int) "d1" 1 (UInt8.to_int v32.d1);
+  Alcotest.(check int) "d32" 32 (UInt8.to_int v32.d32);
   let out32 = Bytes.create 32 in
   Codec.encode alloc_codec32 v32 out32 0;
   Alcotest.(check bytes) "32-field roundtrip" buf32 out32;
   (* 33 fields: the first arity past the table, exercising the recursive arm. *)
   let buf33 = Bytes.init 33 (fun i -> Char.chr (i + 1)) in
   let v33 = Codec.decode_exn alloc_codec33 buf33 0 in
-  Alcotest.(check int) "e1" 1 v33.e1;
-  Alcotest.(check int) "e32" 32 v33.e32;
-  Alcotest.(check int) "e33" 33 v33.e33;
+  Alcotest.(check int) "e1" 1 (UInt8.to_int v33.e1);
+  Alcotest.(check int) "e32" 32 (UInt8.to_int v33.e32);
+  Alcotest.(check int) "e33" 33 (UInt8.to_int v33.e33);
   let out33 = Bytes.create 33 in
   Codec.encode alloc_codec33 v33 out33 0;
   Alcotest.(check bytes) "33-field roundtrip" buf33 out33
@@ -8100,7 +8187,7 @@ type alloc_priority = Low | High
 type alloc_accessor = {
   hi : int;
   lo : int;
-  u8 : int;
+  u8 : UInt8.t;
   u16 : UInt16.t;
   i32 : SInt32.t;
   priority : alloc_priority;
@@ -8115,8 +8202,8 @@ let alloc_i32 = Field.v "I32" int32be
 let alloc_priority =
   Field.v "Priority"
     (map
-       ~decode:(function 0 -> Low | _ -> High)
-       ~encode:(function Low -> 0 | High -> 1)
+       ~decode:(fun v -> if UInt8.equal v UInt8.zero then Low else High)
+       ~encode:(function Low -> UInt8.zero | High -> UInt8.v 1)
        uint8)
 
 let alloc_bf_hi = Codec.(alloc_hi $ fun r -> r.hi)
@@ -8184,7 +8271,7 @@ let test_set_no_allocation () =
   let i32_v = SInt32.of_int 70_000 in
   let u16_v = UInt16.v 513 in
   check_no_per_call_allocation "set bits" (fun () -> set_hi buf 0 3);
-  check_no_per_call_allocation "set uint8" (fun () -> set_u8 buf 0 7);
+  check_no_per_call_allocation "set uint8" (fun () -> set_u8 buf 0 (UInt8.v 7));
   check_no_per_call_allocation "set uint16be" (fun () -> set_u16 buf 0 u16_v);
   check_no_per_call_allocation "set int32be" (fun () -> set_i32 buf 0 i32_v);
   check_no_per_call_allocation "set map" (fun () -> set_priority buf 0 High)
@@ -8269,14 +8356,17 @@ let optional_family name ~present typ =
   Codec.v name
     (fun _ d -> d)
     Codec.
-      [ (f_span_gate $ fun _ -> 1); Field.optional "d" ~present typ $ Fun.id ]
+      [
+        (f_span_gate $ fun _ -> UInt8.v 1);
+        Field.optional "d" ~present typ $ Fun.id;
+      ]
 
 let optional_or_family name ~present typ =
   Codec.v name
     (fun _ d -> d)
     Codec.
       [
-        (f_span_gate $ fun _ -> 1);
+        (f_span_gate $ fun _ -> UInt8.v 1);
         Field.optional_or "d" ~present ~default:"" typ $ Fun.id;
       ]
 
@@ -8467,13 +8557,14 @@ let container_elem_codec =
 let container_case_typ =
   casetype "ContainerCase" uint8
     [
-      case ~index:1 (codec container_elem_codec) ~inject:Fun.id
+      case ~index:(UInt8.v 1) (codec container_elem_codec) ~inject:Fun.id
         ~project:(fun v -> Some v);
-      case ~index:2 uint16be
+      case ~index:(UInt8.v 2) uint16be
         ~inject:(fun v ->
           let v = UInt16.to_int v in
-          (v lsr 8, v land 0xff))
-        ~project:(fun (a, b) -> Some (UInt16.v ((a lsl 8) lor b)));
+          (UInt8.v (v lsr 8), UInt8.v (v land 0xff)))
+        ~project:(fun (a, b) ->
+          Some (UInt16.v ((UInt8.to_int a lsl 8) lor UInt8.to_int b)));
     ]
 
 let container_words name typ buf =
@@ -8636,7 +8727,7 @@ let field_pos_size_codec =
     (fun _len body -> body)
     Codec.
       [
-        f_diag_len $ String.length;
+        (f_diag_len $ fun x -> UInt8.v (String.length x));
         Field.v "body"
           (byte_array ~size:Expr.(Field.ref f_diag_len + field_pos))
         $ Fun.id;
@@ -8662,7 +8753,7 @@ let dep_size_codec =
     (fun _len body -> body)
     Codec.
       [
-        f_diag_len $ String.length;
+        (f_diag_len $ fun x -> UInt8.v (String.length x));
         Field.v "body" (byte_array ~size:(Field.ref f_diag_len)) $ Fun.id;
       ]
 
@@ -8675,7 +8766,7 @@ let two_span_codec =
     (fun _len a n b -> (a, n, b))
     Codec.
       [
-        (f_diag_len $ fun (a, _, _) -> String.length a);
+        (f_diag_len $ fun (a, _, _) -> UInt8.v (String.length a));
         ( Field.v "a" (byte_array ~size:(Field.ref f_diag_len))
         $ fun (a, _, _) -> a );
         (f_n $ fun (_, n, _) -> n);
@@ -8827,12 +8918,12 @@ let test_set_refusal_leaves_buffer_untouched () =
   let outer = Codec.v "SetRollbackOuter" Fun.id Codec.[ outer_f ] in
   let set = Staged.unstage (Codec.set outer outer_f) in
   let buf = Bytes.make 1 '\xee' in
-  (match set buf 0 200 with
+  (match set buf 0 (UInt8.v 200) with
   | () -> Alcotest.fail "Codec.set accepted a value the sub-codec refuses"
   | exception Invalid_argument _ -> ());
   Alcotest.(check string)
     "buffer untouched after a refused set" "\xee" (Bytes.to_string buf);
-  set buf 0 42;
+  set buf 0 (UInt8.v 42);
   Alcotest.(check string)
     "an accepted set still writes" "\x2a" (Bytes.to_string buf)
 
@@ -8925,11 +9016,13 @@ let test_set_bitfield_word_past_buffer_writes_nothing () =
    to a bare [Failure], on fields [Codec.decode] reads without trouble. Check
    both flavours and both gates against what decode returns. *)
 let test_get_static_optional_agrees_with_decode () =
-  let f_len = Field.optional_or "Len" ~present:Expr.true_ ~default:0 uint8 in
+  let f_len =
+    Field.optional_or "Len" ~present:Expr.true_ ~default:UInt8.zero uint8
+  in
   let f_on = Field.optional "On" ~present:Expr.true_ uint8 in
   let f_off = Field.optional "Off" ~present:Expr.false_ uint8 in
   let f_or_off =
-    Field.optional_or "OrOff" ~present:Expr.false_ ~default:7 uint8
+    Field.optional_or "OrOff" ~present:Expr.false_ ~default:(UInt8.v 7) uint8
   in
   let f_data = Field.v "Data" (byte_array ~size:(Field.ref f_len)) in
   let cf_len = Codec.(f_len $ fun (l, _, _, _, _) -> l) in
@@ -8945,18 +9038,29 @@ let test_get_static_optional_agrees_with_decode () =
   let buf = Bytes.of_string "\003\009abc" in
   let len, on, off, or_off, _ = decode_ok (Codec.decode c buf 0) in
   let read f = Staged.unstage (Codec.get c f) buf 0 in
-  Alcotest.(check int) "optional_or, gate on" len (read cf_len);
-  Alcotest.(check (option int)) "optional, gate on" on (read cf_on);
-  Alcotest.(check (option int)) "optional, gate off" off (read cf_off);
   Alcotest.(check int)
-    "optional_or, gate off is the default" or_off (read cf_or_off);
+    "optional_or, gate on" (UInt8.to_int len)
+    (UInt8.to_int (read cf_len));
+  Alcotest.(check (option int))
+    "optional, gate on"
+    (Option.map UInt8.to_int on)
+    (Option.map UInt8.to_int (read cf_on));
+  Alcotest.(check (option int))
+    "optional, gate off"
+    (Option.map UInt8.to_int off)
+    (Option.map UInt8.to_int (read cf_off));
+  Alcotest.(check int)
+    "optional_or, gate off is the default" (UInt8.to_int or_off)
+    (UInt8.to_int (read cf_or_off));
   Alcotest.(check string) "span sized by the optional_or" "abc" (read cf_data);
   (* And the matching setter, so a field [get] can read is one [set] can
      write. The absent gates own no bytes, so writing them moves nothing. *)
-  Staged.unstage (Codec.set c cf_on) buf 0 (Some 5);
+  Staged.unstage (Codec.set c cf_on) buf 0 (Some (UInt8.v 5));
   Staged.unstage (Codec.set c cf_off) buf 0 None;
-  Staged.unstage (Codec.set c cf_or_off) buf 0 7;
-  Alcotest.(check (option int)) "set then get, gate on" (Some 5) (read cf_on);
+  Staged.unstage (Codec.set c cf_or_off) buf 0 (UInt8.v 7);
+  Alcotest.(check (option int))
+    "set then get, gate on" (Some 5)
+    (Option.map UInt8.to_int (read cf_on));
   Alcotest.(check string)
     "the absent gates wrote no bytes" "\003\005abc" (Bytes.to_string buf)
 
@@ -9026,13 +9130,25 @@ let test_repeat_bounded_element_roundtrips () =
     Codec.v "BoundedRep"
       (fun _ xs -> xs)
       Codec.
-        [ (f_total $ fun xs -> 4 * List.length xs); (f_items $ fun xs -> xs) ]
+        [
+          (f_total $ fun xs -> UInt8.v (4 * List.length xs));
+          (f_items $ fun xs -> xs);
+        ]
   in
-  let xs = [ (1, (2, "\000\000")); (3, (4, "\000\000")) ] in
+  let xs =
+    [
+      (UInt8.v 1, (UInt8.v 2, "\000\000")); (UInt8.v 3, (UInt8.v 4, "\000\000"));
+    ]
+  in
   let buf = Bytes.create (Codec.size_of_value outer xs) in
   Codec.encode outer xs buf 0;
   let ys = decode_ok (Codec.decode outer buf 0) in
-  Alcotest.(check bool) "two bounded elements round-trip" true (ys = xs)
+  let elem_equal (a, (b, s)) (a', (b', s')) =
+    UInt8.equal a a' && UInt8.equal b b' && String.equal s s'
+  in
+  Alcotest.(check bool)
+    "two bounded elements round-trip" true
+    (List.equal elem_equal ys xs)
 
 (* -- Suite -- *)
 
@@ -9241,8 +9357,6 @@ let suite =
         test_set_bits_no_silent_truncation;
       Alcotest.test_case "exact width: map reaches the inner typ" `Quick
         test_map_inherits_exact_width;
-      Alcotest.test_case "exact width: unsigned scalars" `Quick
-        test_encode_exact_unsigned_scalar;
       Alcotest.test_case "exact width: UInt32.of_int range" `Quick
         test_uint32_of_int_range;
       Alcotest.test_case "exact width: int64 carrier has no range" `Quick
@@ -9253,8 +9367,6 @@ let suite =
         test_four_byte_signed_preserves_wire;
       Alcotest.test_case "exact width: SInt32.of_int range" `Quick
         test_sint32_of_int_range;
-      Alcotest.test_case "exact width: array and repeat elements" `Quick
-        test_element_exact_width;
       Alcotest.test_case "exact byte field: literal size" `Quick
         test_exact_byte_field_literal_size;
       Alcotest.test_case "exact byte field: expression size" `Quick

--- a/test/test_eval.ml
+++ b/test/test_eval.ml
@@ -7,7 +7,9 @@
 open Wire.Private
 
 let test_int_of () =
-  Alcotest.(check (option int)) "uint8" (Some 7) (Eval.int_of Types.uint8 7);
+  Alcotest.(check (option int))
+    "uint8" (Some 7)
+    (Eval.int_of Types.uint8 (Wire.UInt8.v 7));
   Alcotest.(check (option int))
     "uint16be" (Some 300)
     (Eval.int_of Types.uint16be (Wire.UInt16.v 300));
@@ -42,7 +44,7 @@ let raises_invalid_arg name f =
         (Printexc.to_string e)
 
 let test_int_of_exn_ok () =
-  Alcotest.(check int) "uint8" 7 (Eval.int_of_exn Types.uint8 7);
+  Alcotest.(check int) "uint8" 7 (Eval.int_of_exn Types.uint8 (Wire.UInt8.v 7));
   Alcotest.(check int)
     "uint16be" 300
     (Eval.int_of_exn Types.uint16be (Wire.UInt16.v 300));

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -334,7 +334,8 @@ let test_enum_open_accepts_and_no_refinement () =
   let c = Codec.v "OpenK" (fun v -> v) Codec.[ (Field.v "k" e $ fun v -> v) ] in
   let buf = Bytes.make 1 '\x05' in
   (match Codec.decode c buf 0 with
-  | Ok v -> Alcotest.(check int) "open accepts unlisted value" 5 v
+  | Ok v ->
+      Alcotest.(check int) "open accepts unlisted value" 5 (UInt8.to_int v)
   | Error _ -> Alcotest.fail "open enum wrongly rejected an unlisted value");
   let out = to_3d (Everparse.project ~mode:`Ffi c).module_ in
   Alcotest.(check bool)
@@ -906,7 +907,7 @@ let test_3d_field_pos_rejected () =
 
 type tm_like = {
   hdr : UInt16.t;
-  data_len : int;
+  data_len : UInt8.t;
   packets : packet list;
   ocf : UInt32.t option;
   fecf : UInt16.t option;

--- a/test/test_expr_compiler.ml
+++ b/test/test_expr_compiler.ml
@@ -15,7 +15,7 @@ open Wire.Private
 type ints = (string * int) list
 type i64s = (string * int64) list
 
-let param name : (int, Types.param_input) Types.param_handle =
+let param name : (Wire.UInt8.t, Types.param_input) Types.param_handle =
   {
     Types.id = 1;
     name;

--- a/test/test_field.ml
+++ b/test/test_field.ml
@@ -70,8 +70,8 @@ let test_ref_mapped_field () =
   let f =
     Field.v "Code"
       (Types.map
-         (fun n -> string_of_int n)
-         (fun s -> int_of_string s)
+         (fun n -> string_of_int (Wire.UInt8.to_int n))
+         (fun s -> Wire.UInt8.v (int_of_string s))
          Types.uint8)
   in
   match Field.ref f with
@@ -99,7 +99,11 @@ let test_int64_rejects_field_without_int64_slot () =
     | exception Invalid_argument _ -> ()
   in
   let mapped =
-    Field.v "Mapped" (Types.map Int64.of_int Int64.to_int Types.uint8)
+    Field.v "Mapped"
+      (Types.map
+         (fun n -> Int64.of_int (Wire.UInt8.to_int n))
+         (fun n -> Wire.UInt8.v (Int64.to_int n))
+         Types.uint8)
   in
   check_invalid "mapped field" (fun () ->
       ignore (Field.int64 mapped : int64 Types.expr));
@@ -107,7 +111,7 @@ let test_int64_rejects_field_without_int64_slot () =
       ignore
         (Field.v "Tiny" Types.uint8 ~self_int64:(fun self ->
              Types.Expr.(self = int64 0L))
-          : int Field.t))
+          : Wire.UInt8.t Field.t))
 
 let test_int64_accepts_map_over_uint64 () =
   (* A map over uint64 keeps its int64 slot: [build_populate] fills it with the

--- a/test/test_param.ml
+++ b/test/test_param.ml
@@ -41,8 +41,8 @@ let test_input_binding () =
     Field.v "x" ~constraint_:Expr.(Field.ref f_x <= Param.expr p) uint8
   in
   let c = Codec.v "InputBinding" (fun x -> x) Codec.[ (cf_x $ fun r -> r) ] in
-  let env = Codec.env c |> Param.bind p 42 in
-  Alcotest.(check int) "value" 42 (Param.get env p)
+  let env = Codec.env c |> Param.bind p (UInt8.v 42) in
+  Alcotest.(check int) "value" 42 (UInt8.to_int (Param.get env p))
 
 let test_wide_input_binding_error () =
   let p = Param.input "wide_limit" uint32 in
@@ -79,15 +79,15 @@ let test_output_binding () =
   let c = Codec.v "OutputBinding" (fun x -> x) Codec.[ (cf_x $ fun r -> r) ] in
   let env = Codec.env c in
   (* output param starts at 0 *)
-  Alcotest.(check int) "initial value" 0 (Param.get env out);
+  Alcotest.(check int) "initial value" 0 (UInt8.to_int (Param.get env out));
   (* after decode, output param is written by the action *)
   let buf = Bytes.of_string "\x07" in
   ignore (decode_ok (Codec.decode ~env c buf 0));
-  Alcotest.(check int) "after decode" 7 (Param.get env out)
+  Alcotest.(check int) "after decode" 7 (UInt8.to_int (Param.get env out))
 
 (* -- Input param visible to constraints (via Codec) -- *)
 
-type bounded_record = { x : int }
+type bounded_record = { x : UInt8.t }
 
 let test_input_param_constraint () =
   let limit = Param.input "limit" uint8 in
@@ -98,11 +98,11 @@ let test_input_param_constraint () =
   let c = Codec.v "Bounded" (fun x -> { x }) Codec.[ (cf_x $ fun r -> r.x) ] in
   (* limit=10, x=5: passes *)
   let buf = Bytes.of_string "\x05" in
-  let env = Codec.env c |> Param.bind limit 10 in
+  let env = Codec.env c |> Param.bind limit (UInt8.v 10) in
   let r = decode_ok (Codec.decode ~env c buf 0) in
-  Alcotest.(check int) "x" 5 r.x;
+  Alcotest.(check int) "x" 5 (UInt8.to_int r.x);
   (* limit=3, x=5: fails *)
-  let env = Codec.env c |> Param.bind limit 3 in
+  let env = Codec.env c |> Param.bind limit (UInt8.v 3) in
   expect_constraint_fail (Codec.decode ~env c buf 0)
 
 (* -- Output param written by action (via Codec) -- *)
@@ -119,7 +119,7 @@ let test_output_param_action () =
   let buf = Bytes.of_string "\x2A" in
   let env = Codec.env c in
   ignore (decode_ok (Codec.decode ~env c buf 0));
-  Alcotest.(check int) "out" 42 (Param.get env out)
+  Alcotest.(check int) "out" 42 (UInt8.to_int (Param.get env out))
 
 let test_output_param_computed () =
   let out = Param.output "out" uint16be in
@@ -211,7 +211,7 @@ let test_bind_by_name () =
 
 (* -- Mixed input + output params (via Codec) -- *)
 
-type mixed_record = { a : int; b : int }
+type mixed_record = { a : UInt8.t; b : UInt8.t }
 
 let test_mixed_params () =
   let max_val = Param.input "max_val" uint8 in
@@ -238,16 +238,16 @@ let test_mixed_params () =
   in
   (* a=10, b=20 => out_sum=30, max_val=50 => 30 <= 50: OK *)
   let buf = Bytes.of_string "\x0A\x14" in
-  let env = Codec.env c |> Param.bind max_val 50 in
+  let env = Codec.env c |> Param.bind max_val (UInt8.v 50) in
   ignore (decode_ok (Codec.decode ~env c buf 0));
-  Alcotest.(check int) "out_sum" 30 (Param.get env out_sum);
+  Alcotest.(check int) "out_sum" 30 (UInt8.to_int (Param.get env out_sum));
   (* a=10, b=20 => out_sum=30, max_val=20 => 30 > 20: FAIL *)
-  let env = Codec.env c |> Param.bind max_val 20 in
+  let env = Codec.env c |> Param.bind max_val (UInt8.v 20) in
   expect_constraint_fail (Codec.decode ~env c buf 0)
 
 (* -- Codec.decode ~env:params with -- *)
 
-type record_with_param = { x : int }
+type record_with_param = { x : UInt8.t }
 
 let test_codec_param_decode () =
   let limit = Param.input "limit" uint8 in
@@ -265,9 +265,9 @@ let test_codec_param_decode () =
       Codec.[ (cf_x $ fun r -> r.x) ]
   in
   let buf = Bytes.of_string "\x05" in
-  let env = Codec.env c |> Param.bind limit 10 in
+  let env = Codec.env c |> Param.bind limit (UInt8.v 10) in
   let v = decode_ok (Codec.decode ~env c buf 0) in
-  Alcotest.(check int) "x" 5 v.x
+  Alcotest.(check int) "x" 5 (UInt8.to_int v.x)
 
 let test_codec_param_where_fail () =
   let limit = Param.input "limit" uint8 in
@@ -285,7 +285,7 @@ let test_codec_param_where_fail () =
       Codec.[ (cf_x $ fun r -> r.x) ]
   in
   let buf = Bytes.of_string "\x05" in
-  let env = Codec.env c |> Param.bind limit 3 in
+  let env = Codec.env c |> Param.bind limit (UInt8.v 3) in
   match Codec.decode ~env c buf 0 with
   | Error { kind = Constraint_failed { which = Where; _ }; _ } -> ()
   | Error e -> Alcotest.failf "wrong error: %a" pp_parse_error e
@@ -336,7 +336,7 @@ let test_no_params () =
 
 (* -- Param-driven size -- *)
 
-type param_size_record = { data : string; tag : int }
+type param_size_record = { data : string; tag : UInt8.t }
 
 let ps_size_param = Param.input "data_size" uint8
 
@@ -351,30 +351,36 @@ let param_size_codec =
       ]
 
 let test_param_size_decode () =
-  let env = Codec.env param_size_codec |> Param.bind ps_size_param 4 in
+  let env =
+    Codec.env param_size_codec |> Param.bind ps_size_param (UInt8.v 4)
+  in
   let buf = Bytes.create 5 in
   Bytes.blit_string "ABCD" 0 buf 0 4;
   Bytes.set_uint8 buf 4 0xFF;
   let r = decode_ok (Codec.decode ~env param_size_codec buf 0) in
   Alcotest.(check string) "data" "ABCD" r.data;
-  Alcotest.(check int) "tag" 0xFF r.tag
+  Alcotest.(check int) "tag" 0xFF (UInt8.to_int r.tag)
 
 let test_param_size_different_sizes () =
   (* Same codec, different param values *)
-  let env2 = Codec.env param_size_codec |> Param.bind ps_size_param 2 in
+  let env2 =
+    Codec.env param_size_codec |> Param.bind ps_size_param (UInt8.v 2)
+  in
   let buf2 = Bytes.create 3 in
   Bytes.blit_string "XY" 0 buf2 0 2;
   Bytes.set_uint8 buf2 2 0xAA;
   let r2 = decode_ok (Codec.decode ~env:env2 param_size_codec buf2 0) in
   Alcotest.(check string) "data 2" "XY" r2.data;
-  Alcotest.(check int) "tag 2" 0xAA r2.tag;
-  let env8 = Codec.env param_size_codec |> Param.bind ps_size_param 8 in
+  Alcotest.(check int) "tag 2" 0xAA (UInt8.to_int r2.tag);
+  let env8 =
+    Codec.env param_size_codec |> Param.bind ps_size_param (UInt8.v 8)
+  in
   let buf8 = Bytes.create 9 in
   Bytes.blit_string "12345678" 0 buf8 0 8;
   Bytes.set_uint8 buf8 8 0xBB;
   let r8 = decode_ok (Codec.decode ~env:env8 param_size_codec buf8 0) in
   Alcotest.(check string) "data 8" "12345678" r8.data;
-  Alcotest.(check int) "tag 8" 0xBB r8.tag
+  Alcotest.(check int) "tag 8" 0xBB (UInt8.to_int r8.tag)
 
 let test_param_size_bind_by_name () =
   (* A param-driven size resolves through the field reader (the cell), not the
@@ -386,7 +392,7 @@ let test_param_size_bind_by_name () =
   Bytes.set_uint8 buf 4 0xFF;
   let r = decode_ok (Codec.decode ~env param_size_codec buf 0) in
   Alcotest.(check string) "data" "ABCD" r.data;
-  Alcotest.(check int) "tag" 0xFF r.tag;
+  Alcotest.(check int) "tag" 0xFF (UInt8.to_int r.tag);
   (* same codec, a different bound size *)
   let env2 = Codec.env param_size_codec |> Param.bind_by_name "data_size" 2 in
   let buf2 = Bytes.create 3 in
@@ -394,7 +400,7 @@ let test_param_size_bind_by_name () =
   Bytes.set_uint8 buf2 2 0xAA;
   let r2 = decode_ok (Codec.decode ~env:env2 param_size_codec buf2 0) in
   Alcotest.(check string) "data 2" "XY" r2.data;
-  Alcotest.(check int) "tag 2" 0xAA r2.tag
+  Alcotest.(check int) "tag 2" 0xAA (UInt8.to_int r2.tag)
 
 let test_decode_rejects_unbound_param () =
   (* An input param that drives a field size must be bound before decode, the
@@ -419,12 +425,14 @@ let test_decode_rejects_unbound_param () =
       ignore (Codec.decode ~env param_size_codec buf 0))
 
 let test_param_size_zero () =
-  let env = Codec.env param_size_codec |> Param.bind ps_size_param 0 in
+  let env =
+    Codec.env param_size_codec |> Param.bind ps_size_param (UInt8.v 0)
+  in
   let buf = Bytes.create 1 in
   Bytes.set_uint8 buf 0 0xFF;
   let r = decode_ok (Codec.decode ~env param_size_codec buf 0) in
   Alcotest.(check string) "data" "" r.data;
-  Alcotest.(check int) "tag" 0xFF r.tag
+  Alcotest.(check int) "tag" 0xFF (UInt8.to_int r.tag)
 
 let test_param_size_reentrant_codec () =
   let size = Param.input "reentrant_size" uint8 in
@@ -444,7 +452,7 @@ let test_param_size_reentrant_codec () =
       ~encode:(fun v ->
         reenter (fun codec env ->
             let buf = Bytes.create 2 in
-            Codec.encode ~env codec (7, "Z") buf 0);
+            Codec.encode ~env codec (UInt8.v 7, "Z") buf 0);
         v)
       ~decode:(fun v ->
         reenter (fun codec env ->
@@ -462,16 +470,17 @@ let test_param_size_reentrant_codec () =
         ]
   in
   codec_ref := Some codec;
-  let inner_env = Codec.env codec |> Param.bind size 1 in
+  let inner_env = Codec.env codec |> Param.bind size (UInt8.v 1) in
   inner_env_ref := Some inner_env;
-  let outer_env = Codec.env codec |> Param.bind size 2 in
+  let outer_env = Codec.env codec |> Param.bind size (UInt8.v 2) in
   let buf = Bytes.create 3 in
-  Codec.encode ~env:outer_env codec (9, "AB") buf 0;
+  Codec.encode ~env:outer_env codec (UInt8.v 9, "AB") buf 0;
   Alcotest.(check bytes)
     "outer encode keeps its size" (Bytes.of_string "\x09AB") buf;
+  let tag, data = decode_ok (Codec.decode ~env:outer_env codec buf 0) in
   Alcotest.(check (pair int string))
     "outer decode keeps its size" (9, "AB")
-    (decode_ok (Codec.decode ~env:outer_env codec buf 0))
+    (UInt8.to_int tag, data)
 
 let test_param_size_in_casetype () =
   (* Casetype dispatch must preserve the outer encode context when its selected
@@ -485,7 +494,7 @@ let test_param_size_in_casetype () =
   let typ =
     casetype "ParamCase" uint8
       [
-        case ~index:1 (codec inner)
+        case ~index:(UInt8.v 1) (codec inner)
           ~inject:(fun value -> `Body value)
           ~project:(function `Body value -> Some value);
       ]
@@ -493,7 +502,7 @@ let test_param_size_in_casetype () =
   let outer =
     Codec.v "ParamCaseOuter" Fun.id Codec.[ Field.v "case" typ $ Fun.id ]
   in
-  let env = Codec.env outer |> Param.bind size 2 in
+  let env = Codec.env outer |> Param.bind size (UInt8.v 2) in
   let buf = Bytes.create 3 in
   Codec.encode ~env outer (`Body "AB") buf 0;
   Alcotest.(check bytes) "encoded casetype" (Bytes.of_string "\x01AB") buf;
@@ -516,12 +525,13 @@ let test_param_through_typ_wrappers () =
   let wrapped = where Expr.true_ (codec inner) in
   let field = Field.optional "body" ~present:Expr.true_ wrapped in
   let outer = Codec.v "ParamWrappedOuter" Fun.id Codec.[ field $ Fun.id ] in
-  let env = Codec.env outer |> Param.bind limit 100 in
+  let env = Codec.env outer |> Param.bind limit (UInt8.v 100) in
   let buf = Bytes.of_string "\x2d" in
   Alcotest.(check (result (option int) string))
     "decoded wrapped codec" (Ok (Some 45))
-    (string_error (Codec.decode ~env outer buf 0));
-  Codec.encode ~env outer (Some 45) buf 0;
+    (Result.map (Option.map UInt8.to_int)
+       (string_error (Codec.decode ~env outer buf 0)));
+  Codec.encode ~env outer (Some (UInt8.v 45)) buf 0;
   Alcotest.(check bytes) "encoded wrapped codec" (Bytes.of_string "\x2d") buf
 
 (* -- Concurrent decode -- *)
@@ -574,14 +584,18 @@ let test_multi_domain_decode () =
       Codec.[ f_a $ fst; checked_b $ snd ]
   in
   let worker value =
-    let env = Codec.env codec |> Param.bind limit value in
+    let env = Codec.env codec |> Param.bind limit (UInt8.v value) in
     let buf = Bytes.make 2 (Char.chr value) in
     let ok = ref true in
+    let expected = UInt8.v value in
     for _ = 1 to 1_000 do
       match Codec.decode ~env codec buf 0 with
-      | Ok decoded ->
-          if decoded <> (value, value) || Param.get env observed <> value then
-            ok := false
+      | Ok (a, b) ->
+          if
+            not
+              (UInt8.equal a expected && UInt8.equal b expected
+              && UInt8.equal (Param.get env observed) expected)
+          then ok := false
       | Error _ -> ok := false
     done;
     !ok

--- a/test/test_shape.ml
+++ b/test/test_shape.ml
@@ -97,7 +97,8 @@ let test_nested_where_rejected () =
     [
       Types.field "n" Types.uint8;
       Types.field "maybe"
-        (Types.optional_or guard ~default:0 (Types.where guard Types.uint8));
+        (Types.optional_or guard ~default:Wire.UInt8.zero
+           (Types.where guard Types.uint8));
     ];
   (* The container may be reached through a decoration, so the walk has to see
      past a [map] to the element underneath. *)
@@ -116,8 +117,8 @@ let test_where_in_case_body_rejected () =
   let tagged =
     Types.casetype "Body" Types.uint8
       [
-        Types.case ~index:1 (Types.where guard Types.uint8) ~inject:Fun.id
-          ~project:(fun v -> Some v);
+        Types.case ~index:(Wire.UInt8.v 1) (Types.where guard Types.uint8)
+          ~inject:Fun.id ~project:(fun v -> Some v);
       ]
   in
   rejects "casetype case body" ~codec:"Tagged" ~mentions:[ "payload" ]

--- a/test/test_uint8.ml
+++ b/test/test_uint8.ml
@@ -1,0 +1,86 @@
+(* Tests for UInt8, the unsigned 8-bit carrier behind [uint8]. The range lives
+   in the type, so what is left to check is the constructor's refusal and the
+   byte layout: every value of the type is one an unsigned byte holds, and no
+   encoder downstream has to ask again. *)
+
+open Wire
+
+(* [v] refuses a number the field cannot hold rather than masking it to a legal
+   one the caller did not mean: 511 masks to a perfectly good 255 that no
+   decoder, [validate] or generated C validator could tell from the number the
+   caller wrote. *)
+let test_v_refuses_out_of_range () =
+  List.iter
+    (fun n ->
+      match UInt8.v n with
+      | x -> Alcotest.failf "v %d built %a" n UInt8.pp x
+      | exception Invalid_argument _ -> ())
+    [ 0x100; 511; -1; -0x80; max_int; min_int ]
+
+let test_v_accepts_the_whole_range () =
+  for n = 0 to 0xFF do
+    Fmt.kstr
+      (fun msg -> Alcotest.(check int) msg n)
+      "v %d round-trips" n
+      (UInt8.to_int (UInt8.v n))
+  done
+
+let test_v_opt () =
+  Alcotest.(check (option int))
+    "in range" (Some 0xFF)
+    (Option.map UInt8.to_int (UInt8.v_opt 0xFF));
+  Alcotest.(check bool) "out of range" true (UInt8.v_opt 0x100 = None)
+
+(* [min_int] and [max_int] are the field's ends, not the carrier's. *)
+let test_bounds () =
+  Alcotest.(check int) "min_int" 0 (UInt8.to_int UInt8.min_int);
+  Alcotest.(check int) "max_int" 0xFF (UInt8.to_int UInt8.max_int);
+  Alcotest.(check int) "zero" 0 (UInt8.to_int UInt8.zero)
+
+let test_roundtrip () =
+  let buf = Bytes.create 1 in
+  for n = 0 to 0xFF do
+    UInt8.set buf 0 (UInt8.v n);
+    Fmt.kstr
+      (fun msg -> Alcotest.(check int) msg n)
+      "%d survives the byte" n
+      (UInt8.to_int (UInt8.get buf 0))
+  done
+
+(* Pin the byte so the read and write paths cannot drift apart, and so a
+   pattern with the top bit set is the large positive number it spells rather
+   than the negative one the same byte would spell signed. *)
+let test_byte_layout () =
+  Alcotest.(check int)
+    "0xFE reads 254" 0xFE
+    (UInt8.to_int (UInt8.get (Bytes.of_string "\xFE") 0));
+  Alcotest.(check int)
+    "0x80 reads 128" 0x80
+    (UInt8.to_int (UInt8.get (Bytes.of_string "\x80") 0));
+  let out = Bytes.create 1 in
+  UInt8.set out 0 UInt8.max_int;
+  Alcotest.(check string) "max_int writes 0xFF" "\xFF" (Bytes.to_string out)
+
+let test_equal () =
+  Alcotest.(check bool) "reflexive" true (UInt8.equal (UInt8.v 42) (UInt8.v 42));
+  Alcotest.(check bool)
+    "min_int <> max_int" false
+    (UInt8.equal UInt8.min_int UInt8.max_int)
+
+let test_pp () =
+  Alcotest.(check string) "max_int" "255" (Fmt.str "%a" UInt8.pp UInt8.max_int)
+
+let suite =
+  ( "uint8",
+    [
+      Alcotest.test_case "v refuses out of range" `Quick
+        test_v_refuses_out_of_range;
+      Alcotest.test_case "v accepts the whole range" `Quick
+        test_v_accepts_the_whole_range;
+      Alcotest.test_case "v_opt" `Quick test_v_opt;
+      Alcotest.test_case "bounds" `Quick test_bounds;
+      Alcotest.test_case "roundtrip" `Quick test_roundtrip;
+      Alcotest.test_case "byte layout" `Quick test_byte_layout;
+      Alcotest.test_case "equal" `Quick test_equal;
+      Alcotest.test_case "pp" `Quick test_pp;
+    ] )

--- a/test/test_uint8.mli
+++ b/test/test_uint8.mli
@@ -1,0 +1,4 @@
+(** Tests for the [uint8] module. *)
+
+val suite : string * unit Alcotest.test_case list
+(** Alcotest suite. *)

--- a/test/test_wire.ml
+++ b/test/test_wire.ml
@@ -17,7 +17,9 @@ let reader_decode_ok typ reader =
   | Ok v -> v
   | Error e -> Alcotest.failf "%a" pp_parse_error e
 
+let uint8_testable = Alcotest.testable UInt8.pp UInt8.equal
 let uint16_testable = Alcotest.testable UInt16.pp UInt16.equal
+let read_u8 reader = UInt8.to_int (reader_decode_ok uint8 reader)
 let read_u16 typ reader = UInt16.to_int (reader_decode_ok typ reader)
 
 (* Helper: encode to string via streaming writer with [chunk_size] buffer *)
@@ -50,7 +52,7 @@ let test_expr_equality_operators () =
 let test_parse_uint8 () =
   let input = "\x42" in
   match of_string uint8 input with
-  | Ok v -> Alcotest.(check int) "uint8 value" 0x42 v
+  | Ok v -> Alcotest.(check int) "uint8 value" 0x42 (UInt8.to_int v)
   | Error e -> Alcotest.failf "%a" pp_parse_error e
 
 let test_parse_uint16_le () =
@@ -89,7 +91,9 @@ let test_parse_array () =
   let input = "\x01\x02\x03" in
   let t = array ~len:(int 3) uint8 in
   match of_string t input with
-  | Ok v -> Alcotest.(check (list int)) "array values" [ 1; 2; 3 ] v
+  | Ok v ->
+      Alcotest.(check (list int))
+        "array values" [ 1; 2; 3 ] (List.map UInt8.to_int v)
   | Error e -> Alcotest.failf "%a" pp_parse_error e
 
 let test_parse_byte_array () =
@@ -287,7 +291,7 @@ let test_rest_of_buffer_codec () =
   in
   match Codec.decode ~env codec buf 0 with
   | Ok (h, d) ->
-      Alcotest.(check int) "header" 1 h;
+      Alcotest.(check int) "header" 1 (UInt8.to_int h);
       Alcotest.(check string) "data" "HELLO" d
   | Error e -> Alcotest.failf "%a" pp_parse_error e
 
@@ -302,7 +306,7 @@ let test_all_bytes_in_codec () =
   let buf = Bytes.of_string "\x2AHello" in
   match Codec.decode codec buf 0 with
   | Ok (h, d) ->
-      Alcotest.(check int) "header" 0x2A h;
+      Alcotest.(check int) "header" 0x2A (UInt8.to_int h);
       Alcotest.(check string) "data" "Hello" d
   | Error e -> Alcotest.failf "%a" pp_parse_error e
 
@@ -320,14 +324,14 @@ let test_codec_all_bytes_tail () =
   let f_payload = Field.v "Payload" (codec inner) in
   let outer = Codec.v "Outer" (fun p -> p) Codec.[ (f_payload $ fun p -> p) ] in
   let roundtrip label tail =
-    let v = (0x42, tail) in
+    let v = (UInt8.v 0x42, tail) in
     let sz = 1 + String.length tail in
     let buf = Bytes.create sz in
     Codec.encode outer v buf 0;
     Alcotest.(check int) (label ^ ": buf length") sz (Bytes.length buf);
     match Codec.decode outer buf 0 with
     | Ok (h, d) ->
-        Alcotest.(check int) (label ^ ": header") 0x42 h;
+        Alcotest.(check int) (label ^ ": header") 0x42 (UInt8.to_int h);
         Alcotest.(check string) (label ^ ": tail") tail d
     | Error e -> Alcotest.failf "%s decode: %a" label pp_parse_error e
   in
@@ -345,7 +349,7 @@ let test_all_zeros_in_codec () =
   let ok_buf = Bytes.of_string "\x55\x00\x00\x00" in
   (match Codec.decode codec ok_buf 0 with
   | Ok (h, p) ->
-      Alcotest.(check int) "tag" 0x55 h;
+      Alcotest.(check int) "tag" 0x55 (UInt8.to_int h);
       Alcotest.(check string) "padding" "\000\000\000" p
   | Error e -> Alcotest.failf "%a" pp_parse_error e);
   let bad_buf = Bytes.of_string "\x55\x00\x01\x00" in
@@ -603,7 +607,7 @@ let test_param_size_encode () =
   let c, p_len = param_codec () in
   List.iter
     (fun n ->
-      let env = Codec.env c |> Param.bind p_len n in
+      let env = Codec.env c |> Param.bind p_len (UInt8.v n) in
       let payload = String.make n 'A' in
       let buf = Bytes.create 32 in
       Codec.encode ~env c { payload } buf 0;
@@ -617,7 +621,7 @@ let test_param_size_encode () =
 
 let test_param_encode_length_mismatch () =
   let c, p_len = param_codec () in
-  let env = Codec.env c |> Param.bind p_len 4 in
+  let env = Codec.env c |> Param.bind p_len (UInt8.v 4) in
   let buf = Bytes.create 16 in
   match Codec.encode ~env c { payload = "ab" } buf 0 with
   | () -> Alcotest.fail "expected Invalid_argument"
@@ -756,7 +760,7 @@ let test_field_pos_fail () =
   | Error { kind = Constraint_failed _; _ } -> ()
   | Error e -> Alcotest.failf "wrong error: %a" pp_parse_error e
 
-type sizeof_action_record = { a : int; b : UInt16.t; c : int }
+type sizeof_action_record = { a : UInt8.t; b : UInt16.t; c : UInt8.t }
 
 let test_sizeof_this_with_action () =
   (* sizeof_this visible to actions: assign out = sizeof_this at field c *)
@@ -777,13 +781,16 @@ let test_sizeof_this_with_action () =
   let env = Codec.env c in
   let buf = Bytes.of_string "\x01\x00\x02\x00" in
   match Codec.decode ~env c buf 0 with
-  | Ok _ -> Alcotest.(check int) "sizeof_this via action" 3 (Param.get env out)
+  | Ok _ ->
+      Alcotest.(check int)
+        "sizeof_this via action" 3
+        (UInt8.to_int (Param.get env out))
   | Error e -> Alcotest.failf "sizeof_this action: %a" pp_parse_error e
 
 (* -- Encoding tests -- *)
 
 let test_encode_uint8 () =
-  let encoded = to_string uint8 0x42 in
+  let encoded = to_string uint8 (UInt8.v 0x42) in
   Alcotest.(check string) "uint8 encoding" "\x42" encoded
 
 let test_encode_uint16_le () =
@@ -804,7 +811,7 @@ let test_encode_uint32_be () =
 
 let test_encode_array () =
   let t = array ~len:(int 3) uint8 in
-  let encoded = to_string t [ 1; 2; 3 ] in
+  let encoded = to_string t (List.map UInt8.v [ 1; 2; 3 ]) in
   Alcotest.(check string) "array encoding" "\x01\x02\x03" encoded
 
 let seq_array : ('a, 'a array) seq_map =
@@ -830,11 +837,18 @@ let expect_direct_array_cardinality label typ value expected actual =
 
 let test_encode_array_cardinality () =
   let list = array ~len:(int 3) uint8 in
-  expect_direct_array_cardinality "short list" list [ 1; 2 ] 3 2;
-  expect_direct_array_cardinality "long list" list [ 1; 2; 3; 4 ] 3 4;
+  expect_direct_array_cardinality "short list" list
+    (List.map UInt8.v [ 1; 2 ])
+    3 2;
+  expect_direct_array_cardinality "long list" list
+    (List.map UInt8.v [ 1; 2; 3; 4 ])
+    3 4;
   let custom = array_seq seq_array ~len:(int 3) uint8 in
-  expect_direct_array_cardinality "short custom sequence" custom [| 1; 2 |] 3 2;
-  expect_direct_array_cardinality "long custom sequence" custom [| 1; 2; 3; 4 |]
+  expect_direct_array_cardinality "short custom sequence" custom
+    (Array.map UInt8.v [| 1; 2 |])
+    3 2;
+  expect_direct_array_cardinality "long custom sequence" custom
+    (Array.map UInt8.v [| 1; 2; 3; 4 |])
     3 4
 
 let expect_direct_repeat_encode_error label typ value =
@@ -962,8 +976,8 @@ let test_region_cardinality_contract () =
     Codec.v "InvariantArray" Fun.id Codec.[ Field.v "items" array_typ $ Fun.id ]
   in
   for n = 0 to 5 do
-    let values = List.init n Fun.id in
-    check_invariant_encoding ~equal:(List.equal Int.equal)
+    let values = List.init n UInt8.v in
+    check_invariant_encoding ~equal:(List.equal UInt8.equal)
       (Fmt.str "array count %d" n)
       array_typ array_codec values
   done;
@@ -1053,7 +1067,7 @@ let test_bits_roundtrip_all_combos () =
 (* -- Roundtrip tests -- *)
 
 let test_roundtrip_uint8 () =
-  roundtrip "roundtrip uint8" uint8 Alcotest.int 0x42
+  roundtrip "roundtrip uint8" uint8 uint8_testable (UInt8.v 0x42)
 
 let test_roundtrip_uint16 () =
   roundtrip "roundtrip uint16" uint16 uint16_testable (UInt16.v 0x1234)
@@ -1066,8 +1080,8 @@ let test_roundtrip_uint32 () =
 let test_roundtrip_array () =
   roundtrip "roundtrip array"
     (array ~len:(int 5) uint8)
-    Alcotest.(list int)
-    [ 1; 2; 3; 4; 5 ]
+    (Alcotest.list uint8_testable)
+    (List.map UInt8.v [ 1; 2; 3; 4; 5 ])
 
 let test_roundtrip_byte_array () =
   roundtrip "roundtrip byte_array"
@@ -1137,14 +1151,14 @@ let test_encode_rejects_unlisted_enum () =
   let closed = enum "Code" [ ("A", 1); ("B", 2) ] uint8 in
   let open_ = enum_open "Code" [ ("A", 1); ("B", 2) ] uint8 in
   expect_typ_encode_rejects "closed enum" ~names:[ "Code"; "got 99" ] (fun () ->
-      to_string closed 99);
+      to_string closed (UInt8.v 99));
   expect_typ_decode_rejects "closed enum" closed "\099";
-  Alcotest.(check string) "listed value" "\002" (to_string closed 2);
+  Alcotest.(check string) "listed value" "\002" (to_string closed (UInt8.v 2));
   (* An open enum names known codes without restricting them. *)
-  Alcotest.(check string) "open enum" "\099" (to_string open_ 99);
+  Alcotest.(check string) "open enum" "\099" (to_string open_ (UInt8.v 99));
   (* The streaming writer shares the kernel, so it rejects the same value. *)
   expect_typ_encode_rejects "closed enum streamed" ~names:[ "got 99" ]
-    (fun () -> encode_chunked ~chunk_size:1 closed 99)
+    (fun () -> encode_chunked ~chunk_size:1 closed (UInt8.v 99))
 
 let test_encode_rejects_non_zero_padding () =
   expect_typ_encode_rejects "all_zeros" ~names:[ "all_zeros"; "0x61" ]
@@ -1159,19 +1173,19 @@ let test_encode_rejects_non_zero_padding () =
 let test_encode_rejects_where_violation () =
   let t = where Expr.(int 3 = int 7) uint8 in
   expect_typ_encode_rejects "where" ~names:[ "where constraint" ] (fun () ->
-      to_string t 3);
+      to_string t (UInt8.v 3));
   expect_typ_decode_rejects "where" t "\003";
   Alcotest.(check string)
     "satisfied cond" "\003"
-    (to_string (where Expr.(int 7 = int 7) uint8) 3)
+    (to_string (where Expr.(int 7 = int 7) uint8) (UInt8.v 3))
 
 (* -- Streaming: cross-slice boundary tests -- *)
 
 (* Parse roundtrip with every chunk size forcing boundary straddles *)
 let test_stream_uint8 () =
-  let encoded = to_string uint8 42 in
+  let encoded = to_string uint8 (UInt8.v 42) in
   match parse_chunked ~chunk_size:1 uint8 encoded with
-  | Ok v -> Alcotest.(check int) "uint8 chunk=1" 42 v
+  | Ok v -> Alcotest.(check int) "uint8 chunk=1" 42 (UInt8.to_int v)
   | Error e -> Alcotest.failf "uint8 chunk=1: %a" pp_parse_error e
 
 let test_stream_uint16_chunk1 () =
@@ -1229,7 +1243,7 @@ let test_stream_reader_sequential_fixed () =
   let reader =
     Bytesrw.Bytes.Reader.of_string ~slice_length:8 "\x01\x02\x03\x04\x05"
   in
-  Alcotest.(check int) "first" 0x01 (reader_decode_ok uint8 reader);
+  Alcotest.(check int) "first" 0x01 (read_u8 reader);
   Alcotest.(check int) "second" 0x0203 (read_u16 uint16be reader);
   Alcotest.(check int) "third" 0x0405 (read_u16 uint16be reader);
   Alcotest.(check bool)
@@ -1246,7 +1260,7 @@ let test_stream_reader_sequential_cross_slice () =
 let test_stream_reader_sequential_zeroterm () =
   let reader = Bytesrw.Bytes.Reader.of_string ~slice_length:2 "abc\000\x7f" in
   Alcotest.(check string) "text" "abc" (reader_decode_ok zeroterm reader);
-  Alcotest.(check int) "tail" 0x7f (reader_decode_ok uint8 reader)
+  Alcotest.(check int) "tail" 0x7f (read_u8 reader)
 
 (* Rewind on error: a failed decode pushes back everything it consumed, so
    the same bytes decode under another description (one test per of_reader
@@ -1257,9 +1271,9 @@ let test_stream_rewind_fixed () =
   let reader = Bytesrw.Bytes.Reader.of_string ~slice_length:8 "\xff\x01\x02" in
   (match Wire.of_reader bad reader with
   | Error { kind = Invalid_enum _; _ } -> ()
-  | Ok v -> Alcotest.failf "expected enum failure, got %d" v
+  | Ok v -> Alcotest.failf "expected enum failure, got %d" (UInt8.to_int v)
   | Error e -> Alcotest.failf "expected Invalid_enum: %a" pp_parse_error e);
-  Alcotest.(check int) "rewound first" 0xff (reader_decode_ok uint8 reader);
+  Alcotest.(check int) "rewound first" 0xff (read_u8 reader);
   Alcotest.(check int) "rest intact" 0x0102 (read_u16 uint16be reader)
 
 let test_stream_rewind_partial_fixed () =
@@ -1269,7 +1283,7 @@ let test_stream_rewind_partial_fixed () =
   | Ok v -> Alcotest.failf "expected eof, got %d" (UInt32.to_int v)
   | Error e -> Alcotest.failf "expected Unexpected_eof: %a" pp_parse_error e);
   Alcotest.(check int) "rewound" 0x0102 (read_u16 uint16be reader);
-  Alcotest.(check int) "rest intact" 0x03 (reader_decode_ok uint8 reader)
+  Alcotest.(check int) "rest intact" 0x03 (read_u8 reader)
 
 let test_stream_rewind_incremental () =
   let reader = Bytesrw.Bytes.Reader.of_string ~slice_length:1 "abc" in
@@ -1277,7 +1291,7 @@ let test_stream_rewind_incremental () =
   | Error { kind = Missing_terminator; _ } -> ()
   | Ok s -> Alcotest.failf "expected missing NUL, got %S" s
   | Error e -> Alcotest.failf "expected Missing_terminator: %a" pp_parse_error e);
-  Alcotest.(check int) "rewound" 0x61 (reader_decode_ok uint8 reader);
+  Alcotest.(check int) "rewound" 0x61 (read_u8 reader);
   Alcotest.(check int) "rest intact" 0x6263 (read_u16 uint16be reader)
 
 let test_stream_rewind_consumes_rest () =
@@ -1328,10 +1342,12 @@ let test_enum_open_of_string_accepts_unlisted () =
     (* 50, not a named code *)
   in
   (match Codec.decode c (Bytes.of_string unlisted) 0 with
-  | Ok v -> Alcotest.(check int) "codec decode accepts unlisted" 50 v
+  | Ok v ->
+      Alcotest.(check int) "codec decode accepts unlisted" 50 (UInt8.to_int v)
   | Error e -> Alcotest.failf "codec rejected unlisted: %a" pp_parse_error e);
   match of_string typ unlisted with
-  | Ok v -> Alcotest.(check int) "of_string accepts unlisted" 50 v
+  | Ok v ->
+      Alcotest.(check int) "of_string accepts unlisted" 50 (UInt8.to_int v)
   | Error e -> Alcotest.failf "of_string rejected unlisted: %a" pp_parse_error e
 
 (* [bit], [lookup], [enum], [enum_open] and [variants] all refine the integer a


### PR DESCRIPTION
`Wire.uint8` used to decode to a native `int` and range-check on the way to the wire; it now decodes to `Wire.UInt8.t`, a `private int` whose range is the field's, so a value the byte cannot hold is refused where it is built. Read one with `UInt8.to_int` and build one with `UInt8.v`. Last of the four carriers, after #330, #333 and #335. `check_unsigned_encode` stays: every `bits ~width` slice still hands it a bare `int`.