### PR TITLE
types: credit a refinement to the field it compares

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -69,7 +69,11 @@
   terminator has to be written rather than drawn. It seeds from the extremes as
   well as from noise, and repairs a missing terminator the way it already
   repaired a short input (#360, @samoht)
-
+- `Wire.Everparse.Raw.field_seeds` credits a refinement's values to the field it
+  compares rather than to the field carrying it, and reads a struct-level
+  `where` where the projection puts it. A constraint written on one field about
+  another, and any codec-level `where`, previously yielded no values at all
+  (#362, @samoht)
 ## 1.2.0
 
 ### Added

--- a/lib/everparse.mli
+++ b/lib/everparse.mli
@@ -268,13 +268,16 @@ module Raw : sig
 
   val field_seeds : struct_ -> field_seed list
   (** [field_seeds s] is, for each named whole-byte integer field of [s] whose
-      declaration singles out values, the byte slot it occupies and those
-      values: the constant an equality or inequality refinement names, the
-      values either side of an ordering refinement's boundary, and the members
-      of a closed enumeration. A casetype field seeds too: its tag is parsed at
-      the start of the field's own bytes, so the slot is the tag's and the
-      values are the case indices. Bitfields are omitted because their base word
-      is shared, so a byte offset alone cannot seed one.
+      any refinement in the record compares against a value, the byte slot it
+      occupies and those values: the constant an equality or inequality names,
+      the values either side of an ordering boundary, and the members of a
+      closed enumeration. A refinement is credited to the field it compares
+      rather than to the field carrying it, and a struct-level [where] is read
+      where the projection puts it, so a field's values are the ones the
+      generated validator tests it against. A casetype field seeds too: its tag
+      is parsed at the start of the field's own bytes, so the slot is the tag's
+      and the values are the case indices. Bitfields are omitted because their
+      base word is shared, so a byte offset alone cannot seed one.
 
       The list over-approximates: it names candidates worth trying, not values
       the description is guaranteed to admit, so a consumer must run each

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -3690,33 +3690,43 @@ let neighbours k =
    values. This is intentionally an over-approximation: consumers must ask the
    codec for the verdict, so an inadmissible candidate costs one retry rather
    than producing a wrong oracle. *)
-let constraint_values name (e : bool expr) =
-  let is_self : type a. a expr -> bool = function
-    | Ref (_, n) -> String.equal n name
-    | _ -> false
+(* Which field a comparison names, and the value it names for it. The generated
+   validator checks a refinement at the field it is attached to but compares
+   whatever fields the expression references, so a literal belongs to the field
+   on the other side of the comparison rather than to the field carrying the
+   constraint: [UINT8 d { (len < 2) }] singles out a value for [len], not for
+   [d]. *)
+let constraint_bindings (e : bool expr) : (string * int64 list) list =
+  let named : type a. a expr -> string option = function
+    | Ref (_, n) -> Some n
+    | _ -> None
   in
   let literal : type a. a expr -> int64 option = function
     | Int k -> Some (Int64.of_int k)
     | Int64 k -> Some k
     | _ -> None
   in
-  let against : type a. a expr -> a expr -> int64 option =
+  let against : type a. a expr -> a expr -> (string * int64) option =
    fun x y ->
-    if is_self x then literal y else if is_self y then literal x else None
+    match (named x, literal y) with
+    | Some n, Some k -> Some (n, k)
+    | _ -> (
+        match (named y, literal x) with
+        | Some n, Some k -> Some (n, k)
+        | _ -> None)
   in
-  let rec go : bool expr -> int64 list = function
+  let bind f a b =
+    match against a b with Some (n, k) -> [ (n, f k) ] | None -> []
+  in
+  let rec go : bool expr -> (string * int64 list) list = function
     | And (a, b) | Or (a, b) -> go a @ go b
     | Not a -> go a
-    | Eq (a, b) -> ( match against a b with Some k -> [ k ] | None -> [])
-    | Ne (a, b) -> ( match against a b with Some k -> [ k ] | None -> [])
-    | Lt (a, b) -> (
-        match against a b with Some k -> neighbours k | None -> [])
-    | Le (a, b) -> (
-        match against a b with Some k -> neighbours k | None -> [])
-    | Gt (a, b) -> (
-        match against a b with Some k -> neighbours k | None -> [])
-    | Ge (a, b) -> (
-        match against a b with Some k -> neighbours k | None -> [])
+    | Eq (a, b) -> bind (fun k -> [ k ]) a b
+    | Ne (a, b) -> bind (fun k -> [ k ]) a b
+    | Lt (a, b) -> bind neighbours a b
+    | Le (a, b) -> bind neighbours a b
+    | Gt (a, b) -> bind neighbours a b
+    | Ge (a, b) -> bind neighbours a b
     | _ -> []
   in
   go e
@@ -3737,13 +3747,11 @@ let rec enum_seed_values : type a. a typ -> int64 list = function
   | Optional_or { inner; _ } -> enum_seed_values inner
   | _ -> []
 
-let rec typ_constraints : type a. string -> a typ -> int64 list =
- fun name -> function
-  | Where { cond; inner } ->
-      constraint_values name cond @ typ_constraints name inner
-  | Map { inner; _ } -> typ_constraints name inner
-  | Optional { inner; _ } -> typ_constraints name inner
-  | Optional_or { inner; _ } -> typ_constraints name inner
+let rec typ_bindings : type a. a typ -> (string * int64 list) list = function
+  | Where { cond; inner } -> constraint_bindings cond @ typ_bindings inner
+  | Map { inner; _ } -> typ_bindings inner
+  | Optional { inner; _ } -> typ_bindings inner
+  | Optional_or { inner; _ } -> typ_bindings inner
   | _ -> []
 
 let int_slots s =
@@ -3800,6 +3808,27 @@ let rec casetype_tag_seed : type a. a typ -> (int_slot * int64 list) option =
   | _ -> None
 
 let field_seeds s =
+  (* Read the record the way the projection does. A struct-level [where] is
+     lowered onto the last field it references before EverParse sees it, so
+     lower it here rather than keeping a second rule about where a constraint
+     lives, and collect every refinement's values across the whole record: the
+     generated validator checks a refinement at the field carrying it but
+     compares whatever it references. *)
+  let _, fields = lower_where_to_field_constraint s.where s.fields in
+  let bindings =
+    List.concat_map
+      (fun (Field f) ->
+        (match f.constraint_ with
+          | Some c -> constraint_bindings c
+          | None -> [])
+        @ typ_bindings f.field_typ)
+      fields
+  in
+  let named name =
+    List.concat_map
+      (fun (n, vs) -> if String.equal n name then vs else [])
+      bindings
+  in
   let seed name slot values =
     match List.sort_uniq Int64.compare values with
     | [] -> None
@@ -3808,19 +3837,11 @@ let field_seeds s =
   let of_field (Field f) =
     match (f.field_name, int_slot_of_typ f.field_typ) with
     | Some name, Some slot ->
-        let from_field =
-          match f.constraint_ with
-          | Some constraint_ -> constraint_values name constraint_
-          | None -> []
-        in
-        seed name slot
-          (from_field
-          @ typ_constraints name f.field_typ
-          @ enum_seed_values f.field_typ)
+        seed name slot (named name @ enum_seed_values f.field_typ)
     | Some name, None -> (
         match casetype_tag_seed f.field_typ with
         | Some (slot, values) -> seed name slot values
         | None -> None)
     | None, _ -> None
   in
-  List.filter_map of_field s.fields
+  List.filter_map of_field fields

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -1119,13 +1119,16 @@ val int_slots : struct_ -> (string * int_slot) list
     singles out particular values. *)
 
 val field_seeds : struct_ -> field_seed list
-(** [field_seeds s] is, for each named whole-byte integer field of [s] whose
-    declaration singles out values, the byte slot it occupies and those values:
-    the constant an equality or inequality refinement names, the values either
-    side of an ordering refinement's boundary, and the members of a closed
-    enumeration. A casetype field seeds too: its tag is parsed at the start of
-    the field's own bytes, so the slot is the tag's and the values are the case
-    indices. Fields with no such value, and fields that are not whole-byte
+(** [field_seeds s] is, for each named whole-byte integer field of [s] whose any
+    refinement in the record compares against a value, the byte slot it occupies
+    and those values: the constant an equality or inequality names, the values
+    either side of an ordering boundary, and the members of a closed
+    enumeration. A refinement is credited to the field it compares rather than
+    to the field carrying it, and a struct-level [where] is read where the
+    projection puts it, so a field's values are the ones the generated validator
+    tests it against. A casetype field seeds too: its tag is parsed at the start
+    of the field's own bytes, so the slot is the tag's and the values are the
+    case indices. Fields with no such value, and fields that are not whole-byte
     integers (bitfields in particular, whose base word is shared), are omitted.
 
     The list over-approximates: it names candidates worth trying, not values the

--- a/lib/wire.mli
+++ b/lib/wire.mli
@@ -1542,13 +1542,16 @@ module Everparse : sig
 
     val field_seeds : struct_ -> field_seed list
     (** [field_seeds s] is, for each named whole-byte integer field of [s] whose
-        declaration singles out values, the byte slot it occupies and those
-        values: the constant an equality or inequality refinement names, the
-        values either side of an ordering refinement's boundary, and the members
-        of a closed enumeration. A casetype field seeds too: its tag is parsed
-        at the start of the field's own bytes, so the slot is the tag's and the
-        values are the case indices. Bitfields are omitted because their base
-        word is shared, so a byte offset alone cannot seed one.
+        any refinement in the record compares against a value, the byte slot it
+        occupies and those values: the constant an equality or inequality names,
+        the values either side of an ordering boundary, and the members of a
+        closed enumeration. A refinement is credited to the field it compares
+        rather than to the field carrying it, and a struct-level [where] is read
+        where the projection puts it, so a field's values are the ones the
+        generated validator tests it against. A casetype field seeds too: its
+        tag is parsed at the start of the field's own bytes, so the slot is the
+        tag's and the values are the case indices. Bitfields are omitted because
+        their base word is shared, so a byte offset alone cannot seed one.
 
         The list over-approximates: it names candidates worth trying, not values
         the description is guaranteed to admit, so a consumer must run each

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -637,6 +637,44 @@ let test_casetype_tag_field_seed () =
       Alcotest.failf "expected one seed for the casetype tag, got %d"
         (List.length seeds)
 
+(* A refinement is checked at the field carrying it but compares whatever it
+   references, so the values it names belong to the field on the other side.
+   Crediting them to the carrier reported nothing for either field, and a
+   struct-level [where] was not read at all, though the projection lowers it
+   onto a field before EverParse sees it. *)
+let test_seeds_follow_the_compared_field () =
+  let f_len = Field.v "len" uint8 in
+  let carried =
+    Codec.v "Carried"
+      (fun l d -> (l, d))
+      Codec.
+        [
+          (f_len $ fun (l, _) -> l);
+          ( Field.v "d" (where Expr.(Field.ref f_len < int 2) uint8)
+          $ fun (_, d) -> d );
+        ]
+  in
+  let f_v = Field.v "v" uint8 in
+  let record_where =
+    Codec.v "RecordWhere"
+      ~where:Expr.(Field.ref f_v < int 4)
+      (fun v -> v)
+      Codec.[ (f_v $ fun v -> v) ]
+  in
+  let named c =
+    List.map
+      (fun (s : field_seed) -> (s.field, s.values))
+      (field_seeds (struct_of_codec c))
+  in
+  Alcotest.(check (list (pair string (list int64))))
+    "the value belongs to the field the refinement compares"
+    [ ("len", [ 1L; 2L; 3L ]) ]
+    (named carried);
+  Alcotest.(check (list (pair string (list int64))))
+    "a struct-level where is read where the projection puts it"
+    [ ("v", [ 3L; 4L; 5L ]) ]
+    (named record_where)
+
 (* A [lookup] admits exactly the indices into its table, and no other part of a
    field's declaration names them, so without a seed a generated corpus never
    reaches an accepted record and the codec reads as unfuzzable. *)
@@ -1730,6 +1768,8 @@ let suite =
         `Quick test_doc_merge_shared_sub_codec;
       Alcotest.test_case "3d: casetype tag over map/where/uint64 bases" `Quick
         test_3d_casetype_tag_int_carriers;
+      Alcotest.test_case "seeds: follow the compared field" `Quick
+        test_seeds_follow_the_compared_field;
       Alcotest.test_case "seeds: lookup names its table indices" `Quick
         test_lookup_field_seed;
       Alcotest.test_case "seeds: casetype tag names its case indices" `Quick


### PR DESCRIPTION
`field_seeds` credited a literal to the field carrying the constraint rather than the field it compares, so `UINT8 d { (len < 2) }` reported nothing for either `d` or `len`, though the record plainly singles out a value for `len`. A struct-level `where` was not read at all, even though the projection lowers it onto a field before EverParse sees it.

It now reads the record the way the projection does, reusing that same lowering rather than keeping a second rule about where a constraint lives.

Stacked on #360.