### PR TITLE
types: keep a case body's refinement in the generated validator

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -60,25 +60,33 @@
   the bytes that were missing rather than a negative count. `Wire.of_reader`
   computes how much more to read from that number, so a negative one left it
   asking for a position behind what it had already buffered (#359, @samoht)
-- `Wire.Codec.min_wire_size` reports the region a `zeroterm_at_most` field
-  occupies rather than zero, so a buffer sized from it holds the record. A
-  parse error from a `zeroterm` field with no terminator also names the field
-  it came from (#361, @samoht)
+
 - `Wire_3d.generate_corpus` reaches records whose accepting side sits at an
   extreme, such as a predicate satisfied at the minimum or a string whose
   terminator has to be written rather than drawn. It seeds from the extremes as
   well as from noise, and repairs a missing terminator the way it already
   repaired a short input (#360, @samoht)
+
+- `Wire.Codec.min_wire_size` reports the region a `zeroterm_at_most` field
+  occupies rather than zero, so a buffer sized from it holds the record. A
+  parse error from a `zeroterm` field with no terminator also names the field
+  it came from (#361, @samoht)
+
 - `Wire.Everparse.Raw.field_seeds` credits a refinement's values to the field it
   compares rather than to the field carrying it, and reads a struct-level
   `where` where the projection puts it. A constraint written on one field about
   another, and any codec-level `where`, previously yielded no values at all
   (#362, @samoht)
+
 - A casetype whose tag is a `variants`, a `lookup`, a plain `map` or a bare
   `uint64` now dispatches in the generated C as it does in OCaml. The tag was
   not recognised as an integer one, so the union was rewritten to a tag followed
   by opaque bytes: EverParse accepted the schema and the validator checked no
   case body at all, while `Codec.decode` rejected the same input (#363, @samoht)
+
+- A casetype case body keeps the refinement its type carries. A closed enum's
+  membership and a `lookup`'s index bound were dropped from the generated
+  validator, which then accepted bodies `Codec.decode` rejects (#364, @samoht)
 
 ## 1.2.0
 

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -3064,6 +3064,62 @@ let lookup_bound_cond raw_name field_typ =
   | Some len -> Some (Lt (Ref (I, raw_name), Int len))
   | None -> None
 
+(* How a declaration position renders a type: the base to print, its suffix, and
+   the refinement that has to follow the name. Shared by [pp_field] and
+   [pp_casetype_cases] so a case body carries the same membership, index bound
+   and [where] a field of that type would. Rendering a case body through
+   [field_suffix] alone dropped every one of them, and the generated validator
+   then accepted bodies the codec rejects. *)
+let render_typ_at : type a.
+    name:string ->
+    widenable:string list ->
+    own:bool expr option ->
+    a typ ->
+    (Format.formatter -> unit) * field_suffix * bool expr option =
+ fun ~name ~widenable ~own field_typ ->
+  (* Extract Where constraints from the type so they appear as field
+     constraints in the 3D output, not inline in the type. *)
+  let where_cond, typ = extract_where_constraint field_typ in
+  let bound_cond = lookup_bound_cond name field_typ in
+  (* The documentation projection types the field as its named enum, so
+     EverParse enforces membership through the type. The codegen projection
+     instead emits membership as a refinement on the base type, which the OCaml
+     decoder mirrors on decode. *)
+  let doc_enum =
+    if !render_enum_as_type then enum_type_name field_typ else None
+  in
+  let enum_cond =
+    match (doc_enum, enum_cases_of field_typ) with
+    | None, Some (v0 :: rest) ->
+        Some
+          (List.fold_left
+             (fun acc v -> Or (acc, Eq (Ref (I, name), Int v)))
+             (Eq (Ref (I, name), Int v0))
+             rest)
+    | _ -> None
+  in
+  let constraint_ =
+    combine_constraints
+      (combine_constraints (combine_constraints own where_cond) bound_cond)
+      enum_cond
+  in
+  (* Rewrite a signed field's ordering refinement to its two's-complement
+     unsigned form (the field projects to an unsigned type), and reject a float
+     ordering refinement, which has no faithful unsigned projection. *)
+  let constraint_ =
+    Option.map (project_refinement ~name ~kind:(scalar_kind typ)) constraint_
+  in
+  let constraint_ =
+    Option.map (project_field_arith name widenable) constraint_
+  in
+  let suffix, pp_base = field_suffix typ in
+  let pp_base =
+    match doc_enum with
+    | Some n -> fun ppf -> Fmt.string ppf n
+    | None -> pp_base
+  in
+  (pp_base, suffix, constraint_)
+
 let pp_field widenable ppf (Field f) =
   let raw_name, name =
     match f.field_name with
@@ -3074,50 +3130,8 @@ let pp_field widenable ppf (Field f) =
         let s = Fmt.str "_anon_%d" n in
         (s, s)
   in
-  (* Extract Where constraints from the type so they appear as field
-     constraints in the 3D output, not inline in the type. *)
-  let where_cond, typ = extract_where_constraint f.field_typ in
-  let bound_cond = lookup_bound_cond raw_name f.field_typ in
-  (* The documentation projection types the field as its named enum, so
-     EverParse enforces membership through the type. The codegen projection
-     instead emits membership as a refinement on the base type, which the OCaml
-     decoder mirrors on decode. *)
-  let doc_enum =
-    if !render_enum_as_type then enum_type_name f.field_typ else None
-  in
-  let enum_cond =
-    match (doc_enum, enum_cases_of f.field_typ) with
-    | None, Some (v0 :: rest) ->
-        Some
-          (List.fold_left
-             (fun acc v -> Or (acc, Eq (Ref (I, raw_name), Int v)))
-             (Eq (Ref (I, raw_name), Int v0))
-             rest)
-    | _ -> None
-  in
-  let constraint_ =
-    combine_constraints
-      (combine_constraints
-         (combine_constraints f.constraint_ where_cond)
-         bound_cond)
-      enum_cond
-  in
-  (* Rewrite a signed field's ordering refinement to its two's-complement
-     unsigned form (the field projects to an unsigned type), and reject a float
-     ordering refinement, which has no faithful unsigned projection. *)
-  let constraint_ =
-    Option.map
-      (project_refinement ~name:raw_name ~kind:(scalar_kind typ))
-      constraint_
-  in
-  let constraint_ =
-    Option.map (project_field_arith raw_name widenable) constraint_
-  in
-  let suffix, pp_base = field_suffix typ in
-  let pp_base =
-    match doc_enum with
-    | Some n -> fun ppf -> Fmt.string ppf n
-    | None -> pp_base
+  let pp_base, suffix, constraint_ =
+    render_typ_at ~name:raw_name ~widenable ~own:f.constraint_ f.field_typ
   in
   Option.iter (pp_field_doc ppf) f.field_doc;
   Fmt.pf ppf "@,%t %s%a" pp_base name pp_field_suffix suffix;
@@ -3290,9 +3304,12 @@ let pp_casetype_cases : type k.
   List.iteri
     (fun i (tag_opt, Pack_typ typ) ->
       let field_name = Fmt.str "v%d" i in
-      let suffix, pp_base = field_suffix typ in
+      let pp_base, suffix, constraint_ =
+        render_typ_at ~name:field_name ~widenable:[] ~own:None typ
+      in
       let pp_body ppf () =
-        Fmt.pf ppf "%t %s%a" pp_base field_name pp_field_suffix suffix
+        Fmt.pf ppf "%t %s%a" pp_base field_name pp_field_suffix suffix;
+        Option.iter (Fmt.pf ppf " { %a }" pp_expr) constraint_
       in
       match tag_opt with
       | None -> Fmt.pf ppf "@,default: %a;" pp_body ()

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -557,6 +557,43 @@ let test_doc_merge_shared_sub_codec () =
   check "sub first" (write "wire_doc_merge_shared_a" [ sub; parent ]);
   check "parent first" (write "wire_doc_merge_shared_b" [ parent; sub ])
 
+(* A case body was rendered through the type suffix alone, never through the
+   refinement machinery a field of the same type goes through, so a closed
+   enum's membership and a lookup's index bound vanished from the generated
+   validator while the codec kept enforcing them. *)
+let test_casetype_case_bodies_keep_refinements () =
+  let c =
+    Codec.v "CaseRef"
+      (fun v -> v)
+      Codec.
+        [
+          ( Field.v "b"
+              (casetype "CBody" uint8
+                 [
+                   case ~index:(UInt8.v 1)
+                     (enum "RCode" [ ("C7", 7); ("C9", 9) ] uint8)
+                     ~inject:(fun v -> `E v)
+                     ~project:(function `E v -> Some v | _ -> None);
+                   case ~index:(UInt8.v 2)
+                     (lookup [ 0; 1; 2 ] uint8)
+                     ~inject:(fun v -> `L v)
+                     ~project:(function `L v -> Some v | _ -> None);
+                 ])
+          $ fun v -> v );
+        ]
+  in
+  let out = to_3d (Everparse.project ~mode:`Ffi c).module_ in
+  Alcotest.(check bool)
+    "the enum body keeps its membership" true
+    (contains ~sub:"{ ((v0 == 7) || (v0 == 9)) }" out);
+  Alcotest.(check bool)
+    "the lookup body keeps its index bound" true
+    (contains ~sub:"{ (v1 < 3) }" out);
+  (* The codec rejects a body the unrefined validator would have accepted. *)
+  match Codec.decode c (Bytes.of_string "\x01\x05") 0 with
+  | Ok _ -> Alcotest.fail "expected the enum body to be refused"
+  | Error _ -> ()
+
 (* A tag the dispatch gate did not admit was routed to the rewrite meant for
    string tags, where the union collapses to a tag plus [all_bytes]: EverParse
    accepted the schema and the generated validator checked no case body at all,
@@ -1802,6 +1839,8 @@ let suite =
         test_doc_merge_name_collision;
       Alcotest.test_case "doc: merge keeps a shared sub-codec's entrypoint"
         `Quick test_doc_merge_shared_sub_codec;
+      Alcotest.test_case "3d: casetype case bodies keep refinements" `Quick
+        test_casetype_case_bodies_keep_refinements;
       Alcotest.test_case "3d: integer casetype tags dispatch" `Quick
         test_casetype_integer_tags_dispatch;
       Alcotest.test_case "3d: casetype tag over map/where/uint64 bases" `Quick


### PR DESCRIPTION
A casetype case body rendered through the type suffix alone and never through the refinement machinery a field of the same type goes through, so a closed enum's membership and a `lookup`'s index bound were dropped:

    before   case 1: UINT8 v0;
    after    case 1: UINT8 v0 { ((v0 == 7) || (v0 == 9)) };

EverParse accepted the unrefined form, so the generated validator took bodies `Codec.decode` rejects. Both positions now render through one function, since two paths for one decision is what let them diverge.

Stacked on #362.