### PR TITLE
fuzz: put the corpus oracle and its unreached shapes in the gate

### DIFF
--- a/fuzz/3d/fuzz_everparse.ml
+++ b/fuzz/3d/fuzz_everparse.ml
@@ -126,7 +126,139 @@ let extract_cases =
                 Alcobar.failf "EverParse rejected a generated schema:\n%s" m);
       ]
 
+(* {1 Corpus oracle}
+
+   [Wire_3d.generate_corpus] is the differential's oracle: the verdict column it
+   writes is what the generated C validator is checked against. Nothing checked
+   the oracle itself, so a wrong verdict did not refuse, it disagreed, and the
+   disagreement was reported against the validator rather than against the
+   harness. Sweep the registry through it and replay every line against the
+   codec it claims to speak for.
+
+   The replay is written out here rather than reusing [Wire_3d]'s own verdict,
+   so the check does not lean on the code it is checking. It answers the same
+   question: does the record decode, validate, and span exactly the bytes on the
+   line, under that line's parameters. *)
+
+let corpus_count = 24
+
+let bytes_of_hex h =
+  if String.equal h "-" then Bytes.empty
+  else
+    Bytes.init
+      (String.length h / 2)
+      (fun i -> Char.chr (int_of_string ("0x" ^ String.sub h (2 * i) 2)))
+
+(* [name params hex verdict] per line; [params] is "-" or comma separated. *)
+let corpus_lines codec =
+  let buf = Buffer.create 4096 in
+  let ppf = Fmt.with_buffer buf in
+  Wire_3d.generate_corpus ~count:corpus_count ppf [ Wire_3d.pack codec ];
+  Format.pp_print_flush ppf ();
+  Buffer.contents buf |> String.split_on_char '\n'
+  |> List.filter_map (fun line ->
+      match String.split_on_char ' ' line with
+      | [ _; params; hex; verdict ] ->
+          let pvals =
+            if String.equal params "-" then []
+            else List.map int_of_string (String.split_on_char ',' params)
+          in
+          Some (pvals, hex, String.equal verdict "1")
+      | _ -> None)
+
+let input_params codec =
+  match (Wire.Everparse.project ~mode:`Standalone codec).source with
+  | Some source -> Wire.Everparse.Raw.input_param_names source
+  | None -> []
+
+let env_of codec pnames pvals =
+  match pnames with
+  | [] -> None
+  | _ ->
+      Some
+        (List.fold_left2
+           (fun env name value -> Wire.Param.bind_by_name name value env)
+           (Wire.Codec.env codec) pnames pvals)
+
+let record_spans codec env b =
+  match Wire.Codec.decode ?env codec b 0 with
+  | Error _ -> false
+  | Ok _ -> (
+      match
+        Wire.Codec.validate ?env codec b 0;
+        Wire.Codec.wire_size_at ?env codec b 0
+      with
+      | n -> Int.equal n (Bytes.length b)
+      | exception Wire.Parse_error _ -> false)
+
+(* Shapes whose accepting side the seeder cannot construct, so
+   [generate_corpus] refuses rather than emit a corpus that says the same thing
+   about every input. Pinned so the set stays visible: a shape that newly stops
+   being seedable is a regression, and one that becomes seedable has to be
+   dropped from here. Vacuity is the seeder reporting that it cannot build a
+   record, which is exactly how the casetype-tag and length-field gaps hid, as
+   an absence rather than a failure. *)
+let no_corpus_seed =
+  [
+    (* Accepts every buffer it is given, so there is no rejecting side to
+       reach. One-sided by nature rather than by omission. *)
+    "all_bytes";
+    (* Needs a NUL at the right offset, and a terminator is not a value any
+       field declaration singles out, so nothing seeds it. *)
+    "zeroterm";
+    "zeroterm_at_most(1)";
+    "zeroterm_at_most(8)";
+    (* Constraint-shaped: the accepting side is a predicate over the record
+       rather than a value some field's declaration names, which is the only
+       thing [field_seeds] reports. Several of these look like seeding gaps
+       rather than inherent properties; shrinking this list is the follow-up,
+       and pinning it is what makes the set visible enough to shrink. *)
+    "optional_dyn_after_span";
+    "typ_where";
+    "field_constraint";
+    "field_int";
+    "param_input";
+    "nan_float64";
+  ]
+
+let corpus_oracle_case (label, Fuzz_gen.Pack g) =
+  let codec = Fuzz_gen.codec g in
+  Alcobar.test_case ("corpus oracle " ^ label)
+    [ const () ]
+    (fun () ->
+      match corpus_lines codec with
+      | exception Failure msg ->
+          if not (List.mem label no_corpus_seed) then
+            Alcobar.failf "%s: generate_corpus refused a corpus: %s" label msg
+      | lines ->
+          if List.mem label no_corpus_seed then
+            Alcobar.failf "%s: is seedable now; drop it from [no_corpus_seed]"
+              label;
+          let pnames = input_params codec in
+          List.iter
+            (fun (pvals, hex, verdict) ->
+              let env = env_of codec pnames pvals in
+              let b = bytes_of_hex hex in
+              let spans = record_spans codec env b in
+              if not (Bool.equal spans verdict) then
+                Alcobar.failf
+                  "%s: corpus records %b for params [%s] %s, the codec answers \
+                   %b"
+                  label verdict
+                  (String.concat "," (List.map string_of_int pvals))
+                  hex spans)
+            lines)
+
+let corpus_cases () =
+  if not (normal_mode ()) then []
+  else
+    Fuzz_gen.registry
+    |> List.filter (fun (name, _) -> not (List.mem name no_3d_projection))
+    |> List.map corpus_oracle_case
+
 let suite =
   if Fuzz_gen.file_input_mode () then
     ("everparse", Fuzz_gen.afl_everparse_cases "everparse")
-  else ("everparse", pp_cases () @ nested_pp_cases () @ extract_cases)
+  else
+    ( "everparse",
+      pp_cases () @ nested_pp_cases () @ corpus_cases () @ extract_cases )

--- a/fuzz/gen/fuzz_gen.ml
+++ b/fuzz/gen/fuzz_gen.ml
@@ -2464,20 +2464,27 @@ let combine_env_strategies (strategies : env_strategy option list) :
    an [int] and lifted into the discriminator's carrier here. The composer's
    default branch ignores the matched tag and always re-encodes the fixed [t],
    so adapt to the tag-aware API. *)
-let casetype_case_def (Case c) =
+let casetype_case_def_with lift (Case c) =
   match (c.index, c.default_tag) with
   | Some i, _ ->
-      Wire.case ~index:(Wire.UInt8.v i) c.inner.typ ~inject:c.inject
-        ~project:c.project
+      Wire.case ~index:(lift i) c.inner.typ ~inject:c.inject ~project:c.project
   | None, Some t ->
-      let t = Wire.UInt8.v t in
+      let t = lift t in
       Wire.default c.inner.typ
         ~inject:(fun _tag w -> c.inject w)
         ~project:(fun a -> Option.map (fun w -> (t, w)) (c.project a))
   | None, None -> invalid_arg "casetype_u8: case must supply ~index or ~tag"
 
-let casetype_u8 name cases =
-  let typ = Wire.casetype name Wire.uint8 (List.map casetype_case_def cases) in
+(* The discriminator is a parameter because a casetype dispatches on any enum,
+   and an enum takes any base with an integer view: the tag reaches the
+   case-index projection wrapped in a [lookup]'s map, behind a [where], or over
+   a 64-bit base. Generating only a bare [uint8] tag left every one of those
+   carriers unreached. [lift] carries a case's integer index into whatever the
+   tag's carrier turns out to be. *)
+let casetype_tagged name tag lift cases =
+  let typ =
+    Wire.casetype name tag (List.map (casetype_case_def_with lift) cases)
+  in
   let codec = codec_of_typ typ in
   let n = max 1 (List.length cases) in
   let env_strategy =
@@ -2522,6 +2529,8 @@ let casetype_u8 name cases =
     fields = [];
     adversarial_value = None;
   }
+
+let casetype_u8 name cases = casetype_tagged name Wire.uint8 Wire.UInt8.v cases
 
 (* A direct [Wire.casetype] over a wider discriminator, with a default branch
    that preserves the actual unclaimed tag. This mirrors [Wire.default]'s API
@@ -4648,6 +4657,43 @@ let registry_casetype =
         ~project:(function `Other v -> Some v | _ -> None);
     ]
 
+(* One casetype per integer carrier an enum base can take. Each dispatches the
+   same two branches; what differs is what the tag's case index has to be
+   projected through, which is where the projection used to assert. *)
+let tagged_cases =
+  [
+    case ~index:1 uint16be
+      ~inject:(fun v -> `A v)
+      ~project:(function `A v -> Some v | _ -> None);
+    case ~index:2 uint32be
+      ~inject:(fun v -> `B v)
+      ~project:(function `B v -> Some v | _ -> None);
+  ]
+
+let registry_casetype_enum_tag =
+  casetype_tagged "RegEnumTag"
+    (Wire.enum "RegEnumTagKind" [ ("A", 1); ("B", 2) ] Wire.uint8)
+    Wire.UInt8.v tagged_cases
+
+let registry_casetype_lookup_tag =
+  casetype_tagged "RegLookupTag"
+    (Wire.enum "RegLookupTagKind"
+       [ ("A", 1); ("B", 2) ]
+       (Wire.lookup [ 0; 1; 2 ] Wire.uint8))
+    Fun.id tagged_cases
+
+let registry_casetype_where_tag =
+  casetype_tagged "RegWhereTag"
+    (Wire.enum "RegWhereTagKind"
+       [ ("A", 1); ("B", 2) ]
+       (Wire.where Wire.Expr.(Wire.int 0 = Wire.int 0) Wire.uint8))
+    Wire.UInt8.v tagged_cases
+
+let registry_casetype_u64_tag =
+  casetype_tagged "RegU64Tag"
+    (Wire.enum "RegU64TagKind" [ ("A", 1); ("B", 2) ] Wire.uint64)
+    Wire.UInt64.of_int tagged_cases
+
 let unsigned_scalar_gens =
   [
     ("uint8", Pack uint8);
@@ -4843,6 +4889,10 @@ let composite_gens =
     ("record_bits(4+12,U16be)", Pack registry_bits_u16be);
     ("casetype_u8", Pack registry_casetype);
     ("casetype_u16be_default", Pack casetype_u16be_default);
+    ("casetype_enum_tag", Pack registry_casetype_enum_tag);
+    ("casetype_lookup_tag", Pack registry_casetype_lookup_tag);
+    ("casetype_where_tag", Pack registry_casetype_where_tag);
+    ("casetype_u64_tag", Pack registry_casetype_u64_tag);
     ("field_anon", Pack field_anon);
   ]
 
@@ -6262,6 +6312,56 @@ let once_case name check =
         check ()
       end)
 
+(* [write ~mode:`Standalone] is only a merge when it is handed more than one
+   schema, and a one-element list never sees a name twice, so the dedup went
+   unexercised. A sub-codec packed as a codec of its own and also reached
+   through another codec's field is the shape that drives it: the same struct
+   projects twice, once carrying the entrypoint marker and the codec's doc and
+   once carrying neither, and the merged spec has to collapse them into one
+   declaration that keeps both. *)
+let merged_write_once ~outdir =
+  let shared =
+    Wire.Codec.v "FuzzShared" ~doc:"The shared sub-codec." Fun.id
+      Wire.Codec.[ Wire.Field.v "v" Wire.uint8 $ Fun.id ]
+  in
+  let parent =
+    Wire.Codec.v "FuzzParent"
+      (fun k s -> (k, s))
+      Wire.Codec.
+        [
+          Wire.Field.v "k" Wire.uint8 $ fst;
+          Wire.Field.v "s" (Wire.codec shared) $ snd;
+        ]
+  in
+  let project c = Wire.Everparse.project ~mode:`Standalone c in
+  let name = "ApiMerged" in
+  (* Either order has to give the same spec: which schema was projected first
+     decides nothing about what the type is. *)
+  List.iter
+    (fun schemas ->
+      Wire.Everparse.write ~mode:`Standalone ~outdir ~name schemas;
+      let path =
+        Filename.concat outdir (String.capitalize_ascii name ^ ".3d")
+      in
+      let out = In_channel.with_open_text path In_channel.input_all in
+      let occurrences sub =
+        let n = String.length sub and len = String.length out in
+        let rec go i acc =
+          if i + n > len then acc
+          else if String.equal (String.sub out i n) sub then go (i + n) (acc + 1)
+          else go (i + 1) acc
+        in
+        go 0 0
+      in
+      if occurrences "} FuzzShared;" <> 1 then
+        Alcobar.failf "merged spec declares FuzzShared %d times, expected once"
+          (occurrences "} FuzzShared;");
+      if occurrences "entrypoint\ntypedef struct WireFuzzShared" <> 1 then
+        Alcobar.failf "merged spec dropped FuzzShared's entrypoint marker";
+      if occurrences "The shared sub-codec." <> 1 then
+        Alcobar.failf "merged spec dropped FuzzShared's doc comment")
+    [ [ project shared; project parent ]; [ project parent; project shared ] ]
+
 let check_write_helpers_once () =
   let codec = fst5 (api_access_codec ()) in
   let schema = Wire.Everparse.project ~mode:`Ffi codec in
@@ -6272,6 +6372,7 @@ let check_write_helpers_once () =
   (try Sys.mkdir outdir 0o700 with Sys_error _ -> ());
   Wire.Everparse.write ~mode:`Ffi ~outdir [ schema ];
   Wire.Everparse.write ~mode:`Standalone ~outdir ~name:"ApiDoc" [ doc_schema ];
+  merged_write_once ~outdir;
   Wire.Everparse.Raw.to_3d_file ~enum_as_type:true
     (Filename.concat outdir "ApiRawDirect.3d")
     schema.module_

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -2609,6 +2609,11 @@ let rec enum_type_name : type a. a typ -> string option = function
   | Apply { typ; _ } -> enum_type_name typ
   | _ -> None
 
+(* A [where] anywhere in a field's type becomes a field constraint, including
+   one under an [enum] or a [map]: 3D takes at most one refinement after a field
+   name, so leaving an inner one to render inline on the type produced two
+   stacked braces and a syntax error. Rebuilding the wrapper around the
+   extracted inner keeps the type it renders as unchanged. *)
 let rec extract_where_constraint : type a. a typ -> bool expr option * a typ =
  fun typ ->
   match typ with
@@ -2616,6 +2621,14 @@ let rec extract_where_constraint : type a. a typ -> bool expr option * a typ =
       match extract_where_constraint inner with
       | Some c2, inner' -> (Some (And (cond, c2)), inner')
       | None, inner' -> (Some cond, inner'))
+  | Enum ({ base; _ } as e) -> (
+      match extract_where_constraint base with
+      | None, _ -> (None, typ)
+      | Some c, base' -> (Some c, Enum { e with base = base' }))
+  | Map ({ inner; _ } as m) -> (
+      match extract_where_constraint inner with
+      | None, _ -> (None, typ)
+      | Some c, inner' -> (Some c, Map { m with inner = inner' }))
   | _ -> (None, typ)
 
 let combine_constraints a b =
@@ -3109,11 +3122,34 @@ let pp_field widenable ppf (Field f) =
   Option.iter (Fmt.pf ppf " %a" pp_action) f.action;
   Fmt.string ppf ";"
 
+(* The scalar an enum-shaped type projects to, seen through the transparent
+   wrappers. Used where a type has to render without an enum declaration to
+   refer to. *)
+let rec pp_scalar_of : type a. Format.formatter -> a typ -> unit =
+ fun ppf t ->
+  match t with
+  | Enum { base; _ } -> pp_scalar_of ppf base
+  | Map { inner; _ } -> pp_scalar_of ppf inner
+  | Where { inner; _ } -> pp_scalar_of ppf inner
+  | Apply { typ; _ } -> pp_scalar_of ppf typ
+  | t -> pp_typ ppf t
+
+(* A parameter's type renders under the same rule as a field's: the named enum
+   only where the module declares enum types, and the base it projects to
+   otherwise. Naming an enum unconditionally left the codegen projection
+   referring to a type it never declares, and a [where]-wrapped base rendering
+   as a refinement, which is not a parameter type at all. *)
+let pp_param_typ : type a. Format.formatter -> a typ -> unit =
+ fun ppf t ->
+  match if !render_enum_as_type then enum_type_name t else None with
+  | Some n -> Fmt.string ppf (escape_3d n)
+  | None -> pp_scalar_of ppf t
+
 let pp_param ppf p =
   let (Pack_typ t) = p.param_typ in
   let name = escape_3d p.param_name in
-  if p.mutable_ then Fmt.pf ppf "mutable %a *%s" pp_typ t name
-  else Fmt.pf ppf "%a %s" pp_typ t name
+  if p.mutable_ then Fmt.pf ppf "mutable %a *%s" pp_param_typ t name
+  else Fmt.pf ppf "%a %s" pp_param_typ t name
 
 let pp_params ppf params =
   if not (List.is_empty params) then
@@ -3227,13 +3263,26 @@ let pp_casetype_cases : type k.
  fun ppf tag cases ->
   (* When the switch tag is an enum, EverParse requires each case label to be the
      enum constant name, not the raw integer it stands for. *)
-  let enum_label k =
-    match tag with
-    | Enum { cases = ecases; _ } ->
-        List.find_map
-          (fun (n, v) -> if Int.equal v k then Some n else None)
-          ecases
+  (* Only where the module declares enum types: the codegen projection renders
+     the tag as its base scalar, so a constant name there would refer to a type
+     the module never declares. Seen through the transparent wrappers, since the
+     tag's enum can sit behind a [lookup]'s map or a [where]. *)
+  let rec named_cases : type k. k typ -> (string * int) list option = function
+    | Enum { cases; _ } -> Some cases
+    | Map { inner; _ } -> named_cases inner
+    | Where { inner; _ } -> named_cases inner
+    | Apply { typ; _ } -> named_cases typ
     | _ -> None
+  in
+  let enum_label k =
+    if not !render_enum_as_type then None
+    else
+      match named_cases tag with
+      | Some ecases ->
+          List.find_map
+            (fun (n, v) -> if Int.equal v k then Some n else None)
+            ecases
+      | None -> None
   in
   List.iteri
     (fun i (tag_opt, Pack_typ typ) ->

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -114,7 +114,16 @@ let test_casetype_enum_tag_labels () =
       kind
       [ decl_case 0 uint32; decl_case 2 uint16 ]
   in
-  let output = to_3d (module_ [ d ]) in
+  (* Only where the module declares the enum type. The codegen projection
+     renders the tag as its base scalar, so a constant name there would refer to
+     a type it never declares. *)
+  let m =
+    module_
+      [
+        enum_decl "PageKind" [ ("LeafIndex", 0); ("InteriorIndex", 2) ] uint8; d;
+      ]
+  in
+  let output = to_3d ~enum_as_type:true m in
   Alcotest.(check bool)
     "low case uses the enum constant name" true
     (contains ~sub:"case LeafIndex:" output);
@@ -123,7 +132,10 @@ let test_casetype_enum_tag_labels () =
     (contains ~sub:"case InteriorIndex:" output);
   Alcotest.(check bool)
     "no raw-integer case label" false
-    (contains ~sub:"case 2:" output)
+    (contains ~sub:"case 2:" output);
+  Alcotest.(check bool)
+    "the enum it names is declared" true
+    (contains ~sub:"enum PageKind" output)
 
 let test_casetype_wide_index_error () =
   let high = Wire.Private.UInt32.be (Bytes.of_string "\x80\x00\x00\x00") 0 in


### PR DESCRIPTION
Three paths the schema bugs in this stack escaped through, all in the generator rather than in wire.

`Wire_3d.generate_corpus` was not in the Crowbar gate at all, so the verdict column a differential trusts had no coverage. A wrong verdict does not refuse, it disagrees, and the disagreement gets reported against the generated C validator. Every registry shape now runs through it and every emitted line is replayed against the codec it claims to speak for, written out here rather than calling back into the verdict it is checking. Reinstating the bug #350 fixed makes it fire on `param_size` and `rest_bytes`, which is the cfdp failure caught at the harness.

The shapes whose accepting side the seeder cannot construct are now pinned rather than absent. That set was unobservable before, which is exactly how the casetype-tag and length-field gaps hid; a shape that becomes seedable fails until it is removed from the list. One entry turned out to be a real gap and is fixed in #355 instead of pinned.

The generator only ever built a bare `uint8` or `uint16be` casetype tag, so every other carrier an enum base can take was unreachable and #347's assert could not be hit. The discriminator is now a parameter, with four registry entries covering plain, over a `lookup`'s map, behind a `where`, and 64-bit. The last of those found #356 on its first run.

And `Everparse.write ~mode:`Standalone` was only ever handed one schema, so no name was seen twice and the merge that dedups a shared type was dead code. It now writes a sub-codec alongside the parent that embeds it, in both orders.

Tooling only, so no changelog entry. Top of the stack, on #356.