### PR TITLE
build: add a cppcheck target over the hand-written C

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,28 @@ jobs:
       - run: opam exec -- dune build @check
       - run: opam exec -- merlint --build
 
+  # Static analysis over the hand-written C. EverParse proves the parsers it
+  # generates, but nothing covered the benchmark C written by hand around them,
+  # in a project whose shipped deliverable is a C archive. The lane needs no
+  # opam switch, so it costs a checkout and an apt install, and it is wired as
+  # a normal blocking lane on that basis. cppcheck comes from the runner image,
+  # so an image bump can bring a version with new checks; that shows up here as
+  # a red lane on an unrelated pull request, and is fixed in the C or in the
+  # suppression list, never by dropping the lane.
+  cppcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - run: sudo apt-get update && sudo apt-get install -y cppcheck
+
+      # make cppcheck skips when the tool is absent, which would leave this
+      # lane green having checked nothing. Fail here instead if apt did not
+      # deliver it, and record the version the findings came from.
+      - run: cppcheck --version
+
+      - run: make cppcheck
+
   # One AFL job per fuzzer: fuzz/ fuzzes the [wire] library (round-trip and
   # validation) and fuzz/3d/ fuzzes [wire_3d] (the EverParse / 3D projection),
   # mirroring the lib/ layout. The [afl] profile (dune-workspace) instruments

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ make bench-gateway      # TM frame reassembly
 make bench-clcw         # CLCW polling loop
 make prof               # CPU profile with Instruments (open prof.trace)
 make memtrace           # allocation hotspots via memtrace
+make cppcheck           # static analysis of the hand-written C (skips if cppcheck absent)
 make clean              # dune clean
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY: build test test-wasm 3d bench bench-demo bench-routing bench-gateway bench-clcw \
-       prof memtrace memtrace-demo memtrace-routing memtrace-gateway memtrace-clcw clean
+       prof memtrace memtrace-demo memtrace-routing memtrace-gateway memtrace-clcw \
+       cppcheck clean
 
 build:
 	dune build
@@ -68,6 +69,34 @@ memtrace-gateway:
 memtrace-clcw:
 	BUILD_EVERPARSE=1 MEMTRACE=clcw.ctf dune exec --profile=release bench/clcw/bench.exe
 	memtrace_hotspots clcw.ctf
+
+# Static analysis over the project's hand-written C: the benchmark application
+# loops and the header they share. EverParse proves the parsers it generates;
+# nothing covered the C written by hand around them. The file list comes from
+# git rather than a literal so a new hand-written file cannot escape it, and
+# every tracked .c/.h is hand-written, as the generated parsers are produced
+# into _build and never committed. -I bench resolves bench_common.h, so a
+# finding inside it surfaces too. The headers that stay unresolved are external
+# (OCaml's caml/*, EverParse's generated schemas): pointing cppcheck at OCaml's
+# headers multiplies the #ifdef configuration space by sixty and finds nothing.
+# unusedFunction fires on every CAMLprim, whose only caller is the OCaml
+# runtime. cppcheck prints the name of each file it opens, which is the proof
+# that the list reached it.
+cppcheck:
+	@if ! command -v cppcheck >/dev/null 2>&1; then \
+	  echo "cppcheck not found: skipping (brew install cppcheck)"; \
+	  exit 0; \
+	fi; \
+	files=$$(git ls-files '*.c' '*.h'); \
+	if [ -z "$$files" ]; then \
+	  echo "error: found no hand-written C to check"; exit 1; \
+	fi; \
+	cppcheck --enable=all --check-level=exhaustive --inconclusive \
+	  --std=c11 --language=c -I bench \
+	  --suppress=missingIncludeSystem --suppress=missingInclude \
+	  --suppress=unusedFunction --suppress=checkersReport \
+	  --suppress=normalCheckLevelMaxBranches --suppress=unmatchedSuppression \
+	  --inline-suppr --error-exitcode=1 $$files
 
 clean:
 	dune clean


### PR DESCRIPTION
The shipped deliverable is a verified C archive, but the hand-written C in `bench/` gets no static analysis: EverParse's proofs cover only what it generates. This adds `make cppcheck` over the tracked C and a CI lane for it. The file list comes from `git ls-files`, since generated C is never committed, so it cannot go stale the way a literal list would. Zero findings on the C as it stands.