### PR TITLE
codec: report byte counts and extents a caller can size from

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -56,6 +56,15 @@
   field it was read from rather than at byte 0, so seeking to the offset a parse
   error names lands on the field whatever base the frame sits at (#356, @samoht)
 
+- A parse error from a field whose start ran past the end of the input reports
+  the bytes that were missing rather than a negative count. `Wire.of_reader`
+  computes how much more to read from that number, so a negative one left it
+  asking for a position behind what it had already buffered (#359, @samoht)
+- `Wire.Codec.min_wire_size` reports the region a `zeroterm_at_most` field
+  occupies rather than zero, so a buffer sized from it holds the record. A
+  parse error from a `zeroterm` field with no terminator also names the field
+  it came from (#361, @samoht)
+
 ## 1.2.0
 
 ### Added

--- a/lib/codec.ml
+++ b/lib/codec.ml
@@ -40,6 +40,13 @@ let const_span_reader ~field_off n read =
   else fun _runtime _input_end _buf base ->
     raise_out_of_range ~at:(base + field_off) (Int64.of_int n)
 
+let rec nul_scan buf ~at ~limit i =
+  if i >= limit then raise_missing_terminator ~at
+  else if Bytes.get_uint8 buf i = 0 then i
+  else nul_scan buf ~at ~limit (i + 1)
+
+let zeroterm_nul_pos buf ~first ~limit = nul_scan buf ~at:first ~limit first
+
 (* The refinement of a [byte_array_where] lives in its reader: every compiled
    path that yields the span runs it, so [Codec.decode] and [Codec.validate]
    reject the same bytes as [Wire.of_string] and as the EverParse validator
@@ -385,6 +392,14 @@ let rec build_field_reader_ctx : type a.
   | Byte_slice { size = Int n } ->
       const_span_reader ~field_off n (fun _runtime _input_end buf base ->
           Slice.make_or_eod buf ~first:(base + field_off) ~length:n)
+  (* The region is fixed, so the field compiles on this path like any other
+     constant span; the value is the bytes up to the NUL within it, and
+     [zeroterm_nul_pos] refuses a region with no terminator. *)
+  | Zeroterm_at_most { size = Int n } ->
+      const_span_reader ~field_off n (fun _runtime _input_end buf base ->
+          let first = base + field_off in
+          let nul = zeroterm_nul_pos buf ~first ~limit:(first + n) in
+          Bytes.sub_string buf first (nul - first))
   | Where { inner; _ } -> build_field_reader_ctx inner field_off
   | Enum { base; cases; closed; _ } ->
       let read = build_field_reader_ctx base field_off in
@@ -1474,12 +1489,6 @@ and iter_param_refs_fields f fields where =
 (* Kept at top level: as a local closure the scan would be heap-allocated on
    every terminator search, and a repeat of NUL-terminated elements searches
    once per element on a count the sender picks through the byte budget. *)
-let rec nul_scan buf ~at ~limit i =
-  if i >= limit then raise_missing_terminator ~at
-  else if Bytes.get_uint8 buf i = 0 then i
-  else nul_scan buf ~at ~limit (i + 1)
-
-let zeroterm_nul_pos buf ~first ~limit = nul_scan buf ~at:first ~limit first
 
 (* Byte size of a casetype tag. The tag is always a fixed-size scalar int, so
    the common widths answer directly: [field_wire_size] would box a [Some n]
@@ -2469,14 +2478,26 @@ let compile_repeat : type elt seq r.
        fun _arr runtime input_end buf base -> check runtime input_end buf base);
   }
 
+(* [expected] is a byte count, so a span whose offset overran the buffer cannot
+   report its size: that size comes out negative, and every consumer does
+   arithmetic on the count (the streaming reader's retry target, the corpus
+   seeder's growth target), which a negative turns into a position behind what
+   is already buffered. Report the bytes missing before the read could start
+   instead, and keep the size for the ordinary case of a span that simply
+   reaches too far. *)
+let missing_before ~first ~sz ~len =
+  if sz < 0 || first < 0 then max 0 (first - len) else sz
+
 (* The span [first, first + sz) must lie inside [buf]. Both ends derive from
    length fields, i.e. untrusted input: a span sized past the buffer, or a
    negative size from an overrun offset, would crash the read with a raw
    [Invalid_argument] that escapes the decode result. Report the missing bytes
    as end-of-input instead. *)
 let[@inline] check_span_bounds buf ~first ~sz =
-  if sz < 0 || first < 0 || first + sz > Bytes.length buf then
-    raise_eof ~at:first ~expected:sz
+  let len = Bytes.length buf in
+  if sz < 0 || first < 0 || first + sz > len then
+    raise_eof ~at:first
+      ~expected:(missing_before ~first ~sz ~len)
       ~got:(bytes_from (Input_end.of_bytes buf) first)
 
 (* Absolute index of the first NUL at or after [first], searching up to (but
@@ -2503,7 +2524,8 @@ let var_bytes_reader : type a.
          [make_or_eod] with a raw [Invalid_argument] that escapes the decode
          result. Fail cleanly instead. *)
       if sz < 0 || first < 0 then
-        raise_eof ~at:first ~expected:sz
+        raise_eof ~at:first
+          ~expected:(missing_before ~first ~sz ~len:(Bytes.length buf))
           ~got:(bytes_from (Input_end.of_bytes buf) first)
   | _ -> check_span_bounds buf ~first ~sz);
   match typ with
@@ -2767,12 +2789,26 @@ let prepend_field_check name f arr runtime input_end buf base =
   with Types.Parse_error e ->
     raise (Types.Parse_error { e with field = name :: e.field })
 
-(* A casetype's extent comes from dispatching on its tag, and the record's
-   bounds check walks that extent before any field reader runs, so an unknown
-   tag surfaces from the size walk rather than from the wrapped reader. Name the
-   field there too, or the failure reaches the caller with no path at all. *)
-let attribute_size_errors typ name size_fn =
-  match typ with Casetype _ -> prepend_field name size_fn | _ -> size_fn
+(* Some extents are resolved by walking the field's own bytes, and the record's
+   bounds check does that walk before any field reader runs, so the failure
+   surfaces from the size walk rather than from the wrapped reader: a casetype
+   dispatching on an unknown tag, a zero-terminated string with no terminator.
+   Name the field there too, or the failure reaches the caller with no path at
+   all. Every other extent is arithmetic over fields already read and raises
+   nothing of its own. *)
+let attribute_size_errors : type a.
+    a typ ->
+    string ->
+    (runtime -> Input_end.t -> bytes -> int -> int) ->
+    runtime ->
+    Input_end.t ->
+    bytes ->
+    int ->
+    int =
+ fun typ name size_fn ->
+  match typ with
+  | Casetype _ | Zeroterm -> prepend_field name size_fn
+  | _ -> size_fn
 
 let compile_var_bytes : type a r.
     layout_ctx -> (a, r) field -> (a, r) compiled_field =

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -3605,7 +3605,10 @@ let rec field_wire_size : type a. a typ -> int option = function
   | Unit -> Some 0
   | Byte_array { size = Int n }
   | Byte_array_where { size = Int n; _ }
-  | Byte_slice { size = Int n } ->
+  | Byte_slice { size = Int n }
+  (* A bounded zero-terminated string spans its whole region whatever the
+     terminator's position, as [elem_size_of] already reports it. *)
+  | Zeroterm_at_most { size = Int n } ->
       Some n
   | Where { inner; _ } -> field_wire_size inner
   | Enum { base; _ } -> field_wire_size base

--- a/test/test_codec.ml
+++ b/test/test_codec.ml
@@ -830,6 +830,67 @@ let test_codec_array_cardinality () =
     [| UInt8.v 1; UInt8.v 2; UInt8.v 3; UInt8.v 4 |]
     3 4
 
+(* A bounded zero-terminated string occupies its whole region whatever the
+   terminator's position, so a buffer sized from the codec's own minimum has to
+   hold it. It reported zero, because the field had no reader on the fixed-size
+   compile path and so compiled as variable-size; the terminator check has to
+   survive the move. And a [zeroterm] field's terminator is found by the size
+   walk, which named no field until now. *)
+let test_zeroterm_extent_and_attribution () =
+  let bounded =
+    Codec.v "Ztam" Fun.id
+      Codec.[ Field.v "s" (zeroterm_at_most ~size:(int 8)) $ Fun.id ]
+  in
+  Alcotest.(check int)
+    "the region is the minimum size" 8
+    (Codec.min_wire_size bounded);
+  (match Codec.decode bounded (Bytes.of_string "abcdefgh") 0 with
+  | Ok _ -> Alcotest.fail "expected a missing terminator"
+  | Error { kind = Missing_terminator; _ } -> ()
+  | Error _ -> Alcotest.fail "wrong error for an unterminated region");
+  (match Codec.decode bounded (Bytes.of_string "abc\x00defg") 0 with
+  | Ok v -> Alcotest.(check string) "reads up to the NUL" "abc" v
+  | Error _ -> Alcotest.fail "expected the terminated region to decode");
+  let greedy = Codec.v "Zt" Fun.id Codec.[ Field.v "s" zeroterm $ Fun.id ] in
+  match Codec.decode greedy (Bytes.of_string "ab") 0 with
+  | Ok _ -> Alcotest.fail "expected a missing terminator"
+  | Error { kind = Missing_terminator; field; _ } ->
+      Alcotest.(check (list string)) "names the field" [ "s" ] field
+  | Error _ -> Alcotest.fail "wrong error for an unterminated string"
+
+(* [expected] is documented as a count of bytes, and every consumer does
+   arithmetic on it: the streaming reader's retry target and the corpus seeder's
+   growth target both read it that way. A greedy field whose start overran the
+   buffer used to report the negative size the offset produced, which reads as
+   "nothing is missing" and sends both consumers backwards. *)
+let test_eof_expected_is_a_byte_count () =
+  let f_len = Field.v "len" uint8 in
+  let c =
+    Codec.v "Greedy"
+      (fun l s t -> (l, s, t))
+      Codec.
+        [
+          (f_len $ fun (l, _, _) -> l);
+          ( Field.v "span" (byte_array ~size:(Field.ref f_len))
+          $ fun (_, s, _) -> s );
+          (Field.v "tail" all_zeros $ fun (_, _, t) -> t);
+        ]
+  in
+  (* [len] is 20, so the tail starts at 21 in a two-byte buffer. *)
+  let buf = Bytes.of_string "\x14\x00" in
+  match Codec.decode c buf 0 with
+  | Ok _ -> Alcotest.fail "expected the overrun to be refused"
+  | Error { kind = Unexpected_eof { expected; got }; at; _ } ->
+      Alcotest.(check bool)
+        (Fmt.str "expected is a byte count, not %d" expected)
+        true (expected >= 0);
+      (* The shortfall names exactly where the read starts, which is what both
+         consumers compute from it. *)
+      Alcotest.(check int)
+        "the shortfall reaches the read" at
+        (Bytes.length buf + expected - got)
+  | Error _ -> Alcotest.fail "expected an end-of-input refusal"
+
 (* A value too wide for the native int is refused by the conversion, which is
    handed the value and nothing else and so reports byte 0. The reader knows
    where it found it, and a caller that seeks to the reported offset has to land
@@ -9780,6 +9841,10 @@ let suite =
         test_casetype_field_logout;
       Alcotest.test_case "casetype field: default" `Quick
         test_casetype_field_default;
+      Alcotest.test_case "zeroterm: extent and field attribution" `Quick
+        test_zeroterm_extent_and_attribution;
+      Alcotest.test_case "decode: eof expected is a byte count" `Quick
+        test_eof_expected_is_a_byte_count;
       Alcotest.test_case "decode: out-of-range offset follows the frame" `Quick
         test_out_of_range_offset_follows_the_frame;
       Alcotest.test_case "size_of_value: resolves param-driven sizes" `Quick


### PR DESCRIPTION
Two ways a size came back wrong.

A field whose start ran past the end of the input reported the negative size its offset produced. `expected` is documented as a byte count and both consumers do arithmetic on it, so `Wire.of_reader`'s retry target asked for a position behind what it had already buffered.

A bounded zero-terminated field reported a minimum wire size of zero, because the fixed-size compile path had no reader for it and the field compiled as variable-size. A buffer sized from the codec's own minimum was then short. Adding the reader is what makes the extent honest; the terminator check survives the move, which the test pins.

Stacked on #357.