### PR TITLE
3d: seed from the extremes and repair a missing terminator

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -64,6 +64,11 @@
   occupies rather than zero, so a buffer sized from it holds the record. A
   parse error from a `zeroterm` field with no terminator also names the field
   it came from (#361, @samoht)
+- `Wire_3d.generate_corpus` reaches records whose accepting side sits at an
+  extreme, such as a predicate satisfied at the minimum or a string whose
+  terminator has to be written rather than drawn. It seeds from the extremes as
+  well as from noise, and repairs a missing terminator the way it already
+  repaired a short input (#360, @samoht)
 
 ## 1.2.0
 

--- a/fuzz/3d/fuzz_everparse.ml
+++ b/fuzz/3d/fuzz_everparse.ml
@@ -201,24 +201,9 @@ let record_spans codec env b =
 let no_corpus_seed =
   [
     (* Accepts every buffer it is given, so there is no rejecting side to
-       reach. One-sided by nature rather than by omission. *)
+       reach. One-sided by nature rather than by omission, and the only entry
+       here that a better seeder could not remove. *)
     "all_bytes";
-    (* Needs a NUL at the right offset, and a terminator is not a value any
-       field declaration singles out, so nothing seeds it. *)
-    "zeroterm";
-    "zeroterm_at_most(1)";
-    "zeroterm_at_most(8)";
-    (* Constraint-shaped: the accepting side is a predicate over the record
-       rather than a value some field's declaration names, which is the only
-       thing [field_seeds] reports. Several of these look like seeding gaps
-       rather than inherent properties; shrinking this list is the follow-up,
-       and pinning it is what makes the set visible enough to shrink. *)
-    "optional_dyn_after_span";
-    "typ_where";
-    "field_constraint";
-    "field_int";
-    "param_input";
-    "nan_float64";
   ]
 
 let corpus_oracle_case (label, Fuzz_gen.Pack g) =

--- a/lib/3d/wire_3d.ml
+++ b/lib/3d/wire_3d.ml
@@ -1259,12 +1259,16 @@ let seed_for seeds (e : Wire.parse_error) =
         seeds
   | [] -> None
 
-(* An EOF can be repaired by growing the input. Other failures can be repaired
-   when the failing field's declaration names candidate values. *)
+(* An EOF can be repaired by growing the input, and a missing terminator by
+   writing one where the scan gave up: both are structural, so neither needs a
+   value the declaration singles out. Anything else is repairable only when the
+   failing field's declaration names candidate values. *)
 let repair_for ~seeds ~len (e : Wire.parse_error) =
   match e.kind with
   | Wire.Unexpected_eof { expected; got } when expected > got ->
       `Grow (len + expected - got)
+  | Wire.Missing_terminator when e.at < len -> `Terminate e.at
+  | Wire.Missing_terminator -> `Grow (e.at + 1)
   | _ -> (
       match seed_for seeds e with
       | Some seed -> `Place (e.at, seed)
@@ -1273,9 +1277,9 @@ let repair_for ~seeds ~len (e : Wire.parse_error) =
 (* Construct one accepting input by repeatedly asking the codec how to repair
    the earliest failure. The field offsets come from parse errors rather than a
    static layout, so the same loop works after variable-width prefixes. *)
-let seed_input ?env rng ~seeds ~center c =
+let seed_input ?env rng ~seeds ~center ~fill c =
   let fuel = ref ((2 * List.length seeds) + 6) in
-  let buf = ref (random_bytes rng (max 1 center)) in
+  let buf = ref (fill rng (max 1 center)) in
   let placed = ref [] in
   let out = ref None in
   let place off (seed : Raw.field_seed) =
@@ -1311,6 +1315,7 @@ let seed_input ?env rng ~seeds ~center c =
     | `Reject e -> (
         match repair_for ~seeds ~len:(Bytes.length !buf) e with
         | `Grow n -> grow n
+        | `Terminate off -> Bytes.set !buf off '\000'
         | `Place (off, seed) -> place off seed
         | `Stuck -> fuel := 0)
   done;
@@ -1362,13 +1367,31 @@ let mutate rng seed =
 (* Try a bounded number of fresh byte/parameter combinations for each desired
    accepting seed. An unsolved constraint is reported by the vacuity check
    rather than spinning. *)
+(* Where a record's accepting side sits at an extreme, a uniform draw never
+   lands on it: a predicate satisfied at the minimum, a terminator in the first
+   byte, a float pattern the bytes have to spell out. Start from the extremes as
+   well as from noise and let the same repair loop settle the rest, which costs
+   a way to solve for the value nothing at all. *)
+let extremal_fills =
+  [| (fun _rng n -> Bytes.make n '\000'); (fun _rng n -> Bytes.make n '\255') |]
+
 let corpus_seeds ?env_of rng ~seeds ~center ~draw_params ~want c =
   let env_of = match env_of with Some f -> f | None -> fun _ -> None in
-  let found = ref [] and attempts = ref (4 * want) in
+  let n_extremal = Array.length extremal_fills in
+  (* The extremes are tried first and are deterministic, so they are extra
+     attempts rather than a share of the random ones: a shape whose accepting
+     side is only ever found by chance keeps every draw it had. *)
+  let found = ref []
+  and tried = ref 0
+  and attempts = ref ((4 * want) + n_extremal) in
   while List.length !found < want && !attempts > 0 do
     decr attempts;
+    let fill =
+      if !tried < n_extremal then extremal_fills.(!tried) else random_bytes
+    in
+    incr tried;
     let pvals = draw_params () in
-    match seed_input ?env:(env_of pvals) rng ~seeds ~center c with
+    match seed_input ?env:(env_of pvals) rng ~seeds ~center ~fill c with
     | Some (b, placed) -> found := (pvals, b, placed) :: !found
     | None -> ()
   done;


### PR DESCRIPTION
The corpus seeder drew uniform bytes and abandoned the codec on its first unrepairable error, so a record whose accepting side sits at an extreme was never reached: a predicate satisfied at the minimum, a terminator that has to be written rather than drawn. Ten shapes reported a vacuous corpus for that reason.

The extremes are extra starting points rather than a share of the random ones, so a shape only ever found by chance keeps every draw it had. That mattered: taking a share regressed `array(3,bounded_u8)`, which had never been seeded at all and passed on twelve uniform draws finding one by luck.

A missing terminator is repaired the way a short input already was, since both are structural and need no value the declaration singles out.

The pinned unseedable set goes from ten entries to one, and `all_bytes` stays because it accepts every buffer and has no rejecting side to reach.

Stacked on #359.