### PR TITLE
types: say what a repeat's byte budget is for when it refuses

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,14 @@
   own codec accepts, and a differential over that corpus blamed the generated C
   validator for the harness's answer (#350, @samoht)
 
+- `Field.repeat` now explains itself when the encoded elements do not fill the
+  declared byte budget. The budget is the region size the description declares,
+  which encode holds the values to as well, so a caller who does not know that
+  size where the codec is built should take it as a `Param.input` rather than
+  baking in a literal. The documentation also records that there is no sizeless
+  repeat and why: 3D's only list construct is the byte budget, so a repeat that
+  consumed whatever remained would have no projection (#351, @samoht)
+
 ## 1.2.0
 
 ### Added

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -780,7 +780,12 @@ let exact_repeat_elements seq ~expected ~size_of values =
   in
   let actual = List.fold_left (fun total (_, size) -> total + size) 0 sized in
   if actual <> expected then
-    Fmt.invalid_arg "Wire.repeat: expected %d bytes, got %d" expected actual;
+    Fmt.invalid_arg
+      "Wire.repeat: byte budget is %d but the elements span %d. The budget is \
+       the region size the description declares, and encode holds the values \
+       to it; if that size is not known where the codec is built, take it as a \
+       Param.input and bind it per call rather than baking in a literal."
+      expected actual;
   sized
 
 (* A fixed-size byte field is exact. Truncating a long value or zero-padding a

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -512,9 +512,17 @@ module Field : sig
       encoding raises [Invalid_argument] when the supplied values span fewer or
       more bytes than [size]. It projects to 3D as [t name[:byte-size size]].
       There is no count-driven form: "a count field, then that many
-      variable-size elements" is expressible neither here nor in 3D (3D arrays
-      are byte-budgeted), so that shape needs caller-side iteration over the
-      element parser. *)
+      variable-size elements" is expressible neither here nor in 3D, whose only
+      list construct is the byte budget ([elem[n]] is rejected for any element
+      wider than a byte), so that shape needs caller-side iteration over the
+      element parser.
+
+      There is no sizeless form either, for the same reason: 3D has no
+      rest-of-region list, so a repeat that consumed whatever remained would
+      have no projection. When the region size is not known where the codec is
+      built, take it as a {!Param.input} and bind it per call. Baking in a
+      literal makes the budget a constant the encoder will also hold the values
+      to, which is a promise the values cannot keep. *)
 
   val repeat_seq :
     string ->

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -830,6 +830,27 @@ let test_codec_array_cardinality () =
     [| UInt8.v 1; UInt8.v 2; UInt8.v 3; UInt8.v 4 |]
     3 4
 
+(* A literal byte budget is the region size the description declares, and since
+   1.2.0 encode holds the values to it too. A caller who does not know that size
+   where the codec is built has nothing truthful to put there, and 3D has no
+   rest-of-region list to offer as a sizeless alternative, so the refusal has to
+   name the one thing that does work. *)
+let test_repeat_budget_mismatch_names_the_remedy () =
+  let c =
+    Codec.v "Region" Fun.id
+      Codec.[ Field.repeat "items" ~size:(int 0) uint16be $ Fun.id ]
+  in
+  match Codec.size_of_value c [ UInt16.v 1; UInt16.v 2 ] with
+  | _ -> Alcotest.fail "expected the budget mismatch to be refused"
+  | exception Invalid_argument msg ->
+      Alcotest.(check bool)
+        "names the budget and what the values came to" true
+        (contains ~sub:"byte budget is 0" msg
+        && contains ~sub:"elements span 4" msg);
+      Alcotest.(check bool)
+        "points at the parameter, not a literal" true
+        (contains ~sub:"Param.input" msg)
+
 (* Field.repeat over a zeroterm element: a list of NUL-terminated strings
    within a byte budget. Used to raise Failure at decode; now decodes and
    projects through a synthesised element struct. *)
@@ -9716,6 +9737,8 @@ let suite =
         test_casetype_field_logout;
       Alcotest.test_case "casetype field: default" `Quick
         test_casetype_field_default;
+      Alcotest.test_case "repeat: budget mismatch names the remedy" `Quick
+        test_repeat_budget_mismatch_names_the_remedy;
       Alcotest.test_case "casetype field: no match names the field" `Quick
         test_casetype_no_match_names_field;
       Alcotest.test_case "casetype field: no match is Invalid_tag" `Quick


### PR DESCRIPTION
`Field.repeat`'s `~size` is the region size the description declares. Since #238 landed in 1.2.0 the encoder holds the values to it as well, which is the right direction: otherwise the encoder writes M bytes while the frame's length field says N and nothing catches it. But a caller who does not know that size where the codec is built has nothing truthful to put there, and the refusal read `Wire.repeat: expected 0 bytes, got 12`, which names neither the cause nor a way out.

There is no sizeless repeat to reach for instead, and that is not wire's choice. 3D's only list construct is the byte budget:

    BElem items[:byte-size n]          ->  EverParse succeeded!
    BElem items[n]                     ->  Error: Expected a byte array
    BElem items[:byte-size-remaining]  ->  syntax error
    BElem items[]                      ->  syntax error

The count form is rejected for any element wider than a byte, not just variable-size ones, so a repeat consuming whatever remained would have no projection at all. The refusal now says what the budget is and points at `Param.input`, and the docs record why there is no sizeless form.

Top of the stack, on #350.