### PR TITLE
3d: bring a runaway length back into range when seeding

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,12 @@
   `Wire_3d.generate_corpus` can reach a tagged record instead of reporting the
   codec as vacuous (#348, @samoht)
 
+- `Wire_3d.generate_corpus` no longer gives up on a record whose length field
+  the byte draw filled with a huge value. A draw asking for more bytes than a
+  corpus line can carry is brought back into range rather than the codec being
+  abandoned, which covers both dependent and unconstrained length fields
+  (#349, @samoht)
+
 ## 1.2.0
 
 ### Added

--- a/lib/3d/wire_3d.ml
+++ b/lib/3d/wire_3d.ml
@@ -1278,16 +1278,30 @@ let seed_input ?env rng ~seeds ~center c =
   let buf = ref (random_bytes rng (max 1 center)) in
   let placed = ref [] in
   let out = ref None in
-  let grow n =
-    if n >= 0 && n <> Bytes.length !buf && n <= max_corpus_input then
-      buf := resize rng !buf n
-    else fuel := 0
-  in
   let place off (seed : Raw.field_seed) =
     let values = Array.of_list seed.values in
-    write_slot !buf off seed.slot
-      values.(Random.State.int rng (Array.length values));
-    if not (List.mem_assoc off !placed) then placed := (off, seed) :: !placed
+    let value = values.(Random.State.int rng (Array.length values)) in
+    write_slot !buf off seed.slot value;
+    if not (List.mem_assoc off !placed) then
+      placed := (off, (seed, value)) :: !placed
+  in
+  (* A record asking for more bytes than a corpus line may carry was sized by a
+     length field the byte draw filled with a huge value. No parse error names
+     that field -- the demand surfaces on the record's whole extent -- so damp
+     every length at once: zeroed bytes are the smallest value each can hold.
+     The values already settled are written back, so the loop resumes from the
+     progress it had made rather than starting over. *)
+  let damp () =
+    Bytes.fill !buf 0 (Bytes.length !buf) '\000';
+    List.iter
+      (fun (off, ((seed : Raw.field_seed), value)) ->
+        write_slot !buf off seed.slot value)
+      !placed
+  in
+  let grow n =
+    if n > max_corpus_input then damp ()
+    else if n >= 0 && n <> Bytes.length !buf then buf := resize rng !buf n
+    else fuel := 0
   in
   while !out = None && !fuel > 0 do
     decr fuel;
@@ -1312,7 +1326,7 @@ let neighbours v =
    stale validator whose boundary differs by one without relying on chance. *)
 let boundary_inputs seed placed =
   List.concat_map
-    (fun (off, (field_seed : Raw.field_seed)) ->
+    (fun (off, ((field_seed : Raw.field_seed), _)) ->
       field_seed.values |> List.concat_map neighbours
       |> List.sort_uniq Int64.compare
       |> List.map (fun value ->

--- a/test/3d/test_wire_3d.ml
+++ b/test/3d/test_wire_3d.ml
@@ -646,6 +646,33 @@ let test_corpus_seeds_a_casetype_tag () =
     (Fmt.str "corpus keeps unmatched tags (%d rejected)" rejected)
     true (rejected > 0)
 
+(* An unconstrained length field filled from uniform bytes asks for gigabytes,
+   and the demand surfaces on the record's whole extent, naming no field to
+   repair. Growing to it is impossible, so the seeder must damp the length
+   instead of giving up on the codec. *)
+let corpus_length_codec =
+  let open Wire in
+  let len = Field.v "len" uint32be in
+  Codec.v "Load"
+    (fun l d -> (l, d))
+    [
+      Codec.( $ ) len (fun (l, _) -> l);
+      Codec.( $ )
+        (Field.v "data" (byte_array ~size:(Field.ref len)))
+        (fun (_, d) -> d);
+    ]
+
+let test_corpus_damps_a_runaway_length () =
+  let accepted, rejected =
+    corpus_verdicts [ Wire_3d.pack corpus_length_codec ]
+  in
+  Alcotest.(check bool)
+    (Fmt.str "corpus reaches a well-sized record (%d accepted)" accepted)
+    true (accepted > 0);
+  Alcotest.(check bool)
+    (Fmt.str "corpus keeps mis-sized records (%d rejected)" rejected)
+    true (rejected > 0)
+
 (* A whole-record where-clause has no failing field offset to repair. Refuse a
    one-sided corpus instead of allowing an always-rejecting validator to pass. *)
 let corpus_unseedable_codec =
@@ -1811,6 +1838,8 @@ let suite =
         test_corpus_refuses_when_vacuous;
       Alcotest.test_case "corpus: seeds a casetype tag" `Quick
         test_corpus_seeds_a_casetype_tag;
+      Alcotest.test_case "corpus: damps a runaway length" `Quick
+        test_corpus_damps_a_runaway_length;
       Alcotest.test_case "generate_standalone (needs 3d.exe)" `Quick
         test_generate_standalone;
       Alcotest.test_case "archive hides raw validators (needs 3d.exe)" `Quick


### PR DESCRIPTION
A record sized from a length field the byte draw filled at random asks for gigabytes, and no parse error names that field: the demand surfaces on the record's whole extent. Growing to it is impossible, so the seeder abandoned the codec and `generate_corpus` reported it vacuous. That covers dependent lengths as well as unconstrained ones.

A draw asking for more bytes than a corpus line can carry now has its length fields brought back to their smallest value, with the seeds already settled written back, so the loop resumes from the progress it had made.

Measured on the shapes that were stuck, all previously 0 accepted:

    SquashfsExtInode        30 accepted, 34 rejected
    dependent length        27 accepted, 37 rejected
    unconstrained length     8 accepted, 56 rejected

Stacked on #348.