### PR TITLE
3d: name the status variable EverParse binds in the wrapper check

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ### Fixed
 
+- `Wire_3d.generate_c` works against EverParse releases after v2026.02.25. The
+  whole-buffer check it adds to each generated wrapper named a variable those
+  releases renamed, so the emitted C referenced an undeclared identifier and
+  failed to compile (#367, @samoht)
+
 - `Wire.Everparse.write` no longer refuses a family in which a sub-codec is both
   packed as a codec of its own and reached through another codec's field,
   reporting the two as conflicting definitions of one type. They differ only in

--- a/lib/3d/wire_3d.ml
+++ b/lib/3d/wire_3d.ml
@@ -636,33 +636,78 @@ let fields_c_files schemas =
    backstop is the differential runtest, whose corpus includes over-length
    inputs the oracle rejects. *)
 let wrapper_success_tail = "\t\treturn FALSE;\n\t}\n\treturn TRUE;\n}"
-let wrapper_consumption_check = "result != (uint64_t) len"
 
-let wrapper_hardened_tail =
-  "\t\treturn FALSE;\n\
-   \t}\n\
-   \tif (result != (uint64_t) len)\n\
-   \t{\n\
-   \t\treturn FALSE;\n\
-   \t}\n\
-   \treturn TRUE;\n\
-   }"
+(* The wrapper binds the validator's result to a local whose name EverParse
+   has changed across releases ([result] up to v2026.02.25, [ep_status] by
+   v2026.08.21), so read the name back out of the wrapper instead of assuming
+   one: hard-coding it produced a check against an undeclared identifier, and
+   the generated C stopped compiling. *)
+let wrapper_status_binding =
+  Re.compile
+    (Re.seq
+       [
+         Re.str "uint64_t";
+         Re.rep1 Re.space;
+         Re.group
+           (Re.seq
+              [
+                Re.alt [ Re.alpha; Re.char '_' ];
+                Re.rep (Re.alt [ Re.alnum; Re.char '_' ]);
+              ]);
+         Re.rep Re.space;
+         Re.char '=';
+         Re.rep (Re.compl [ Re.char '\n' ]);
+         Re.str "Validate";
+       ])
+
+let wrapper_status_var src =
+  Option.map
+    (fun g -> Re.Group.get g 1)
+    (Re.exec_opt wrapper_status_binding src)
+
+let wrapper_consumption_check var = var ^ " != (uint64_t) len"
+
+let wrapper_hardened_tail var =
+  Fmt.str
+    "\t\treturn FALSE;\n\
+     \t}\n\
+     \tif (%s)\n\
+     \t{\n\
+     \t\treturn FALSE;\n\
+     \t}\n\
+     \treturn TRUE;\n\
+     }"
+    (wrapper_consumption_check var)
+
+let harden_wrapper_source src =
+  let var =
+    match wrapper_status_var src with
+    | Some v -> v
+    | None ->
+        failwith
+          "unrecognized EverParse wrapper shape: no validator status binding"
+  in
+  (* Tested before the success tail, which the hardened form still ends with:
+     matching that first would splice in a second, redundant check. *)
+  if Re.execp (Re.compile (Re.str (wrapper_consumption_check var))) src then src
+  else
+    let tail = Re.compile (Re.str wrapper_success_tail) in
+    if Re.execp tail src then
+      Re.replace_string tail ~by:(wrapper_hardened_tail var) src
+    else
+      failwith
+        "unrecognized EverParse wrapper shape; cannot insert the \
+         full-consumption check"
 
 let harden_wrapper ~outdir base =
   let path = Filename.concat outdir (base ^ "Wrapper.c") in
   if Sys.file_exists path then begin
     let src = In_channel.with_open_text path In_channel.input_all in
-    let tail = Re.compile (Re.str wrapper_success_tail) in
-    if Re.execp tail src then
-      Out_channel.with_open_text path (fun oc ->
-          Out_channel.output_string oc
-            (Re.replace_string tail ~by:wrapper_hardened_tail src))
-    else if not (Re.execp (Re.compile (Re.str wrapper_consumption_check)) src)
-    then
-      Fmt.failwith
-        "%s: unrecognized EverParse wrapper shape; cannot insert the \
-         full-consumption check"
-        path
+    match harden_wrapper_source src with
+    | hardened ->
+        Out_channel.with_open_text path (fun oc ->
+            Out_channel.output_string oc hardened)
+    | exception Failure msg -> Fmt.failwith "%s: %s" path msg
   end
 
 let run_everparse_files ?(quiet = true) ~outdir files =

--- a/lib/3d/wire_3d.mli
+++ b/lib/3d/wire_3d.mli
@@ -176,6 +176,18 @@ val generate_c : ?quiet:bool -> outdir:string -> Wire.Everparse.t list -> unit
 
     Requires [3d.exe] (EverParse) in PATH. *)
 
+val harden_wrapper_source : string -> string
+(** [harden_wrapper_source src] is the EverParse wrapper [src] with its success
+    tail rewritten to also require that the validator consumed the whole buffer,
+    which is the rewrite {!generate_c} applies to each emitted wrapper. The
+    validator's status variable is read back out of [src], since EverParse has
+    renamed it across releases.
+
+    @raise Failure
+      if [src] is neither a wrapper shape this recognizes nor one already
+      carrying its own consumption check, rather than returning a prefix
+      recognizer. *)
+
 val run : ?quiet:bool -> outdir:string -> Wire.Everparse.t list -> unit
 (** [run ?quiet ~outdir schemas] runs the full pipeline: writes [.3d] files,
     invokes EverParse, and produces C validators. The [quiet] flag is passed

--- a/test/3d/test_wire_3d.ml
+++ b/test/3d/test_wire_3d.ml
@@ -927,6 +927,47 @@ let test_doc_differential_trailing_bytes () =
       (`Lines [ "RangeMsg - 0102 1"; "RangeMsg - 010203 0"; "RangeMsg - 01 0" ])
     [ Wire_3d.pack diff_range_codec ]
 
+(* EverParse renamed the wrapper's status local between releases ([result] up
+   to v2026.02.25, [ep_status] by v2026.08.21). The consumption check has to
+   name whichever one the wrapper actually binds; naming a fixed one emitted C
+   referencing an undeclared identifier, which failed to compile. *)
+let wrapper_src var =
+  Fmt.str
+    "BOOLEAN WCheckW(uint8_t *base, uint32_t len) {\n\
+     \tWFields frame;\n\
+     \tuint64_t %s = WValidateW( (uint8_t*)&frame, &DefaultErrorHandler, base, \
+     len, 0);\n\
+     \tif (EverParseIsError(%s))\n\
+     \t{\n\
+     \t\treturn FALSE;\n\
+     \t}\n\
+     \treturn TRUE;\n\
+     }"
+    var var
+
+let test_wrapper_hardening_names_the_status_var () =
+  List.iter
+    (fun var ->
+      let hardened = Wire_3d.harden_wrapper_source (wrapper_src var) in
+      let want = Fmt.str "if (%s != (uint64_t) len)" var in
+      if not (Re.execp (Re.compile (Re.str want)) hardened) then
+        Alcotest.failf "hardened wrapper for %S lacks %S:\n%s" var want hardened)
+    [ "result"; "ep_status" ]
+
+let test_wrapper_hardening_is_idempotent () =
+  let once = Wire_3d.harden_wrapper_source (wrapper_src "ep_status") in
+  Alcotest.(check string)
+    "already hardened" once
+    (Wire_3d.harden_wrapper_source once)
+
+let test_wrapper_hardening_refuses_unknown_shape () =
+  match
+    Wire_3d.harden_wrapper_source
+      "BOOLEAN WCheckW(uint8_t *base, uint32_t len) { return TRUE; }"
+  with
+  | _ -> Alcotest.fail "expected an unrecognized wrapper shape to be refused"
+  | exception Failure _ -> ()
+
 (* End-to-end compile+run. Generates C for a schema, invokes the same
    cc command [generate_dune] emits, runs the resulting binary. This is
    the one test that catches every kind of name mismatch between what
@@ -1968,6 +2009,12 @@ let suite =
       Alcotest.test_case "bare uint64 projects" `Slow test_bare_uint64_projects;
       Alcotest.test_case "nested field projects through EverParse" `Slow
         test_nested_field_projects;
+      Alcotest.test_case "wrapper hardening names the status var" `Quick
+        test_wrapper_hardening_names_the_status_var;
+      Alcotest.test_case "wrapper hardening is idempotent" `Quick
+        test_wrapper_hardening_is_idempotent;
+      Alcotest.test_case "wrapper hardening refuses an unknown shape" `Quick
+        test_wrapper_hardening_refuses_unknown_shape;
       Alcotest.test_case "e2e: compile + run across naming conventions" `Slow
         test_e2e_compile_run;
     ] )


### PR DESCRIPTION
EverParse renamed the local holding the validator's result in its generated
wrapper after v2026.02.25 (`result` became `ep_status`). Wire rewrites that
wrapper to require full-buffer consumption, and the rewrite named the old
variable, so the emitted C referenced an undeclared identifier and stopped
compiling against any newer release. The name is now read back out of the
wrapper.

The reordering that came with it makes the rewrite idempotent: the hardened
form still ends with the success tail it matches on, so a second pass used to
insert a duplicate check.
