### PR TITLE
docs: condense the unreleased changelog to user-visible changes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,17 +2,13 @@
 
 ### Added
 
-- Add `Wire.UInt64`, the unsigned 64-bit carrier behind `uint64` and `uint64be`
-  (#323, @samoht)
+- Support wasm_of_ocaml (31-bit int) and js_of_ocaml (32-bit int). Codecs no
+  longer silently truncate values that exceed the target's native integer range
+  (#232, @samoht)
 
-- Add `Wire.UInt32`, the unsigned 32-bit carrier behind `uint32` and `uint32be`.
-  It was reachable before only as `Wire.Private.UInt32`, with `Optint.t` as the
-  public type (#322, @samoht)
-
-- Add `Wire.SInt32`, the signed 32-bit carrier behind `int32` and `int32be`. It
-  is deliberately not interchangeable with the unsigned 32-bit carrier: the two
-  share a representation, so a value read with the wrong signedness would be a
-  silent misparse rather than a type error (#321, @samoht)
+- Add `Wire.Expr.lsr64`, an int64 logical shift right by a constant amount, for
+  isolating the high bits of a full-width field inside a constraint. It projects
+  to a 3D refinement EverParse verifies (#232, @samoht)
 
 - Add `Wire.Codec.field_readers` and `Wire.Everparse.Raw.int_slots`.
   `field_readers` is the decoder's own reader for every named int-valued field,
@@ -21,136 +17,73 @@
   integer field (#318, @samoht)
 
 - Add `Wire.Everparse.Raw.field_seeds`, exposing constrained whole-byte integer
-  values so generated corpora can construct inputs that uniform bytes would
-  never reach (#314, @samoht)
+  values, and seed `Wire_3d.generate_corpus` from them and from accepted inputs,
+  so a generated corpus reaches values uniform bytes never would. A one-sided
+  corpus, which cannot tell a validator from a constant answer, is now refused
+  (#314, @samoht)
 
 - Add `Wire.equal_error_kind`, structural equality on error kinds ignoring
-  location (#299, @samoht)
-
-- Add `Wire.Everparse.equal_field_action_form` (#302, @samoht)
-
-- Add `Wire.Expr.lsr64`, an int64 logical shift right by a constant amount, for
-  isolating the high bits of a full-width field inside a constraint. It projects
-  to a 3D refinement EverParse verifies (#232, @samoht)
-
-- Support wasm_of_ocaml (31-bit int) and js_of_ocaml (32-bit int). Codecs no
-  longer silently truncate values that exceed the target's native integer range
-  (#232, @samoht)
+  location, and `Wire.Everparse.equal_field_action_form` (#299, #302, @samoht)
 
 - Document how to make a whole field group conditional with `Field.optional`
   over a sub-codec, keeping the group's byte-length prefix and dependent
   `Field.repeat` local to the group while later fields stay in the parent codec
   (#236, @samoht)
 
-- Extend the fuzz suite to hostile values given to `Codec.encode`, not only
-  hostile bytes given to `Codec.decode`: a generated value must either be
-  refused with `Invalid_argument` or encode to bytes that decode back unchanged
-  (#263, @samoht)
-
 ### Changed
 
-- **Breaking:** `int8` decodes to `Wire.SInt8.t`, a `private int` whose range is
-  the field's, rather than a native `int`. Read one with `Wire.SInt8.to_int`,
-  build one with the range-checked `Wire.SInt8.v` (#330, @samoht)
+- **Breaking:** A fixed-width integer field decodes to a carrier whose range is
+  the field's, so a value it cannot hold is refused where it is built instead of
+  being masked into a legal-looking one on the way to the wire: `uint8` to
+  `Wire.UInt8.t`, `int8` to `SInt8.t`, `uint16` and `uint16be` to `UInt16.t`,
+  `int16` and `int16be` to `SInt16.t`, `uint32` and `uint32be` to `UInt32.t`
+  (was `Optint.t`), `int32` and `int32be` to `SInt32.t`, `uint64` and `uint64be`
+  to `UInt64.t` (was `int64`). The 8- and 16-bit carriers are a `private int`,
+  read with `to_int` and built with the range-checked `v`; the wider ones are
+  abstract, read with `to_int32` / `to_int64` and built with `of_int32` /
+  `of_int64` or the range-checked `of_int`. `SInt32` and `UInt32` are
+  deliberately not interchangeable: they share a representation, so a value read
+  with the wrong signedness would be a silent misparse rather than a type error
+  (#321, #322, #323, #330, #333, #335, #336, @samoht)
 
-- **Breaking:** `int16` and `int16be` decode to `Wire.SInt16.t`, a `private
-  int` whose range is the field's, rather than a native `int`. Read one with
-  `Wire.SInt16.to_int`, build one with the range-checked `Wire.SInt16.v`
-  (#333, @samoht)
+- **Breaking:** `Wire.uint` decodes to `Optint.Int63.t` rather than a native
+  `int`, spelled as that type rather than the `Wire.Private` alias: a 7-byte
+  value needs 56 bits, which used to truncate on a narrow-int target. Read it
+  with `Optint.Int63.to_int` / `to_int64` (#232, #270, @samoht)
 
-- **Breaking:** `uint16` and `uint16be` decode to `Wire.UInt16.t`, a `private
-  int` whose range is the field's, rather than a native `int`. Read one with
-  `Wire.UInt16.to_int`, build one with the range-checked `Wire.UInt16.v`
-  (#335, @samoht)
-
-- **Breaking:** `uint8` decodes to `Wire.UInt8.t`, a `private int` whose range
-  is the field's, rather than a native `int`. Read one with
-  `Wire.UInt8.to_int`, build one with the range-checked `Wire.UInt8.v`
-  (#336, @samoht)
-
-- `Wire.enum`, `Wire.enum_open`, `Wire.variants`, `Wire.lookup` and `Wire.bit`
-  accept any integer-valued base, not only one that decodes to a native `int`.
-  An enum, variant mapping, lookup table or flag can now sit over `uint32`,
-  `int32` or `uint64` as readily as over `uint8`, and projects to EverParse the
-  same way (#328, @samoht)
-
-- **Breaking:** `uint64` and `uint64be` decode to an abstract `Wire.UInt64.t`
-  rather than `int64`, so an unsigned field can no longer be read where a signed
-  one is expected. Convert with `Wire.UInt64.to_int64` and build with
-  `of_int64`. `Wire.Field.int64` now accepts a field of any type carrying a
-  64-bit slot, which is the set it already checked for at run time (#323,
-  @samoht)
-
-- **Breaking:** `uint32` and `uint32be` decode to an abstract `Wire.UInt32.t`
-  rather than `Optint.t`, and `Wire.UInt32.of_int` refuses a number outside the
-  range instead of masking it to a legal value the caller did not mean. Convert
-  a decoded field with `Wire.UInt32.to_int32` or `to_int`, and reinterpret a bit
-  pattern with `of_int32` (#322, @samoht)
-
-- **Breaking:** `int32` and `int32be` decode to `Wire.SInt32.t` rather than a
-  native `int`, and `Wire.rest_bytes` accepts a parameter of any integer type
-  rather than only an `int` one. Convert a decoded field with
-  `Wire.SInt32.to_int32`, and build one with `Wire.SInt32.of_int32` or the
-  range-checked `of_int` (#321, @samoht)
+- Integer-valued combinators no longer insist on a native `int` base.
+  `Wire.enum`, `enum_open`, `variants`, `lookup` and `bit` sit over `uint32`,
+  `int32` or `uint64` as readily as over `uint8`, and project to EverParse the
+  same way; `Wire.rest_bytes` takes a size parameter of any integer type, and
+  `Wire.Field.int64` a field of any type carrying a 64-bit slot (#321, #323,
+  #328, @samoht)
 
 - **Breaking:** Require OCaml 5.3, up from 5.2 (#320, @samoht)
-
-- The EverParse differential compares decoded field values, not only the
-  accept/reject verdict. On an input both sides accept, every field the two can
-  both report must carry the same value; two decoders that agree on which bytes
-  are valid and read a different number out of them used to pass (#318, @samoht)
-
-- Seed `Wire_3d.generate_corpus` from accepted inputs and constraint boundaries,
-  and refuse one-sided corpora, which cannot distinguish a validator from a
-  constant answer (#314, @samoht)
-
-- **Breaking:** Remove `uint63` and `uint63be`. An 8-byte field spans more
-  values than their `Optint.Int63.t` carrier holds, and decoding masked the
-  difference away instead of failing: eight `0xff` bytes arrived as
-  `0x3fff_ffff_ffff_ffff` and were written back out as those bytes, with no
-  error on either path, while the generated C validator passed the same frame
-  through untouched. Use `uint64` / `uint64be` instead, whose `int64` carrier is
-  exactly the eight bytes on the wire, and convert an existing value with
-  `Optint.Int63.to_int64`. `Wire.uint ~size` is unaffected: its carrier is exact
-  for the one to seven bytes it accepts (#316, @samoht)
 
 - **Breaking:** `Codec.encode` and `Wire.to_string` raise `Invalid_argument` on
   a value their own decoder rejects, rather than writing bytes that fail to read
   back: an unlisted value in a closed `enum`, a non-zero byte in an `all_zeros`
   padding field, a `byte_array_where` byte that fails its `~per_byte`
   refinement, and a record whose `where` clause or field `~constraint_` does not
-  hold for the values supplied. Encoding a well-formed value is unchanged
-  (#263, @samoht)
+  hold. Encoding a well-formed value is unchanged (#263, @samoht)
 
-- **Breaking:** Encoding an integer a field cannot hold now raises
-  `Invalid_argument` instead of dropping the bits that do not fit. A fixed width
-  accepts exactly what its decoder produces, `0` to `2^n - 1` unsigned and
-  `-2^(n-1)` to `2^(n-1) - 1` signed, so `int8` refuses `200` rather than
-  writing it back as `-56`, and `bits ~width` and `uint ~size` accept exactly
-  their declared width. Applies to `Wire.to_string`, `Codec.encode` and
-  `Codec.set` alike. A masked value is itself legal at that width, so nothing
-  downstream could tell it from a value meant that way (#275, @samoht)
+- **Breaking:** Encoding an integer a field cannot hold raises
+  `Invalid_argument` instead of dropping the bits that do not fit, so `int8`
+  refuses `200` rather than writing it back as `-56`, and `bits ~width` and
+  `uint ~size` accept exactly their declared width. A masked value is itself
+  legal at that width, so nothing downstream could tell it from a value meant
+  that way. Applies to `Wire.to_string`, `Codec.encode` and `Codec.set` alike
+  (#275, @samoht)
 
 - **Breaking:** Encoding a `byte_array`, `byte_array_where` or `byte_slice`
   whose length differs from its declared `~size` raises `Invalid_argument`. It
   used to truncate a longer value, zero-pad a shorter one, or, through the
-  streaming writer, write the value's own length and desynchronise every
-  following field, so the bytes on the wire could differ from the value a caller
-  had signed, hashed or length-prefixed. For a short value in a fixed-size
-  region use `zeroterm_at_most`, which is NUL-terminated and round-trips
-  (#259, @samoht)
+  streaming writer, desynchronise every following field, so the bytes on the
+  wire could differ from the value a caller had signed, hashed or
+  length-prefixed. For a short value in a fixed-size region use
+  `zeroterm_at_most`, which is NUL-terminated and round-trips (#259, @samoht)
 
-- Require `bytesrw` >= 0.4.0, for `Bytes.Slice.drop_first_or_eod`
-  (#297, @samoht)
-
-- `Wire.uint` decodes to `Optint.Int63.t` rather than a native `int`: a 7-byte
-  value needs 56 bits, which does not fit an int on a narrow-int target and used
-  to truncate there. Read the value with `Optint.Int63.to_int` / `to_int64`
-  (#232, @samoht)
-
-- Spell `Wire.uint`'s result type as `Optint.Int63.t` rather than the `UInt63.t`
-  alias, reachable only through the unstable `Wire.Private`. Same type, same
-  63-bit carrier (#270, @samoht)
+- Require `bytesrw` >= 0.4.0 (#297, @samoht)
 
 - `Codec.load_word` reads the bitfield base word as an `Optint.t` (was a native
   `int`) and `Codec.extract` takes it, so the word-at-a-time batch API is exact
@@ -174,285 +107,204 @@
 
 ### Fixed
 
-- `Codec.validate` no longer decodes a sub-codec reached through an `array`, a
-  `nested` region or a casetype case body: it checks in place, as it already did
-  for a plain field and a `Field.repeat` element, and allocates nothing
-  (#329, @samoht)
-
-- A `zeroterm` read through `Wire.of_reader` no longer costs time quadratic in
-  its length, at the top level or inside a codec: a 64 KiB string arriving one
-  byte at a time took 1.7 s and now takes a millisecond (#331, @samoht)
-
-- `Wire.nested` now sizes a value from the region's own bytes even when the
-  length field it depends on sits past the region: the end-of-input it reports
-  no longer counts bytes the parse was never handed (#332, @samoht)
-
 - A value with no fixed wire size read through `Wire.of_reader` no longer costs
   time and memory quadratic in its length. The reader rebuilt the whole
   accumulated buffer and re-parsed it from offset zero after every slice, so a
-  4 KiB frame arriving a byte at a time allocated 1,194,134 words where it now
-  allocates 19,082 (#325, @samoht)
+  64 KiB `zeroterm` arriving one byte at a time took 1.7 s where it now takes a
+  millisecond, at the top level and inside a codec alike (#325, #331, @samoht)
 
-- A value parsed inside a `nested` region or a `repeat` budget no longer reports
-  an end-of-input whose byte count was read from outside that region. A region
-  too short to carry the length field the value's size depends on was sized from
-  whatever the buffer held past it, so the reported shortfall named bytes the
-  parse never claimed; it now names the length field's own extent (#326,
-  @samoht)
+- `Codec.validate` allocates a constant amount whatever the sender sends, and
+  nothing at all for a codec with no parameters. It used to run the field
+  readers for their checks and drop what they built, so a refined span, a
+  `zeroterm_at_most`, an `all_zeros`, a `repeat`'s elements and a closed
+  `enum`'s named cases each cost memory in proportion to lengths and counts the
+  sender chooses. Sub-codecs reached through an `array`, a `nested` region or a
+  casetype case body are checked in place too, and `Codec.decode` no longer
+  keeps a second copy of a span it returns (#286, #289, #290, #292, #293, #294,
+  #295, #329, @samoht)
 
-- `uint64` values now order as unsigned numbers. The carrier was `int64`, whose
-  comparison reads the top bit as a sign and so ranked
-  0xFFFF_FFFF_FFFF_FFFF, the largest `uint64`, below zero (#323, @samoht)
-
-- `uint32` values now order as unsigned numbers on every target. The carrier was
-  `Optint.t`, which is `Int32` where the native `int` is narrower than the
-  field, so a comparison ranked 0xFFFFFFFF, the largest `uint32`, below 1 under
-  js_of_ocaml and wasm_of_ocaml (#322, @samoht)
-
-- A 4-byte signed field no longer alters the frame it decodes where the native
-  `int` is narrower than the field. Under wasm_of_ocaml an `int` is 31 bits, so
-  `int32` dropped the top bits on the way in and the encode-side range check
-  disabled itself, sending the value back out as different bytes with no error
-  on either path (#321, @samoht)
+- A fixed-offset `Codec.get` or `Codec.set` with no parameters, and
+  `Wire.of_string` / `Wire.of_bytes` on a struct type, no longer allocate per
+  call: direct scalars represented as immediate OCaml values, bitfields, enums
+  and immediate-valued maps measure zero words on a non-Flambda release build,
+  and the validator cache lookup no longer builds a closure and an option. Boxed
+  results such as `int64`, and allocations performed by a `map` callback itself,
+  remain visible to callers. The same accessors are also faster than before
+  (#239, #269, @samoht)
 
 - A fresh domain's first decode or validate no longer costs about a word per
   compiled validator the program ever built, which reached roughly 1 MB at
   50,000 validators and was charged even to domains that never decode
   (#320, @samoht)
 
-- The single-file documentation build no longer regenerates the committed
-  `<Name>.3d` behind your back. It was a promoted rule target the install stanza
-  depended on, so every build rewrote it before the drift check compared it, and
-  a schema that no longer matched its codec could not fail `runtest`. The
-  committed schema is now a plain source: drift fails `runtest`, and `dune
-  promote` writes the new bytes after an intended codec change (#317, @samoht)
+- `Codec.decode` and `Codec.validate` no longer accept bytes that
+  `Wire.of_string` and the EverParse validator built from the same schema
+  reject. A sub-codec field's constraints, `where`, closed-enum membership,
+  `~per_byte` refinements and actions were skipped, a `byte_array_where`'s
+  `~per_byte` ran on the direct parser alone, and a `Field.repeat` whose byte
+  budget does not split into whole elements passed (#268, #305, #311, @samoht)
 
-- Fix `Codec.validate` skipping a sub-codec field's constraints, `where`,
-  closed-enum membership, `per_byte` refinements and actions, which now reject
-  the same bytes as decoding and generated EverParse validators (#311, @samoht)
-
-- Fix `Codec.{get,set}` on a bitfield whose base word is not entirely inside the
-  buffer. A `u32` word is assembled from unchecked byte reads, so a short frame
-  read at an application-chosen offset answered with the bytes that followed it,
-  and `set` wrote over them and left half a word behind when it raised. An
-  attacker sending a truncated frame could read and corrupt whatever sits after
-  it in the buffer. The word's span is now checked before it is touched
-  (#288, @samoht)
-
-- Fix `Codec.set` on a `byte_array`, `byte_array_where` or `byte_slice` whose
-  `~size` is only known at decode time. It wrote the value's own length rather
-  than the field's declared size, so an oversized value that still fitted the
-  buffer ran past the field and overwrote the fields after it with no error to
-  signal it. It now raises `Invalid_argument` unless the value is exactly that
-  many bytes, the contract encoding already had (#262, @samoht)
-
-- Fix `Codec.set` on a sub-codec, casetype or array field. The writer laid the
-  value down and only then checked it, so a refused value reached the buffer
-  against the documented promise to leave it untouched; those writers now
-  restore the bytes they replaced. `Codec.encode` is not transactional and now
-  says so: after a failed encode the destination holds a partial record
-  (#280, @samoht)
-
-- Fix `Codec.{get,set}` on an `optional` or `optional_or` field whose gate is
-  fixed at construction. `get` raised
-  `Failure "build_field_reader: unsupported type"` on a shape `Codec.decode`
-  reads without trouble; both accessors now handle it. A runtime gate stays
-  unsupported and refuses with `Invalid_argument` naming the shape
-  (#280, @samoht)
-
-- Fix `Codec.size_of_value` on a casetype value no case projects. It answered
-  with the tag width for a value `Codec.encode` refuses, so a caller sized a
-  buffer for a write that could never happen. It now raises `Invalid_argument`
-  like encode, and `Codec.set` refuses before writing (#296, @samoht)
-
-- Fix `Codec.size_of_value` on fixed-size `byte_array`, `byte_array_where` and
-  `byte_slice` fields, which now reports their declared width, so a buffer
-  allocated from it exactly fits the bytes written (#238, @samoht)
-
-- Fix `Codec.validate` raising `Invalid_argument` where a parse error was due.
-  It reaches a field at whatever offset the layout computes and those reads were
-  unguarded, so an overlong variable-size field pushing its successors past the
-  end of the buffer crashed the documented gate for untrusted input. Same for
-  `Wire.of_bytes` and `Wire.of_string` on a struct, an `optional` gated on a
+- `Codec.validate` no longer raises `Invalid_argument` where a parse error was
+  due. It reaches a field at whatever offset the layout computes and those reads
+  were unguarded, so an overlong variable-size field pushing its successors past
+  the end of the buffer crashed the documented gate for untrusted input. Same
+  for `Wire.of_bytes` and `Wire.of_string` on a struct, an `optional` gated on a
   runtime expression, and a `uint` of runtime width. All now report end of input
   at the field's own offset (#271, #276, @samoht)
 
-- Fix `Codec.decode` and `Codec.validate` on a `byte_array_where`. The
-  `~per_byte` refinement ran on the direct parser alone, so both accepted spans
-  that `Wire.of_string` and the EverParse validator built from the same schema
-  reject, and validate is the documented gate before reading untrusted bytes
-  zero-copy (#268, @samoht)
+- `Codec.get` and `Codec.set` no longer read or write past the field they name.
+  A bitfield's base word is assembled from byte reads that went unchecked, so a
+  truncated frame read at an application-chosen offset answered with the bytes
+  that followed it and `set` overwrote them, leaving half a word behind when it
+  raised; and a `byte_array`, `byte_array_where` or `byte_slice` whose `~size`
+  is known only at decode time wrote the value's own length, running over the
+  fields after it with no error. Both spans are now checked first (#262, #288,
+  @samoht)
 
-- Fix `Codec.validate` accepting a `Field.repeat` whose byte budget does not
-  split into whole elements. `Codec.decode` and the EverParse validator built
-  from the same schema both reject it (#305, @samoht)
+- `Codec.set` on a sub-codec, casetype or array field no longer leaves a refused
+  value in the buffer. The writer laid the value down and only then checked it,
+  against the documented promise to leave the buffer untouched; those writers
+  now restore the bytes they replaced. `Codec.encode` is not transactional and
+  now says so: after a failed encode the destination holds a partial record
+  (#280, @samoht)
 
-- Fix `Codec.validate` allocating in proportion to lengths the sender chooses.
-  It ran the field readers for their checks and dropped what they built, so a
-  refined span, a `zeroterm_at_most` and an `all_zeros` each cost a copy of the
-  payload, a `repeat` cost its whole element sequence plus a box per wide scalar
-  or span element, and a closed `enum` cost three words per named case on every
-  element read. The checks now run over the buffer where it lies, gated spans
-  included, so what validate allocates is constant in the frame size, the
-  element count and the case count, and a codec with no parameters allocates
-  nothing at all. `Codec.decode` no longer pays for a second copy of a span it
-  returns (#286, #289, #290, #292, #293, #294, #295, @samoht)
+- `Codec.get` and `Codec.set` handle an `optional` or `optional_or` field whose
+  gate is fixed at construction, a shape `Codec.decode` reads without trouble
+  and `get` used to raise `Failure "build_field_reader: unsupported type"` on. A
+  runtime gate stays unsupported and refuses with `Invalid_argument` naming the
+  shape (#280, @samoht)
 
-- Fix `Wire.of_string` and `Wire.of_bytes` allocating a closure and an option on
-  every decode of a struct type, from the validator cache lookup (#269, @samoht)
+- `Codec.size_of_value` no longer answers for a write that cannot happen or
+  under-reports a field's width: a casetype value no case projects raises
+  `Invalid_argument` as encode does, and `Codec.set` refuses before writing,
+  while a fixed-size `byte_array`, `byte_array_where` or `byte_slice` reports
+  its declared width, so a buffer allocated from the answer exactly fits the
+  bytes written (#238, #296, @samoht)
 
-- Fix the per-call allocation of a parameter-free fixed-offset `Codec.get` or
-  `Codec.set`: direct scalars represented as immediate OCaml values, bitfields,
-  enums, and maps whose callbacks return immediate values measure zero words on
-  a non-Flambda release build. Boxed results such as `int64`, and allocations
-  performed by a map callback itself, remain visible to callers. The same
-  accessors are also faster than before (#239, @samoht)
+- `Unexpected_eof` reports byte counts, not buffer positions, and counts only
+  bytes the parse was handed. The `expected` and `got` fields carried absolute
+  positions at several sites, so the pair shifted with the offset the frame was
+  read at and could come out equal to each other; and a value inside a `nested`
+  region or a `repeat` budget was sized from whatever the buffer held past the
+  region, so the reported shortfall named bytes the parse never claimed
+  (#285, #326, #332, @samoht)
 
-- Fix the byte offset a parse error reports. A failing field `~constraint_`, an
-  `enum` membership failure and a staged read through a bitfield reported the
-  enclosing record's base, and a `lookup` tag out of range reported byte 0
-  whatever offset the frame was read at, so a caller locating the field from
-  `at` read or rewrote the wrong bytes. Each now names the field's own offset; a
-  dynamic layout still reports the record base (#306, @samoht)
+- A parse error names the field's own offset, so a caller locating the field
+  from `at` no longer reads or rewrites the wrong bytes. A failing field
+  `~constraint_`, an `enum` membership failure and a staged read through a
+  bitfield reported the enclosing record's base, and a `lookup` tag out of range
+  reported byte 0 whatever offset the frame was read at. A dynamic layout still
+  reports the record base (#306, @samoht)
 
-- Fix `Unexpected_eof`'s `expected` and `got`. Six sites passed absolute buffer
-  positions where the fields are documented as byte counts, so the pair shifted
-  with the offset the frame was read at and could come out equal to each other.
-  They now report the bytes the value asked for against the bytes that were
-  there (#285, @samoht)
-
-- Fix the error reported for a failure under a size or offset expression. A
+- A failure under a size or offset expression reports its own error. A
   validation error or an exception from a `map` callback came out as an end of
   input on a buffer that was long enough, and a byte span whose size expression
-  went negative escaped as `Invalid_argument "String.sub"`. Truncation is now
-  raised by the reads themselves, naming the missing span, the other two keep
-  their own message and a value out of range (#267, @samoht)
+  went negative escaped as `Invalid_argument "String.sub"`; truncation is now
+  raised by the reads themselves, naming the missing span (#267, @samoht)
 
-- Fix `Field.repeat` consuming and emitting more or less than its declared byte
-  budget. Fixed-width remainders, variable-width elements that cross the
-  boundary, and encode under- and overshoots are now rejected instead of being
-  accepted (#238, @samoht)
+- `Field.repeat`, `array`, `array_seq` and `nested` hold to their declared size
+  on decode and encode. A repeat consumed or emitted more or less than its byte
+  budget, the array encoders accepted a short value and left zero-filled phantom
+  elements, and `nested` let its inner value consume less than the region. Use
+  `nested_at_most` where trailing region padding is intentional; it remains
+  permissive and zero-pads on encode (#238, @samoht)
 
-- Fix the `array` and `array_seq` encoders accepting a value with the wrong
-  element count: a short value left zero-filled phantom elements. They now
-  require exactly the declared number, and reject a long value before any bytes
-  are written (#238, @samoht)
+- `Codec.v` rejects duplicate field names, and distinct parameter handles with
+  the same name. Name-based field access and parameter environments silently
+  aliased the first declaration (#238, @samoht)
 
-- Fix `nested`, which now requires its inner value to consume exactly the
-  declared region on decode and encode. Use `nested_at_most` when trailing
-  region padding is intentional; it remains permissive and zero-pads on encode
-  (#238, @samoht)
-
-- Fix a constant size or length expression such as `Expr.(int 2 + int 2)`, which
-  now behaves exactly like the literal `int 4`. It used to slip past every check
-  and fast path that looks for a literal size, so such a field encoded without
-  its exact-length check, reported its codec as variable-size, and bypassed the
+- A constant size or length expression such as `Expr.(int 2 + int 2)` behaves
+  exactly like the literal `int 4`. It used to slip past every check and fast
+  path that looks for a literal size, so such a field encoded without its
+  exact-length check, reported its codec as variable-size, and bypassed the
   `uint` 1-7 size guard (#259, @samoht)
 
-- Fix `Codec.v` accepting duplicate field names, and distinct parameter handles
-  with the same name. Name-based field access and parameter environments
-  silently aliased the first declaration (#238, @samoht)
+- Operations on the same parametric codec are safe to re-enter and interleave
+  across fibers with different `Param.env` values: embedded codecs, casetype
+  bodies, fixed-size wrappers and repeated elements no longer read another
+  operation's field sizes. An env built for a different codec is rejected first,
+  on encode, decode, validation and staged getters alike, including where the
+  parameter counts happen to match (#237, #239, @samoht)
 
-- Fix operations on the same parametric codec being unsafe to re-enter or
-  interleave across fibers with different `Param.env` values. Embedded codecs,
-  casetype bodies, fixed-size wrappers and repeated elements no longer read
-  another operation's field sizes (#239, @samoht)
+- A field wider than the target's native `int` no longer decodes or encodes
+  wrong under wasm_of_ocaml and js_of_ocaml. A bitfield touching bit 31 of its
+  base word dropped that bit, a 4-byte signed field dropped the top bits on the
+  way in and sent the frame back out as different bytes with the encode-side
+  range check disabled, and a NaN passed a float64 `is_finite` check. The
+  emitted 3D refinements are unchanged (#232, #321, @samoht)
 
-- Fix codec operations reading the positional slots of a `Param.env` created for
-  another codec, which is now rejected first. This applies to encode, decode,
-  validation and staged getters, including codecs whose parameter counts happen
-  to match (#237, @samoht)
+- A value too wide for the native `int` reports a typed `Value_out_of_range`, or
+  a contextual `Invalid_argument` naming the case index or parameter, where
+  reading a `uint32`, `uint63` or `uint` field, projecting a casetype and
+  `Param.bind` used to leak a bare Optint `Failure`. The validation slots mirror
+  only values the int can hold, as `uint64` already did (#232, #237, @samoht)
 
-- Fix casetype projection and `Param.bind` leaking an Optint `Failure` on a
-  narrow-int target for an unfittable `uint32`, `uint63` or `uint` value. They
-  now raise a contextual `Invalid_argument` naming the case index or parameter
-  (#237, @samoht)
+- `uint32` and `uint64` values order as unsigned numbers on every target. Their
+  carriers compared the top bit as a sign, so the largest value of each ranked
+  below 1 (#322, #323, @samoht)
 
-- Fix 32-bit bitfields on a narrow-int target: a field touching bit 31 of its
-  base word used to decode and encode with that bit dropped there
-  (#232, @samoht)
+- A shape with no valid encoding or no EverParse projection is refused at
+  construction with a clear error, rather than building and misbehaving later: a
+  `Field.repeat` element whose greedy tail sits inside a sub-codec and so
+  swallows every element after it, a zero-size byte span as an `array` or
+  `Field.repeat` element, an `optional` field that can expose a consume-rest
+  payload with another field after it, and a `field * constant` byte size whose
+  `field <= bound` constraint lets the maximum reach EverParse's `2^32` limit.
+  Products without that conclusive shape stay deferred to EverParse, avoiding
+  speculative rejections (#237, #239, #256, #266, #280, @samoht)
 
-- Fix `is_finite` / `is_nan` on a float64 field, which now evaluate the full
-  64-bit pattern, so a NaN can no longer pass validation on a narrow-int target.
-  The emitted 3D refinement is unchanged (#232, @samoht)
+- A `Field.repeat` element that turns out to consume no bytes reports an
+  end-of-input error from `Wire.of_string` and `Wire.of_bytes` instead of
+  looping forever (#256, @samoht)
 
-- Fix reading a `uint32` / `uint63` field whose value exceeds the native int
-  leaking a bare `Failure` out of decode on a narrow-int target: constraint
-  evaluation raises the typed `Value_out_of_range`, and the validation slots
-  mirror only values the int can hold, as `uint64` already did (#232, @samoht)
+- `Wire.Ascii` diagrams render every expression a size or constraint can
+  contain. Bitmasks, shifts, division, casts, conditionals, `sizeof` and
+  parameter references used to print as a bare `?`, so a trailing payload sized
+  by `Wire.rest_bytes` showed up as `(? - ? bytes)` (#257, @samoht)
 
-- Reject a `Field.repeat` element whose greedy tail sits inside a sub-codec.
-  Such a tail runs to the end of the repeat's byte budget and swallows every
-  element after it, so the shape has no valid multi-element encoding; `repeat`
-  only looked at the element's own last field (#280, @samoht)
+- Generated C no longer enforces the wrong specification when names collide. Two
+  codecs whose artifacts differ only in the leading capital or in an uppercase
+  run, and two codecs of a family that declare different types under the same
+  name, are refused with a clear error instead of the second write winning and
+  leaving the shadowed codec's stubs validating against another codec's spec;
+  and two domains building descriptions at once can no longer mint the same
+  synthesised `byte_array_where` element name, whose 3D typedef was then emitted
+  twice. Types declared identically by several codecs still collapse to a single
+  declaration (#255, #266, #272, @samoht)
 
-- Reject a byte span of literal size zero as an `array` element. It built on the
-  OCaml side but has no 3D projection, EverParse refusing a list whose element
-  consumes no bytes; `Field.repeat` already refused it (#266, @samoht)
+- The generated FFI stubs no longer lose field values. The parse callback
+  collected the boxed arguments in a bare `value` array, which is not a GC root,
+  so a minor collection triggered by a later box could move or reclaim an
+  earlier one and the continuation silently received garbage. `CAMLlocalN` now
+  roots them (#272, @samoht)
 
-- Reject a `byte_array` or `byte_slice` element of size zero in `Field.repeat`
-  and `Field.repeat_seq`, and report an end-of-input error from `Wire.of_string`
-  / `Wire.of_bytes` instead of looping forever when a repeat element turns out
-  to consume no bytes (#256, @samoht)
-
-- Reject an optional field that can expose a consume-rest payload and is
-  followed by another field, rather than letting that payload swallow the
-  remainder of the enclosing codec (#239, @samoht)
-
-- Reject at construction, with a clear error, a byte-size product
-  `field * constant` whose `field <= bound` constraint lets the maximum reach
-  EverParse's `2^32` limit. Products without this conclusive shape remain
-  deferred to EverParse, avoiding speculative rejections (#237, @samoht)
-
-- Fix `Wire.Ascii` diagrams, which now render every expression a size or
-  constraint can contain. Bitmasks, shifts, division, casts, conditionals,
-  `sizeof` and parameter references used to print as a bare `?`, so a trailing
-  payload sized by `Wire.rest_bytes` showed up as `(? - ? bytes)`
-  (#257, @samoht)
-
-- Fix the counter naming the synthesised element type of a `byte_array_where`.
-  Two domains building descriptions at once could mint the same name, whose 3D
-  typedef was then emitted twice (#266, @samoht)
-
-- Reject two codecs whose generated artifacts collide, names differing only in
-  the leading capital (one `.3d` file) or in an uppercase run (two `_Fields.h`
-  sharing an include guard and a plug struct tag). The second write used to win,
-  leaving the shadowed codec's stubs validating against another codec's spec
-  (#272, @samoht)
-
-- Fix standalone `Wire.Everparse.write` emitting only the first of two codecs of
-  a family that declare different types under the same name, generating verified
-  C that enforces the wrong specification for every other codec. It now fails
-  with a clear error. Types declared identically by several codecs still
-  collapse to a single emitted declaration (#255, @samoht)
-
-- Fix the generated FFI stubs losing field values. The parse callback collected
-  the boxed arguments in a bare `value` array, which is not a GC root, so a
-  minor collection triggered by a later box could move or reclaim an earlier one
-  and the continuation silently received garbage. `CAMLlocalN` now roots them
-  (#272, @samoht)
-
-- Fix the emitted `EverParseEndianness.h` on a target that is neither
+- The emitted `EverParseEndianness.h` compiles on a target that is neither
   Linux/glibc nor Apple. The `__BYTE_ORDER__` branch was spliced only when the
   header was absent, which it never is, so the header a cross-compiled
   standalone archive gets stopped at `#error "Unsupported platform"`
   (#272, @samoht)
 
-- Fix EverParse generation interpreting output paths, executable paths and
+- EverParse generation no longer interprets output paths, executable paths and
   schema filenames that contain spaces or shell metacharacters as commands
   (#239, @samoht)
 
-- Add a `dune runtest` check that diffs a package's committed `.3d` specs and
-  `dune.inc` against freshly generated ones, so editing a codec without
-  refreshing them fails with a promotable report instead of leaving a stale spec
-  committed (#235, @samoht)
-
-- Install a `<Name>.provenance` stamp with the EverParse C, recording the stdlib
-  BLAKE2b-256 digest of the `.3d` it was built from. `dune runtest` rechecks it
-  without EverParse, so a changed spec can no longer keep stale C
-  (#235, @samoht)
+- A package's committed `.3d` specs, `dune.inc` and EverParse C can no longer go
+  stale. `dune runtest` diffs the specs and rules against freshly generated ones
+  and rechecks an installed `<Name>.provenance` stamp holding the stdlib
+  BLAKE2b-256 digest of the `.3d` the C was built from, no EverParse needed. The
+  committed schema is a plain source rather than a promoted build target, so
+  drift fails `runtest` with a promotable report and `dune promote` writes the
+  new bytes after an intended codec change (#235, #317, @samoht)
 
 ### Removed
+
+- **Breaking:** Remove `uint63` and `uint63be`. An 8-byte field spans more
+  values than their `Optint.Int63.t` carrier holds, and decoding masked the
+  difference away instead of failing, on both the OCaml and the generated C
+  path. Use `uint64` / `uint64be` instead, whose carrier is exactly the eight
+  bytes on the wire, and convert an existing value with `Optint.Int63.to_int64`.
+  `Wire.uint ~size` is unaffected: its carrier is exact for the one to seven
+  bytes it accepts (#316, @samoht)
 
 - Delete the dependency on `eio`. Nothing in the library used it, it was only
   ever linked, unused, into `wire.diff` (#233, @samoht)


### PR DESCRIPTION
The unreleased block had grown to 85 entries over 459 lines, one per PR rather than one per user-visible change, with the exact-carrier work alone accounting for ten near-identical entries. It is now 48 entries over 311 lines, grouped by the change a reader upgrading would act on, with test-infrastructure and build-rule entries dropped and their references carried onto the user-facing entry that covers the same work. The set of PR references is unchanged.