### PR TITLE
types: seed a casetype tag from its case indices

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,14 @@
   longer fails the 3D projection with an assertion failure. Every integer
   carrier an enum base accepts now yields a case label (#347, @samoht)
 
+- A parse error from an unmatched casetype tag now names the casetype field. It
+  used to arrive with an empty field path, leaving a caller no way to tell which
+  field the bad tag belonged to (#348, @samoht)
+
+- `Wire.Everparse.Raw.field_seeds` now names a casetype's case indices, so
+  `Wire_3d.generate_corpus` can reach a tagged record instead of reporting the
+  codec as vacuous (#348, @samoht)
+
 ## 1.2.0
 
 ### Added

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -2729,6 +2729,28 @@ let compile_var_size_fn : type a.
       in
       compile_expr ~sizeof_this ctx.field_readers size_expr
 
+(* Prepend [name] to the field path of a parse error escaping [f], so a failure
+   deep in a nested decode accumulates its root-to-leaf path as the exception
+   unwinds. Only fields that can raise an attributable error are wrapped; a plain
+   scalar read raises only [Unexpected_eof] from the record's bounds check, which
+   is recorded without a path. *)
+let prepend_field name f runtime input_end buf base =
+  try f runtime input_end buf base
+  with Types.Parse_error e ->
+    raise (Types.Parse_error { e with field = name :: e.field })
+
+let prepend_field_check name f arr runtime input_end buf base =
+  try f arr runtime input_end buf base
+  with Types.Parse_error e ->
+    raise (Types.Parse_error { e with field = name :: e.field })
+
+(* A casetype's extent comes from dispatching on its tag, and the record's
+   bounds check walks that extent before any field reader runs, so an unknown
+   tag surfaces from the size walk rather than from the wrapped reader. Name the
+   field there too, or the failure reaches the caller with no path at all. *)
+let attribute_size_errors typ name size_fn =
+  match typ with Casetype _ -> prepend_field name size_fn | _ -> size_fn
+
 let compile_var_bytes : type a r.
     layout_ctx -> (a, r) field -> (a, r) compiled_field =
  fun ctx fld ->
@@ -2736,6 +2758,7 @@ let compile_var_bytes : type a r.
   let off_fn = off_fn_of ctx in
   let validator_off = validator_off_of ctx in
   let size_fn = compile_var_size_fn ctx typ ~off_fn in
+  let size_fn = attribute_size_errors typ fld.name size_fn in
   let field_access : field_access =
     match ctx.next_off with
     | Static n -> Variable { off = n; size_fn }
@@ -3254,21 +3277,6 @@ let rec field_reader_validates : type a. a Types.typ -> bool = function
      into [elem]. *)
   | Types.Repeat _ -> true
   | _ -> true
-
-(* Prepend [name] to the field path of a parse error escaping [f], so a failure
-   deep in a nested decode accumulates its root-to-leaf path as the exception
-   unwinds. Only fields that can raise an attributable error are wrapped; a plain
-   scalar read raises only [Unexpected_eof] from the record's bounds check, which
-   is recorded without a path. *)
-let prepend_field name f runtime input_end buf base =
-  try f runtime input_end buf base
-  with Types.Parse_error e ->
-    raise (Types.Parse_error { e with field = name :: e.field })
-
-let prepend_field_check name f arr runtime input_end buf base =
-  try f arr runtime input_end buf base
-  with Types.Parse_error e ->
-    raise (Types.Parse_error { e with field = name :: e.field })
 
 (* Tag a field's reader and its two validators with [name] so a parse error
    escaping any of them carries the field in its path; [attributable = false] (a

--- a/lib/everparse.mli
+++ b/lib/everparse.mli
@@ -271,8 +271,10 @@ module Raw : sig
       declaration singles out values, the byte slot it occupies and those
       values: the constant an equality or inequality refinement names, the
       values either side of an ordering refinement's boundary, and the members
-      of a closed enumeration. Bitfields are omitted because their base word is
-      shared, so a byte offset alone cannot seed one.
+      of a closed enumeration. A casetype field seeds too: its tag is parsed at
+      the start of the field's own bytes, so the slot is the tag's and the
+      values are the case indices. Bitfields are omitted because their base word
+      is shared, so a byte offset alone cannot seed one.
 
       The list over-approximates: it names candidates worth trying, not values
       the description is guaranteed to admit, so a consumer must run each

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -3613,7 +3613,57 @@ let int_slots s =
       | _ -> None)
     s.fields
 
+(* The wire bytes a tag constant stands for, as the [int64] a seed carries.
+   Deliberately not routed through [int_of]: a four-byte magic overflows a
+   native [int] on a 31-bit target, and a seed has to survive there -- which is
+   why [field_seed] holds [int64] in the first place. A signed value keeps its
+   sign here and [write_slot] lays down its two's complement. *)
+let rec tag_wire_value : type k. k typ -> k -> int64 option =
+ fun typ k ->
+  match typ with
+  | Uint8 -> Some (Int64.of_int (UInt8.to_int k))
+  | Int8 -> Some (Int64.of_int (SInt8.to_int k))
+  | Uint16 _ -> Some (Int64.of_int (UInt16.to_int k))
+  | Int16 _ -> Some (Int64.of_int (SInt16.to_int k))
+  | Uint32 _ ->
+      Some (Int64.logand (Int64.of_int32 (UInt32.to_int32 k)) 0xFFFF_FFFFL)
+  | Int32 _ -> Some (Int64.of_int32 (SInt32.to_int32 k))
+  | Uint64 _ -> Some (UInt64.to_int64 k)
+  | Int64 _ -> Some k
+  | Uint_var _ -> Some (Optint.Int63.to_int64 k)
+  | Bits _ -> Some (Int64.of_int k)
+  | Enum { base; _ } -> tag_wire_value base k
+  | Where { inner; _ } -> tag_wire_value inner k
+  | Map { inner; encode; _ } -> tag_wire_value inner (encode k)
+  | Single_elem { elem; _ } -> tag_wire_value elem k
+  | Apply { typ; _ } -> tag_wire_value typ k
+  | _ -> None
+
+(* A casetype parses its tag inline, at the start of the field's own bytes, so
+   the field seeds like an integer even though it is not one: the slot is the
+   tag's and the values it singles out are the case indices. A [default] branch
+   claims every remaining tag and names no value, so it contributes none. *)
+let rec casetype_tag_seed : type a. a typ -> (int_slot * int64 list) option =
+  function
+  | Casetype { tag; cases; _ } ->
+      let index (Case_branch { cb_tag; _ }) =
+        Option.bind cb_tag (tag_wire_value tag)
+      in
+      Option.map
+        (fun slot -> (slot, List.filter_map index cases))
+        (int_slot_of_typ tag)
+  | Where { inner; _ } -> casetype_tag_seed inner
+  | Map { inner; _ } -> casetype_tag_seed inner
+  | Optional { inner; _ } -> casetype_tag_seed inner
+  | Optional_or { inner; _ } -> casetype_tag_seed inner
+  | _ -> None
+
 let field_seeds s =
+  let seed name slot values =
+    match List.sort_uniq Int64.compare values with
+    | [] -> None
+    | values -> Some { field = name; slot; values }
+  in
   let of_field (Field f) =
     match (f.field_name, int_slot_of_typ f.field_typ) with
     | Some name, Some slot ->
@@ -3622,13 +3672,14 @@ let field_seeds s =
           | Some constraint_ -> constraint_values name constraint_
           | None -> []
         in
-        let values =
-          from_field
+        seed name slot
+          (from_field
           @ typ_constraints name f.field_typ
-          @ enum_seed_values f.field_typ
-          |> List.sort_uniq Int64.compare
-        in
-        if values = [] then None else Some { field = name; slot; values }
-    | _ -> None
+          @ enum_seed_values f.field_typ)
+    | Some name, None -> (
+        match casetype_tag_seed f.field_typ with
+        | Some (slot, values) -> seed name slot values
+        | None -> None)
+    | None, _ -> None
   in
   List.filter_map of_field s.fields

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -1112,7 +1112,9 @@ val field_seeds : struct_ -> field_seed list
     declaration singles out values, the byte slot it occupies and those values:
     the constant an equality or inequality refinement names, the values either
     side of an ordering refinement's boundary, and the members of a closed
-    enumeration. Fields with no such value, and fields that are not whole-byte
+    enumeration. A casetype field seeds too: its tag is parsed at the start of
+    the field's own bytes, so the slot is the tag's and the values are the case
+    indices. Fields with no such value, and fields that are not whole-byte
     integers (bitfields in particular, whose base word is shared), are omitted.
 
     The list over-approximates: it names candidates worth trying, not values the

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -1532,8 +1532,10 @@ module Everparse : sig
         declaration singles out values, the byte slot it occupies and those
         values: the constant an equality or inequality refinement names, the
         values either side of an ordering refinement's boundary, and the members
-        of a closed enumeration. Bitfields are omitted because their base word
-        is shared, so a byte offset alone cannot seed one.
+        of a closed enumeration. A casetype field seeds too: its tag is parsed
+        at the start of the field's own bytes, so the slot is the tag's and the
+        values are the case indices. Bitfields are omitted because their base
+        word is shared, so a byte offset alone cannot seed one.
 
         The list over-approximates: it names candidates worth trying, not values
         the description is guaranteed to admit, so a consumer must run each

--- a/test/3d/test_wire_3d.ml
+++ b/test/3d/test_wire_3d.ml
@@ -613,6 +613,39 @@ let test_corpus_straddles_a_constraint () =
     true (rejected > 0);
   Alcotest.(check int) "every line carries a verdict" 256 (accepted + rejected)
 
+(* Two four-byte magic tags out of 2^32: uniform bytes never select a case, and
+   the tag is not a field of its own but the head of the casetype's bytes. The
+   corpus must seed it from the case indices. *)
+let corpus_casetype_codec =
+  let open Wire in
+  let body =
+    casetype "Node" uint32be
+      [
+        case
+          ~index:(UInt32.of_int32 0x4c454146l)
+          uint8
+          ~inject:(fun v -> `Leaf v)
+          ~project:(function `Leaf v -> Some v | _ -> None);
+        case
+          ~index:(UInt32.of_int32 0x4e4f4445l)
+          uint16
+          ~inject:(fun v -> `Branch v)
+          ~project:(function `Branch v -> Some v | _ -> None);
+      ]
+  in
+  Codec.v "Page" Fun.id [ Codec.( $ ) (Field.v "body" body) Fun.id ]
+
+let test_corpus_seeds_a_casetype_tag () =
+  let accepted, rejected =
+    corpus_verdicts [ Wire_3d.pack corpus_casetype_codec ]
+  in
+  Alcotest.(check bool)
+    (Fmt.str "corpus selects a case (%d accepted)" accepted)
+    true (accepted > 0);
+  Alcotest.(check bool)
+    (Fmt.str "corpus keeps unmatched tags (%d rejected)" rejected)
+    true (rejected > 0)
+
 (* A whole-record where-clause has no failing field offset to repair. Refuse a
    one-sided corpus instead of allowing an always-rejecting validator to pass. *)
 let corpus_unseedable_codec =
@@ -1776,6 +1809,8 @@ let suite =
         test_corpus_straddles_a_constraint;
       Alcotest.test_case "corpus refuses when vacuous" `Quick
         test_corpus_refuses_when_vacuous;
+      Alcotest.test_case "corpus: seeds a casetype tag" `Quick
+        test_corpus_seeds_a_casetype_tag;
       Alcotest.test_case "generate_standalone (needs 3d.exe)" `Quick
         test_generate_standalone;
       Alcotest.test_case "archive hides raw validators (needs 3d.exe)" `Quick

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -6641,6 +6641,31 @@ let test_casetype_no_match_invalid_tag () =
   | Ok _ -> Alcotest.fail "decode accepted an unmatched casetype tag"
   | Error _ -> Alcotest.fail "wrong error for an unmatched casetype tag"
 
+(* A casetype's extent depends on which case the tag selects, so the record's
+   bounds walk dispatches on the tag before any field reader runs, and that is
+   where an unknown tag surfaces. The failure must still name the field: a
+   caller repairing malformed input has only the path to go on. *)
+let test_casetype_no_match_names_field () =
+  let typ =
+    Wire.casetype "Sized" Wire.uint8
+      [
+        Wire.case ~index:(UInt8.v 1) Wire.uint8
+          ~inject:(fun v -> `A v)
+          ~project:(function `A v -> Some v | _ -> None);
+        Wire.case ~index:(UInt8.v 2) Wire.uint16
+          ~inject:(fun v -> `B v)
+          ~project:(function `B v -> Some v | _ -> None);
+      ]
+  in
+  let c = Codec.v "Tagged" Fun.id Codec.[ Field.v "body" typ $ Fun.id ] in
+  match Codec.decode c (Bytes.of_string "\x63\x00\x00") 0 with
+  | Error { kind = Invalid_tag n; field; at } ->
+      Alcotest.(check int) "unmatched tag" 99 n;
+      Alcotest.(check int) "at the casetype field" 0 at;
+      Alcotest.(check (list string)) "names the field" [ "body" ] field
+  | Ok _ -> Alcotest.fail "decode accepted an unmatched casetype tag"
+  | Error _ -> Alcotest.fail "wrong error for an unmatched casetype tag"
+
 (* The default branch recovers the matched tag and re-encodes it, so an
    arbitrary unclaimed tag round-trips (the DHCP / TCP-options shape). *)
 type tlv = Known of UInt16.t | Unknown of (UInt8.t * string)
@@ -9691,6 +9716,8 @@ let suite =
         test_casetype_field_logout;
       Alcotest.test_case "casetype field: default" `Quick
         test_casetype_field_default;
+      Alcotest.test_case "casetype field: no match names the field" `Quick
+        test_casetype_no_match_names_field;
       Alcotest.test_case "casetype field: no match is Invalid_tag" `Quick
         test_casetype_no_match_invalid_tag;
       Alcotest.test_case "casetype default recovers matched tag" `Quick

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -590,6 +590,41 @@ let test_3d_casetype_tag_int_carriers () =
        (enum "EWhere" [ ("A", 0) ] (where Expr.(int 0 = int 0) uint8))
        (UInt8.v 0))
 
+(* A casetype's tag sits at the start of the field's own bytes and takes one of
+   a closed set of case indices, so the field is seedable even though it is not
+   itself an integer. Without the seed a fuzzed corpus never reaches a valid
+   tag. *)
+let test_casetype_tag_field_seed () =
+  let body =
+    casetype "Body" uint32be
+      [
+        case
+          ~index:(UInt32.of_int32 0x4c454146l)
+          uint8
+          ~inject:(fun v -> `Leaf v)
+          ~project:(function `Leaf v -> Some v | _ -> None);
+        case
+          ~index:(UInt32.of_int32 0x4e4f4445l)
+          uint16
+          ~inject:(fun v -> `Node v)
+          ~project:(function `Node v -> Some v | _ -> None);
+      ]
+  in
+  let c =
+    Codec.v "Page" (fun v -> v) Codec.[ (Field.v "body" body $ fun v -> v) ]
+  in
+  match field_seeds (struct_of_codec c) with
+  | [ seed ] ->
+      Alcotest.(check string) "names the casetype field" "body" seed.field;
+      Alcotest.(check int) "slot is the tag's width" 4 seed.slot.width;
+      Alcotest.(check (list int64))
+        "values are the case indices"
+        [ 0x4c454146L; 0x4e4f4445L ]
+        seed.values
+  | seeds ->
+      Alcotest.failf "expected one seed for the casetype tag, got %d"
+        (List.length seeds)
+
 let test_doc_field_citation () =
   (* [Field.v ~doc] renders as a plain [/* ... */] comment above the field --
      3d.exe rejects [/*++ --*/] at field position, so the per-field note uses
@@ -1665,6 +1700,8 @@ let suite =
         `Quick test_doc_merge_shared_sub_codec;
       Alcotest.test_case "3d: casetype tag over map/where/uint64 bases" `Quick
         test_3d_casetype_tag_int_carriers;
+      Alcotest.test_case "seeds: casetype tag names its case indices" `Quick
+        test_casetype_tag_field_seed;
       Alcotest.test_case "doc: field ~doc renders as citation comment" `Quick
         test_doc_field_citation;
       Alcotest.test_case "doc: bit order matches schema projection" `Quick


### PR DESCRIPTION
A casetype parses its tag at the start of the field's own bytes, so the field is seedable even though it is not itself an integer: the slot is the tag's and the values are the case indices. Without that, `Wire_3d.generate_corpus` never reaches a valid tag and reports the codec as vacuous, which is how this read as a schema problem rather than a wire one.

The seed alone is not enough. Commit b511d6d lands first because a casetype's extent is resolved by the record's bounds walk before any field reader runs, and that walk was unwrapped, so the rejection arrived with an empty field path and the seeder had nothing to place it against.

Corpus for a two-magic tagged record goes from 0 accepted / 64 rejected to a straddle.

Stacked on #347.