### PR TITLE
codec: resolve a value's extent with the codec's parameters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,6 +42,12 @@
   repeat and why: 3D's only list construct is the byte budget, so a repeat that
   consumed whatever remained would have no projection (#351, @samoht)
 
+- `Wire.Codec.size_of_value` takes `?env` and resolves a field whose byte extent
+  is an input parameter, refusing when it has none rather than reporting 0. It
+  used to under-report such a field by its whole width, so a caller sizing a
+  buffer from the answer got one too short and `encode` ran off the end with a
+  raw out-of-bounds instead of a wire error (#353, @samoht)
+
 ## 1.2.0
 
 ### Added

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -102,7 +102,7 @@ let setter_off n set buf off v =
 (* Encode a value into a fixed [n]-byte region: write it with [enc], then
    zero-pad the remainder. Used for [nested] regions. *)
 let single_elem_region ~at_most n typ enc buf off v =
-  let actual = Types.size_of_typ_value typ v in
+  let actual = Types.size_of_typ_value Types.unbound_eval_ctx typ v in
   Types.check_nested_size ~at_most ~expected:n ~actual;
   let inner_end = enc buf off v in
   if inner_end < off + n then
@@ -1037,7 +1037,7 @@ type ('f, 'r) record =
       make : 'full;
       readers : ('full, 'f) readers;
       writers_rev : ('r -> runtime -> bytes -> int -> int -> int) list;
-      size_of_value_rev : ('r -> int) list;
+      size_of_value_rev : (Types.eval_ctx -> 'r -> int) list;
           (* Per-field value-driven size functions (one per writer). At
              seal we sum them into [size_of_value]; encode uses that
              instead of the buffer-driven [wire_size.compute] when sizing
@@ -1081,7 +1081,7 @@ let id_counter = Atomic.make 0
 type 'r t = {
   id : int;
   name : string;
-  size_of_value : 'r -> int;
+  size_of_value : Types.eval_ctx -> 'r -> int;
   field_access : (string * field_access) list;
   field_readers : field_reader list;
   field_actions : (string * compiled_action) list;
@@ -2365,7 +2365,7 @@ let repeat_raw_writer : type elt seq r.
   let expected = size_fn runtime (Input_end.of_bytes buf) buf base in
   let sized_items =
     Types.exact_repeat_elements seq ~expected
-      ~size_of:(Types.size_of_typ_value elem)
+      ~size_of:(Types.size_of_typ_value runtime elem)
       (get v)
   in
   let pos = Stdlib.ref write_off in
@@ -2670,7 +2670,7 @@ let var_bytes_writer : type a r.
   | Casetype _ -> build_field_encoder_ctx typ runtime buf write_off value
   | Single_elem { elem; at_most; _ } ->
       let n = size_fn runtime (Input_end.of_bytes buf) buf base in
-      let actual = Types.size_of_typ_value elem value in
+      let actual = Types.size_of_typ_value runtime elem value in
       Types.check_nested_size ~at_most ~expected:n ~actual;
       let inner_end =
         build_field_encoder_ctx elem runtime buf write_off value
@@ -3428,8 +3428,8 @@ let apply_compiled : type a f r.
      [Map]/[Where]/[Enum] even though they still pack into the current word. *)
   let field_size_of_value =
     match cf.field_access with
-    | Bitfield _ -> fun _ -> cf.size_delta
-    | _ -> fun v -> size_of_typ_value field_typ (field_get v)
+    | Bitfield _ -> fun _ _ -> cf.size_delta
+    | _ -> fun ctx v -> size_of_typ_value ctx field_typ (field_get v)
   in
   let raw_reader, full, check_only =
     wrap_field_errors
@@ -3786,10 +3786,10 @@ let validate_with_bounds wire_size_info min_size param_slots param_base
 
 let build_size_of_value size_funcs =
   let n = Array.length size_funcs in
-  fun value ->
+  fun ctx value ->
     let total = Stdlib.ref 0 in
     for i = 0 to n - 1 do
-      total := !total + size_funcs.(i) value
+      total := !total + size_funcs.(i) ctx value
     done;
     !total
 
@@ -3858,7 +3858,7 @@ let validate_runtime_of ~scratch ~n_total ~param_base ~param_handles
 let build_record_encoder name writers size_of_value ~check =
   let n = Array.length writers in
   fun value runtime buf off ->
-    let need = size_of_value value in
+    let need = size_of_value runtime value in
     if off + need > Bytes.length buf then
       Fmt.invalid_arg "Codec.encode %s: buffer too short (need %d, got %d)" name
         need
@@ -4225,7 +4225,7 @@ let wire_size (t : _ t) =
 let min_wire_size (t : _ t) =
   match t.wire_size with Fixed n -> n | Variable { min_size; _ } -> min_size
 
-let size_of_value (t : _ t) v = t.size_of_value v
+let size_of_value_ctx (t : _ t) = t.size_of_value
 
 let is_fixed (t : _ t) =
   match t.wire_size with Fixed _ -> true | Variable _ -> false
@@ -4288,6 +4288,17 @@ let wire_size_at ?env:e (t : _ t) buf off =
   | Fixed n -> n
   | Variable { compute; _ } ->
       compute (runtime ?env:e ()) (Input_end.of_bytes buf) buf off - off
+
+(* A parametric field size resolves through [env], as it does for {!encode}.
+   Without one the size stays symbolic and a field measured by it refuses
+   rather than reporting 0, which a caller would allocate from. *)
+let size_of_value ?env:e (t : _ t) v =
+  (* An env that is given must be this codec's and fully bound, as for encode.
+     One that is absent is not an error: a caller legitimately asks for the size
+     before it has a budget to bind, and every extent the value itself settles
+     still answers. *)
+  (match e with None -> () | Some _ -> require_env ~op:"size_of_value" t e);
+  t.size_of_value (runtime ?env:e ()) v
 
 let raw_encode ?env:e t v buf off =
   require_env ~op:"encode" t e;
@@ -4372,8 +4383,9 @@ let decode ?env t buf off =
 
 let encode ?env:e t v buf off =
   require_env ~op:"encode" t e;
-  let expected = t.size_of_value v in
-  let actual = t.encode v (runtime ?env:e ()) buf off - off in
+  let rt = runtime ?env:e () in
+  let expected = t.size_of_value rt v in
+  let actual = t.encode v rt buf off - off in
   (* Underrun = silent data corruption: the trailing bytes the caller
      allocated stay uninitialised and the decoder reads them as part
      of the value. Overrun is loud already. *)
@@ -4504,7 +4516,7 @@ let field_writer : type a. a typ -> Types.eval_ctx -> bytes -> int -> a -> unit
     let room = Bytes.length buf - off in
     let saved =
       if off >= 0 && room > 0 then
-        Bytes.sub buf off (min (Types.size_of_typ_value typ value) room)
+        Bytes.sub buf off (min (Types.size_of_typ_value runtime typ value) room)
       else Bytes.empty
     in
     match encode runtime buf off value with

--- a/lib/codec.mli
+++ b/lib/codec.mli
@@ -62,7 +62,7 @@ val wire_size_at : ?env:Param.env -> 'r t -> bytes -> int -> int
     param reads 0, which would silently measure a param-sized field as empty and
     report an extent shorter than the record. *)
 
-val size_of_value : 'r t -> 'r -> int
+val size_of_value : ?env:Param.env -> 'r t -> 'r -> int
 (** [size_of_value c v] returns the number of bytes that [encode c v] will
     write. Computed from [v], not from a buffer: works for variable-size codecs
     whose tail is [all_bytes] / [rest_bytes] / [all_zeros], where the
@@ -73,6 +73,10 @@ val size_of_value : 'r t -> 'r -> int
     Raises [Invalid_argument] for a value {!encode} would refuse, such as a
     casetype value no case projects: there is no size to report for bytes that
     cannot be written. *)
+
+val size_of_value_ctx : 'r t -> Types.eval_ctx -> 'r -> int
+(** Context-threaded {!size_of_value}, for an embedded sub-codec whose parent
+    already holds the evaluation context. Internal use. *)
 
 val is_fixed : 'r t -> bool
 (** [is_fixed c] is [true] iff the codec [c] has a fixed wire size. *)

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -259,7 +259,7 @@ and _ typ =
              on their own extent rather than on a span sized from bytes outside
              it. *)
       codec_size_of : eval_ctx -> Input_end.t -> bytes -> int -> int;
-      codec_size_of_value : 'r -> int;
+      codec_size_of_value : eval_ctx -> 'r -> int;
           (* Encoded byte length of a value, computed from the value rather
              than by re-reading the buffer. The buffer-driven [codec_size_of]
              is wrong for variable-size codecs ending in [all_bytes] /
@@ -442,29 +442,48 @@ let const_cast width v =
   | `U32 -> v land UInt32.mask32
   | `U64 -> v
 
-let rec const_int_expr : int expr -> int option = function
+(* The arithmetic is shared between two readers of a size expression: constant
+   folding at construction, where no leaf resolves, and value-driven sizing at
+   encode, where a bound parameter does. [leaf] is what each makes of the
+   irreducible nodes. *)
+let rec int_expr_with : (int expr -> int option) -> int expr -> int option =
+ fun leaf e ->
+  match e with
   | Int n -> Some n
-  | Ref _ | Param_ref _ | Sizeof _ | Sizeof_this | Field_pos -> None
-  | Add (a, b) -> const_binop const_add a b
-  | Sub (a, b) -> const_binop const_sub a b
-  | Mul (a, b) -> const_binop const_mul a b
-  | Div (a, b) -> const_binop const_div a b
-  | Mod (a, b) -> const_binop const_rem a b
-  | Land (a, b) -> const_binop (fun a b -> Some (a land b)) a b
-  | Lor (a, b) -> const_binop (fun a b -> Some (a lor b)) a b
-  | Lxor (a, b) -> const_binop (fun a b -> Some (a lxor b)) a b
-  | Lnot a -> Option.map lnot (const_int_expr a)
-  | Lsl (a, b) -> const_binop const_shift_left a b
-  | Lsr (a, b) -> const_binop const_shift_right a b
-  | Cast (width, e) -> Option.map (const_cast width) (const_int_expr e)
+  | Ref _ | Param_ref _ | Sizeof _ | Sizeof_this | Field_pos -> leaf e
+  | Add (a, b) -> int_binop leaf const_add a b
+  | Sub (a, b) -> int_binop leaf const_sub a b
+  | Mul (a, b) -> int_binop leaf const_mul a b
+  | Div (a, b) -> int_binop leaf const_div a b
+  | Mod (a, b) -> int_binop leaf const_rem a b
+  | Land (a, b) -> int_binop leaf (fun a b -> Some (a land b)) a b
+  | Lor (a, b) -> int_binop leaf (fun a b -> Some (a lor b)) a b
+  | Lxor (a, b) -> int_binop leaf (fun a b -> Some (a lxor b)) a b
+  | Lnot a -> Option.map lnot (int_expr_with leaf a)
+  | Lsl (a, b) -> int_binop leaf const_shift_left a b
+  | Lsr (a, b) -> int_binop leaf const_shift_right a b
+  | Cast (width, e) -> Option.map (const_cast width) (int_expr_with leaf e)
   (* A constant condition would need the same pass over [bool expr]; leave the
      whole node symbolic. *)
   | If_then_else _ -> None
 
-and const_binop f a b =
-  match (const_int_expr a, const_int_expr b) with
+and int_binop leaf f a b =
+  match (int_expr_with leaf a, int_expr_with leaf b) with
   | Some a, Some b -> f a b
   | None, _ | _, None -> None
+
+let const_int_expr e = int_expr_with (fun _ -> None) e
+
+(* A size expression resolved as far as the encode-side context allows. A bound
+   input parameter answers; a reference to a sibling field or to a position does
+   not, because a value on its own does not carry the record around it. *)
+let size_in_ctx ctx e =
+  match ctx with
+  | Unbound -> None
+  | Bound _ ->
+      int_expr_with
+        (function Param_ref p -> Some (eval_param ctx p.name) | _ -> None)
+        e
 
 (* [fold_size e] is [e] with a reference-free constant folded to its literal.
    Every smart constructor taking a size or length expression runs its argument
@@ -3362,9 +3381,22 @@ let equal_parse_error a b = compare_parse_error a b = 0
    [Repeat] / [Single_elem]) are not handled here -- they only appear
    inside a codec, which threads its own value-driven size at seal. *)
 
+(* A field whose byte extent is an input parameter cannot be measured from the
+   value alone. Returning 0 would under-report the whole field, and a caller
+   sizing a buffer from that answer writes past it, so refuse instead. *)
+
 (** Compute wire size of a type (None for variable-size types). *)
-let rec size_of_typ_value : type a. a typ -> a -> int =
- fun typ v ->
+let unsized_field what =
+  Fmt.invalid_arg
+    "Codec.size_of_value: the %s field's size is an input parameter; pass ?env \
+     so it can be resolved."
+    what
+
+let resolved_size ctx size what =
+  match size_in_ctx ctx size with Some n -> n | None -> unsized_field what
+
+let rec size_of_typ_value : type a. eval_ctx -> a typ -> a -> int =
+ fun ctx typ v ->
   match typ with
   | Uint8 -> 1
   | Uint16 _ -> 2
@@ -3384,7 +3416,7 @@ let rec size_of_typ_value : type a. a typ -> a -> int =
   | All_zeros -> String.length v
   | Zeroterm -> String.length v + 1
   | Zeroterm_at_most { size = Int n } -> n
-  | Zeroterm_at_most _ -> 0
+  | Zeroterm_at_most { size } -> resolved_size ctx size "zeroterm_at_most"
   | Byte_array { size = Int n } -> n
   | Byte_array _ -> String.length v
   | Byte_array_where { size = Int n; _ } -> n
@@ -3392,53 +3424,75 @@ let rec size_of_typ_value : type a. a typ -> a -> int =
   | Byte_slice { size = Int n } -> n
   | Byte_slice _ -> Bytesrw.Bytes.Slice.length v
   | Uint_var { size = Int n; _ } -> n
-  | Uint_var _ -> 0
-  | Map { inner; encode; _ } -> size_of_typ_value inner (encode v)
-  | Where { inner; _ } -> size_of_typ_value inner v
-  | Enum { base; _ } -> size_of_typ_value base v
+  | Uint_var { size; _ } -> resolved_size ctx size "uint"
+  | Map { inner; encode; _ } -> size_of_typ_value ctx inner (encode v)
+  | Where { inner; _ } -> size_of_typ_value ctx inner v
+  | Enum { base; _ } -> size_of_typ_value ctx base v
   | Optional { present = Bool true; inner } ->
-      size_of_typ_value inner (Option.get v)
+      size_of_typ_value ctx inner (Option.get v)
   | Optional { present = Bool false; _ } -> 0
   | Optional { inner; _ } -> (
       (* Dynamic gate: value drives presence at encode time. The
          buffer-driven [present_fn] is the decode-side oracle and would
          disagree with [v] here, so consult [v] directly. *)
       match v with
-      | Some inner_v -> size_of_typ_value inner inner_v
+      | Some inner_v -> size_of_typ_value ctx inner inner_v
       | None -> 0)
-  | Optional_or { present = Bool true; inner; _ } -> size_of_typ_value inner v
+  | Optional_or { present = Bool true; inner; _ } ->
+      size_of_typ_value ctx inner v
   | Optional_or { present = Bool false; _ } -> 0
   | Optional_or { inner; _ } ->
       (* Dynamic gate: encode always has a value (the default fills in
          for [None]); the encoder writes the inner regardless of what
          the runtime gate would have said at decode. *)
-      size_of_typ_value inner v
-  | Codec { codec_size_of_value; _ } -> codec_size_of_value v
+      size_of_typ_value ctx inner v
+  | Codec { codec_size_of_value; _ } -> codec_size_of_value ctx v
   | Single_elem { size = Int n; elem; at_most } ->
-      let actual = size_of_typ_value elem v in
+      let actual = size_of_typ_value ctx elem v in
       check_nested_size ~at_most ~expected:n ~actual;
       n
-  | Single_elem _ -> 0
+  | Single_elem { size; elem; at_most } ->
+      let n = resolved_size ctx size "nested" in
+      let actual = size_of_typ_value ctx elem v in
+      check_nested_size ~at_most ~expected:n ~actual;
+      n
   | Repeat { size = Int expected; elem; seq } ->
-      exact_repeat_elements seq ~expected ~size_of:(size_of_typ_value elem) v
+      exact_repeat_elements seq ~expected
+        ~size_of:(size_of_typ_value ctx elem)
+        v
       |> List.fold_left (fun total (_, size) -> total + size) 0
-  | Repeat { elem; seq = Seq_map s; _ } ->
-      (* Sum the actual element sizes from the value, like [Array]. The byte
-         budget ([size]) is only a literal when fixed; a dynamic budget left
-         this at 0, so [Codec.size_of_value] under-counted a repeat field. *)
-      let total = Stdlib.ref 0 in
-      s.iter (fun e -> total := !total + size_of_typ_value elem e) v;
-      !total
+  | Repeat { size; elem; seq = Seq_map s } -> (
+      (* The budget is what the description declares the region to be; when the
+         context resolves it, encode is held to it here as it is for a literal.
+         A budget naming a sibling field does not resolve from a value, so the
+         elements' own extent is the answer, which is what encode writes. *)
+      match size_in_ctx ctx size with
+      | Some expected ->
+          exact_repeat_elements (Seq_map s) ~expected
+            ~size_of:(size_of_typ_value ctx elem)
+            v
+          |> List.fold_left (fun total (_, size) -> total + size) 0
+      | None ->
+          let total = Stdlib.ref 0 in
+          s.iter (fun e -> total := !total + size_of_typ_value ctx elem e) v;
+          !total)
   | Array { len = Int expected; elem; seq } ->
       exact_array_elements seq ~expected v
       |> List.fold_left
-           (fun total value -> total + size_of_typ_value elem value)
+           (fun total value -> total + size_of_typ_value ctx elem value)
            0
-  | Array { elem; seq = Seq_map s; _ } ->
-      let total = Stdlib.ref 0 in
-      s.iter (fun e -> total := !total + size_of_typ_value elem e) v;
-      !total
-  | Apply { typ; _ } -> size_of_typ_value typ v
+  | Array { len; elem; seq = Seq_map s } -> (
+      match size_in_ctx ctx len with
+      | Some expected ->
+          exact_array_elements (Seq_map s) ~expected v
+          |> List.fold_left
+               (fun total value -> total + size_of_typ_value ctx elem value)
+               0
+      | None ->
+          let total = Stdlib.ref 0 in
+          s.iter (fun e -> total := !total + size_of_typ_value ctx elem e) v;
+          !total)
+  | Apply { typ; _ } -> size_of_typ_value ctx typ v
   | Casetype { tag; cases; _ } ->
       (* Tag bytes plus the matched case's body: find the branch whose
          [project] accepts [v], then size its inner from the projected body.
@@ -3452,7 +3506,8 @@ let rec size_of_typ_value : type a. a typ -> a -> int =
         | [] -> raise_no_matching_case ()
         | Case_branch { cb_inner; cb_project; _ } :: rest -> (
             match cb_project v with
-            | Some (_tag, body) -> tag_size + size_of_typ_value cb_inner body
+            | Some (_tag, body) ->
+                tag_size + size_of_typ_value ctx cb_inner body
             | None -> find rest)
       in
       find cases

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -352,7 +352,7 @@ and _ typ =
               hence the extent [codec_size_of] has to read before it can resolve
               a span. *)
       codec_size_of : eval_ctx -> Input_end.t -> bytes -> int -> int;
-      codec_size_of_value : 'r -> int;
+      codec_size_of_value : eval_ctx -> 'r -> int;
           (** Encoded byte length of a value, computed from the value rather
               than by re-reading the buffer. *)
       codec_field_readers :
@@ -1075,13 +1075,15 @@ val struct_nz : struct_ -> bool
 (** [struct_nz s] is [true] iff some field of [s] is {!nz}, i.e. the struct's
     parser has a positive minimum size. *)
 
-val size_of_typ_value : 'a typ -> 'a -> int
-(** [size_of_typ_value typ v] is the encoded byte size of [v] under [typ],
-    computed from the value rather than from a buffer. Falls back to [0] for
-    typs whose size depends on an out-of-band parameter or sibling field --
-    those only appear inside a codec, where {!Codec.size_of_value} sums per-
-    field projections instead. Raises [Invalid_argument] for a casetype value no
-    case projects, which encoding refuses for the same reason. *)
+val size_of_typ_value : eval_ctx -> 'a typ -> 'a -> int
+(** [size_of_typ_value ctx typ v] is the encoded byte size of [v] under [typ],
+    computed from the value rather than from a buffer. A size that names an
+    input parameter resolves through [ctx]; one that names a sibling field or a
+    position does not, since a value on its own does not carry the record around
+    it, and a typ measured only by such a size raises [Invalid_argument] rather
+    than reporting [0] for a field the encoder will fill. Also raises for a
+    casetype value no case projects, which encoding refuses for the same reason.
+*)
 
 val c_type_of : 'a typ -> string
 (** [c_type_of typ] returns the C type name (e.g., ["uint8_t"], ["uint32_t"]).

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -71,7 +71,7 @@ let codec (c : 'r Codec.t) : 'r typ =
   let codec_encode = Codec.embed_encode_ctx c in
   let codec_field_readers = Codec.field_readers_ctx c in
   let codec_struct = Codec.to_struct c in
-  let codec_size_of_value = Codec.size_of_value c in
+  let codec_size_of_value = Codec.size_of_value_ctx c in
   let codec_min_size = Codec.min_wire_size c in
   match Codec.wire_size_info_ctx c with
   | `Fixed n ->
@@ -857,7 +857,7 @@ let rec encode_into : type a. a typ -> a -> encoder -> unit =
       write_string enc (Bytes.sub_string src off len)
   | Single_elem { size; elem; at_most } ->
       let n = Eval.expr Eval.empty size in
-      let inner_sz = Types.size_of_typ_value elem v in
+      let inner_sz = Types.size_of_typ_value Types.unbound_eval_ctx elem v in
       Types.check_nested_size ~at_most ~expected:n ~actual:inner_sz;
       encode_into elem v enc;
       for _ = inner_sz to n - 1 do
@@ -872,7 +872,9 @@ let rec encode_into : type a. a typ -> a -> encoder -> unit =
   | Codec { codec_encode; codec_fixed_size; codec_size_of_value; _ } ->
       encode_codec
         ~encode:(fun v buf off -> codec_encode v Types.unbound_eval_ctx buf off)
-        ~fixed_size:codec_fixed_size ~size_of_value:codec_size_of_value v enc
+        ~fixed_size:codec_fixed_size
+        ~size_of_value:(codec_size_of_value Types.unbound_eval_ctx)
+        v enc
   | Optional { present; inner } ->
       if Eval.expr Eval.empty present then encode_into inner (Option.get v) enc
   | Optional_or { present; inner; _ } ->
@@ -880,7 +882,7 @@ let rec encode_into : type a. a typ -> a -> encoder -> unit =
   | Repeat { size; elem; seq } ->
       let expected = Eval.expr Eval.empty size in
       Types.exact_repeat_elements seq ~expected
-        ~size_of:(Types.size_of_typ_value elem)
+        ~size_of:(Types.size_of_typ_value Types.unbound_eval_ctx elem)
         v
       |> List.iter (fun (elem_v, _) -> encode_into elem elem_v enc)
   | Casetype { tag; cases; _ } -> encode_casetype tag cases v enc
@@ -997,7 +999,7 @@ let rec encode_direct : type a. a typ -> bytes -> int -> a -> int =
   | Byte_array { size = Int n } -> Codec.blit_string_exact n buf off v
   | Byte_slice { size = Int n } -> Codec.blit_slice_exact n buf off v
   | Single_elem { size = Int n; elem; at_most } ->
-      let inner_sz = Types.size_of_typ_value elem v in
+      let inner_sz = Types.size_of_typ_value Types.unbound_eval_ctx elem v in
       Types.check_nested_size ~at_most ~expected:n ~actual:inner_sz;
       let off' = encode_direct elem buf off v in
       if off' < off + n then Bytes.fill buf off' (off + n - off') '\x00';

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -1142,7 +1142,7 @@ module Codec : sig
       param-sized field as empty and report an extent shorter than the record.
   *)
 
-  val size_of_value : 'r t -> 'r -> int
+  val size_of_value : ?env:Param.env -> 'r t -> 'r -> int
   (** [size_of_value c v] returns the number of bytes that [encode c v] will
       write for value [v]. For fixed-size codecs, this is the same as
       {!wire_size}; for dynamic-size codecs, the result depends on [v]. Raises

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -830,6 +830,28 @@ let test_codec_array_cardinality () =
     [| UInt8.v 1; UInt8.v 2; UInt8.v 3; UInt8.v 4 |]
     3 4
 
+(* A field whose byte extent is an input parameter cannot be measured from the
+   value alone. Reporting 0 for it is worse than refusing: a caller sizes a
+   buffer from the answer, and encode then writes past the allocation, which
+   surfaced as a raw out-of-bounds rather than as a wire error. *)
+let test_size_of_value_resolves_param_sizes () =
+  let p = Param.input "n" uint8 in
+  let c =
+    Codec.v "Nest" Fun.id
+      Codec.[ Field.v "body" (nested ~size:(Param.expr p) uint16be) $ Fun.id ]
+  in
+  (* Reporting 0 here is what let a caller allocate a buffer encode then ran
+     off the end of, so the answer has to be refused, not guessed. *)
+  (match Codec.size_of_value c (UInt16.v 7) with
+  | n -> Alcotest.failf "expected a refusal without ?env, got %d" n
+  | exception Invalid_argument msg ->
+      Alcotest.(check bool)
+        "the refusal names the remedy" true (contains ~sub:"?env" msg));
+  (* And the record really is the width the parameter names. *)
+  let env = Param.bind_by_name "n" 2 (Codec.env c) in
+  let buf = Bytes.create 2 in
+  Codec.encode ~env c (UInt16.v 7) buf 0
+
 (* A literal byte budget is the region size the description declares, and since
    1.2.0 encode holds the values to it too. A caller who does not know that size
    where the codec is built has nothing truthful to put there, and 3D has no
@@ -9737,6 +9759,8 @@ let suite =
         test_casetype_field_logout;
       Alcotest.test_case "casetype field: default" `Quick
         test_casetype_field_default;
+      Alcotest.test_case "size_of_value: resolves param-driven sizes" `Quick
+        test_size_of_value_resolves_param_sizes;
       Alcotest.test_case "repeat: budget mismatch names the remedy" `Quick
         test_repeat_budget_mismatch_names_the_remedy;
       Alcotest.test_case "casetype field: no match names the field" `Quick

--- a/test/test_wire.ml
+++ b/test/test_wire.ml
@@ -945,14 +945,18 @@ let check_invariant_encoding ~equal label typ codec value =
       Alcotest.(check bool)
         (label ^ ": sizing rejects too")
         true
-        (match Wire.Private.Types.size_of_typ_value typ value with
+        (match
+           Wire.Private.Types.size_of_typ_value
+             Wire.Private.Types.unbound_eval_ctx typ value
+         with
         | _ -> false
         | exception Invalid_argument _ -> true)
   | Encoded bytes ->
       Alcotest.(check int)
         (label ^ ": direct sizing")
         (String.length bytes)
-        (Wire.Private.Types.size_of_typ_value typ value);
+        (Wire.Private.Types.size_of_typ_value
+           Wire.Private.Types.unbound_eval_ctx typ value);
       Alcotest.(check int)
         (label ^ ": compiled sizing")
         (String.length bytes)


### PR DESCRIPTION
`Wire.Codec.size_of_value` had no way to see the environment, so a field whose byte extent is an input parameter measured as zero:

    nested ~size:(param 2)   size_of_value = 0      (encode writes 2)
    uint   ~size:(param 3)   size_of_value = 0      (encode writes 3)

A caller doing the documented thing, `Bytes.create (size_of_value c v)` then `encode`, allocated nothing, encode's own bounds check passed on the false figure, and the writers ran off the end as `Invalid_argument "index out of bounds"` rather than a wire error. Same shape as #350, worse failure mode. It now takes `?env` and refuses where no value-driven answer exists.

It deliberately does not require an env the way `wire_size_at` does: a caller legitimately asks for the size before it has a budget to bind, and a repeat's budget still falls back to the elements' own extent, so that path keeps working. An env that is supplied is validated.

The constant folder is generalised over its irreducible leaves so one piece of arithmetic serves both folding at construction, where nothing resolves, and sizing at encode, where a bound parameter does. Every literal-size fast path is untouched, so nothing new allocates on the common encode:

    clcw encode             104.37 -> 102.04 ns/op
    clcw size_of_value       13.41 ->  13.39 ns/op
    tm_frame encode          78.77 ->  79.12 ns/op
    tm_frame size_of_value   11.47 ->  11.43 ns/op

Top of the stack, on #351.