### PR TITLE
codec: project a sub-codec's own types before the codec that uses them

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -107,12 +107,18 @@
 
 ### Fixed
 
+- A codec that embeds a sub-codec now projects to a schema EverParse accepts
+  whatever that sub-codec holds. The types a sub-codec's own fields name were
+  declared after it rather than before, and a refined byte span reached only
+  through a sub-codec was never declared at all, so EverParse rejected the
+  schema with a "not found" naming a type the codec does use (#344, @samoht)
+
 - Generating C for a codec with a long name no longer fails with
   `Invalid_argument "List.iter2"`. Past a certain length the generated callback
   declarations wrap onto a second line, which the field-plug generator read as
   no declarations at all; both layouts are read now, and a header that still
   cannot be read is named in the error rather than surfacing as a crash
-  somewhere else (@samoht)
+  somewhere else (#344, @samoht)
 
 - A value with no fixed wire size read through `Wire.of_reader` no longer costs
   time and memory quadratic in its length. The reader rebuilt the whole

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -107,6 +107,13 @@
 
 ### Fixed
 
+- Generating C for a codec with a long name no longer fails with
+  `Invalid_argument "List.iter2"`. Past a certain length the generated callback
+  declarations wrap onto a second line, which the field-plug generator read as
+  no declarations at all; both layouts are read now, and a header that still
+  cannot be read is named in the error rather than surfacing as a crash
+  somewhere else (@samoht)
+
 - A value with no fixed wire size read through `Wire.of_reader` no longer costs
   time and memory quadratic in its length. The reader rebuilt the whole
   accumulated buffer and re-parsed it from offset zero after every slice, so a

--- a/fuzz/gen/fuzz_gen.ml
+++ b/fuzz/gen/fuzz_gen.ml
@@ -2998,9 +2998,13 @@ let map_of (Any a) =
 let where_of (Any a) =
   Any { g = where a.g; size = a.size; label = "wh:" ^ a.label }
 
-let pair_of (Any a) (Any b) =
+(* [name] is the sub-codec's 3D struct name. It is a parameter because a
+   projection keys its typedefs by name: two records that share a name collapse
+   onto whichever body projects first, so a composition holding more than one of
+   them has to name each apart. *)
+let pair_of name (Any a) (Any b) =
   let g =
-    Codec.v "R2"
+    Codec.v name
       ~equal:(fun (x1, y1) (x2, y2) -> a.g.equal x1 x2 && b.g.equal y1 y2)
       (fun x y -> (x, y))
       Codec.[ a.g $ fst; b.g $ snd ]
@@ -3014,12 +3018,12 @@ let pair_of (Any a) (Any b) =
       label = "(" ^ a.label ^ "," ^ b.label ^ ")";
     }
 
-(* Flat records of arity 3 and 4: like [pair_of] but for more fields, so the
+(* Records of arity 3 and 4: like [pair_of] but for more fields, so the
    Boltzmann sampler can emit records wider than a pair. Each unpacks its [Any]
-   elements and seals a flat [Codec.v]. *)
-let rec3_of (Any a) (Any b) (Any c) =
+   elements and seals one [Codec.v]. *)
+let rec3_of name (Any a) (Any b) (Any c) =
   let g =
-    Codec.v "R3"
+    Codec.v name
       ~equal:(fun (x1, y1, z1) (x2, y2, z2) ->
         a.g.equal x1 x2 && b.g.equal y1 y2 && c.g.equal z1 z2)
       (fun x y z -> (x, y, z))
@@ -3037,9 +3041,9 @@ let rec3_of (Any a) (Any b) (Any c) =
       label = Fmt.str "(%s,%s,%s)" a.label b.label c.label;
     }
 
-let rec4_of (Any a) (Any b) (Any c) (Any d) =
+let rec4_of name (Any a) (Any b) (Any c) (Any d) =
   let g =
-    Codec.v "R4"
+    Codec.v name
       ~equal:(fun (x1, y1, z1, w1) (x2, y2, z2, w2) ->
         a.g.equal x1 x2 && b.g.equal y1 y2 && c.g.equal z1 z2 && d.g.equal w1 w2)
       (fun x y z w -> (x, y, z, w))
@@ -3160,18 +3164,18 @@ let rec gen_fixed depth : any Alcobar.gen =
           bind1_opt (gen_fixed (depth - 1)) (array_seq_of 2);
           bind1 (gen_fixed (depth - 1)) map_of;
           bind1 (gen_fixed (depth - 1)) where_of;
-          bind2 (gen_fixed (depth - 1)) (gen_fixed (depth - 1)) pair_of;
+          bind2 (gen_fixed (depth - 1)) (gen_fixed (depth - 1)) (pair_of "R2");
           bind3
             (gen_fixed (depth - 1))
             (gen_fixed (depth - 1))
             (gen_fixed (depth - 1))
-            rec3_of;
+            (rec3_of "R3");
           bind4
             (gen_fixed (depth - 1))
             (gen_fixed (depth - 1))
             (gen_fixed (depth - 1))
             (gen_fixed (depth - 1))
-            rec4_of;
+            (rec4_of "R4");
         ])
 
 let rec gen_any depth : any Alcobar.gen =
@@ -3192,18 +3196,18 @@ let rec gen_any depth : any Alcobar.gen =
           bind1_opt (gen_fixed (depth - 1)) nested_at_most_of;
           bind1_opt (gen_fixed (depth - 1)) (array_of 2);
           bind1_opt (gen_fixed (depth - 1)) (array_seq_of 2);
-          bind2 (gen_any (depth - 1)) (gen_any (depth - 1)) pair_of;
+          bind2 (gen_any (depth - 1)) (gen_any (depth - 1)) (pair_of "R2");
           bind3
             (gen_any (depth - 1))
             (gen_any (depth - 1))
             (gen_any (depth - 1))
-            rec3_of;
+            (rec3_of "R3");
           bind4
             (gen_any (depth - 1))
             (gen_any (depth - 1))
             (gen_any (depth - 1))
             (gen_any (depth - 1))
-            rec4_of;
+            (rec4_of "R4");
           bind2 (gen_any (depth - 1)) (gen_any (depth - 1)) casetype_of;
         ])
 
@@ -4966,13 +4970,14 @@ let afl_env_cases ?max_len label =
    A well-distributed random codec sampler. Rather than enumerate a handpicked
    set, [sample] draws codecs whose shape follows a Boltzmann law: the arity of
    a record is geometric (the Boltzmann distribution for a sequence, tuned to a
-   small expected size via [continue]), and each field is drawn from a fixed
-   leaf vocabulary that deliberately over-samples weird / adversarial shapes.
-   It stays in the fixed-size fragment (flat records and homogeneous arrays of
-   leaves) so the differential fuzzer can compile every sample to a standalone C
-   validator. Driven by a [Random.State.t], so a [seed] reproduces the exact
-   set: the differential's generator and its runner both call [sample] with the
-   same seed and agree on the shapes. *)
+   small expected size via [continue]), and each field is drawn either from a
+   fixed leaf vocabulary that deliberately over-samples weird / adversarial
+   shapes or, recursively, from the sampler itself. It stays in the fixed-size
+   fragment (records and homogeneous arrays) so the differential fuzzer can
+   compile every sample to a standalone C validator. Driven by a
+   [Random.State.t], so a [seed] reproduces the exact set: the differential's
+   generator and its runner both call [sample] with the same seed and agree on
+   the shapes. *)
 
 (* Fixed-size leaf vocabulary: every leaf has a standalone validator, so a flat
    record or array of them compiles to one C entrypoint. The sampler chooses
@@ -5066,65 +5071,165 @@ let sample_arity rng ~continue ~max_arity =
   in
   go 1
 
-(* The shape of one sampled codec, paired with the leaf-vocabulary labels it
-   draws (in draw order). The sampler stays in the fixed-size fragment, so a
-   composition is only a flat record of leaves or an array of one leaf --
-   "depth" here is record arity and array presence, not arbitrary nesting.
-   Exposed alongside each sample so coverage metrics read the structure directly
-   rather than parsing the debug label. *)
-type sample_shape = Leaf | Array | Record of int
+(* The shape of one sampled codec as a tree, paired with the leaf-vocabulary
+   labels it draws (in draw order). An array element and a record field are each
+   a shape in their own right, so an array can sit next to other fields, and a
+   record or an array can sit under either. Exposed alongside each sample so
+   coverage metrics read the structure directly rather than parsing the debug
+   label. *)
+type sample_shape =
+  | Leaf
+  | Array of sample_shape  (** element shape *)
+  | Record of sample_shape list  (** field shapes, in declaration order *)
+
 type sample_meta = { shape : sample_shape; leaves : string list }
 
-(* One Boltzmann-distributed projectable codec, with the structural metadata
-   needed for coverage metrics. A composition Wire refuses to build (e.g. a
-   bitfield array element) raises [Invalid_argument]; fall back to a bare leaf so
-   the sampler never crashes. The leaves drawn are recorded as a side effect, so
-   the RNG draw sequence is byte-identical to a plain sampler and a given seed
-   reproduces the exact same set. *)
-let boltzmann_any rng : any * sample_meta =
-  let regular = Array.of_list sampler_regular_leaves in
-  let adversarial = Array.of_list sampler_adversarial_leaves in
-  let pick xs = xs.(Random.State.int rng (Array.length xs)) in
-  let drawn = ref [] in
-  let leaf () =
-    let a =
-      if Random.State.int rng 4 = 0 then pick regular else pick adversarial
+let rec equal_shape a b =
+  match (a, b) with
+  | Leaf, Leaf -> true
+  | Array x, Array y -> equal_shape x y
+  | Record xs, Record ys -> List.equal equal_shape xs ys
+  | (Leaf | Array _ | Record _), _ -> false
+
+let rec shape_depth = function
+  | Leaf -> 1
+  | Array s -> 1 + shape_depth s
+  | Record fs -> 1 + List.fold_left (fun d s -> max d (shape_depth s)) 0 fs
+
+let rec shape_has_array = function
+  | Leaf -> false
+  | Array _ -> true
+  | Record fs -> List.exists shape_has_array fs
+
+(* An array that shares its record with at least one other field. This is the
+   shape where a mis-sized element does the most damage: it shifts the offset of
+   every field after it, which a record whose only field is the array cannot
+   show. *)
+let rec shape_has_array_beside_fields = function
+  | Leaf -> false
+  | Array s -> shape_has_array_beside_fields s
+  | Record fs ->
+      List.compare_length_with fs 1 > 0
+      && List.exists (function Array _ -> true | Leaf | Record _ -> false) fs
+      || List.exists shape_has_array_beside_fields fs
+
+(* An array whose element repeats again inside itself. Wire rejects an array
+   directly under an array (3D projects an array as a count of fixed-size
+   elements, and a list is not one), so the reachable form is an array of a
+   record that holds an array. *)
+let rec shape_has_nested_repetition = function
+  | Leaf -> false
+  | Array s -> shape_has_array s || shape_has_nested_repetition s
+  | Record fs -> List.exists shape_has_nested_repetition fs
+
+(* How deep a sample may nest. The branching is subcritical on its own (a node
+   composes with probability 1/2 and then has 1.875 children on average), so the
+   budget only caps the tail; 3 is the floor that reaches an array of a record
+   holding an array, which needs a record between the two arrays. *)
+let sample_budget = 3
+let sampler_regular_pool = Array.of_list sampler_regular_leaves
+let sampler_adversarial_pool = Array.of_list sampler_adversarial_leaves
+
+(* One leaf, adversarially biased 3:1, appended to [drawn] so the caller ends up
+   with the vocabulary the sample actually holds. *)
+let sample_leaf rng drawn =
+  let pool =
+    if Random.State.int rng 4 = 0 then sampler_regular_pool
+    else sampler_adversarial_pool
+  in
+  let a = pool.(Random.State.int rng (Array.length pool)) in
+  let (Any l) = a in
+  drawn := l.label :: !drawn;
+  a
+
+(* One node of a sampled shape. Each draws its own arity: 1 stops at a leaf,
+   otherwise the node is an array of one shape or a record of that many shapes,
+   and the recursion repeats until [budget] runs out. The set of legal shapes is
+   unchanged -- the same leaf vocabulary and the same three combinators, every
+   intermediate node fixed-size.
+
+   A composition Wire refuses to build (an array of arrays, an array of a
+   bitfield) raises [Invalid_argument] or yields [None]; that node drops back to
+   a bare leaf, and the leaves the abandoned subtree recorded are rolled back so
+   the caller's list holds exactly what the returned codec does. [uid] names the
+   sub-codecs apart, since a projection keys its typedefs by name. *)
+let sample_node rng ~drawn ~uid budget =
+  let bare () = (sample_leaf rng drawn, Leaf) in
+  let compose f =
+    let saved = !drawn in
+    let fallback () =
+      drawn := saved;
+      bare ()
     in
-    let (Any l) = a in
-    drawn := l.label :: !drawn;
-    a
+    match f () with
+    | Some r -> r
+    | None -> fallback ()
+    | exception Invalid_argument _ -> fallback ()
   in
-  let k = sample_arity rng ~continue:0.5 ~max_arity:4 in
-  let shape = ref Leaf in
-  let result =
-    try
-      if k = 1 then leaf ()
-      else if Random.State.bool rng then
-        match array_of (1 + Random.State.int rng 6) (leaf ()) with
-        | Some a ->
-            shape := Array;
-            a
-        | None -> leaf ()
-      else
-        match k with
-        | 2 ->
-            shape := Record 2;
-            pair_of (leaf ()) (leaf ())
-        | 3 ->
-            shape := Record 3;
-            rec3_of (leaf ()) (leaf ()) (leaf ())
-        | _ ->
-            shape := Record 4;
-            rec4_of (leaf ()) (leaf ()) (leaf ()) (leaf ())
-    with Invalid_argument _ -> leaf ()
+  (* A name with an upper-case letter past the first cannot collide with the
+     entrypoint name [sampled] derives from the label, which [camel_of_label]
+     lower-cases. *)
+  let fresh k =
+    incr uid;
+    Fmt.str "R%dN%d" k !uid
   in
-  (result, { shape = !shape; leaves = List.rev !drawn })
+  let rec draw budget =
+    let k = sample_arity rng ~continue:0.5 ~max_arity:4 in
+    if budget <= 0 || k = 1 then bare ()
+    else if Random.State.bool rng then draw_array budget
+    else draw_record budget k
+  and draw_array budget =
+    let n = 1 + Random.State.int rng 6 in
+    compose (fun () ->
+        let element, inner = draw (budget - 1) in
+        Option.map (fun a -> (a, Array inner)) (array_of n element))
+  and draw_record budget k =
+    compose (fun () ->
+        let fields = draw_fields (budget - 1) k in
+        let name = fresh k in
+        let shape = Record (List.map snd fields) in
+        match List.map fst fields with
+        | [ a; b ] -> Some (pair_of name a b, shape)
+        | [ a; b; c ] -> Some (rec3_of name a b c, shape)
+        | [ a; b; c; d ] -> Some (rec4_of name a b c d, shape)
+        | _ -> None)
+  (* Explicit recursion rather than [List.init], so the fields are drawn left to
+     right and the draw order is fixed by this code alone. *)
+  and draw_fields budget k =
+    if k <= 0 then []
+    else
+      let field = draw budget in
+      field :: draw_fields budget (k - 1)
+  in
+  draw budget
+
+(* One Boltzmann-distributed projectable codec, with the structural metadata
+   needed for coverage metrics. The draw sequence is a pure function of [rng],
+   so a seed reproduces the exact same set: the differential's generator and its
+   runner rely on it to agree on the shapes. *)
+let boltzmann_any rng : any * sample_meta =
+  let drawn = ref [] in
+  let uid = ref 0 in
+  let result, shape = sample_node rng ~drawn ~uid sample_budget in
+  (result, { shape; leaves = List.rev !drawn })
+
+(* A nested shape's label nests too, so it grows with the tree. The label names
+   the codec, and the codec name becomes a C identifier and a file name in the
+   differential's generated schema directory, so cap the shape part: the
+   [smp<i>_] prefix is what makes the name unique, and the rest is for reading. *)
+let sample_label i shape =
+  let max_shape = 64 in
+  let shape =
+    if String.length shape <= max_shape then shape
+    else String.sub shape 0 max_shape
+  in
+  Fmt.str "smp%d_%s" i shape
 
 let sampled ~seed ~count : (string * packed * sample_meta) list =
   let rng = Random.State.make [| seed |] in
   List.init count (fun i ->
       let Any a, meta = boltzmann_any rng in
-      let label = Fmt.str "smp%d_%s" i a.label in
+      let label = sample_label i a.label in
       (label, rename_case label (Pack a.g), meta))
 
 let sample ~seed ~count : (string * packed) list =
@@ -5443,6 +5548,23 @@ let check_sampler_invariants () =
         Alcobar.failf "sample label %S does not start with %S" label prefix)
     labels
 
+(* The differential's code generator and its runner each call [sample] at the
+   same seed and pair the results up by label; they are two processes, so
+   nothing but reproducibility keeps them comparing the same codec. A draw
+   sequence that depended on anything outside [rng] -- evaluation order, a
+   counter shared between samples, a hash -- would have them silently compare
+   mismatched shapes rather than fail. Redraw the differential's own seed and
+   count, and pin both the labels and the shapes. *)
+let check_sampler_reproducible () =
+  let shapes () =
+    List.map (fun (label, _, m) -> (label, m.shape)) (sampled ~seed:1 ~count:64)
+  in
+  let first = shapes () in
+  let again = shapes () in
+  let same (l1, s1) (l2, s2) = String.equal l1 l2 && equal_shape s1 s2 in
+  if not (List.equal same first again) then
+    Alcobar.failf "sample ~seed:1 is not reproducible across two calls"
+
 let check_sampler_adversarial_bias () =
   let adversarial = any_labels sampler_adversarial_leaves in
   let is_adversarial l = List.mem l adversarial in
@@ -5458,9 +5580,22 @@ let check_sampler_adversarial_bias () =
       "adversarial-biased sampler produced %d/256 weird/adversarial shapes"
       adversarial_hits
 
-let shape_is_leaf = function Leaf -> true | _ -> false
-let shape_is_array = function Array -> true | _ -> false
-let shape_is_record_arity n = function Record k -> k = n | _ -> false
+let shape_is_leaf = function Leaf -> true | Array _ | Record _ -> false
+let shape_is_array = function Array _ -> true | Leaf | Record _ -> false
+
+let shape_is_record_arity n = function
+  | Record fs -> List.compare_length_with fs n = 0
+  | Leaf | Array _ -> false
+
+(* [p] holds somewhere in the tree, not only at its root: nesting is the point,
+   so a record of arity 3 buried under an array still counts as one seen. *)
+let rec shape_exists p s =
+  p s
+  ||
+  match s with
+  | Leaf -> false
+  | Array e -> shape_exists p e
+  | Record fs -> List.exists (shape_exists p) fs
 
 (* Beyond the gross 3:1 adversarial-bias ratio ([check_sampler_adversarial_bias]),
    enforce that one deterministic sample actually spreads across the grammar:
@@ -5478,10 +5613,13 @@ let check_sampler_distribution () =
   let checks =
     [
       ("no bare leaves", has_shape shape_is_leaf);
-      ("no arrays", has_shape shape_is_array);
-      ("no record of arity 2", has_shape (shape_is_record_arity 2));
-      ("no record of arity 3", has_shape (shape_is_record_arity 3));
-      ("no record of arity 4", has_shape (shape_is_record_arity 4));
+      ("no arrays", has_shape (shape_exists shape_is_array));
+      ( "no record of arity 2",
+        has_shape (shape_exists (shape_is_record_arity 2)) );
+      ( "no record of arity 3",
+        has_shape (shape_exists (shape_is_record_arity 3)) );
+      ( "no record of arity 4",
+        has_shape (shape_exists (shape_is_record_arity 4)) );
       ( "no little-endian multibyte int",
         has_any [ "u16"; "u32"; "u64"; "i16"; "i32"; "i64" ] );
       ( "no big-endian multibyte int",
@@ -5508,6 +5646,26 @@ let check_sampler_distribution () =
   List.iter
     (fun (what, ok) ->
       if not ok then Alcobar.failf "sampler distribution: %s" what)
+    checks
+
+(* The three shapes a flat sampler cannot reach, and the three the differential
+   most wants: an array next to another field, an array inside an array's
+   element, and a third level of structure over either. A mis-sized inner value
+   shifts every field that follows it, and only a nested draw ever puts a field
+   after one. Kept apart from [check_sampler_distribution] so a regression here
+   names the nesting rather than the vocabulary. *)
+let check_sampler_nesting () =
+  let metas = List.map (fun (_, _, m) -> m) (sampled ~seed:7 ~count:256) in
+  let has p = List.exists (fun m -> p m.shape) metas in
+  let checks =
+    [
+      ("no array beside other record fields", has shape_has_array_beside_fields);
+      ("no array of a repeating element", has shape_has_nested_repetition);
+      ("no three-level shape", has (fun s -> shape_depth s >= 3));
+    ]
+  in
+  List.iter
+    (fun (what, ok) -> if not ok then Alcobar.failf "sampler nesting: %s" what)
     checks
 
 (* How many registry entries the per-field properties actually reach. Staging an
@@ -5551,10 +5709,12 @@ let invariant_cases label =
     const_case (label ^ " registry") check_registry_invariants;
     const_case (label ^ " composition vocabulary") check_composition_vocabulary;
     const_case (label ^ " sampler") check_sampler_invariants;
+    const_case (label ^ " sampler reproducible") check_sampler_reproducible;
     const_case
       (label ^ " sampler adversarial bias")
       check_sampler_adversarial_bias;
     const_case (label ^ " sampler distribution") check_sampler_distribution;
+    const_case (label ^ " sampler nesting") check_sampler_nesting;
     const_case (label ^ " field access reach") check_field_reach;
   ]
 

--- a/fuzz/gen/fuzz_gen.mli
+++ b/fuzz/gen/fuzz_gen.mli
@@ -146,15 +146,18 @@ val codec : 'a t -> 'a Wire.Codec.t
 
 val sample : seed:int -> count:int -> (string * packed) list
 (** [sample ~seed ~count] is a deterministic, well-distributed Boltzmann sample
-    of [count] codecs in the fixed-size fragment (flat records and homogeneous
-    arrays of leaves), each renamed to a unique struct name. Record arity
-    follows a geometric (Boltzmann-for-sequence) law and each leaf is drawn from
-    a fixed vocabulary that deliberately oversamples the weird / adversarial
-    shapes (3:1 over the regular leaves) -- refined byte spans, range bounds,
-    cross-field constraints and variable-width integers included, since bugs
-    cluster there; {!val-invariant_cases} asserts the resulting spread across
-    the grammar. The same [seed] yields the same set, so a code generator and
-    its consumer can agree on the shapes. *)
+    of [count] codecs in the fixed-size fragment (records and homogeneous
+    arrays), each renamed to a unique struct name. The shape is drawn as a tree:
+    an array element and a record field are themselves sampled shapes, so a
+    sample can nest a record under an array, put an array next to other fields,
+    or stack a third level over either. Record arity follows a geometric
+    (Boltzmann-for-sequence) law and each leaf is drawn from a fixed vocabulary
+    that deliberately oversamples the weird / adversarial shapes (3:1 over the
+    regular leaves) -- refined byte spans, range bounds, cross-field constraints
+    and variable-width integers included, since bugs cluster there;
+    {!val-invariant_cases} asserts the resulting spread across the grammar. The
+    same [seed] yields the same set, so a code generator and its consumer can
+    agree on the shapes. *)
 
 val binds_env : packed -> bool
 (** [binds_env p] is [true] when [p]'s codec references a [Param.input] /

--- a/lib/3d/wire_3d.ml
+++ b/lib/3d/wire_3d.ml
@@ -124,38 +124,56 @@ let check_name_collisions schemas =
   check "the file" (fun s -> file_base s ^ ".3d");
   check "the C identifier" c_ident
 
+let extern_api_path ~outdir s =
+  Filename.concat outdir (file_base s ^ "_ExternalAPI.h")
+
 (* EverParse normalizes extern callback names in ways that are awkward to
    mirror exactly (runs of uppercase after a digit get lowercased, trailing
    uppercase runs get lowercased, ...). Rather than re-implement EverParse's
    rule and drift from it over time, we read the normalized names straight
-   out of the [_ExternalAPI.h] file EverParse has just generated. *)
+   out of the [_ExternalAPI.h] file EverParse has just generated.
+
+   KaRaMeL pretty-prints the declaration to a column budget, so a long enough
+   schema name puts [extern void] and the name it introduces on separate lines.
+   Scanning the file as one string rather than line by line reads both layouts. *)
 let read_extern_names ~outdir s =
-  let path = Filename.concat outdir (file_base s ^ "_ExternalAPI.h") in
-  let ic = open_in path in
-  let names = ref [] in
-  (try
-     while true do
-       let line = input_line ic in
-       match
-         ( String.index_opt line '(',
-           String.index_opt line ' ',
-           String.length line )
-       with
-       | Some lp, _, _ when String.length line >= 11 ->
-           let prefix = "extern void " in
-           let plen = String.length prefix in
-           if
-             String.length line > plen
-             && String.sub line 0 plen = prefix
-             && lp > plen
-           then
-             let name = String.sub line plen (lp - plen) in
-             names := name :: !names
-       | _ -> ()
-     done
-   with End_of_file -> ());
-  close_in ic;
-  List.rev !names
+  let text =
+    In_channel.with_open_text (extern_api_path ~outdir s) In_channel.input_all
+  in
+  let len = String.length text in
+  let prefix = "extern void" in
+  let plen = String.length prefix in
+  let is_space c = c = ' ' || c = '\t' || c = '\n' || c = '\r' in
+  let is_ident c =
+    (c >= 'A' && c <= 'Z')
+    || (c >= 'a' && c <= 'z')
+    || (c >= '0' && c <= '9')
+    || c = '_'
+  in
+  let starts_prefix i =
+    i + plen <= len
+    &&
+    let rec same k = k = plen || (text.[i + k] = prefix.[k] && same (k + 1)) in
+    same 0
+  in
+  let skip pred i =
+    let j = ref i in
+    while !j < len && pred text.[!j] do
+      incr j
+    done;
+    !j
+  in
+  let rec scan i acc =
+    if i >= len then List.rev acc
+    else if starts_prefix i && i + plen < len && is_space text.[i + plen] then
+      let start = skip is_space (i + plen) in
+      let stop = skip is_ident start in
+      if stop > start && stop < len && text.[stop] = '(' then
+        scan stop (String.sub text start (stop - start) :: acc)
+      else scan (i + plen) acc
+    else scan (i + 1) acc
+  in
+  scan 0 []
 
 (* EverParse's top-level validator function follows its own normalization rule
    and includes the 3D struct tag after [Validate]. Rather than duplicate that
@@ -528,8 +546,17 @@ let write_fields_impl ~outdir s =
      uppercase runs after a digit are lowercased). Read the actual symbol
      names from the just-generated [_ExternalAPI.h] rather than re-deriving
      them. Order matches the declaration order of the extern functions,
-     which matches [plug_setters]. *)
+     which matches [plug_setters]. A header this cannot read yields too few
+     names, and pairing them off silently would emit a [_Fields.c] missing
+     setters the validator calls; say which file came up short instead. *)
   let physical_names = read_extern_names ~outdir s in
+  if List.compare_lengths setters physical_names <> 0 then
+    Fmt.invalid_arg
+      "Wire_3d: codec %S declares %d extern setter(s) but %d were read from \
+       %s; the generated header is not in a layout this understands"
+      s.name (List.length setters)
+      (List.length physical_names)
+      (extern_api_path ~outdir s);
   let path = Filename.concat outdir (base ^ "_Fields.c") in
   let oc = open_out path in
   let ppf = Format.formatter_of_out_channel oc in

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -1676,6 +1676,18 @@ let rec wrapper_refined_byte : type a. a typ -> (string * bool expr) option =
   | Where { inner; _ } -> wrapper_refined_byte inner
   | _ -> None
 
+(* The synthesised 1-byte struct a refined span renders as, emitted once per
+   name. [refined_byte_typedefs] only walks the entrypoint's own fields, so a
+   span reached through a sub-codec, an array element or a case body has no
+   other source of a declaration. *)
+let emit_refined_byte seen acc elt_var cond =
+  let synth = synth_name_of_elt_var elt_var in
+  if not (Hashtbl.mem seen synth) then begin
+    Hashtbl.add seen synth ();
+    acc :=
+      typedef (struct_ synth [ field elt_var ~constraint_:cond uint8 ]) :: !acc
+  end
+
 let rec collect_casetype_decls : type a.
     (string, unit) Hashtbl.t -> decl list Stdlib.ref -> a typ -> unit =
  fun seen acc typ ->
@@ -1689,14 +1701,7 @@ let rec collect_casetype_decls : type a.
     if not (Hashtbl.mem seen name) then begin
       Hashtbl.add seen name ();
       (match wrapper_refined_byte elem with
-      | Some (elt_var, cond) ->
-          let synth = synth_name_of_elt_var elt_var in
-          if not (Hashtbl.mem seen synth) then begin
-            Hashtbl.add seen synth ();
-            acc :=
-              typedef (struct_ synth [ field elt_var ~constraint_:cond uint8 ])
-              :: !acc
-          end
+      | Some (elt_var, cond) -> emit_refined_byte seen acc elt_var cond
       | None -> ());
       acc := typedef (struct_ name [ field "v" elem ]) :: !acc
     end
@@ -1717,11 +1722,11 @@ let rec collect_casetype_decls : type a.
   | Codec { codec_name; codec_struct; _ } when not (Hashtbl.mem seen codec_name)
     ->
       (* Embedded sub-codec: emit its struct alongside the parent so 3D
-         references to [codec_name] resolve. Recurse into the sub-codec's
-         own fields to catch nested casetype / sub-codec dependencies. *)
+         references to [codec_name] resolve, and only after visiting its own
+         fields, so whatever they name is declared ahead of it. *)
       Hashtbl.add seen codec_name ();
-      acc := typedef codec_struct :: !acc;
-      List.iter (fun (Field f) -> extract f.field_typ) codec_struct.fields
+      List.iter (fun (Field f) -> extract f.field_typ) codec_struct.fields;
+      acc := typedef codec_struct :: !acc
   | Codec _ -> ()
   | Map { inner; _ } -> extract inner
   | Where { inner; _ } -> extract inner
@@ -1752,6 +1757,8 @@ let rec collect_casetype_decls : type a.
   | Single_elem { elem; _ } ->
       extract elem;
       Option.iter (fun n -> emit_wrapper n elem) (single_elem_struct elem)
+  | Byte_array_where { elt_var; cond; _ } ->
+      emit_refined_byte seen acc elt_var cond
   | _ -> ()
 
 let casetype_decls_of_struct (s : struct_) : decl list =

--- a/test/3d/test_wire_3d.ml
+++ b/test/3d/test_wire_3d.ml
@@ -1694,6 +1694,63 @@ let test_keyword_field_escaped () =
   Alcotest.(check bool) "match_ field" true (contains out "match_");
   Alcotest.(check bool) "type_ field" true (contains out "type_")
 
+(* KaRaMeL pretty-prints an extern declaration to a column budget, so a schema
+   name long enough to push the declaration past it lands [extern void] on one
+   line and the symbol it introduces on the next. Both layouts have to read, and
+   a header holding no declaration at all has to say so by name: pairing the
+   symbols off against the schema's setters is what fails otherwise, from a call
+   site that cannot tell which file came up short. Fabricate the header rather
+   than shell out, so this runs in the lanes with no EverParse. *)
+let test_extern_names_wrapped () =
+  let base = "Smp27bits15u16belsbbits15u16belsbbits15u16belsbbits15u1" in
+  let schema =
+    Wire.Everparse.Raw.project_struct ~mode:`Ffi
+      (struct_ base [ field "f0" uint16be; field "f1" uint8 ])
+  in
+  let setters = Wire.Everparse.plug_setters schema in
+  let symbol i = Fmt.str "%sSetter%d" base i in
+  let wrapped =
+    String.concat ""
+      (List.mapi
+         (fun i (_, c_type) ->
+           Fmt.str
+             "extern void\n\
+              %s(\n\
+             \  WIRECTX *ctx,\n\
+             \  uint32_t idx,\n\
+             \  %s v\n\
+              );\n\n"
+             (symbol i) c_type)
+         setters)
+  in
+  let fields_impl header =
+    let dir = Filename.temp_dir "wire_3d_extern" "" in
+    Fun.protect
+      ~finally:(fun () -> Wire_3d.rm_rf dir)
+      (fun () ->
+        Out_channel.with_open_bin
+          (Filename.concat dir (base ^ "_ExternalAPI.h"))
+          (fun oc -> Out_channel.output_string oc header);
+        Wire_3d.write_fields ~outdir:dir [ schema ];
+        read_file (Filename.concat dir (base ^ "_Fields.c")))
+  in
+  Alcotest.(check bool)
+    "the schema declares setters to pair" true (setters <> []);
+  let impl = fields_impl wrapped in
+  List.iteri
+    (fun i _ ->
+      Alcotest.(check bool)
+        (Fmt.str "setter %d read across the wrap" i)
+        true
+        (contains impl (Fmt.str "void %s(WIRECTX *ctx," (symbol i))))
+    setters;
+  match fields_impl "/* nothing to read here */\n" with
+  | impl -> Alcotest.failf "a header with no declaration produced %S" impl
+  | exception Invalid_argument msg ->
+      Alcotest.(check bool)
+        "the failure names the header it could not read" true
+        (contains msg (base ^ "_ExternalAPI.h"))
+
 let suite =
   ( "wire_3d",
     [
@@ -1739,6 +1796,8 @@ let suite =
         test_doc_differential_caps_name;
       Alcotest.test_case "doc differential trailing bytes (needs 3d.exe)" `Quick
         test_doc_differential_trailing_bytes;
+      Alcotest.test_case "extern names across a wrapped declaration" `Quick
+        test_extern_names_wrapped;
       Alcotest.test_case "uses_wire_ctx" `Quick test_uses_wire_ctx;
       Alcotest.test_case "has_3d_exe" `Quick test_has_3d_exe;
       Alcotest.test_case "main exists" `Quick test_main_exists;

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -6,6 +6,12 @@ open Test_helpers
 
 let contains ~sub s = Re.execp (Re.compile (Re.str sub)) s
 
+(* Return the byte offset of the first occurrence of [sub] in [s], or -1 if not
+   found. Used to assert relative declaration and field ordering. *)
+let index_of ~sub s =
+  let re = Re.compile (Re.str sub) in
+  match Re.exec_opt re s with Some g -> Re.Group.start g 0 | None -> -1
+
 let test_bitfields () =
   let f_y = field "y" (bits ~width:10 U32) in
   let f_z = field "z" (bits ~width:16 U32) in
@@ -556,6 +562,80 @@ let test_3d_nested_byte_array_where () =
     "refined-byte typedef is defined, not just referenced" true
     (contains ~sub:"} _RefByte_" output)
 
+let test_3d_sub_codec_declaration_order () =
+  (* 3D resolves a type name against what is already declared, so a sub-codec's
+     typedef has to follow every typedef its own fields name. It takes three
+     levels to tell the two orders apart: with only a sub-codec of leaves the
+     entrypoint is the sole referrer and any order works. *)
+  let leaf =
+    Codec.v "OrdLeaf"
+      (fun a b -> (a, b))
+      Codec.
+        [
+          (Field.v "a" uint8 $ fun (a, _) -> a);
+          (Field.v "b" uint16be $ fun (_, b) -> b);
+        ]
+  in
+  let middle =
+    Codec.v "OrdMiddle"
+      (fun a b -> (a, b))
+      Codec.
+        [
+          (Field.v "l" (codec leaf) $ fun (a, _) -> a);
+          (Field.v "c" uint8 $ fun (_, b) -> b);
+        ]
+  in
+  let top =
+    Codec.v "OrdTop"
+      (fun a b -> (a, b))
+      Codec.
+        [
+          (Field.v "m" (codec middle) $ fun (a, _) -> a);
+          (Field.v "z" uint8 $ fun (_, b) -> b);
+        ]
+  in
+  let output = to_3d (Everparse.project ~mode:`Ffi top).module_ in
+  let leaf_decl = index_of ~sub:"} OrdLeaf;" output in
+  let middle_decl = index_of ~sub:"} OrdMiddle;" output in
+  Alcotest.(check bool) "OrdLeaf declared" true (leaf_decl >= 0);
+  Alcotest.(check bool) "OrdMiddle declared" true (middle_decl >= 0);
+  Alcotest.(check bool)
+    "OrdLeaf declared before the OrdMiddle whose field names it" true
+    (leaf_decl < middle_decl)
+
+let test_3d_sub_codec_refined_byte_typedef () =
+  (* The synthesised refined-byte struct is collected from the entrypoint's own
+     fields, so a refined span reached only through a sub-codec had nothing
+     declaring it: the schema named a type it never defined. Reach one the way
+     an array element does, and check the typedef is defined and defined before
+     the sub-codec whose field names it. *)
+  let span =
+    byte_array_where ~size:(int 3) ~per_byte:(fun b -> Expr.(b < int 128))
+  in
+  let inner =
+    Codec.v "RefInner"
+      (fun a b -> (a, b))
+      Codec.
+        [
+          (Field.v "s" span $ fun (a, _) -> a);
+          (Field.v "n" uint16be $ fun (_, b) -> b);
+        ]
+  in
+  let top =
+    Codec.v "RefTop"
+      (fun v -> v)
+      Codec.[ (Field.v "xs" (array ~len:(int 2) (codec inner)) $ fun v -> v) ]
+  in
+  let output = to_3d (Everparse.project ~mode:`Ffi top).module_ in
+  let synth_decl = index_of ~sub:"} _RefByte_" output in
+  let inner_decl = index_of ~sub:"} RefInner;" output in
+  Alcotest.(check bool)
+    "refined-byte typedef is defined, not just referenced" true (synth_decl >= 0);
+  Alcotest.(check bool) "RefInner declared" true (inner_decl >= 0);
+  Alcotest.(check bool)
+    "the refined-byte typedef precedes the sub-codec naming it" true
+    (synth_decl < inner_decl)
+
 let test_3d_static_optional_transparent () =
   (* A statically-present optional projects as its inner: a byte-span or
      composite inner keeps its offset setter (passing the field value made
@@ -1037,12 +1117,6 @@ let test_3d_tm_like () =
    widths don't fill the word, prepending anonymous padding. These tests
    lock in that the reorder actually happens in the emitted 3D text. *)
 
-(* Return the byte offset of the first occurrence of [sub] in [s],
-   or -1 if not found. Used to assert relative field ordering. *)
-let index_of ~sub s =
-  let re = Re.compile (Re.str sub) in
-  match Re.exec_opt re s with Some g -> Re.Group.start g 0 | None -> -1
-
 let test_3d_bitorder_u8msb_reorder () =
   (* Non-native: (U8, Msb_first). EverParse native for UINT8 is LSB-first,
      so the projection reverses [a; b] to [b; a] in the emitted 3D text.
@@ -1500,6 +1574,10 @@ let suite =
         test_doc_bit_order_matches_schema;
       Alcotest.test_case "3d: nested byte_array_where refined typedef" `Quick
         test_3d_nested_byte_array_where;
+      Alcotest.test_case "3d: sub-codec declaration order" `Quick
+        test_3d_sub_codec_declaration_order;
+      Alcotest.test_case "3d: sub-codec refined-byte typedef" `Quick
+        test_3d_sub_codec_refined_byte_typedef;
       Alcotest.test_case "3d: static optional transparent projection" `Quick
         test_3d_static_optional_transparent;
       Alcotest.test_case "3d: absent optional projects to unit" `Quick


### PR DESCRIPTION
The differential sampler only ever drew flat shapes, so nothing exercised a codec three levels deep. Making it nest turned two projection bugs red at once: a sub-codec's declarations came out after the codec referencing them and a refined byte span reached only through a sub-codec was never declared, and a schema name long enough to wrap the generated callback declarations crashed the field-plug generator with `Invalid_argument "List.iter2"`. The second was already reachable on main and seed 1 had simply never drawn it. The sampler commit comes first and is red on its own; the two fixes follow.