### PR TITLE
types: seed a lookup from its table indices

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -48,6 +48,10 @@
   buffer from the answer got one too short and `encode` ran off the end with a
   raw out-of-bounds instead of a wire error (#353, @samoht)
 
+- `Wire.Everparse.Raw.field_seeds` names the indices a `Wire.lookup` admits, so
+  `Wire_3d.generate_corpus` can reach an accepted record for a table-dispatched
+  field instead of reporting the codec as vacuous (#355, @samoht)
+
 ## 1.2.0
 
 ### Added

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -3650,6 +3650,12 @@ let constraint_values name (e : bool expr) =
 let rec enum_seed_values : type a. a typ -> int64 list = function
   | Enum { cases; closed = true; _ } ->
       List.map (fun (_, value) -> Int64.of_int value) cases
+  (* A [lookup] admits exactly the indices into its table. Naming both ends is
+     enough to straddle it: the seeder needs one accepting value, and the
+     boundary cases it derives already step either side of each. Listing the
+     whole table would multiply out through those without saying more. *)
+  | Map { index_bound = Some n; _ } when n > 0 ->
+      if n = 1 then [ 0L ] else [ 0L; Int64.of_int (n - 1) ]
   | Where { inner; _ } -> enum_seed_values inner
   | Map { inner; _ } -> enum_seed_values inner
   | Optional { inner; _ } -> enum_seed_values inner

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -625,6 +625,24 @@ let test_casetype_tag_field_seed () =
       Alcotest.failf "expected one seed for the casetype tag, got %d"
         (List.length seeds)
 
+(* A [lookup] admits exactly the indices into its table, and no other part of a
+   field's declaration names them, so without a seed a generated corpus never
+   reaches an accepted record and the codec reads as unfuzzable. *)
+let test_lookup_field_seed () =
+  let c =
+    Codec.v "Picked"
+      (fun v -> v)
+      Codec.[ (Field.v "k" (lookup [ `A; `B; `C ] uint8) $ fun v -> v) ]
+  in
+  match field_seeds (struct_of_codec c) with
+  | [ seed ] ->
+      Alcotest.(check string) "names the field" "k" seed.field;
+      Alcotest.(check (list int64))
+        "names both ends of the table" [ 0L; 2L ] seed.values
+  | seeds ->
+      Alcotest.failf "expected one seed for the lookup, got %d"
+        (List.length seeds)
+
 let test_doc_field_citation () =
   (* [Field.v ~doc] renders as a plain [/* ... */] comment above the field --
      3d.exe rejects [/*++ --*/] at field position, so the per-field note uses
@@ -1700,6 +1718,8 @@ let suite =
         `Quick test_doc_merge_shared_sub_codec;
       Alcotest.test_case "3d: casetype tag over map/where/uint64 bases" `Quick
         test_3d_casetype_tag_int_carriers;
+      Alcotest.test_case "seeds: lookup names its table indices" `Quick
+        test_lookup_field_seed;
       Alcotest.test_case "seeds: casetype tag names its case indices" `Quick
         test_casetype_tag_field_seed;
       Alcotest.test_case "doc: field ~doc renders as citation comment" `Quick


### PR DESCRIPTION
A `Wire.lookup` admits exactly the indices into its table, and no other part of a field's declaration names them, so `field_seeds` reported nothing for such a field and `Wire_3d.generate_corpus` never reached an accepted record. The codec read as one that could not be fuzzed rather than as one wire could not seed.

Found by the corpus sweep in the branch above this one, which is what made the set of unseedable shapes visible in the first place.

Stacked on #353.