### PR TITLE
codec: resolve a record's extent with the codec's parameters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,13 @@
   abandoned, which covers both dependent and unconstrained length fields
   (#349, @samoht)
 
+- `Wire.Codec.wire_size_at` takes `?env` and refuses without one when the codec
+  has input params, as `decode` already did. An unbound param reads 0, so a
+  param-sized field measured as empty and the reported extent was shorter than
+  the record; `Wire_3d.generate_corpus` recorded a reject verdict for input its
+  own codec accepts, and a differential over that corpus blamed the generated C
+  validator for the harness's answer (#350, @samoht)
+
 ## 1.2.0
 
 ### Added

--- a/lib/3d/wire_3d.ml
+++ b/lib/3d/wire_3d.ml
@@ -1193,7 +1193,7 @@ let codec_verdict ?env c buf =
   | Ok _ -> (
       match
         Wire.Codec.validate ?env c buf 0;
-        Wire.Codec.wire_size_at c buf 0
+        Wire.Codec.wire_size_at ?env c buf 0
       with
       | n -> if n = Bytes.length buf then `Accept else `Resize n
       | exception Wire.Parse_error e -> `Reject e)

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -4225,12 +4225,6 @@ let wire_size (t : _ t) =
 let min_wire_size (t : _ t) =
   match t.wire_size with Fixed n -> n | Variable { min_size; _ } -> min_size
 
-let wire_size_at (t : _ t) buf off =
-  match t.wire_size with
-  | Fixed n -> n
-  | Variable { compute; _ } ->
-      compute no_runtime (Input_end.of_bytes buf) buf off - off
-
 let size_of_value (t : _ t) v = t.size_of_value v
 
 let is_fixed (t : _ t) =
@@ -4281,6 +4275,19 @@ let require_env ~op t = function
              before use."
             op t.name
             (String.concat ", " missing))
+
+(* The record's extent as the buffer describes it. A parametric span resolves
+   through [env]: without one every [Param.expr] reads 0, so a param-sized field
+   measures as empty and the answer comes back quietly short. That is not a
+   smaller record, it is a different verdict about the same bytes, so a codec
+   with input params refuses here exactly as it does on [decode] rather than
+   answering. *)
+let wire_size_at ?env:e (t : _ t) buf off =
+  require_env ~op:"wire_size_at" t e;
+  match t.wire_size with
+  | Fixed n -> n
+  | Variable { compute; _ } ->
+      compute (runtime ?env:e ()) (Input_end.of_bytes buf) buf off - off
 
 let raw_encode ?env:e t v buf off =
   require_env ~op:"encode" t e;

--- a/lib/codec.mli
+++ b/lib/codec.mli
@@ -55,8 +55,12 @@ val wire_size : 'r t -> int
 val min_wire_size : 'r t -> int
 (** Minimum wire size in bytes (for variable-length codecs). *)
 
-val wire_size_at : 'r t -> bytes -> int -> int
-(** Compute the actual wire size from a buffer at a given offset. *)
+val wire_size_at : ?env:Param.env -> 'r t -> bytes -> int -> int
+(** Compute the actual wire size from a buffer at a given offset. A codec whose
+    field sizes are driven by an input param needs [?env] to resolve them, and
+    raises [Invalid_argument] without it, the same as {!decode}: an unbound
+    param reads 0, which would silently measure a param-sized field as empty and
+    report an extent shorter than the record. *)
 
 val size_of_value : 'r t -> 'r -> int
 (** [size_of_value c v] returns the number of bytes that [encode c v] will

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -1126,8 +1126,13 @@ module Codec : sig
   val min_wire_size : 'r t -> int
   (** Minimum wire size of the codec. *)
 
-  val wire_size_at : 'r t -> bytes -> int -> int
-  (** Computes the actual wire size from a buffer at the given base offset. *)
+  val wire_size_at : ?env:Param.env -> 'r t -> bytes -> int -> int
+  (** Computes the actual wire size from a buffer at the given base offset. A
+      codec whose field sizes are driven by an input param needs [?env] to
+      resolve them, and raises [Invalid_argument] without it, the same as
+      {!decode}: an unbound param reads 0, which would silently measure a
+      param-sized field as empty and report an extent shorter than the record.
+  *)
 
   val size_of_value : 'r t -> 'r -> int
   (** [size_of_value c v] returns the number of bytes that [encode c v] will

--- a/test/3d/test_wire_3d.ml
+++ b/test/3d/test_wire_3d.ml
@@ -673,6 +673,78 @@ let test_corpus_damps_a_runaway_length () =
     (Fmt.str "corpus keeps mis-sized records (%d rejected)" rejected)
     true (rejected > 0)
 
+(* A span sized from an input param. The record's extent is only computable with
+   the env bound: without one every [Param.expr] resolves to 0, so the span
+   measures as empty and the extent comes back shorter than the record. *)
+let corpus_param_span_codec =
+  let open Wire in
+  let size = Param.input "size" uint8 in
+  Codec.v "ParamSpan"
+    (fun k d -> (k, d))
+    [
+      Codec.( $ ) (Field.v "kind" uint8) fst;
+      Codec.( $ ) (Field.v "data" (byte_array ~size:(Param.expr size))) snd;
+    ]
+
+(* One [name params hex verdict] corpus line, split into the parts a reader
+   needs to replay it. *)
+let corpus_lines ?(count = 128) codecs =
+  let buf = Buffer.create 4096 in
+  let ppf = Fmt.with_buffer buf in
+  Wire_3d.generate_corpus ~count ppf codecs;
+  Format.pp_print_flush ppf ();
+  Buffer.contents buf |> String.split_on_char '\n'
+  |> List.filter_map (fun line ->
+      match String.split_on_char ' ' line with
+      | [ _; params; hex; verdict ] ->
+          Some (int_of_string params, hex, String.equal verdict "1")
+      | _ -> None)
+
+let bytes_of_hex h =
+  if String.equal h "-" then Bytes.empty
+  else
+    Bytes.init
+      (String.length h / 2)
+      (fun i -> Char.chr (int_of_string ("0x" ^ String.sub h (2 * i) 2)))
+
+(* The corpus verdict is the differential's oracle, so a wrong one does not
+   refuse, it disagrees -- and the disagreement is reported against the C
+   validator rather than against the harness. Nothing else checks the oracle,
+   so replay every line through the codec it claims to speak for. Deliberately
+   an independent reimplementation of the verdict, not a call into it. *)
+let test_corpus_verdict_resolves_params () =
+  let open Wire in
+  let c = corpus_param_span_codec in
+  let lines = corpus_lines [ Wire_3d.pack c ] in
+  Alcotest.(check bool) "the corpus is non-empty" true (lines <> []);
+  List.iter
+    (fun (p, hex, verdict) ->
+      let env = Param.bind_by_name "size" p (Codec.env c) in
+      let b = bytes_of_hex hex in
+      (* Sized from the decoded value, not from [wire_size_at]: an oracle that
+         went back through the extent reader would be re-using the thing it is
+         meant to check. *)
+      let accepts =
+        match Codec.decode ~env c b 0 with
+        | Error _ -> false
+        | Ok v -> (
+            match
+              Codec.validate ~env c b 0;
+              Codec.size_of_value c v
+            with
+            | n -> Int.equal n (Bytes.length b)
+            | exception Wire.Parse_error _ -> false)
+      in
+      if not (Bool.equal accepts verdict) then
+        Alcotest.failf "corpus records %b for size=%d %s, the codec answers %b"
+          verdict p hex accepts)
+    lines;
+  (* With the extent measured without the env, the only records that can span
+     their whole buffer are the ones whose param is 0. *)
+  Alcotest.(check bool)
+    "an accepted record binds a non-zero param" true
+    (List.exists (fun (p, _, v) -> p <> 0 && v) lines)
+
 (* A whole-record where-clause has no failing field offset to repair. Refuse a
    one-sided corpus instead of allowing an always-rejecting validator to pass. *)
 let corpus_unseedable_codec =
@@ -1836,6 +1908,8 @@ let suite =
         test_corpus_straddles_a_constraint;
       Alcotest.test_case "corpus refuses when vacuous" `Quick
         test_corpus_refuses_when_vacuous;
+      Alcotest.test_case "corpus: verdict resolves input params" `Quick
+        test_corpus_verdict_resolves_params;
       Alcotest.test_case "corpus: seeds a casetype tag" `Quick
         test_corpus_seeds_a_casetype_tag;
       Alcotest.test_case "corpus: damps a runaway length" `Quick


### PR DESCRIPTION
`Wire.Codec.wire_size_at` read every `Param.expr` as 0, so a param-sized field measured as empty and the reported extent came back shorter than the record. `Wire_3d.generate_corpus` passes an env to `decode` and `validate` but had none to pass here, so it recorded a reject verdict for input its own codec accepts. That verdict column is the differential's oracle, so the disagreement was reported against the generated C validator rather than against the harness, which is where the cfdp mismatches came from.

This is the dangerous member of the set: unlike the others it answers instead of refusing. `wire_size_at` now takes `?env` and refuses without one when the codec has input params, exactly as `decode` and `encode` already did.

    decode      ~env  ->  ok, 4-byte record
    wire_size_at      ->  1        (before)
    wire_size_at ~env ->  4        (after)

The regression test replays every corpus line through the codec it claims to speak for, sizing from the decoded value rather than back through `wire_size_at`, so the oracle is checked against something other than itself. Nothing did that before.

Top of the stack, on #349.