### PR TITLE
dev: one pinned merlint for the lane and the hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,12 +88,20 @@ jobs:
       - run: opam install . --deps-only --with-test
       - run: opam repository add tangled git+https://tangled.org/gazagnaire.org/opam-overlay.git --rank=-1
 
-      - run: opam install merlint
+      # The overlay carries merlint.dev alone, and its source is the tip of
+      # merlint's main branch, so an unpinned install changes the rules under
+      # this lane between one run and the next. scripts/lint names the commit
+      # the project is linted with; installing that one is what lets a clean
+      # run on a laptop predict this lane.
+      - run: |
+          opam pin add -y -n merlint \
+            "git+https://tangled.org/gazagnaire.org/merlint#$(scripts/lint --commit)"
+          opam install merlint
 
       # merlint --build runs this itself but reports only the exit code, so
       # run it here first to get the compiler error on its own line.
       - run: opam exec -- dune build @check
-      - run: opam exec -- merlint --build
+      - run: make lint
 
   # Static analysis over the hand-written C. EverParse proves the parsers it
   # generates, but nothing covered the benchmark C written by hand around them,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,7 @@
 ```
 make build              # dune build
 make test               # dune runtest
+make lint               # merlint, the same run as CI (needs merlint)
 make test-wasm          # test/wasm under node via wasm_of_ocaml (needs wasm_of_ocaml, node)
 make 3d                 # validate all schemas with 3d.exe (needs 3d.exe)
 make bench              # EverParse C vs OCaml (needs 3d.exe)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test test-wasm 3d bench bench-demo bench-routing bench-gateway bench-clcw \
+.PHONY: build test test-wasm lint 3d bench bench-demo bench-routing bench-gateway bench-clcw \
        prof memtrace memtrace-demo memtrace-routing memtrace-gateway memtrace-clcw \
        cppcheck clean
 
@@ -7,6 +7,11 @@ build:
 
 test:
 	dune runtest
+
+# The same run as CI's merlint lane, down to the scope and the linter's
+# commit. scripts/lint holds both.
+lint:
+	scripts/lint
 
 # Runs test/wasm under node with wasm_of_ocaml (31-bit ints), then fails on
 # any integer-overflow truncation warning from wire's own code. optint's two

--- a/scripts/lint
+++ b/scripts/lint
@@ -1,0 +1,56 @@
+#!/bin/sh
+# The project's lint run. CI's merlint lane and scripts/pre-commit both go
+# through here, so what a laptop reports is what the lane reports.
+#
+# Whole project, no file arguments, which is what the lane has always run.
+# Two branches passed a staged-files-only run here and then failed the lane on
+# a finding the narrower scope never asks about, at half an hour a round trip,
+# so there is one scope now and this is it.
+#
+# Not a dune alias: [merlint --build] shells out to [dune build @check], and a
+# dune action that calls dune waits on the build lock its own parent holds,
+# which merlint retries for a minute before giving up.
+
+set -eu
+
+# The tangled overlay carries merlint.dev alone, and its source is the tip of
+# merlint's main branch, so an install without this pin builds whatever landed
+# upstream that morning. CI installs the commit named here. Bump it on purpose,
+# reading what changed, rather than by standing still.
+merlint_commit=2fd9aaff2b3e4703699d5e25e13478b4e715595d
+
+if [ "${1-}" = "--commit" ]; then
+  echo "$merlint_commit"
+  exit 0
+fi
+
+# scripts/pre-commit passes --optional: a checkout without merlint is still a
+# checkout you can commit from. An explicit [make lint] has been asked for a
+# verdict, and reports that it has none.
+optional=false
+if [ "${1-}" = "--optional" ]; then
+  optional=true
+fi
+
+if ! opam exec -- sh -c 'command -v merlint' >/dev/null 2>&1; then
+  cat >&2 <<MSG
+merlint not found. Install the commit this project is linted with:
+  opam repository add tangled \\
+    git+https://tangled.org/gazagnaire.org/opam-overlay.git --rank=-1
+  opam pin add -yn merlint \\
+    git+https://tangled.org/gazagnaire.org/merlint#$merlint_commit
+  opam install merlint
+MSG
+  if [ "$optional" = true ]; then
+    exit 0
+  fi
+  exit 1
+fi
+
+# Which linter this run got, next to the one it was meant to get. The two are
+# the same only where the pin was installed, and a verdict from a merlint the
+# project did not pin is a verdict this lane cannot promise.
+echo "merlint $(opam exec -- sh -c 'command -v merlint') \
+version $(opam exec -- merlint --version), pinned $merlint_commit"
+
+exec opam exec -- merlint --build

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -25,10 +25,13 @@ if ! opam exec -- dune build @check >/tmp/git-merlint-hook.log 2>&1; then
   exit 1
 fi
 
-git diff --cached --name-only --diff-filter=ACM -z -- \
-  '*.ml' '*.mli' '*.mll' '*.mly' \
-  | xargs -0 merlint >/tmp/git-merlint-hook.log 2>&1 \
-  || {
-    echo "merlint failed; see /tmp/git-merlint-hook.log for details" >&2
-    exit 1
-  }
+# Whole project, through the same script CI's lane calls, rather than the
+# staged files: the lane's verdict is one verdict over everything, and a run
+# scoped to the staged files answers a narrower question that has twice come
+# out green under a red lane. It reads the worktree, so a finding parked in a
+# file this commit does not touch surfaces here rather than on the lane.
+# --optional keeps a checkout without merlint installed committable.
+if ! scripts/lint --optional >/tmp/git-merlint-hook.log 2>&1; then
+  echo "merlint failed; see /tmp/git-merlint-hook.log for details" >&2
+  exit 1
+fi


### PR DESCRIPTION
Two PRs passed a local merlint run today and then failed the CI lane on E106, at half an hour each. The local binary was never missing the rule; the lane and the hook were running different binaries over different file sets, and nothing pinned either. CI now installs merlint at a fixed commit, the hook and the lane both run `make lint`, and that runs the same argument-free command over the whole project. The pinned sha lives in one place, `scripts/lint --commit`.