### PR TITLE
codec: report an out-of-range value at the field it came from

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -52,6 +52,10 @@
   `Wire_3d.generate_corpus` can reach an accepted record for a table-dispatched
   field instead of reporting the codec as vacuous (#355, @samoht)
 
+- A value too wide for the platform's native integer is now reported at the
+  field it was read from rather than at byte 0, so seeking to the offset a parse
+  error names lands on the field whatever base the frame sits at (#356, @samoht)
+
 ## 1.2.0
 
 ### Added

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -293,10 +293,21 @@ let enum_checker ~to_int cases ~at v =
   Types.check_enum_decode ~at ~cases (to_int v);
   v
 
+(* [to_int] is handed the value alone, so a carrier wider than the native int
+   reports its refusal at byte 0. Relocate it to the field, as the element
+   reader does. Only a wide carrier can raise, so the narrow ones keep the bare
+   checker and pay nothing for the handler. *)
+let enum_checker_wide ~to_int cases ~at v =
+  Types.relocate_at ~at (fun () ->
+      Types.check_enum_decode ~at ~cases (to_int v));
+  v
+
 (* An open enum ([closed = false]) accepts any base value: the names only
    document known members, so decode does not reject the rest. *)
-let enum_check ~to_int cases closed =
-  if closed then enum_checker ~to_int cases else fun ~at:_ v -> v
+let enum_check ~base ~to_int cases closed =
+  if not closed then fun ~at:_ v -> v
+  else if Types.int_view_is_total base then enum_checker ~to_int cases
+  else enum_checker_wide ~to_int cases
 
 (* Encode-side twin of [enum_check], gated on [closed] by the same rule so the
    two halves admit exactly the same values. Encoding an unlisted value raises
@@ -377,7 +388,9 @@ let rec build_field_reader_ctx : type a.
   | Where { inner; _ } -> build_field_reader_ctx inner field_off
   | Enum { base; cases; closed; _ } ->
       let read = build_field_reader_ctx base field_off in
-      let check = enum_check ~to_int:(Types.int_of_exn base) cases closed in
+      let check =
+        enum_check ~base ~to_int:(Types.int_of_exn base) cases closed
+      in
       fun runtime input_end buf base ->
         check ~at:(base + field_off) (read runtime input_end buf base)
   | Map { inner; decode; index_bound; _ } ->
@@ -466,7 +479,9 @@ let rec build_immediate_reader : type a.
       match build_immediate_reader base field_off with
       | None -> None
       | Some read ->
-          let check = enum_check ~to_int:(Types.int_of_exn base) cases closed in
+          let check =
+            enum_check ~base ~to_int:(Types.int_of_exn base) cases closed
+          in
           Some (fun buf base -> check ~at:(at base) (read buf base)))
   | Map { inner; decode; index_bound; _ } -> (
       match build_immediate_reader inner field_off with
@@ -697,7 +712,9 @@ let rec build_populate : type a.
   | Float64 Big -> populate_float64 idx Bytes.get_int64_be
   | Where { inner; _ } -> build_populate inner idx reader
   | Enum { base; cases; closed; _ } ->
-      let check = enum_check ~to_int:(Types.int_of_exn base) cases closed in
+      let check =
+        enum_check ~base ~to_int:(Types.int_of_exn base) cases closed
+      in
       build_populate base idx (fun runtime input_end buf b ->
           check ~at:b (reader runtime input_end buf b))
   | Map { inner; encode; _ } ->
@@ -1512,7 +1529,13 @@ let rec read_elem : type a. a typ -> runtime -> Input_end.t -> bytes -> int -> a
          through the byte budget. *)
       let v = read_elem base runtime input_end buf off in
       if closed then
-        Types.check_enum_decode ~at:off ~cases (Types.int_of_exn base v);
+        (* A base whose values all fit the native int cannot raise on the way to
+           its integer view, so it skips the relocating handler entirely. *)
+        if Types.int_view_is_total base then
+          Types.check_enum_decode ~at:off ~cases (Types.int_of_exn base v)
+        else
+          Types.relocate_at ~at:off (fun () ->
+              Types.check_enum_decode ~at:off ~cases (Types.int_of_exn base v));
       v
   | Casetype { tag; cases; _ } ->
       let tag_val = read_elem tag runtime input_end buf off in
@@ -2927,10 +2950,12 @@ let rec compile_field : type a r.
          the named cases. [compile_field] would otherwise strip the cases and
          accept any base value, unlike the EverParse validator. *)
       let cf = compile_field ctx { fld with typ = base } in
-      let check = enum_check ~to_int:(Types.int_of_exn base) cases closed in
+      let check =
+        enum_check ~base ~to_int:(Types.int_of_exn base) cases closed
+      in
       (* [populate] reads the field's integer slot rather than its value, so it
          checks membership on the integer the slot already holds. *)
-      let int_check = enum_check ~to_int:Fun.id cases closed in
+      let int_check = enum_check ~base ~to_int:Fun.id cases closed in
       let get = fld.get in
       let encode_check =
         enum_encode_check ~name ~cases ~closed ~to_int:(Types.int_of_exn base)
@@ -4461,7 +4486,9 @@ let rec build_staged_reader : type a.
   | Where { inner; _ }, _ -> build_staged_reader inner access
   | Enum { base; cases; closed; _ }, _ ->
       let read = build_staged_reader base access in
-      let check = enum_check ~to_int:(Types.int_of_exn base) cases closed in
+      let check =
+        enum_check ~base ~to_int:(Types.int_of_exn base) cases closed
+      in
       let at = access_at access in
       fun runtime input_end buf base ->
         check
@@ -4609,7 +4636,9 @@ let rec build_immediate_staged_reader : type a.
       match build_immediate_staged_reader base access with
       | None -> None
       | Some read ->
-          let check = enum_check ~to_int:(Types.int_of_exn base) cases closed in
+          let check =
+            enum_check ~base ~to_int:(Types.int_of_exn base) cases closed
+          in
           let off = immediate_access_off access in
           Some (fun buf base -> check ~at:(base + off) (read buf base)))
   | Map { inner; decode; index_bound; _ }, _ -> (

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -96,6 +96,14 @@ let map_decode ~index_bound decode =
       fun ~at v ->
         try decode v with Parse_error e -> raise (Parse_error { e with at }))
 
+(* [int_of_exn] is handed a value and nothing else, so an out-of-range one has
+   no offset to name and reports 0, the same blind spot [map_decode] covers for
+   a lookup. A reader knows where it found the value, so relocate the failure
+   there; only a carrier wider than the native int can raise, and the handler is
+   installed only for those, so a byte- or word-wide read pays nothing. *)
+let relocate_at ~at f =
+  try f () with Parse_error e -> raise (Parse_error { e with at })
+
 let raise_invalid_enum ~at ~value ~valid =
   raise_error ~at (Invalid_enum { value; valid })
 
@@ -591,6 +599,21 @@ let rec int_of : type a. a typ -> a -> int option =
   | Type_ref _ | Qualified_ref _ | Codec _ | Optional _ | Optional_or _
   | Repeat _ ->
       None
+
+(* Whether every value of a carrier fits the native int, so its integer view
+   cannot fail. A reader over one of these needs no relocating handler: the
+   narrow widths always fit, and the wide ones depend on [Sys.int_size], which
+   is 63 on a native build and 31 under wasm_of_ocaml. *)
+let rec int_view_is_total : type a. a typ -> bool = function
+  | Uint8 | Int8 | Uint16 _ | Int16 _ | Bits _ -> true
+  | Uint32 _ | Int32 _ -> Sys.int_size > 32
+  | Uint64 _ | Int64 _ | Uint_var _ -> false
+  | Enum { base; _ } -> int_view_is_total base
+  | Where { inner; _ } -> int_view_is_total inner
+  | Single_elem { elem; _ } -> int_view_is_total elem
+  | Apply { typ; _ } -> int_view_is_total typ
+  | Map { inner; _ } -> int_view_is_total inner
+  | _ -> false
 
 (* Hot-path variant of [int_of] for the cross-field size/offset/present
    readers, which need a plain [int]. Returns it directly (no [Some] box on the

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -654,6 +654,15 @@ val int_of : 'a typ -> 'a -> int option
     not fit the native int (a {!val-uint64} over 2{^ 62}) and for a type with no
     integer view. *)
 
+val relocate_at : at:int -> (unit -> 'a) -> 'a
+(** [relocate_at ~at f] runs [f], moving any parse error it raises to byte [at].
+    A conversion handed a value alone has no offset to name and reports 0; the
+    reader that found the value does. *)
+
+val int_view_is_total : 'a typ -> bool
+(** [int_view_is_total typ] is [true] when every value of [typ] fits the native
+    int, so taking its integer view cannot fail and needs no relocation. *)
+
 val int_of_exn : 'a typ -> 'a -> int
 (** [int_of_exn typ v] is {!val-int_of} without the [option]: it returns the
     [int] directly (no boxing on the numeric path) and raises {!Parse_error}

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -830,6 +830,27 @@ let test_codec_array_cardinality () =
     [| UInt8.v 1; UInt8.v 2; UInt8.v 3; UInt8.v 4 |]
     3 4
 
+(* A value too wide for the native int is refused by the conversion, which is
+   handed the value and nothing else and so reports byte 0. The reader knows
+   where it found it, and a caller that seeks to the reported offset has to land
+   on the field rather than on the start of the buffer, whatever base the frame
+   sits at. *)
+let test_out_of_range_offset_follows_the_frame () =
+  let c =
+    Codec.v "Wide" Fun.id
+      Codec.[ Field.v "k" (enum "K" [ ("A", 1) ] uint64) $ Fun.id ]
+  in
+  let at_of base b =
+    match Codec.decode c b base with
+    | Ok _ -> Alcotest.fail "expected the wide value to be refused"
+    | Error e -> e.at
+  in
+  let wide = Bytes.make 8 '\xff' in
+  Alcotest.(check int) "at base 0" 0 (at_of 0 wide);
+  Alcotest.(check int)
+    "at base 8" 8
+    (at_of 8 (Bytes.cat (Bytes.make 8 '\x00') wide))
+
 (* A field whose byte extent is an input parameter cannot be measured from the
    value alone. Reporting 0 for it is worse than refusing: a caller sizes a
    buffer from the answer, and encode then writes past the allocation, which
@@ -9759,6 +9780,8 @@ let suite =
         test_casetype_field_logout;
       Alcotest.test_case "casetype field: default" `Quick
         test_casetype_field_default;
+      Alcotest.test_case "decode: out-of-range offset follows the frame" `Quick
+        test_out_of_range_offset_follows_the_frame;
       Alcotest.test_case "size_of_value: resolves param-driven sizes" `Quick
         test_size_of_value_resolves_param_sizes;
       Alcotest.test_case "repeat: budget mismatch names the remedy" `Quick


### PR DESCRIPTION
`Types.int_of_exn` is handed a value and nothing else, so a carrier wider than the platform's native int reported its refusal at byte 0. The enum's own `~at:off` is computed but never applies, because the conversion raises before the membership check is reached. Seeking to the offset a parse error names landed on the start of the buffer instead of on the field, for any `uint64`, `int64` or `uint` enum, on both the element reader and the compiled field reader.

    base 0: at=0    base 8: at=0     (before)
    base 0: at=0    base 8: at=8     (after)

This is the blind spot `map_decode` already covers for a lookup, so the failure is relocated the same way. Only a carrier that can overflow installs the handler, so a byte- or word-wide enum keeps the identical checker; the clcw polling bench is unchanged at 7.1 ns/op.

Found by the casetype tag carriers added in the branch above this one, on their first run.

Stacked on #355.