### PR TITLE
everparse: keep a shared sub-codec's entrypoint through the merge

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,14 @@
+## unreleased
+
+### Fixed
+
+- `Wire.Everparse.write` no longer refuses a family in which a sub-codec is both
+  packed as a codec of its own and reached through another codec's field,
+  reporting the two as conflicting definitions of one type. They differ only in
+  how the type is used, not in what it is, so they now collapse into a single
+  declaration that still gets a validator of its own and keeps the codec's doc
+  comment, whichever schema was projected first (#346, @samoht)
+
 ## 1.2.0
 
 ### Added

--- a/lib/everparse.ml
+++ b/lib/everparse.ml
@@ -636,8 +636,19 @@ let write_ffi ~outdir schemas =
     (fun s -> Types.to_3d_file (Filename.concat outdir (filename s)) s.module_)
     schemas
 
-(* Identity of a declaration for merge purposes: the 3D it renders to on its
-   own. [Types.decl] holds closures (codec and map encode/decode pairs), so
+(* The entrypoint marker and the doc comment say how a typedef is used, not what
+   it is: the same struct projects with [entrypoint] set when it is packed as a
+   codec of its own and clear when it is reached through another codec's field,
+   and only the codec-derived projection carries the doc. Strip both before
+   comparing, so a sub-codec shared between a packed codec and its parent is one
+   declaration rather than a conflict. [output] and [extern_] stay in: they
+   change what the declaration is, not what it is for. *)
+let decl_shape = function
+  | Types.Typedef t -> Types.Typedef { t with entrypoint = false; doc = None }
+  | d -> d
+
+(* Identity of a declaration for merge purposes: the 3D its shape renders to on
+   its own. [Types.decl] holds closures (codec and map encode/decode pairs), so
    polymorphic equality raises on it, and the rendered text is exactly what the
    merged file would say about the type. Rendering is deterministic: its only
    render-time global, the anonymous-field counter, is reset per struct.
@@ -645,9 +656,44 @@ let write_ffi ~outdir schemas =
    two identical ones still compare equal and the projection error surfaces at
    emit time as before, not as a spurious collision. *)
 let decl_identity d =
-  match Types.to_3d ~enum_as_type:true (Types.module_ [ d ]) with
+  match Types.to_3d ~enum_as_type:true (Types.module_ [ decl_shape d ]) with
   | text -> Ok text
   | exception e -> Error (Printexc.to_string e)
+
+let decl_name = function
+  | Types.Typedef { struct_ = { name; _ }; _ } -> Some name
+  | Types.Enum_decl { name; _ } | Types.Casetype_decl { name; _ } -> Some name
+  | Types.Define { name; _ } | Types.Extern_fn { name; _ } -> Some name
+  | _ -> None
+
+(* The entrypoint marker and the doc comment a merged typedef should end up
+   with: the union over every copy of it. A sub-codec that one schema packs as
+   its own codec and another reaches through a field is declared once, and this
+   is what keeps that one declaration's validator and prose whichever schema
+   happened to contribute it first. *)
+let typedef_roles (ts : t list) =
+  let roles = Hashtbl.create 16 in
+  let note d =
+    match (decl_name d, d) with
+    | Some n, Types.Typedef { entrypoint; doc; _ } ->
+        let seen_entry, seen_doc =
+          Option.value (Hashtbl.find_opt roles n) ~default:(false, None)
+        in
+        let doc = match seen_doc with None -> doc | kept -> kept in
+        Hashtbl.replace roles n (seen_entry || entrypoint, doc)
+    | _ -> ()
+  in
+  List.iter (fun (t : t) -> List.iter note t.module_.decls) ts;
+  roles
+
+let with_role roles d =
+  match (decl_name d, d) with
+  | Some n, Types.Typedef t ->
+      let entrypoint, doc =
+        Option.value (Hashtbl.find_opt roles n) ~default:(t.entrypoint, t.doc)
+      in
+      Types.Typedef { t with entrypoint; doc }
+  | _ -> d
 
 (* Merge several clean (doc) schemas into one module: union their decls, keeping
    the first definition of each named typedef / enum / casetype so a type shared
@@ -657,13 +703,8 @@ let decl_identity d =
    Two schemas declaring different types under one name cannot both be honoured
    by a single merged spec, so that is rejected rather than resolved silently. *)
 let merge ~name (ts : t list) : t =
-  let decl_name = function
-    | Types.Typedef { struct_ = { name; _ }; _ } -> Some name
-    | Types.Enum_decl { name; _ } | Types.Casetype_decl { name; _ } -> Some name
-    | Types.Define { name; _ } | Types.Extern_fn { name; _ } -> Some name
-    | _ -> None
-  in
   let seen = Hashtbl.create 16 in
+  let roles = typedef_roles ts in
   let keep owner d =
     match decl_name d with
     | None -> true
@@ -689,6 +730,7 @@ let merge ~name (ts : t list) : t =
           acc t.module_.decls)
       [] ts
     |> List.rev
+    |> List.map (with_role roles)
   in
   { name; module_ = Types.module_ decls; wire_size = None; source = None }
 

--- a/lib/everparse.mli
+++ b/lib/everparse.mli
@@ -144,8 +144,12 @@ val write : ?mode:mode -> outdir:string -> ?name:string -> t list -> unit
     [~name] is ignored. With [`Standalone] (the default), the schemas are merged
     into a single [<name>.3d] -- a type shared across several codecs is emitted
     once -- so a whole protocol family reads as one spec, and [~name] is
-    required. Raises [Invalid_argument] if two schemas declare different types
-    under the same name, since one merged spec cannot honour both. *)
+    required. A sub-codec packed as a codec of its own and also reached through
+    another codec's field is one such shared type; the surviving declaration
+    keeps the entrypoint marker and the doc comment either copy carried, so it
+    still gets a validator of its own. Raises [Invalid_argument] if two schemas
+    declare different types under the same name, since one merged spec cannot
+    honour both. *)
 
 module Raw : sig
   type nonrec struct_ = struct_

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -1416,8 +1416,12 @@ module Everparse : sig
       and [~name] is ignored. With [`Standalone] (the default), the schemas are
       merged into a single [<name>.3d] -- a type shared across several codecs is
       emitted once -- so a whole protocol family reads as one spec, and [~name]
-      is required. Raises [Invalid_argument] if two schemas declare different
-      types under the same name, since one merged spec cannot honour both. *)
+      is required. A sub-codec packed as a codec of its own and also reached
+      through another codec's field is one such shared type; the surviving
+      declaration keeps the entrypoint marker and the doc comment either copy
+      carried, so it still gets a validator of its own. Raises
+      [Invalid_argument] if two schemas declare different types under the same
+      name, since one merged spec cannot honour both. *)
 
   module Raw : sig
     (** Escape hatch for manual 3D authoring.

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -497,6 +497,54 @@ let test_doc_merge_name_collision () =
     "equal copies declared once" 1
     (List.length (Re.all (Re.compile (Re.str "enum Shared")) content))
 
+(* A sub-codec packed as a codec of its own and also reached through another
+   codec's field projects twice: once carrying [entrypoint] and the codec's doc,
+   once carrying neither. Both describe the same type, so the merge must collapse
+   them instead of reading the markers as a conflicting redeclaration -- and the
+   surviving copy must keep the entrypoint whichever schema came first, or the
+   shared type silently loses its validator. *)
+let test_doc_merge_shared_sub_codec () =
+  let shared =
+    Codec.v "Chunk" ~doc:"The shared chunk header."
+      (fun v -> v)
+      Codec.[ (Field.v "len" uint8 $ fun v -> v) ]
+  in
+  let outer =
+    Codec.v "Frame"
+      (fun k c -> (k, c))
+      Codec.
+        [
+          (Field.v "kind" uint8 $ fun (k, _) -> k);
+          (Field.v "chunk" (codec shared) $ fun (_, c) -> c);
+        ]
+  in
+  let dir = Filename.get_temp_dir_name () in
+  let write name schemas =
+    Everparse.write ~mode:`Standalone ~outdir:dir ~name schemas;
+    let path = Filename.concat dir (String.capitalize_ascii name ^ ".3d") in
+    let content = In_channel.with_open_text path In_channel.input_all in
+    Sys.remove path;
+    content
+  in
+  let sub = Everparse.project ~mode:`Standalone shared in
+  let parent = Everparse.project ~mode:`Standalone outer in
+  let check order content =
+    Alcotest.(check int)
+      (order ^ ": Chunk declared once")
+      1
+      (List.length (Re.all (Re.compile (Re.str "} Chunk;")) content));
+    Alcotest.(check bool)
+      (order ^ ": Chunk keeps its entrypoint")
+      true
+      (contains ~sub:"entrypoint\ntypedef struct WireChunk" content);
+    Alcotest.(check bool)
+      (order ^ ": Chunk keeps its doc")
+      true
+      (contains ~sub:"The shared chunk header." content)
+  in
+  check "sub first" (write "wire_doc_merge_shared_a" [ sub; parent ]);
+  check "parent first" (write "wire_doc_merge_shared_b" [ parent; sub ])
+
 let test_doc_field_citation () =
   (* [Field.v ~doc] renders as a plain [/* ... */] comment above the field --
      3d.exe rejects [/*++ --*/] at field position, so the per-field note uses
@@ -1568,6 +1616,8 @@ let suite =
         test_doc_merge_dedup;
       Alcotest.test_case "doc: merge rejects conflicting redeclaration" `Quick
         test_doc_merge_name_collision;
+      Alcotest.test_case "doc: merge keeps a shared sub-codec's entrypoint"
+        `Quick test_doc_merge_shared_sub_codec;
       Alcotest.test_case "doc: field ~doc renders as citation comment" `Quick
         test_doc_field_citation;
       Alcotest.test_case "doc: bit order matches schema projection" `Quick


### PR DESCRIPTION
`Everparse.write ~mode:Standalone` refuses a family in which a sub-codec is both packed as a codec of its own and reached through another codec's field, reporting the two projections as conflicting definitions of one type. They differ only in the entrypoint marker and the doc comment, which say how the type is used rather than what it is, so wire cannot regenerate a schema wire itself wrote. The committed `Squashfs.3d` is exactly that arrangement.

The merged declaration now carries the entrypoint and the doc that either copy had, whichever schema was projected first, so the shared type keeps a validator of its own. Regenerating that shape end to end gets `EverParse succeeded!` with `CheckWireInodeHeaderRest` among the generated validators.

Bottom of a five-branch stack; the other four follow.