### PR TITLE
types: dispatch a casetype on every integer tag

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -74,6 +74,12 @@
   `where` where the projection puts it. A constraint written on one field about
   another, and any codec-level `where`, previously yielded no values at all
   (#362, @samoht)
+- A casetype whose tag is a `variants`, a `lookup`, a plain `map` or a bare
+  `uint64` now dispatches in the generated C as it does in OCaml. The tag was
+  not recognised as an integer one, so the union was rewritten to a tag followed
+  by opaque bytes: EverParse accepted the schema and the validator checked no
+  case body at all, while `Codec.decode` rejected the same input (#363, @samoht)
+
 ## 1.2.0
 
 ### Added

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -1506,11 +1506,14 @@ let list_elem_pp : type a.
 (* True for tag types that the 3D side can dispatch on natively: integer-
    shaped scalars plus enums. String/byte tags use the two-step shape
    (split into adjacent fields, dispatch in caller code) instead. *)
-let is_int_dispatch_typ : type a. a typ -> bool = function
-  | Uint8 | Uint16 _ | Uint32 _ | Uint_var _ | Int8 | Int16 _ | Int32 _ | Bits _
-  | Enum _ ->
-      true
-  | _ -> false
+(* Whether a casetype dispatches on an integer tag. This has to admit exactly
+   what [case_index_to_expr] can project, which is every carrier with an integer
+   view: disagreeing sends the casetype down the string-tag rewrite, where the
+   whole union collapses to a tag plus [all_bytes] and the generated validator
+   checks no case body at all. A [variants] or [lookup] tag is a [Map] over an
+   integer and dispatches like one. *)
+let is_int_dispatch_typ : type a. a typ -> bool =
+ fun typ -> is_int_representable typ
 
 let int32_case_index k =
   match SInt32.to_int_opt k with

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -557,6 +557,42 @@ let test_doc_merge_shared_sub_codec () =
   check "sub first" (write "wire_doc_merge_shared_a" [ sub; parent ]);
   check "parent first" (write "wire_doc_merge_shared_b" [ parent; sub ])
 
+(* A tag the dispatch gate did not admit was routed to the rewrite meant for
+   string tags, where the union collapses to a tag plus [all_bytes]: EverParse
+   accepted the schema and the generated validator checked no case body at all,
+   while the OCaml codec dispatched normally. The gate has to admit exactly what
+   the case-index projection can render. *)
+let test_casetype_integer_tags_dispatch () =
+  let dispatches name tag lift =
+    let c =
+      Codec.v name
+        (fun v -> v)
+        Codec.
+          [
+            ( Field.v "b"
+                (casetype (name ^ "Body") tag
+                   [
+                     case ~index:(lift 0) uint8 ~inject:Fun.id
+                       ~project:Option.some;
+                   ])
+            $ fun v -> v );
+          ]
+    in
+    let out =
+      to_3d ~enum_as_type:true (Everparse.project ~mode:`Standalone c).module_
+    in
+    Alcotest.(check bool)
+      (name ^ ": dispatches on the tag")
+      true
+      (contains ~sub:"switch (tag)" out);
+    Alcotest.(check bool)
+      (name ^ ": does not swallow the body as bytes")
+      false
+      (contains ~sub:"all_bytes" out)
+  in
+  dispatches "Lk" (lookup [ 0; 1 ] uint8) Fun.id;
+  dispatches "U6" uint64 UInt64.of_int
+
 (* A casetype dispatches on any enum, and an enum takes any base with an integer
    view, so a tag reaches the case-index projection wrapped in a [lookup]'s map,
    behind a [where], or over a 64-bit base. Each still names one integer per
@@ -1766,6 +1802,8 @@ let suite =
         test_doc_merge_name_collision;
       Alcotest.test_case "doc: merge keeps a shared sub-codec's entrypoint"
         `Quick test_doc_merge_shared_sub_codec;
+      Alcotest.test_case "3d: integer casetype tags dispatch" `Quick
+        test_casetype_integer_tags_dispatch;
       Alcotest.test_case "3d: casetype tag over map/where/uint64 bases" `Quick
         test_3d_casetype_tag_int_carriers;
       Alcotest.test_case "seeds: follow the compared field" `Quick


### PR DESCRIPTION
The gate deciding whether a casetype dispatches on an integer admitted less than the case-index projection can render: no `uint64` or `int64`, and blind through `map`, `where`, `nested` and `apply`. A `variants`, `lookup`, plain `map` or bare `uint64` tag therefore took the rewrite meant for string tags, and the whole union collapsed:

    VK tag;
    all_bytes b_body;

EverParse accepts that, and the validator checks no case body at all, while `Codec.decode` dispatches normally and rejects an unmatched tag. `variants` is the API the documentation steers callers to.

The gate is now the same predicate the projection uses, so the two cannot disagree again. This is the silent half of the mapped-tag defect; the assertion failure was #347.

Top of the stack, on #361.