### PR TITLE
types: render a formal and a case label as something declared

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -93,6 +93,12 @@
   sub-codecs of different widths produced a validator reading a different number
   of bytes than the codec (#365, @samoht)
 
+- A codec parameter and a casetype case label each render as something the
+  schema declares. A parameter typed by an enum named a type EverParse rejects
+  in that position, a case label named a constant of an enum over a bitfield
+  base that is never declared, and a `uint ~size` parameter named no type at
+  all and is now refused where it is built (#366, @samoht)
+
 ## 1.2.0
 
 ### Added

--- a/lib/param.ml
+++ b/lib/param.ml
@@ -46,9 +46,25 @@ let rec to_int : type a. a Types.typ -> a -> int =
 
 let of_int = Types.of_int
 
+(* A [uint ~size] renders as [UINTBE(n)], which is an array suffix rather than a
+   type, so it cannot name a 3D formal. Rejected here for the same reason
+   [Wire.casetype] rejects it as a tag: the position takes less than a field
+   does. *)
+let rec is_uint_var : type a. a Types.typ -> bool = function
+  | Types.Uint_var _ -> true
+  | Types.Enum { base; _ } -> is_uint_var base
+  | Types.Map { inner; _ } -> is_uint_var inner
+  | Types.Where { inner; _ } -> is_uint_var inner
+  | _ -> false
+
 let check_typ name typ =
   if not (Types.is_int_representable typ) then
     Fmt.invalid_arg "Param.%s: only integer-representable types are supported"
+      name;
+  if is_uint_var typ then
+    Fmt.invalid_arg
+      "Param.%s: a [uint ~size] has no 3D parameter type; use a fixed-width \
+       integer"
       name
 
 let input name typ =

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -3200,15 +3200,21 @@ let pp_param_typ : type a. Format.formatter -> a typ -> unit =
   | Some n -> Fmt.string ppf (escape_3d n)
   | None -> pp_scalar_of ppf t
 
-let pp_param ppf p =
+(* [~as_enum] is what separates the two formal positions. A casetype's switch
+   discriminant may be the enum type, and reads better as it. A struct's formal
+   is used in the size and offset arithmetic of the fields it parameterises, and
+   EverParse requires an integer type there: naming the enum got "Unknown
+   integer type" even with the enum declared. *)
+let pp_param ~as_enum ppf p =
   let (Pack_typ t) = p.param_typ in
   let name = escape_3d p.param_name in
-  if p.mutable_ then Fmt.pf ppf "mutable %a *%s" pp_param_typ t name
-  else Fmt.pf ppf "%a %s" pp_param_typ t name
+  let pp ppf t = if as_enum then pp_param_typ ppf t else pp_scalar_of ppf t in
+  if p.mutable_ then Fmt.pf ppf "mutable %a *%s" pp t name
+  else Fmt.pf ppf "%a %s" pp t name
 
-let pp_params ppf params =
+let pp_params ?(as_enum = false) ppf params =
   if not (List.is_empty params) then
-    Fmt.pf ppf "(%a)" Fmt.(list ~sep:comma pp_param) params
+    Fmt.pf ppf "(%a)" Fmt.(list ~sep:comma (pp_param ~as_enum)) params
 
 (* Collect every [Ref name] occurring in an expression. Used to detect
    field references in struct-level [where] clauses, which 3D's grammar
@@ -3300,7 +3306,7 @@ let pp_struct ppf (s : struct_) =
         | _ -> None)
       fields
   in
-  Fmt.pf ppf "typedef struct %s%a" tag pp_params s.params;
+  Fmt.pf ppf "typedef struct %s%a" tag (pp_params ?as_enum:None) s.params;
   Option.iter (Fmt.pf ppf "@,where (%a)" pp_expr) where;
   Fmt.pf ppf "@,{@[<v 2>";
   List.iter (pp_field widenable ppf) fields;
@@ -3330,7 +3336,11 @@ let pp_casetype_cases : type k.
     | _ -> None
   in
   let enum_label k =
-    if not !render_enum_as_type then None
+    (* [enum_type_name] is the same test that decides whether the tag renders as
+       the enum: an enum over a bitfield base has no 3D enum type and so no
+       declaration, and naming its constant referred to nothing. *)
+    if (not !render_enum_as_type) || Option.is_none (enum_type_name tag) then
+      None
     else
       match named_cases tag with
       | Some ecases ->
@@ -3383,7 +3393,7 @@ let pp_decl ppf = function
       else Fmt.pf ppf "#define %s 0x%x@," name value
   | Extern_fn { name; params; ret = Pack_typ ret } ->
       Fmt.pf ppf "@[<h>extern %a %s(%a)@]@,@," pp_typ ret name
-        Fmt.(list ~sep:comma pp_param)
+        Fmt.(list ~sep:comma (pp_param ~as_enum:false))
         params
   | Extern_probe { init; name } ->
       (* 3D's [EXTERN PROBE q? IDENT] rule has no terminator. *)
@@ -3404,8 +3414,8 @@ let pp_decl ppf = function
           (name, String.sub name 1 (String.length name - 1))
         else ("_" ^ name, name)
       in
-      Fmt.pf ppf "casetype %s%a {@[<v 2>@,switch (%s) {" internal_name pp_params
-        params disc_name;
+      Fmt.pf ppf "casetype %s%a {@[<v 2>@,switch (%s) {" internal_name
+        (pp_params ~as_enum:true) params disc_name;
       pp_casetype_cases ppf tag cases;
       Fmt.pf ppf "@,}@]@,} %s;@,@," public_name
 

--- a/test/test_everparse.ml
+++ b/test/test_everparse.ml
@@ -557,6 +557,43 @@ let test_doc_merge_shared_sub_codec () =
   check "sub first" (write "wire_doc_merge_shared_a" [ sub; parent ]);
   check "parent first" (write "wire_doc_merge_shared_b" [ parent; sub ])
 
+(* A formal's type is rendered in two positions with different rules. A
+   casetype's switch discriminant may be the enum type; a struct's formal is
+   used in the size arithmetic of the fields it parameterises, where EverParse
+   requires an integer type and reported "Unknown integer type" for an enum even
+   once declared. And a case label may name an enum constant only where the enum
+   is declared, which one over a bitfield base never is. *)
+let test_formal_and_label_positions () =
+  let p = Param.input "pn" (enum "PKind" [ ("PA", 1) ] uint8) in
+  let param_codec =
+    Codec.v "PEnum"
+      (fun v -> v)
+      Codec.[ (Field.v "d" (byte_array ~size:(Param.expr p)) $ fun v -> v) ]
+  in
+  let bits_tag =
+    Codec.v "BTag"
+      (fun h b -> (h, b))
+      Codec.
+        [
+          Field.v "hi" (bits ~width:4 U8) $ fst;
+          Field.v "b"
+            (casetype "QBody"
+               (enum "BKind" [ ("BA", 1) ] (bits ~width:4 U8))
+               [ case ~index:1 uint8 ~inject:Fun.id ~project:Option.some ])
+          $ snd;
+        ]
+  in
+  let doc c =
+    to_3d ~enum_as_type:true (Everparse.project ~mode:`Standalone c).module_
+  in
+  Alcotest.(check bool)
+    "a struct formal renders as its integer base" true
+    (contains ~sub:"(UINT8 pn)" (doc param_codec));
+  Alcotest.(check bool)
+    "a bitfield-based enum tag labels by value, not by a name it never declares"
+    false
+    (contains ~sub:"case BA:" (doc bits_tag))
+
 (* Two declarations under one name are two types with one name, and every
    reference resolves to whichever was reached first: two same-named sub-codecs
    of different widths gave a validator reading a different number of bytes than
@@ -1874,6 +1911,8 @@ let suite =
         test_doc_merge_name_collision;
       Alcotest.test_case "doc: merge keeps a shared sub-codec's entrypoint"
         `Quick test_doc_merge_shared_sub_codec;
+      Alcotest.test_case "3d: formal and label positions" `Quick
+        test_formal_and_label_positions;
       Alcotest.test_case "3d: duplicate declaration names rejected" `Quick
         test_duplicate_declaration_names_rejected;
       Alcotest.test_case "3d: casetype case bodies keep refinements" `Quick


### PR DESCRIPTION
Three positions named something the schema does not provide.

A struct's formal is used in the size arithmetic of the fields it parameterises, where EverParse requires an integer type: an enum-typed parameter got `Unknown integer type` even once the enum was declared, so declaring it was the wrong fix and it renders as its base. A casetype's switch discriminant is the position that may be an enum, and keeps it.

A case label named a constant of an enum over a bitfield base, which `enum_decls` never declares.

A `uint ~size` parameter rendered `UINTBE(n)`, an array suffix rather than a type, and is now refused where the parameter is built, as `Wire.casetype` already refuses the same type as a tag.

Stacked on #365.