### PR TITLE
types: project every integer carrier a casetype tag can take

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,10 @@
   declaration that still gets a validator of its own and keeps the codec's doc
   comment, whichever schema was projected first (#346, @samoht)
 
+- A casetype tag whose enum sits over a `lookup`, a `where` or a 64-bit base no
+  longer fails the 3D projection with an assertion failure. Every integer
+  carrier an enum base accepts now yields a case label (#347, @samoht)
+
 ## 1.2.0
 
 ### Added

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -1492,23 +1492,61 @@ let uint_var_case_index k =
         "Wire.casetype: case index %a does not fit this platform's native int"
         UInt63.pp k
 
+(* Both widths project to 3D's UINT64, so the case label is the unsigned
+   reinterpretation of the eight wire bytes -- which is what [int_of] reads out
+   of them, and what the generated [switch] compares against. *)
+let uint64_case_index k =
+  match UInt64.to_int_opt k with
+  | Some index -> index
+  | None ->
+      Fmt.invalid_arg
+        "Wire.casetype: case index %Lu does not fit this platform's native int"
+        (UInt64.to_int64 k)
+
+let int64_case_index k =
+  match Int64.unsigned_to_int k with
+  | Some index -> index
+  | None ->
+      Fmt.invalid_arg
+        "Wire.casetype: case index %Lu does not fit this platform's native int"
+        k
+
 (* Project a case-branch discriminator value of type ['k] to a 3D constant
-   expression. Only called for int-shaped tags; non-int tags don't reach
-   here because their casetype field is rewritten away before
-   [casetype_decls_of_struct] walks it. *)
+   expression. Only called for int-shaped tags; non-int tags don't reach here
+   because their casetype field is rewritten away before
+   [casetype_decls_of_struct] walks it.
+
+   [is_int_dispatch_typ] lets an [Enum] through whatever its base, and [enum]
+   takes any base [is_int_representable] accepts, so every integer carrier
+   reachable that way has to be covered here -- the transparent [map] / [where]
+   / [nested] / [apply] wrappers a [variants] or [lookup] base carries
+   included. The match is left exhaustive so a new typ constructor is a
+   compile error rather than a crash on a schema that uses it. *)
 let rec case_index_to_expr : type k. k typ -> k -> packed_expr =
  fun tag_typ k ->
   match tag_typ with
   | Uint8 -> Pack_expr (Int (UInt8.to_int k))
   | Uint16 _ -> Pack_expr (Int (UInt16.to_int k))
   | Uint32 _ -> Pack_expr (Int (uint32_case_index k))
+  | Uint64 _ -> Pack_expr (Int (uint64_case_index k))
   | Uint_var _ -> Pack_expr (Int (uint_var_case_index k))
   | Int8 -> Pack_expr (Int (SInt8.to_int k))
   | Int16 _ -> Pack_expr (Int (SInt16.to_int k))
   | Int32 _ -> Pack_expr (Int (int32_case_index k))
+  | Int64 _ -> Pack_expr (Int (int64_case_index k))
   | Bits _ -> Pack_expr (Int k)
   | Enum { base; _ } -> case_index_to_expr base k
-  | _ -> assert false (* guarded by [is_int_dispatch_typ] *)
+  | Map { inner; encode; _ } -> case_index_to_expr inner (encode k)
+  | Where { inner; _ } -> case_index_to_expr inner k
+  | Single_elem { elem; _ } -> case_index_to_expr elem k
+  | Apply { typ; _ } -> case_index_to_expr typ k
+  | Float32 _ | Float64 _ | Unit | All_bytes | All_zeros | Zeroterm
+  | Zeroterm_at_most _ | Array _ | Byte_array _ | Byte_array_where _
+  | Byte_slice _ | Casetype _ | Struct _ | Type_ref _ | Qualified_ref _
+  | Codec _ | Optional _ | Optional_or _ | Repeat _ ->
+      invalid_arg
+        "Wire.casetype: this tag type carries no integer case index; use a \
+         fixed-width integer, bitfield, or enum tag."
 
 (* Auto-emit a dispatch + wrapper for each [Casetype] used in a struct.
 

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -545,6 +545,51 @@ let test_doc_merge_shared_sub_codec () =
   check "sub first" (write "wire_doc_merge_shared_a" [ sub; parent ]);
   check "parent first" (write "wire_doc_merge_shared_b" [ parent; sub ])
 
+(* A casetype dispatches on any enum, and an enum takes any base with an integer
+   view, so a tag reaches the case-index projection wrapped in a [lookup]'s map,
+   behind a [where], or over a 64-bit base. Each still names one integer per
+   case, so each must project to a switch on the enum constant. *)
+let test_3d_casetype_tag_int_carriers () =
+  let dispatch name tag index =
+    Codec.v name
+      (fun v -> v)
+      Codec.
+        [
+          ( Field.v "u"
+              (casetype ("Sel" ^ name) tag
+                 [ case ~index uint8 ~inject:Fun.id ~project:Option.some ])
+          $ fun v -> v );
+        ]
+  in
+  let dir = Filename.get_temp_dir_name () in
+  (* Go through [write], not the projected module on its own: the merge is where
+     a synthesised wrapper's own dependencies -- here the tag's enum
+     declaration -- are absorbed, so this is the spec a consumer actually gets. *)
+  let projects what c =
+    let name = "wire_casetype_tag_" ^ String.lowercase_ascii what in
+    Everparse.write ~mode:`Standalone ~outdir:dir ~name
+      [ Everparse.project ~mode:`Standalone c ];
+    let path = Filename.concat dir (String.capitalize_ascii name ^ ".3d") in
+    let out = In_channel.with_open_text path In_channel.input_all in
+    Sys.remove path;
+    Alcotest.(check bool)
+      (what ^ ": switch names the enum constant")
+      true
+      (contains ~sub:"case A:" out);
+    Alcotest.(check bool)
+      (what ^ ": the tag's enum is declared")
+      true
+      (contains ~sub:"enum E" out)
+  in
+  projects "lookup"
+    (dispatch "Map" (enum "EMap" [ ("A", 0) ] (lookup [ 0; 1 ] uint8)) 0);
+  projects "uint64"
+    (dispatch "U64" (enum "EU64" [ ("A", 0) ] uint64) (UInt64.of_int 0));
+  projects "where"
+    (dispatch "Where"
+       (enum "EWhere" [ ("A", 0) ] (where Expr.(int 0 = int 0) uint8))
+       (UInt8.v 0))
+
 let test_doc_field_citation () =
   (* [Field.v ~doc] renders as a plain [/* ... */] comment above the field --
      3d.exe rejects [/*++ --*/] at field position, so the per-field note uses
@@ -1618,6 +1663,8 @@ let suite =
         test_doc_merge_name_collision;
       Alcotest.test_case "doc: merge keeps a shared sub-codec's entrypoint"
         `Quick test_doc_merge_shared_sub_codec;
+      Alcotest.test_case "3d: casetype tag over map/where/uint64 bases" `Quick
+        test_3d_casetype_tag_int_carriers;
       Alcotest.test_case "doc: field ~doc renders as citation comment" `Quick
         test_doc_field_citation;
       Alcotest.test_case "doc: bit order matches schema projection" `Quick


### PR DESCRIPTION
A casetype dispatches on any enum, and `enum` accepts any base with an integer view, so a tag reaches the case-index projection wrapped in a `lookup`'s map, behind a `where`, or over a 64-bit base. All three reach an `assert false` whose comment claims a guard that in fact admits them, and PE's variant of the shape silently produced a validator accepting anything.

Every integer carrier now yields a case label, and the match is exhaustive so a new typ constructor is a compile error rather than a crash on a schema that uses it.

Stacked on #346.